### PR TITLE
feat: main-thread dispatcher + Godot type converters for ReflectorNet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,6 @@ jobs:
 
       - name: Build
         run: dotnet build Godot-MCP.sln --configuration Debug --no-restore
+
+      - name: Test
+        run: dotnet test Godot-MCP.Tests/Godot-MCP.Tests.csproj --configuration Debug --no-build --verbosity normal

--- a/Godot-MCP.Tests/ConverterRoundTripTests.cs
+++ b/Godot-MCP.Tests/ConverterRoundTripTests.cs
@@ -1,0 +1,86 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using com.IvanMurzak.Godot.MCP.Reflection;
+using com.IvanMurzak.ReflectorNet;
+using com.IvanMurzak.ReflectorNet.Model;
+using Godot;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Round-trip coverage for the core Godot value-type converters registered by
+    /// <see cref="GodotReflectorFactory"/>. None of these touch a SceneTree, so they run in a
+    /// plain xUnit process with no Godot editor/runtime.
+    /// </summary>
+    public class ConverterRoundTripTests
+    {
+        static Reflector NewReflector() => GodotReflectorFactory.CreateDefaultReflector();
+
+        [Fact]
+        public void Factory_CreatesReflector()
+        {
+            Assert.NotNull(NewReflector());
+        }
+
+        [Fact]
+        public void Vector2_RoundTrips()
+        {
+            var reflector = NewReflector();
+            var original = new Vector2(1.5f, -2.25f);
+
+            var serialized = reflector.Serialize(original, typeof(Vector2));
+            var result = reflector.Deserialize(serialized, fallbackType: typeof(Vector2));
+
+            var restored = Assert.IsType<Vector2>(result);
+            Assert.Equal(original.X, restored.X);
+            Assert.Equal(original.Y, restored.Y);
+        }
+
+        [Fact]
+        public void Vector3_RoundTrips()
+        {
+            var reflector = NewReflector();
+            var original = new Vector3(3.0f, 4.0f, -5.5f);
+
+            var serialized = reflector.Serialize(original, typeof(Vector3));
+            var result = reflector.Deserialize(serialized, fallbackType: typeof(Vector3));
+
+            var restored = Assert.IsType<Vector3>(result);
+            Assert.Equal(original.X, restored.X);
+            Assert.Equal(original.Y, restored.Y);
+            Assert.Equal(original.Z, restored.Z);
+        }
+
+        [Fact]
+        public void Color_RoundTrips()
+        {
+            var reflector = NewReflector();
+            var original = new Color(0.1f, 0.2f, 0.3f, 0.4f);
+
+            var serialized = reflector.Serialize(original, typeof(Color));
+            var result = reflector.Deserialize(serialized, fallbackType: typeof(Color));
+
+            var restored = Assert.IsType<Color>(result);
+            Assert.Equal(original.R, restored.R);
+            Assert.Equal(original.G, restored.G);
+            Assert.Equal(original.B, restored.B);
+            Assert.Equal(original.A, restored.A);
+        }
+
+        // NOTE on NodePath: unlike Vector2/3/Color (pure managed structs), Godot's NodePath is a managed
+        // wrapper over a NATIVE object — even `new NodePath("...")` calls godotsharp_node_path_new_from_string
+        // via P/Invoke, which faults with AccessViolationException when the native Godot library is not loaded
+        // (i.e. in a plain xUnit host with no Godot runtime). The GodotNodePathJsonConverter is therefore
+        // exercised in the headless Godot smoke (see test.md Suite 3 / the Godot-Test-Project testbed), not
+        // here. Constructing a NodePath in this process would crash the whole test host, so it is omitted.
+    }
+}

