### PR TITLE
feat: scaffold Godot-MCP plugin (Godot 4.3+/.NET 8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  build:
+    name: dotnet build (.NET 8)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Restore
+        run: dotnet restore Godot-MCP.sln
+
+      - name: Build
+        run: dotnet build Godot-MCP.sln --configuration Debug --no-restore

--- a/.gitignore
+++ b/.gitignore
@@ -427,3 +427,33 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
+
+##
+## Godot Engine
+## https://github.com/github/gitignore/blob/main/Godot.gitignore
+##
+
+# Godot 4+ specific ignores
+.godot/
+
+# Godot-specific ignores
+.import/
+export.cfg
+export_presets.cfg
+
+# Imported translations (automatically generated from CSV files)
+*.translation
+
+# Mono-specific ignores (Godot C#)
+.mono/
+data_*/
+mono_crash.*.json
+
+# Godot import metadata
+*.import
+
+##
+## .NET / build output (bare bin not covered by the VisualStudio section above)
+##
+bin/
+obj/

--- a/Godot-MCP.csproj
+++ b/Godot-MCP.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Godot.NET.Sdk/4.3.0">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <Nullable>enable</Nullable>
+    <RootNamespace>com.IvanMurzak.Godot.MCP</RootNamespace>
+    <AssemblyName>Godot-MCP</AssemblyName>
+  </PropertyGroup>
+
+  <!--
+    Reused libraries (shared with Unity-MCP). Referenced via NuGet, never vendored/forked.
+    Versions match the pins in Unity-MCP-Server (com.IvanMurzak.Unity.MCP.Server.csproj).
+    com.IvanMurzak.McpPlugin is the client package; it transitively pulls
+    McpPlugin.Common + ReflectorNet. ReflectorNet is also pinned explicitly to keep the
+    version deterministic.
+  -->
+  <ItemGroup>
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.1" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="6.5.5" />
+  </ItemGroup>
+
+</Project>

--- a/Godot-MCP.sln
+++ b/Godot-MCP.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Godot-MCP", "Godot-MCP.csproj", "{5A9A7840-7190-49D3-9A35-F869C6B60D38}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		ExportDebug|Any CPU = ExportDebug|Any CPU
+		ExportRelease|Any CPU = ExportRelease|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.ExportDebug|Any CPU.ActiveCfg = ExportDebug|Any CPU
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.ExportDebug|Any CPU.Build.0 = ExportDebug|Any CPU
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.ExportRelease|Any CPU.ActiveCfg = ExportRelease|Any CPU
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.ExportRelease|Any CPU.Build.0 = ExportRelease|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
 # Godot-MCP
-Godot-MCP — Model Context Protocol (MCP) integration for the Godot Engine. AI tools for the Godot Editor in C#, with cloud connection to ai-game.dev. Apache-2.0.
+
+**Model Context Protocol (MCP) integration for the [Godot Engine](https://godotengine.org/).**
+The Godot counterpart of [Unity-MCP](https://github.com/IvanMurzak/Unity-MCP) — it lets AI
+assistants drive the Godot Editor through MCP tools written in C#.
+
+> **Status:** early scaffold. The addon boots in the editor and logs a startup line; the MCP
+> connection and tools are landing in follow-up tasks.
+
+## Requirements
+
+- **Godot 4.3+** (C# / .NET edition, Godot.NET.Sdk `4.3.0`)
+- **.NET 8 SDK**
+
+## What it is
+
+Godot-MCP is a Godot **editor addon** (`addons/godot_mcp/`) backed by a `Godot.NET.Sdk` C#
+project. On editor load, a `[Tool]` `EditorPlugin` boots the plugin. Once complete it will
+expose Godot Editor operations as MCP tools and connect to **[ai-game.dev](https://ai-game.dev)**
+— the same cloud backend Unity-MCP uses — so an AI agent can build and edit Godot games.
+
+## Reused libraries
+
+It does **not** fork the MCP/reflection stack — those are shared with Unity-MCP and pulled
+from [nuget.org](https://www.nuget.org/) as `PackageReference`s:
+
+| Package | Version | Role |
+| --- | --- | --- |
+| [`com.IvanMurzak.ReflectorNet`](https://www.nuget.org/packages/com.IvanMurzak.ReflectorNet) | `5.3.1` | Reflection / serialization core |
+| [`com.IvanMurzak.McpPlugin`](https://www.nuget.org/packages/com.IvanMurzak.McpPlugin) | `6.5.5` | MCP plugin client (transitively pulls `McpPlugin.Common` + `ReflectorNet`) |
+
+## Building
+
+`Godot.NET.Sdk` is a NuGet SDK, so a Godot binary is **not** required to compile:
+
+```bash
+dotnet restore
+dotnet build
+```
+
+To run the addon, open the project in Godot 4.3+, then enable **Godot-MCP** under
+*Project → Project Settings → Plugins*.
+
+## License
+
+[Apache-2.0](LICENSE) © Ivan Murzak

--- a/addons/godot_mcp/GodotMcpPlugin.cs
+++ b/addons/godot_mcp/GodotMcpPlugin.cs
@@ -1,0 +1,39 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP
+{
+    /// <summary>
+    /// Editor entry point for the Godot-MCP addon. Referenced by
+    /// <c>addons/godot_mcp/plugin.cfg</c> (the <c>script</c> field) and loaded by the
+    /// Godot Editor when the plugin is enabled.
+    ///
+    /// This scaffold only boots and logs a startup line. The MCP connection to
+    /// ai-game.dev (SignalR client via com.IvanMurzak.McpPlugin) is intentionally
+    /// NOT wired up here — that is a separate downstream task.
+    /// </summary>
+    [Tool]
+    public partial class GodotMcpPlugin : EditorPlugin
+    {
+        public override void _EnterTree()
+        {
+            GD.Print("[Godot-MCP] plugin loaded");
+        }
+
+        public override void _ExitTree()
+        {
+            GD.Print("[Godot-MCP] plugin unloaded");
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/plugin.cfg
+++ b/addons/godot_mcp/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="Godot-MCP"
+description="Model Context Protocol (MCP) integration for the Godot Editor. AI tools in C#, cloud-connected to ai-game.dev."
+author="Ivan Murzak"
+version="0.1.0"
+script="GodotMcpPlugin.cs"


### PR DESCRIPTION
## What this is

Foundation scaffold for **Godot-MCP**, the Godot counterpart of [Unity-MCP](https://github.com/IvanMurzak/Unity-MCP): a Model Context Protocol editor addon for **Godot 4.3+ / .NET 8** written in C#. This PR lays the boot foundation only — **no MCP connection** (that is a separate downstream task).

## What's included

- **`Godot-MCP.csproj`** — `<Project Sdk="Godot.NET.Sdk/4.3.0">`, `net8.0`, `EnableDynamicLoading`, nullable enabled. NuGet `PackageReference`s to the reused libs (not vendored/forked):
  - `com.IvanMurzak.ReflectorNet` **5.3.1**
  - `com.IvanMurzak.McpPlugin` **6.5.5** (client; transitively pulls `McpPlugin.Common` + `ReflectorNet`)
  - Versions match the pins in `Unity-MCP-Server`'s csproj.
- **`Godot-MCP.sln`** — classic `.sln` with `Debug` / `ExportDebug` / `ExportRelease` configs (Godot 4 expects these).
- **`addons/godot_mcp/plugin.cfg`** — addon manifest (name, description, author=Ivan Murzak, version=0.1.0, `script="GodotMcpPlugin.cs"`).
- **`addons/godot_mcp/GodotMcpPlugin.cs`** — `[Tool]` `EditorPlugin` (in `#if TOOLS`) that logs `[Godot-MCP] plugin loaded` on `_EnterTree()`.
- **`addons/godot_mcp/Tools/.gitkeep`** — placeholder for future MCP tools.
- **`.github/workflows/ci.yml`** — restore + build on `ubuntu-latest` with .NET 8 SDK, on push + PR.
- **`README.md`** — what it is, requirements, reused NuGet libs, no-Godot-binary build, ai-game.dev cloud connection.
- **`.gitignore`** — appended Godot (`.godot/`, `*.import`, `.mono/`, export presets) + bare `bin/`/`obj/` on top of the seeded VisualStudio ruleset (merged, not replaced).
- LICENSE (Apache-2.0) verified present and unmodified.

## Addon-entry pattern chosen

`plugin.cfg`'s `script` field points **directly at the C# `.cs` file** (`GodotMcpPlugin.cs`), a `[Tool]`-attributed `EditorPlugin` subclass wrapped in `#if TOOLS`. This is the official Godot 4.3 C# convention ([making_plugins docs](https://docs.godotengine.org/en/4.3/tutorials/plugins/editor/making_plugins.html)) — no `.gd` shim is needed for C# addons.

## Build verification

`Godot.NET.Sdk` is a NuGet SDK, so no Godot binary is required to compile. Verified locally with the pinned **.NET 8 SDK (8.0.421)** via the solution exactly as CI runs:

```
Restored Godot-MCP.csproj
Godot-MCP -> .godot/mono/temp/bin/Debug/Godot-MCP.dll
Build succeeded.
    0 Warning(s)
    0 Error(s)
```

## DoD checklist

- [x] Compiles with `dotnet build` (no Godot binary; verified on .NET 8 SDK)
- [x] Valid Godot addon: `plugin.cfg` + C# `[Tool]` `EditorPlugin` logging a startup line on editor load (no MCP yet)
- [x] NuGet `PackageReference`s to ReflectorNet 5.3.1 + McpPlugin 6.5.5, restore cleanly from nuget.org
- [x] Apache-2.0 LICENSE present & unmodified, real README, merged Godot + .NET `.gitignore`
- [x] CI skeleton (`.github/workflows/ci.yml`: restore + build on push/PR, ubuntu + .NET 8)

## Note for reviewer

The addon **enable/boot in a live Godot 4.3 editor** could not be exercised here (no Godot binary in this environment). The pattern follows the official 4.3 C# docs and the project compiles; a quick manual enable in *Project Settings → Plugins* to confirm the `[Godot-MCP] plugin loaded` log is the one thing worth eyeballing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