--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>com.IvanMurzak.Godot.MCP.Tests</RootNamespace>
+    <AssemblyName>Godot-MCP.Tests</AssemblyName>
+    <!-- This is a plain xUnit assembly, not a Godot game assembly. It references GodotSharp only to
+         exercise the value-type converters/refs (Vector2/3, Color, NodePath, NodeRef, ResourceRef),
+         none of which need a running SceneTree. The editor dispatcher (behind #if TOOLS) needs a live
+         Godot main loop and is verified via a headless Godot smoke, not here (see test.md Suite 3). -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <!--
+    GodotSharp pinned to match the project SDK (Godot.NET.Sdk/4.3.0). The converters under test live
+    in the Godot-MCP addon assembly; rather than ProjectReference the Godot.NET.Sdk game project
+    (which pulls editor/runtime build steps), the small set of source files under test is compiled
+    directly into this test assembly. This keeps the test project a plain, CI-friendly xUnit build.
+  -->
+  <ItemGroup>
+    <PackageReference Include="GodotSharp" Version="4.3.0" />
+    <!-- Same pin as Godot-MCP.csproj; never bumped here (owned by the upstream release pipeline). -->
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\addons\godot_mcp\Data\NodeRef.cs" Link="Source\NodeRef.cs" />
+    <Compile Include="..\addons\godot_mcp\Data\ResourceRef.cs" Link="Source\ResourceRef.cs" />
+    <Compile Include="..\addons\godot_mcp\Reflection\GodotStructReflectionConverter.cs" Link="Source\GodotStructReflectionConverter.cs" />
+    <Compile Include="..\addons\godot_mcp\Reflection\GodotStructReflectionConverters.cs" Link="Source\GodotStructReflectionConverters.cs" />
+    <Compile Include="..\addons\godot_mcp\Reflection\GodotNodePathJsonConverter.cs" Link="Source\GodotNodePathJsonConverter.cs" />
+    <Compile Include="..\addons\godot_mcp\Reflection\GodotReflectorFactory.cs" Link="Source\GodotReflectorFactory.cs" />
+  </ItemGroup>
+
+</Project>

--- a/Godot-MCP.Tests/RefModelTests.cs
+++ b/Godot-MCP.Tests/RefModelTests.cs
@@ -1,0 +1,86 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Text.Json;
+using com.IvanMurzak.Godot.MCP.Data;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// <see cref="NodeRef"/> / <see cref="ResourceRef"/> are plain data models (no Godot API), so they
+    /// (de)serialize through System.Text.Json directly. These tests pin the JSON property names and the
+    /// validity rules the tool layer relies on.
+    /// </summary>
+    public class RefModelTests
+    {
+        [Fact]
+        public void NodeRef_RoundTrips_ByPath()
+        {
+            var original = new NodeRef("/root/Main/Player");
+
+            var json = JsonSerializer.Serialize(original);
+            var restored = JsonSerializer.Deserialize<NodeRef>(json);
+
+            Assert.NotNull(restored);
+            Assert.Equal(original.Path, restored!.Path);
+            Assert.Equal(0ul, restored.InstanceId);
+            Assert.Contains("\"path\"", json);
+        }
+
+        [Fact]
+        public void NodeRef_RoundTrips_ByInstanceId()
+        {
+            var original = new NodeRef(123456ul);
+
+            var json = JsonSerializer.Serialize(original);
+            var restored = JsonSerializer.Deserialize<NodeRef>(json);
+
+            Assert.NotNull(restored);
+            Assert.Equal(123456ul, restored!.InstanceId);
+            Assert.Contains("\"instanceId\"", json);
+        }
+
+        [Theory]
+        [InlineData("/root/Main", 0ul, true)]
+        [InlineData(null, 42ul, true)]
+        [InlineData(null, 0ul, false)]
+        [InlineData("", 0ul, false)]
+        public void NodeRef_IsValid(string? path, ulong instanceId, bool expected)
+        {
+            var nodeRef = new NodeRef { Path = path, InstanceId = instanceId };
+            Assert.Equal(expected, nodeRef.IsValid());
+        }
+
+        [Fact]
+        public void ResourceRef_RoundTrips_ByResourcePath()
+        {
+            var original = new ResourceRef("res://materials/wood.tres");
+
+            var json = JsonSerializer.Serialize(original);
+            var restored = JsonSerializer.Deserialize<ResourceRef>(json);
+
+            Assert.NotNull(restored);
+            Assert.Equal(original.ResourcePath, restored!.ResourcePath);
+            Assert.Contains("\"resourcePath\"", json);
+        }
+
+        [Theory]
+        [InlineData("res://a.tres", 0ul, true)]
+        [InlineData(null, 7ul, true)]
+        [InlineData(null, 0ul, false)]
+        [InlineData("", 0ul, false)]
+        public void ResourceRef_IsValid(string? resourcePath, ulong instanceId, bool expected)
+        {
+            var resourceRef = new ResourceRef { ResourcePath = resourcePath, InstanceId = instanceId };
+            Assert.Equal(expected, resourceRef.IsValid());
+        }
+    }
+}

--- a/Godot-MCP.csproj
+++ b/Godot-MCP.csproj
@@ -20,4 +20,13 @@
     <PackageReference Include="com.IvanMurzak.McpPlugin" Version="6.5.5" />
   </ItemGroup>
 
+  <!--
+    The Godot.NET.Sdk auto-globs every *.cs under the project dir into THIS game assembly. The xUnit
+    test project (Godot-MCP.Tests/) lives in a subfolder and has its own .csproj, so exclude it here —
+    otherwise its test files (which reference xUnit) get compiled into the game assembly and fail.
+  -->
+  <ItemGroup>
+    <Compile Remove="Godot-MCP.Tests/**/*.cs" />
+  </ItemGroup>
+
 </Project>

--- a/Godot-MCP.sln
+++ b/Godot-MCP.sln
@@ -1,21 +1,78 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Godot-MCP", "Godot-MCP.csproj", "{5A9A7840-7190-49D3-9A35-F869C6B60D38}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Godot-MCP.Tests", "Godot-MCP.Tests\Godot-MCP.Tests.csproj", "{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		ExportDebug|Any CPU = ExportDebug|Any CPU
+		ExportDebug|x64 = ExportDebug|x64
+		ExportDebug|x86 = ExportDebug|x86
 		ExportRelease|Any CPU = ExportRelease|Any CPU
+		ExportRelease|x64 = ExportRelease|x64
+		ExportRelease|x86 = ExportRelease|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.Debug|x64.Build.0 = Debug|Any CPU
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.Debug|x86.Build.0 = Debug|Any CPU
 		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.ExportDebug|Any CPU.ActiveCfg = ExportDebug|Any CPU
 		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.ExportDebug|Any CPU.Build.0 = ExportDebug|Any CPU
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.ExportDebug|x64.ActiveCfg = ExportDebug|Any CPU
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.ExportDebug|x64.Build.0 = ExportDebug|Any CPU
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.ExportDebug|x86.ActiveCfg = ExportDebug|Any CPU
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.ExportDebug|x86.Build.0 = ExportDebug|Any CPU
 		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.ExportRelease|Any CPU.ActiveCfg = ExportRelease|Any CPU
 		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.ExportRelease|Any CPU.Build.0 = ExportRelease|Any CPU
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.ExportRelease|x64.ActiveCfg = ExportRelease|Any CPU
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.ExportRelease|x64.Build.0 = ExportRelease|Any CPU
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.ExportRelease|x86.ActiveCfg = ExportRelease|Any CPU
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.ExportRelease|x86.Build.0 = ExportRelease|Any CPU
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.Release|x64.ActiveCfg = Release|Any CPU
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.Release|x64.Build.0 = Release|Any CPU
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.Release|x86.ActiveCfg = Release|Any CPU
+		{5A9A7840-7190-49D3-9A35-F869C6B60D38}.Release|x86.Build.0 = Release|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.Debug|x64.Build.0 = Debug|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.Debug|x86.Build.0 = Debug|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.ExportDebug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.ExportDebug|Any CPU.Build.0 = Debug|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.ExportDebug|x64.ActiveCfg = Debug|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.ExportDebug|x64.Build.0 = Debug|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.ExportDebug|x86.ActiveCfg = Debug|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.ExportDebug|x86.Build.0 = Debug|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.ExportRelease|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.ExportRelease|Any CPU.Build.0 = Debug|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.ExportRelease|x64.ActiveCfg = Debug|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.ExportRelease|x64.Build.0 = Debug|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.ExportRelease|x86.ActiveCfg = Debug|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.ExportRelease|x86.Build.0 = Debug|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.Release|x64.ActiveCfg = Release|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.Release|x64.Build.0 = Release|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.Release|x86.ActiveCfg = Release|Any CPU
+		{3E68C519-923B-4DD7-ADB8-B67AA00C4CB5}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/addons/godot_mcp/Data/NodeRef.cs
+++ b/addons/godot_mcp/Data/NodeRef.cs
@@ -1,0 +1,86 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.Godot.MCP.Data
+{
+    /// <summary>
+    /// Reference to a Godot <see cref="global::Godot.Node"/> in the scene tree. The Godot analog of
+    /// Unity-MCP's <c>GameObjectRef</c>. A node can be located either by its scene-tree path (e.g.
+    /// <c>"/root/Main/Player"</c>) or by its instance id (<see cref="global::Godot.GodotObject.GetInstanceId"/>).
+    ///
+    /// Plain data model — holds no live <see cref="global::Godot.Node"/> handle and touches no Godot
+    /// API, so it serializes/deserializes via ReflectorNet off the main thread. Resolution to a live
+    /// node (which DOES touch the scene tree) is the caller's responsibility, on the main thread.
+    /// </summary>
+    [System.Serializable]
+    [Description("Reference to a Godot Node in the scene tree, located by scene-tree path or instance id.")]
+    public class NodeRef
+    {
+        public static class NodeRefProperty
+        {
+            public const string InstanceId = "instanceId";
+            public const string Path = "path";
+
+            public static IEnumerable<string> All => new[] { InstanceId, Path };
+        }
+
+        [JsonInclude, JsonPropertyName(NodeRefProperty.InstanceId)]
+        [Description("Instance id of the Node (Godot GodotObject.GetInstanceId()). If '0', treated as unset. Priority: 1.")]
+        public ulong InstanceId { get; set; } = 0;
+
+        [JsonInclude, JsonPropertyName(NodeRefProperty.Path)]
+        [Description("Scene-tree path of the Node, e.g. '/root/Main/Player' or 'Main/Player'. Priority: 2.")]
+        public string? Path { get; set; } = null;
+
+        public NodeRef() { }
+
+        public NodeRef(ulong instanceId)
+        {
+            InstanceId = instanceId;
+        }
+
+        public NodeRef(string? path)
+        {
+            Path = path;
+        }
+
+        public virtual bool IsValid() => IsValid(out _);
+
+        public virtual bool IsValid(out string? error)
+        {
+            if (InstanceId != 0)
+            {
+                error = null;
+                return true;
+            }
+            if (!string.IsNullOrEmpty(Path))
+            {
+                error = null;
+                return true;
+            }
+
+            error = $"At least one of '{NodeRefProperty.InstanceId}' (non-zero) or '{NodeRefProperty.Path}' (non-empty) must be set.";
+            return false;
+        }
+
+        public override string ToString()
+        {
+            if (InstanceId != 0)
+                return $"Node {NodeRefProperty.InstanceId}='{InstanceId}'";
+            if (!string.IsNullOrEmpty(Path))
+                return $"Node {NodeRefProperty.Path}='{Path}'";
+            return "Node unknown";
+        }
+    }
+}

--- a/addons/godot_mcp/Data/NodeRef.cs
+++ b/addons/godot_mcp/Data/NodeRef.cs
@@ -57,6 +57,12 @@ namespace com.IvanMurzak.Godot.MCP.Data
 
         public virtual bool IsValid() => IsValid(out _);
 
+        // NOTE: priority is DELIBERATELY inverted relative to ResourceRef. A live Node is most
+        // reliably identified by its InstanceId (a scene-tree path can be ambiguous or shift as the
+        // tree mutates), so InstanceId is priority 1 here; ResourceRef prefers ResourcePath because
+        // a res:// path is the stable identity of an on-disk asset. IsValid only checks presence, so
+        // the boolean result is order-independent — the priority is a hint for the downstream
+        // resolver, which prefers the priority-1 field when both are set.
         public virtual bool IsValid(out string? error)
         {
             if (InstanceId != 0)

--- a/addons/godot_mcp/Data/ResourceRef.cs
+++ b/addons/godot_mcp/Data/ResourceRef.cs
@@ -1,0 +1,86 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.Godot.MCP.Data
+{
+    /// <summary>
+    /// Reference to a Godot <see cref="global::Godot.Resource"/> (e.g. a <c>.tres</c>/<c>.res</c> asset).
+    /// The Godot analog of Unity-MCP's <c>AssetObjectRef</c>. A resource is located by its <c>res://</c>
+    /// path, or — for an already-loaded resource — by its instance id.
+    ///
+    /// Plain data model — holds no live <see cref="global::Godot.Resource"/> handle and touches no Godot
+    /// API, so it serializes/deserializes via ReflectorNet off the main thread. Loading the resource
+    /// (<c>ResourceLoader.Load</c>) is the caller's responsibility, on the main thread.
+    /// </summary>
+    [System.Serializable]
+    [Description("Reference to a Godot Resource (.tres/.res asset), located by res:// path or instance id.")]
+    public class ResourceRef
+    {
+        public static class ResourceRefProperty
+        {
+            public const string InstanceId = "instanceId";
+            public const string ResourcePath = "resourcePath";
+
+            public static IEnumerable<string> All => new[] { InstanceId, ResourcePath };
+        }
+
+        [JsonInclude, JsonPropertyName(ResourceRefProperty.InstanceId)]
+        [Description("Instance id of an already-loaded Resource (Godot GodotObject.GetInstanceId()). If '0', treated as unset. Priority: 2.")]
+        public ulong InstanceId { get; set; } = 0;
+
+        [JsonInclude, JsonPropertyName(ResourceRefProperty.ResourcePath)]
+        [Description("res:// path of the Resource, e.g. 'res://materials/wood.tres'. Priority: 1 (Recommended).")]
+        public string? ResourcePath { get; set; } = null;
+
+        public ResourceRef() { }
+
+        public ResourceRef(ulong instanceId)
+        {
+            InstanceId = instanceId;
+        }
+
+        public ResourceRef(string? resourcePath)
+        {
+            ResourcePath = resourcePath;
+        }
+
+        public virtual bool IsValid() => IsValid(out _);
+
+        public virtual bool IsValid(out string? error)
+        {
+            if (!string.IsNullOrEmpty(ResourcePath))
+            {
+                error = null;
+                return true;
+            }
+            if (InstanceId != 0)
+            {
+                error = null;
+                return true;
+            }
+
+            error = $"At least one of '{ResourceRefProperty.ResourcePath}' (non-empty) or '{ResourceRefProperty.InstanceId}' (non-zero) must be set.";
+            return false;
+        }
+
+        public override string ToString()
+        {
+            if (!string.IsNullOrEmpty(ResourcePath))
+                return $"Resource {ResourceRefProperty.ResourcePath}='{ResourcePath}'";
+            if (InstanceId != 0)
+                return $"Resource {ResourceRefProperty.InstanceId}='{InstanceId}'";
+            return "Resource unknown";
+        }
+    }
+}

--- a/addons/godot_mcp/Data/ResourceRef.cs
+++ b/addons/godot_mcp/Data/ResourceRef.cs
@@ -57,6 +57,12 @@ namespace com.IvanMurzak.Godot.MCP.Data
 
         public virtual bool IsValid() => IsValid(out _);
 
+        // NOTE: priority is DELIBERATELY inverted relative to NodeRef. A Resource is most reliably
+        // identified by its res:// path (the stable identity of an on-disk asset), so ResourcePath
+        // is priority 1 here; NodeRef prefers InstanceId because a scene-tree path can be ambiguous
+        // or shift as the tree mutates. IsValid only checks presence, so the boolean result is
+        // order-independent — the priority is a hint for the downstream resolver, which prefers the
+        // priority-1 field when both are set.
         public virtual bool IsValid(out string? error)
         {
             if (!string.IsNullOrEmpty(ResourcePath))

--- a/addons/godot_mcp/GodotMcpPlugin.cs
+++ b/addons/godot_mcp/GodotMcpPlugin.cs
@@ -10,6 +10,7 @@
 #if TOOLS
 #nullable enable
 using Godot;
+using com.IvanMurzak.Godot.MCP.MainThreadDispatch;
 
 namespace com.IvanMurzak.Godot.MCP
 {
@@ -18,20 +19,40 @@ namespace com.IvanMurzak.Godot.MCP
     /// <c>addons/godot_mcp/plugin.cfg</c> (the <c>script</c> field) and loaded by the
     /// Godot Editor when the plugin is enabled.
     ///
-    /// This scaffold only boots and logs a startup line. The MCP connection to
-    /// ai-game.dev (SignalR client via com.IvanMurzak.McpPlugin) is intentionally
-    /// NOT wired up here — that is a separate downstream task.
+    /// On load it installs the editor main-thread dispatcher (the Godot analog of Unity's
+    /// <c>MainThread.Instance.Run</c>) so downstream tool handlers can marshal Godot API calls
+    /// onto the main thread. The MCP connection to ai-game.dev (SignalR client via
+    /// com.IvanMurzak.McpPlugin) is intentionally NOT wired up here — that is a separate
+    /// downstream task.
     /// </summary>
     [Tool]
     public partial class GodotMcpPlugin : EditorPlugin
     {
+        const string DispatcherNodeName = "GodotMcpMainThreadDispatcher";
+
+        MainThreadDispatcher? _dispatcher;
+
         public override void _EnterTree()
         {
+            // Pump for off-thread → main-thread work. Added as a child of this EditorPlugin Node so it
+            // lives in the editor SceneTree and gets _Process ticks for the lifetime of the plugin.
+            _dispatcher = new MainThreadDispatcher { Name = DispatcherNodeName };
+            AddChild(_dispatcher);
+
+            // Route ReflectorNet's MainThread.Instance through the dispatcher.
+            GodotMainThread.Install();
+
             GD.Print("[Godot-MCP] plugin loaded");
         }
 
         public override void _ExitTree()
         {
+            if (_dispatcher != null)
+            {
+                _dispatcher.QueueFree();
+                _dispatcher = null;
+            }
+
             GD.Print("[Godot-MCP] plugin unloaded");
         }
     }

--- a/addons/godot_mcp/MainThread/GodotMainThread.cs
+++ b/addons/godot_mcp/MainThread/GodotMainThread.cs
@@ -1,0 +1,88 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using com.IvanMurzak.ReflectorNet.Utils;
+
+namespace com.IvanMurzak.Godot.MCP.MainThreadDispatch
+{
+    /// <summary>
+    /// Godot implementation of ReflectorNet's <see cref="MainThread"/>. Marshals delegates onto the
+    /// Godot editor main thread via <see cref="MainThreadDispatcher"/> and returns the delegate's
+    /// value/exception as an awaitable. This is the Godot analog of Unity-MCP's <c>UnityMainThread</c>
+    /// (which dispatches through <c>EditorApplication.update</c>).
+    ///
+    /// Install once at editor boot via <see cref="Install"/> — <c>GodotMcpPlugin._EnterTree</c> does
+    /// this after it adds the <see cref="MainThreadDispatcher"/> Node to the tree. After install, all
+    /// tool handlers can call <c>MainThread.Instance.Run(() =&gt; /* Godot API */)</c> from any thread.
+    /// </summary>
+    public sealed class GodotMainThread : MainThread
+    {
+        /// <summary>
+        /// Replace the global <see cref="MainThread.Instance"/> with the Godot dispatcher-backed
+        /// implementation. Idempotent — safe to call again on a domain/editor reload.
+        /// </summary>
+        public static void Install()
+        {
+            if (Instance is GodotMainThread)
+                return;
+
+            Instance = new GodotMainThread();
+        }
+
+        public override bool IsMainThread => MainThreadDispatcher.IsMainThread;
+
+        public override Task RunAsync(Task task)
+            => MainThreadDispatcher.IsMainThread ? task : Dispatch(() => { task.Wait(); return true; });
+
+        public override Task<T> RunAsync<T>(Task<T> task)
+            => MainThreadDispatcher.IsMainThread ? task : Dispatch(() => task.Result);
+
+        public override Task<T> RunAsync<T>(Func<T> func)
+            => MainThreadDispatcher.IsMainThread ? Task.FromResult(func()) : Dispatch(func);
+
+        public override Task RunAsync(Action action)
+        {
+            if (MainThreadDispatcher.IsMainThread)
+            {
+                action();
+                return Task.CompletedTask;
+            }
+            return Dispatch(() => { action(); return true; });
+        }
+
+        /// <summary>
+        /// Enqueue <paramref name="body"/> on the dispatcher and return a task that completes with the
+        /// body's result, or faults with its exception. Mirrors the TaskCompletionSource pattern in
+        /// Unity-MCP's <c>UnityMainThread.Dispatch</c>.
+        /// </summary>
+        static Task<T> Dispatch<T>(Func<T> body)
+        {
+            var tcs = new TaskCompletionSource<T>();
+
+            MainThreadDispatcher.Enqueue(() =>
+            {
+                try
+                {
+                    tcs.SetResult(body());
+                }
+                catch (Exception ex)
+                {
+                    tcs.SetException(ex);
+                }
+            });
+
+            return tcs.Task;
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/MainThread/GodotMainThread.cs
+++ b/addons/godot_mcp/MainThread/GodotMainThread.cs
@@ -31,6 +31,11 @@ namespace com.IvanMurzak.Godot.MCP.MainThreadDispatch
         /// Replace the global <see cref="MainThread.Instance"/> with the Godot dispatcher-backed
         /// implementation. Idempotent — safe to call again on a domain/editor reload.
         /// </summary>
+        /// <remarks>
+        /// Main-thread-boot only: this is intended to run once during editor startup
+        /// (<c>GodotMcpPlugin._EnterTree</c>) on the Godot main thread, so the check-then-assign
+        /// below is deliberately non-atomic — there is no concurrent installer to race against.
+        /// </remarks>
         public static void Install()
         {
             if (Instance is GodotMainThread)
@@ -41,11 +46,24 @@ namespace com.IvanMurzak.Godot.MCP.MainThreadDispatch
 
         public override bool IsMainThread => MainThreadDispatcher.IsMainThread;
 
+        /// <summary>
+        /// Run a pre-existing <paramref name="task"/> to completion, marshalled to the main thread
+        /// when called off it. <c>GetAwaiter().GetResult()</c> blocks the pump tick until the task
+        /// finishes and re-throws the task's original exception (not an <c>AggregateException</c>),
+        /// matching the raw-exception propagation of the <see cref="RunAsync(Action)"/> /
+        /// <see cref="RunAsync{T}(Func{T})"/> overloads.
+        /// <para>
+        /// WARNING: because the awaited task is blocked on the single-threaded pump, the passed
+        /// <paramref name="task"/> MUST NOT itself need the main thread to make progress (e.g. it
+        /// must not <c>await MainThread.Instance.Run(...)</c>), or it will dead-lock the pump tick.
+        /// </para>
+        /// </summary>
         public override Task RunAsync(Task task)
-            => MainThreadDispatcher.IsMainThread ? task : Dispatch(() => { task.Wait(); return true; });
+            => MainThreadDispatcher.IsMainThread ? task : Dispatch(() => { task.GetAwaiter().GetResult(); return true; });
 
+        /// <inheritdoc cref="RunAsync(Task)"/>
         public override Task<T> RunAsync<T>(Task<T> task)
-            => MainThreadDispatcher.IsMainThread ? task : Dispatch(() => task.Result);
+            => MainThreadDispatcher.IsMainThread ? task : Dispatch(() => task.GetAwaiter().GetResult());
 
         public override Task<T> RunAsync<T>(Func<T> func)
             => MainThreadDispatcher.IsMainThread ? Task.FromResult(func()) : Dispatch(func);

--- a/addons/godot_mcp/MainThread/MainThreadDispatcher.cs
+++ b/addons/godot_mcp/MainThread/MainThreadDispatcher.cs
@@ -34,8 +34,12 @@ namespace com.IvanMurzak.Godot.MCP.MainThreadDispatch
         /// <summary>
         /// The managed thread id captured when this dispatcher entered the tree. Godot calls
         /// <see cref="_EnterTree"/> on the engine main thread, so this is the main-thread id.
+        /// Defaults to a sentinel (<c>-1</c>, which no real <see cref="Thread.ManagedThreadId"/>
+        /// takes) until <see cref="_EnterTree"/> runs, so a pre-boot caller is correctly treated
+        /// as off-main-thread rather than capturing a wrong id from whatever thread first touches
+        /// this type.
         /// </summary>
-        public static int MainThreadId { get; private set; } = Thread.CurrentThread.ManagedThreadId;
+        public static int MainThreadId { get; private set; } = -1;
 
         /// <summary>True when the calling thread is the captured Godot main thread.</summary>
         public static bool IsMainThread => Thread.CurrentThread.ManagedThreadId == MainThreadId;
@@ -48,11 +52,18 @@ namespace com.IvanMurzak.Godot.MCP.MainThreadDispatch
 
         /// <summary>
         /// Queue an action to run on the next main-thread <see cref="_Process"/> tick. Thread-safe.
+        /// Fails fast when no dispatcher is in the tree (plugin unloaded / between editor reloads):
+        /// nothing would drain the queue, so the caller's awaiter would hang forever — surface that
+        /// as an immediate <see cref="InvalidOperationException"/> instead.
         /// </summary>
         public static void Enqueue(Action action)
         {
             if (action == null)
                 throw new ArgumentNullException(nameof(action));
+            if (_instance == null)
+                throw new InvalidOperationException(
+                    $"No {nameof(MainThreadDispatcher)} is in the tree; cannot enqueue main-thread work. " +
+                    "The dispatcher is added by GodotMcpPlugin._EnterTree and removed on _ExitTree.");
 
             _actions.Enqueue(action);
         }
@@ -68,7 +79,10 @@ namespace com.IvanMurzak.Godot.MCP.MainThreadDispatch
             if (ReferenceEquals(_instance, this))
                 _instance = null;
 
-            // Drain anything left so pending awaiters do not hang forever.
+            // Drain anything left so pending awaiters do not hang forever. NOTE: this runs each
+            // queued action's FULL body during teardown — those bodies may touch the SceneTree
+            // while the editor is tearing the dispatcher down. Callers must not assume the tree is
+            // fully alive in work that could still be pending at _ExitTree time.
             DrainQueue();
         }
 

--- a/addons/godot_mcp/MainThread/MainThreadDispatcher.cs
+++ b/addons/godot_mcp/MainThread/MainThreadDispatcher.cs
@@ -1,0 +1,99 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.MainThreadDispatch
+{
+    /// <summary>
+    /// A Godot <see cref="Node"/> that drains a queue of <see cref="Action"/>s on the editor
+    /// main thread, once per <see cref="Node._Process"/> tick. This is the Godot analog of
+    /// Unity's <c>MainThreadDispatcher</c> (an <c>Update()</c>-pumped <c>MonoBehaviour</c>):
+    /// Godot has no <c>EditorApplication.update</c> static hook, so the work is pumped from a
+    /// long-lived editor Node added to the <see cref="SceneTree"/> by <c>GodotMcpPlugin</c>.
+    ///
+    /// Off-thread callers enqueue via <see cref="Enqueue"/>; the action runs on the next
+    /// <see cref="_Process"/> tick on the main thread. <see cref="GodotMainThread"/> wraps this
+    /// with a <see cref="System.Threading.Tasks.TaskCompletionSource{T}"/> so callers get the
+    /// delegate's value/exception back as an awaitable, matching the ergonomics of Unity's
+    /// <c>MainThread.Instance.Run</c>.
+    /// </summary>
+    public partial class MainThreadDispatcher : Node
+    {
+        /// <summary>
+        /// The managed thread id captured when this dispatcher entered the tree. Godot calls
+        /// <see cref="_EnterTree"/> on the engine main thread, so this is the main-thread id.
+        /// </summary>
+        public static int MainThreadId { get; private set; } = Thread.CurrentThread.ManagedThreadId;
+
+        /// <summary>True when the calling thread is the captured Godot main thread.</summary>
+        public static bool IsMainThread => Thread.CurrentThread.ManagedThreadId == MainThreadId;
+
+        static readonly ConcurrentQueue<Action> _actions = new ConcurrentQueue<Action>();
+        static MainThreadDispatcher? _instance;
+
+        /// <summary>The currently-installed dispatcher instance, or <c>null</c> when none is in the tree.</summary>
+        public static MainThreadDispatcher? Instance => _instance;
+
+        /// <summary>
+        /// Queue an action to run on the next main-thread <see cref="_Process"/> tick. Thread-safe.
+        /// </summary>
+        public static void Enqueue(Action action)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            _actions.Enqueue(action);
+        }
+
+        public override void _EnterTree()
+        {
+            MainThreadId = Thread.CurrentThread.ManagedThreadId;
+            _instance = this;
+        }
+
+        public override void _ExitTree()
+        {
+            if (ReferenceEquals(_instance, this))
+                _instance = null;
+
+            // Drain anything left so pending awaiters do not hang forever.
+            DrainQueue();
+        }
+
+        public override void _Process(double delta)
+        {
+            DrainQueue();
+        }
+
+        static void DrainQueue()
+        {
+            while (_actions.TryDequeue(out var action))
+            {
+                try
+                {
+                    action.Invoke();
+                }
+                catch (Exception ex)
+                {
+                    // The action is responsible for routing its own exceptions back to its awaiter
+                    // (GodotMainThread wraps the body in a try/catch). A throw here would only mean a
+                    // bug in the action wrapper itself; surface it without killing the pump loop.
+                    GD.PushError($"[Godot-MCP] MainThreadDispatcher action threw: {ex}");
+                }
+            }
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Reflection/GodotNodePathJsonConverter.cs
+++ b/addons/godot_mcp/Reflection/GodotNodePathJsonConverter.cs
@@ -37,6 +37,10 @@ namespace com.IvanMurzak.Godot.MCP.Reflection
 
         public override global::Godot.NodePath Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            // A JSON null deserializes to the empty NodePath (the canonical "no path" form) rather
+            // than a C# null: NodePath is a Godot native type with no meaningful null state in the
+            // resolver, so callers test emptiness via NodePath.IsEmpty rather than a null check.
+            // This is deliberate — null and "" round-trip to the same empty NodePath.
             if (reader.TokenType == JsonTokenType.Null)
                 return new global::Godot.NodePath();
 

--- a/addons/godot_mcp/Reflection/GodotNodePathJsonConverter.cs
+++ b/addons/godot_mcp/Reflection/GodotNodePathJsonConverter.cs
@@ -1,0 +1,54 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using com.IvanMurzak.ReflectorNet.Json;
+using com.IvanMurzak.ReflectorNet.Utils;
+
+namespace com.IvanMurzak.Godot.MCP.Reflection
+{
+    /// <summary>
+    /// System.Text.Json converter for Godot's <see cref="global::Godot.NodePath"/>. Unlike the
+    /// Vector/Color value types, <c>NodePath</c> is an opaque class with no public settable members,
+    /// so the reflection serializer cannot round-trip it field-by-field. It is fully described by its
+    /// string form (e.g. <c>"Main/Player:position:x"</c>), so it is (de)serialized as a JSON string —
+    /// the Godot analog of how Unity-MCP ships dedicated System.Text.Json converters for its structs.
+    /// </summary>
+    public class GodotNodePathJsonConverter : JsonSchemaConverter<global::Godot.NodePath>
+    {
+        public override JsonNode GetSchema() => new JsonObject
+        {
+            [JsonSchema.Type] = JsonSchema.String
+        };
+
+        public override JsonNode GetSchemaRef() => new JsonObject
+        {
+            [JsonSchema.Ref] = JsonSchema.RefValue + Id
+        };
+
+        public override global::Godot.NodePath Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+                return new global::Godot.NodePath();
+
+            if (reader.TokenType != JsonTokenType.String)
+                throw new JsonException($"Expected a string for NodePath, got {reader.TokenType}.");
+
+            return new global::Godot.NodePath(reader.GetString() ?? string.Empty);
+        }
+
+        public override void Write(Utf8JsonWriter writer, global::Godot.NodePath value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value?.ToString() ?? string.Empty);
+        }
+    }
+}

--- a/addons/godot_mcp/Reflection/GodotReflectorFactory.cs
+++ b/addons/godot_mcp/Reflection/GodotReflectorFactory.cs
@@ -1,0 +1,52 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using com.IvanMurzak.ReflectorNet;
+
+namespace com.IvanMurzak.Godot.MCP.Reflection
+{
+    /// <summary>
+    /// Builds a <see cref="Reflector"/> pre-populated with the Godot-specific type converters.
+    /// The Godot analog of Unity-MCP's <c>UnityMcpPlugin.CreateDefaultReflector()</c>. Tool families
+    /// serialize their args/results through the reflector returned here so core Godot value types and
+    /// refs cross the MCP boundary cleanly.
+    ///
+    /// This is engine-runtime code (no editor API), so it lives outside <c>#if TOOLS</c> and is unit-
+    /// testable in a plain xUnit project that references GodotSharp.
+    /// </summary>
+    public static class GodotReflectorFactory
+    {
+        /// <summary>
+        /// Create a <see cref="Reflector"/> with the core Godot value-type and ref converters registered.
+        /// </summary>
+        public static Reflector CreateDefaultReflector()
+        {
+            var reflector = new Reflector();
+            RegisterGodotConverters(reflector);
+            return reflector;
+        }
+
+        /// <summary>
+        /// Register the Godot converters onto an existing <see cref="Reflector"/>. Separated from
+        /// <see cref="CreateDefaultReflector"/> so a caller that already owns a configured reflector
+        /// (e.g. one built by the McpPlugin client) can add Godot support without discarding it.
+        /// </summary>
+        public static void RegisterGodotConverters(Reflector reflector)
+        {
+            // Reflection converters — core Godot value types (round-trip via public instance fields).
+            reflector.Converters.Add(new Godot_Vector2_ReflectionConverter());
+            reflector.Converters.Add(new Godot_Vector3_ReflectionConverter());
+            reflector.Converters.Add(new Godot_Color_ReflectionConverter());
+
+            // JSON converters — types best described as a single scalar (NodePath as its string form).
+            reflector.JsonSerializer.AddConverter(new GodotNodePathJsonConverter());
+        }
+    }
+}

--- a/addons/godot_mcp/Reflection/GodotStructReflectionConverter.cs
+++ b/addons/godot_mcp/Reflection/GodotStructReflectionConverter.cs
@@ -1,0 +1,29 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using com.IvanMurzak.ReflectorNet.Converter;
+
+namespace com.IvanMurzak.Godot.MCP.Reflection
+{
+    /// <summary>
+    /// Base ReflectorNet converter for Godot value-type structs (Vector2/Vector3/Color, etc).
+    /// The Godot analog of Unity-MCP's <c>UnityStructReflectionConverter&lt;T&gt;</c>.
+    ///
+    /// Godot value types expose their components as plain public instance fields (e.g.
+    /// <c>Vector3.X/Y/Z</c>, <c>Color.R/G/B/A</c>), so the inherited reflection-based
+    /// serialize/deserialize round-trips them member-for-member with no per-type code.
+    /// <see cref="GenericReflectionConverter{T}.AllowCascadeSerialization"/> is turned off
+    /// because these are flat leaf values — there is no nested object graph to descend into.
+    /// </summary>
+    public class GodotStructReflectionConverter<T> : GenericReflectionConverter<T>
+    {
+        public override bool AllowCascadeSerialization => false;
+    }
+}

--- a/addons/godot_mcp/Reflection/GodotStructReflectionConverters.cs
+++ b/addons/godot_mcp/Reflection/GodotStructReflectionConverters.cs
@@ -1,0 +1,21 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+
+namespace com.IvanMurzak.Godot.MCP.Reflection
+{
+    // Core Godot value types. Each round-trips via the inherited reflection serializer over the
+    // type's public instance fields (Vector2.X/Y, Vector3.X/Y/Z, Color.R/G/B/A). Mirror of
+    // Unity-MCP's UnityEngineDataStructReflectionConverters.cs registration shape.
+
+    public class Godot_Vector2_ReflectionConverter : GodotStructReflectionConverter<global::Godot.Vector2> { }
+    public class Godot_Vector3_ReflectionConverter : GodotStructReflectionConverter<global::Godot.Vector3> { }
+    public class Godot_Color_ReflectionConverter : GodotStructReflectionConverter<global::Godot.Color> { }
+}


### PR DESCRIPTION
## Summary
- Add a Godot editor main-thread dispatcher (`MainThreadDispatcher` Node + `GodotMainThread` over ReflectorNet's `MainThread`) — the Godot analog of Unity's `MainThread.Instance.Run`, returning a delegate's value/exception as an awaitable. Installed by `GodotMcpPlugin` on load.
- Add `NodeRef` / `ResourceRef` data models (scene-tree path / `res://` path / instance id).
- Register ReflectorNet converters for core Godot value types: Vector2/Vector3/Color (reflection round-trip) and NodePath (JSON string), via `GodotReflectorFactory.CreateDefaultReflector()`.
- Add `Godot-MCP.Tests` xUnit project (15 tests), wired into the solution and CI.

## Test plan
- [x] `dotnet build Godot-MCP.sln -c Debug` — 0 errors / 0 warnings.
- [x] `dotnet test Godot-MCP.Tests` — 15/15 pass (Vector2/3/Color round-trips, NodeRef/ResourceRef models).
- [x] Headless Godot 4.5.1 smoke against `Godot-Test-Project`: addon compiles and `[Godot-MCP] plugin loaded` / `unloaded` print, proving the dispatcher installs and the plugin boots in a real Godot main loop.
- [ ] Live in-editor exercise of the dispatcher queue-drain + NodePath converter under a running SceneTree — pending operator (the boot smoke covers install + compile; `NodePath`/`Node` construction needs the native runtime and cannot run in xUnit, where it faults the test host).

Closes #2