### PR TITLE
feat: cloud connection — connect Godot-MCP to ai-game.dev (SignalR + bearer) + ping tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -452,6 +452,12 @@ mono_crash.*.json
 # Godot import metadata
 *.import
 
+# Godot 4.4+ generates a per-script `.cs.uid` next to each `.cs` when a project that
+# embeds this addon is opened in the editor (e.g. the Godot-Test-Project testbed, whose
+# junction writes them into `addons/godot_mcp/`). These are editor-local cache artifacts,
+# never source — ignore them repo-wide so they cannot leak into a commit / trip Gate A.
+*.uid
+
 ##
 ## .NET / build output (bare bin not covered by the VisualStudio section above)
 ##

--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -26,8 +26,11 @@
   -->
   <ItemGroup>
     <PackageReference Include="GodotSharp" Version="4.3.0" />
-    <!-- Same pin as Godot-MCP.csproj; never bumped here (owned by the upstream release pipeline). -->
+    <!-- Same pins as Godot-MCP.csproj; never bumped here (owned by the upstream release pipeline).
+         com.IvanMurzak.McpPlugin is needed because GodotMcpConfig extends its ConnectionConfig and
+         Tool_Ping uses its [AiTool]/[AiToolType] attributes — both pure-managed and CI-friendly. -->
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.1" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="6.5.5" />
   </ItemGroup>
 
   <ItemGroup>
@@ -37,6 +40,11 @@
     <Compile Include="..\addons\godot_mcp\Reflection\GodotStructReflectionConverters.cs" Link="Source\GodotStructReflectionConverters.cs" />
     <Compile Include="..\addons\godot_mcp\Reflection\GodotNodePathJsonConverter.cs" Link="Source\GodotNodePathJsonConverter.cs" />
     <Compile Include="..\addons\godot_mcp\Reflection\GodotReflectorFactory.cs" Link="Source\GodotReflectorFactory.cs" />
+    <!-- Connection config + ping tool are pure-managed (no Godot native types / no #if TOOLS), so they
+         compile and run in this plain-xUnit host. GodotMcpConnection.cs is editor-only (#if TOOLS) and
+         instantiates the SignalR client; it is verified via the headless Godot smoke, not here. -->
+    <Compile Include="..\addons\godot_mcp\Connection\GodotMcpConfig.cs" Link="Source\GodotMcpConfig.cs" />
+    <Compile Include="..\addons\godot_mcp\Tools\Tool_Ping.cs" Link="Source\Tool_Ping.cs" />
   </ItemGroup>
 
 </Project>

--- a/Godot-MCP.Tests/GodotMcpConfigTests.cs
+++ b/Godot-MCP.Tests/GodotMcpConfigTests.cs
@@ -1,0 +1,318 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using com.IvanMurzak.Godot.MCP.Connection;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the pure-managed connection-config logic: Cloud/Custom mode selection, cloud URL
+    /// resolution (default + env override + trailing-/mcp normalization), custom host override, and
+    /// mode-aware token selection. These exercise the same code the editor plugin runs at boot, with
+    /// no Godot native types or SignalR client in play — CI-friendly.
+    ///
+    /// <para>
+    /// All tests here mutate process environment variables, so the class is marked
+    /// <c>[Collection("env")]</c> to disable cross-class parallelism against the same env, and every
+    /// test restores the prior values via <see cref="EnvScope"/>.
+    /// </para>
+    /// </summary>
+    [Collection("env")]
+    public class GodotMcpConfigTests
+    {
+        // --- Mode resolution ---
+
+        [Fact]
+        public void DefaultMode_IsCloud()
+        {
+            using var _ = EnvScope.ClearAll();
+            var config = new GodotMcpConfig();
+            Assert.Equal(GodotMcpConnectionMode.Cloud, config.ActiveMode);
+        }
+
+        [Theory]
+        [InlineData("Custom", GodotMcpConnectionMode.Custom)]
+        [InlineData("custom", GodotMcpConnectionMode.Custom)]
+        [InlineData("CLOUD", GodotMcpConnectionMode.Cloud)]
+        public void EnvConnectionMode_Overrides_ConfiguredMode(string envValue, GodotMcpConnectionMode expected)
+        {
+            using var _ = EnvScope.Set(GodotMcpConfig.EnvConnectionMode, envValue);
+            // Configured value is Cloud; env should win (and round-trip for the Cloud case too).
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Cloud };
+            Assert.Equal(expected, config.ActiveMode);
+        }
+
+        [Fact]
+        public void EnvConnectionMode_Unrecognized_FallsBackToConfigured()
+        {
+            using var _ = EnvScope.Set(GodotMcpConfig.EnvConnectionMode, "not-a-mode");
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Custom };
+            Assert.Equal(GodotMcpConnectionMode.Custom, config.ActiveMode);
+        }
+
+        // --- Cloud URL resolution ---
+
+        [Fact]
+        public void CloudUrl_Default_AppendsMcpHubPath()
+        {
+            using var _ = EnvScope.ClearAll();
+            Assert.Equal("https://ai-game.dev/mcp", GodotMcpConfig.ResolveCloudUrl());
+        }
+
+        [Fact]
+        public void CloudUrl_EnvOverride_IsHonored()
+        {
+            using var _ = EnvScope.Set(GodotMcpConfig.EnvCloudUrl, "https://staging.ai-game.dev");
+            Assert.Equal("https://staging.ai-game.dev/mcp", GodotMcpConfig.ResolveCloudUrl());
+        }
+
+        [Fact]
+        public void CloudUrl_EnvOverride_WithTrailingMcp_DoesNotDouble()
+        {
+            using var _ = EnvScope.Set(GodotMcpConfig.EnvCloudUrl, "https://staging.ai-game.dev/mcp");
+            Assert.Equal("https://staging.ai-game.dev/mcp", GodotMcpConfig.ResolveCloudUrl());
+        }
+
+        [Fact]
+        public void CloudUrl_EnvOverride_WithTrailingSlash_IsTrimmed()
+        {
+            using var _ = EnvScope.Set(GodotMcpConfig.EnvCloudUrl, "https://staging.ai-game.dev/");
+            Assert.Equal("https://staging.ai-game.dev/mcp", GodotMcpConfig.ResolveCloudUrl());
+        }
+
+        [Theory]
+        [InlineData("not-a-url")]
+        [InlineData("ftp://ai-game.dev")]
+        [InlineData("   ")]
+        public void CloudUrl_InvalidEnvOverride_FallsBackToDefault(string envValue)
+        {
+            using var _ = EnvScope.Set(GodotMcpConfig.EnvCloudUrl, envValue);
+            Assert.Equal("https://ai-game.dev/mcp", GodotMcpConfig.ResolveCloudUrl());
+        }
+
+        [Fact]
+        public void Host_InCloudMode_ReturnsCloudUrl()
+        {
+            using var _ = EnvScope.ClearAll();
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Cloud };
+            Assert.Equal("https://ai-game.dev/mcp", config.Host);
+        }
+
+        // --- Custom host resolution ---
+
+        [Fact]
+        public void Host_InCustomMode_ReturnsCustomHost()
+        {
+            using var _ = EnvScope.ClearAll();
+            var config = new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Custom,
+                CustomHost = "http://localhost:5300"
+            };
+            Assert.Equal("http://localhost:5300", config.Host);
+        }
+
+        [Fact]
+        public void Host_InCustomMode_EnvHostOverrides()
+        {
+            using var _ = EnvScope.Set(GodotMcpConfig.EnvHost, "http://localhost:9999");
+            var config = new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Custom,
+                CustomHost = "http://localhost:5300"
+            };
+            Assert.Equal("http://localhost:9999", config.Host);
+        }
+
+        [Fact]
+        public void Host_Setter_WritesCustomHost()
+        {
+            using var _ = EnvScope.ClearAll();
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Custom };
+            config.Host = "http://localhost:1234";
+            Assert.Equal("http://localhost:1234", config.CustomHost);
+            Assert.Equal("http://localhost:1234", config.Host);
+        }
+
+        // --- Token selection ---
+
+        [Fact]
+        public void Token_InCloudMode_ReturnsCloudToken()
+        {
+            using var _ = EnvScope.ClearAll();
+            var config = new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Cloud,
+                CloudToken = "cloud-tok",
+                CustomToken = "custom-tok"
+            };
+            Assert.Equal("cloud-tok", config.Token);
+        }
+
+        [Fact]
+        public void Token_InCustomMode_ReturnsCustomToken()
+        {
+            using var _ = EnvScope.ClearAll();
+            var config = new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Custom,
+                CloudToken = "cloud-tok",
+                CustomToken = "custom-tok"
+            };
+            Assert.Equal("custom-tok", config.Token);
+        }
+
+        [Fact]
+        public void Token_EnvOverride_WinsInCloudMode()
+        {
+            using var _ = EnvScope.Set(GodotMcpConfig.EnvToken, "env-tok");
+            var config = new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Cloud,
+                CloudToken = "cloud-tok"
+            };
+            Assert.Equal("env-tok", config.Token);
+        }
+
+        [Fact]
+        public void Token_EnvOverride_WinsInCustomMode()
+        {
+            using var _ = EnvScope.Set(GodotMcpConfig.EnvToken, "env-tok");
+            var config = new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Custom,
+                CustomToken = "custom-tok"
+            };
+            Assert.Equal("env-tok", config.Token);
+        }
+
+        [Fact]
+        public void Token_Setter_RoutesByActiveMode()
+        {
+            using var _ = EnvScope.ClearAll();
+
+            var cloud = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Cloud };
+            cloud.Token = "x";
+            Assert.Equal("x", cloud.CloudToken);
+            Assert.Null(cloud.CustomToken);
+
+            var custom = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Custom };
+            custom.Token = "y";
+            Assert.Equal("y", custom.CustomToken);
+            Assert.Null(custom.CloudToken);
+        }
+
+        // --- Defaults / serialization shape ---
+
+        [Fact]
+        public void Defaults_KeepConnected_True()
+        {
+            using var _ = EnvScope.ClearAll();
+            // KeepConnected drives the reused client's auto-reconnect/backoff; must default on.
+            Assert.True(new GodotMcpConfig().KeepConnected);
+        }
+
+        [Fact]
+        public void Serialization_UsesStableJsonNames()
+        {
+            using var _ = EnvScope.ClearAll();
+            var config = new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Custom,
+                CustomHost = "http://localhost:5300",
+                CustomToken = "ctok",
+                CloudToken = "cloudtok"
+            };
+
+            var json = JsonSerializer.Serialize(config);
+
+            Assert.Contains("\"host\"", json);
+            Assert.Contains("\"token\"", json);
+            Assert.Contains("\"cloudToken\"", json);
+            Assert.Contains("\"connectionMode\"", json);
+        }
+
+        /// <summary>
+        /// Sets/clears process env vars relevant to <see cref="GodotMcpConfig"/> and restores the prior
+        /// values on dispose. Keeps env-driven tests isolated and re-entry-safe.
+        /// </summary>
+        sealed class EnvScope : IDisposable
+        {
+            static readonly string[] Names =
+            {
+                GodotMcpConfig.EnvCloudUrl,
+                GodotMcpConfig.EnvHost,
+                GodotMcpConfig.EnvToken,
+                GodotMcpConfig.EnvConnectionMode
+            };
+
+            readonly Dictionary<string, string?> _prior = new();
+
+            EnvScope()
+            {
+                foreach (var name in Names)
+                    _prior[name] = Environment.GetEnvironmentVariable(name);
+            }
+
+            public static EnvScope ClearAll()
+            {
+                var scope = new EnvScope();
+                foreach (var name in Names)
+                    Environment.SetEnvironmentVariable(name, null);
+                return scope;
+            }
+
+            public static EnvScope Set(string name, string? value)
+            {
+                var scope = ClearAll();
+                Environment.SetEnvironmentVariable(name, value);
+                return scope;
+            }
+
+            public void Dispose()
+            {
+                foreach (var kv in _prior)
+                    Environment.SetEnvironmentVariable(kv.Key, kv.Value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Pins the <c>ping</c> tool's echo/pong contract — the single tool that proves the MCP path.
+    /// Pure-managed; no server needed.
+    /// </summary>
+    public class PingToolTests
+    {
+        [Fact]
+        public void Ping_WithNoMessage_ReturnsPong()
+        {
+            var tool = new com.IvanMurzak.Godot.MCP.Tools.Tool_Ping();
+            Assert.Equal("pong", tool.Ping());
+        }
+
+        [Fact]
+        public void Ping_WithEmptyMessage_ReturnsPong()
+        {
+            var tool = new com.IvanMurzak.Godot.MCP.Tools.Tool_Ping();
+            Assert.Equal("pong", tool.Ping(""));
+        }
+
+        [Fact]
+        public void Ping_WithMessage_EchoesIt()
+        {
+            var tool = new com.IvanMurzak.Godot.MCP.Tools.Tool_Ping();
+            Assert.Equal("hello", tool.Ping("hello"));
+        }
+    }
+}

--- a/Godot-MCP.Tests/GodotMcpConfigTests.cs
+++ b/Godot-MCP.Tests/GodotMcpConfigTests.cs
@@ -61,6 +61,18 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Equal(GodotMcpConnectionMode.Custom, config.ActiveMode);
         }
 
+        [Theory]
+        [InlineData("0")]
+        [InlineData("1")]
+        public void EnvConnectionMode_NumericString_FallsBackToConfigured(string envValue)
+        {
+            // Enum.TryParse would accept numeric strings; we deliberately reject them so only
+            // named values (Cloud/Custom) override the configured mode.
+            using var _ = EnvScope.Set(GodotMcpConfig.EnvConnectionMode, envValue);
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Custom };
+            Assert.Equal(GodotMcpConnectionMode.Custom, config.ActiveMode);
+        }
+
         // --- Cloud URL resolution ---
 
         [Fact]
@@ -135,6 +147,50 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Equal("http://localhost:9999", config.Host);
         }
 
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Host_InCustomMode_NullOrBlankCustomHost_FallsBackToDefault(string? customHost)
+        {
+            using var _ = EnvScope.ClearAll();
+            var config = new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Custom,
+                CustomHost = customHost!
+            };
+            Assert.Equal(GodotMcpConfig.DefaultCustomHost, config.Host);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Host_InCustomMode_EnvHostBlank_FallsBackToConfigured(string envHost)
+        {
+            // A blank EnvHost must not shadow a valid configured CustomHost.
+            using var _ = EnvScope.Set(GodotMcpConfig.EnvHost, envHost);
+            var config = new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Custom,
+                CustomHost = "http://localhost:5300"
+            };
+            Assert.Equal("http://localhost:5300", config.Host);
+        }
+
+        [Theory]
+        [InlineData("not-a-url")]
+        [InlineData("ftp://localhost")]
+        public void Host_InCustomMode_InvalidEnvHost_FallsBackToDefault(string envHost)
+        {
+            using var _ = EnvScope.Set(GodotMcpConfig.EnvHost, envHost);
+            var config = new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Custom,
+                CustomHost = "http://localhost:5300"
+            };
+            Assert.Equal(GodotMcpConfig.DefaultCustomHost, config.Host);
+        }
+
         [Fact]
         public void Host_Setter_WritesCustomHost()
         {
@@ -194,6 +250,15 @@ namespace com.IvanMurzak.Godot.MCP.Tests
                 ConnectionMode = GodotMcpConnectionMode.Custom,
                 CustomToken = "custom-tok"
             };
+            Assert.Equal("env-tok", config.Token);
+        }
+
+        [Fact]
+        public void Token_EnvOverride_StripsWrappingQuotes()
+        {
+            // GODOT_MCP_TOKEN="abc" (shell-quoted) must not send a literal-quote bearer value.
+            using var _ = EnvScope.Set(GodotMcpConfig.EnvToken, "\"env-tok\"");
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Cloud };
             Assert.Equal("env-tok", config.Token);
         }
 

--- a/addons/godot_mcp/Connection/GodotMcpConfig.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConfig.cs
@@ -143,11 +143,14 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// </summary>
         public static GodotMcpConnectionMode ResolveActiveMode(GodotMcpConnectionMode configured)
         {
-            var raw = ReadEnv(EnvConnectionMode);
-            if (string.IsNullOrWhiteSpace(raw))
+            var normalized = NormalizeEnv(ReadEnv(EnvConnectionMode));
+            if (string.IsNullOrEmpty(normalized))
                 return configured;
 
-            if (Enum.TryParse<GodotMcpConnectionMode>(raw.Trim(), ignoreCase: true, out var parsed))
+            // Only honor named enum values; reject numeric strings ("1") that Enum.TryParse
+            // would otherwise accept and silently map to an arbitrary mode.
+            if (Enum.TryParse<GodotMcpConnectionMode>(normalized, ignoreCase: true, out var parsed) &&
+                !int.TryParse(normalized, out _))
                 return parsed;
 
             return configured;
@@ -160,17 +163,12 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// </summary>
         public static string ResolveCloudBaseUrl()
         {
-            var raw = ReadEnv(EnvCloudUrl);
-            if (string.IsNullOrWhiteSpace(raw))
+            var normalized = NormalizeUrl(ReadEnv(EnvCloudUrl));
+            if (string.IsNullOrEmpty(normalized))
                 return DefaultCloudBaseUrl;
 
-            var normalized = raw.Trim().Trim('"').TrimEnd('/');
-
-            if (!Uri.TryCreate(normalized, UriKind.Absolute, out var uri) ||
-                (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
-            {
+            if (!IsValidHttpUrl(normalized))
                 return DefaultCloudBaseUrl;
-            }
 
             if (normalized.EndsWith(CloudHubPath, StringComparison.OrdinalIgnoreCase))
                 normalized = normalized[..^CloudHubPath.Length];
@@ -186,27 +184,61 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// </summary>
         public string ResolveCustomHost()
         {
-            var raw = ReadEnv(EnvHost);
-            if (!string.IsNullOrWhiteSpace(raw))
-                return raw!.Trim().Trim('"');
+            // Prefer the env override, then the configured host; validate each as an http(s) URL
+            // (mirroring ResolveCloudBaseUrl) and fall back to DefaultCustomHost on anything invalid.
+            var envHost = NormalizeUrl(ReadEnv(EnvHost));
+            if (!string.IsNullOrEmpty(envHost))
+                return IsValidHttpUrl(envHost) ? envHost : DefaultCustomHost;
 
-            return string.IsNullOrWhiteSpace(CustomHost) ? DefaultCustomHost : CustomHost;
+            var configuredHost = NormalizeUrl(CustomHost);
+            if (!string.IsNullOrEmpty(configuredHost))
+                return IsValidHttpUrl(configuredHost) ? configuredHost : DefaultCustomHost;
+
+            return DefaultCustomHost;
         }
 
         /// <summary>Resolve the active cloud token, applying the <see cref="EnvToken"/> override.</summary>
         public string? ResolveCloudToken()
         {
-            var raw = ReadEnv(EnvToken);
-            return string.IsNullOrWhiteSpace(raw) ? CloudToken : raw!.Trim();
+            var envToken = NormalizeEnv(ReadEnv(EnvToken));
+            return string.IsNullOrEmpty(envToken) ? CloudToken : envToken;
         }
 
         /// <summary>Resolve the active custom token, applying the <see cref="EnvToken"/> override.</summary>
         public string? ResolveCustomToken()
         {
-            var raw = ReadEnv(EnvToken);
-            return string.IsNullOrWhiteSpace(raw) ? CustomToken : raw!.Trim();
+            var envToken = NormalizeEnv(ReadEnv(EnvToken));
+            return string.IsNullOrEmpty(envToken) ? CustomToken : envToken;
         }
 
         static string? ReadEnv(string name) => Environment.GetEnvironmentVariable(name);
+
+        /// <summary>
+        /// Single normalization for env/config string values: trim surrounding whitespace and a single
+        /// pair of wrapping double-quotes (so <c>GODOT_MCP_TOKEN="abc"</c> yields <c>abc</c>, not a
+        /// bearer value with literal quotes). Returns <c>null</c> for null/blank input.
+        /// </summary>
+        static string? NormalizeEnv(string? raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+                return null;
+
+            return raw.Trim().Trim('"');
+        }
+
+        /// <summary>
+        /// URL-flavored normalization: <see cref="NormalizeEnv"/> plus a trailing-slash trim so URL
+        /// resolvers compare/append cleanly. Returns <c>null</c> for null/blank input.
+        /// </summary>
+        static string? NormalizeUrl(string? raw)
+        {
+            var normalized = NormalizeEnv(raw);
+            return string.IsNullOrEmpty(normalized) ? null : normalized.TrimEnd('/');
+        }
+
+        /// <summary>True when <paramref name="value"/> is an absolute http or https URL.</summary>
+        static bool IsValidHttpUrl(string value) =>
+            Uri.TryCreate(value, UriKind.Absolute, out var uri) &&
+            (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
     }
 }

--- a/addons/godot_mcp/Connection/GodotMcpConfig.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConfig.cs
@@ -1,0 +1,212 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Text.Json.Serialization;
+using com.IvanMurzak.McpPlugin;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// Which MCP server the Godot plugin connects to.
+    /// </summary>
+    public enum GodotMcpConnectionMode
+    {
+        /// <summary>A user-supplied server URL (local dev server, self-hosted, etc.).</summary>
+        Custom,
+
+        /// <summary>The hosted ai-game.dev cloud server.</summary>
+        Cloud
+    }
+
+    /// <summary>
+    /// Connection configuration for the Godot-MCP plugin. The Godot analog of Unity-MCP's
+    /// <c>UnityMcpPlugin.UnityConnectionConfig</c> — it extends the reused
+    /// <see cref="ConnectionConfig"/> from <c>com.IvanMurzak.McpPlugin</c> (so the SignalR client
+    /// consumes <see cref="Host"/>/<see cref="Token"/>/<see cref="KeepConnected"/> unchanged) and
+    /// layers Cloud/Custom mode selection plus environment-variable overrides on top.
+    ///
+    /// <para>
+    /// The URL/token <em>resolution</em> logic lives in pure static helpers
+    /// (<see cref="ResolveCloudBaseUrl"/>, <see cref="ResolveCloudUrl"/>,
+    /// <see cref="ResolveActiveMode"/>) so it is unit-testable in the plain-xUnit
+    /// <c>Godot-MCP.Tests</c> host without constructing any Godot native types or a live
+    /// SignalR client.
+    /// </para>
+    /// </summary>
+    public class GodotMcpConfig : ConnectionConfig
+    {
+        // --- Environment-variable names (Godot analog of UNITY_MCP_*). ---
+
+        /// <summary>Overrides the cloud base URL (analogous to <c>UNITY_MCP_CLOUD_URL</c>).</summary>
+        public const string EnvCloudUrl = "GODOT_MCP_CLOUD_URL";
+
+        /// <summary>Overrides the custom-mode server host (used only in <see cref="GodotMcpConnectionMode.Custom"/>).</summary>
+        public const string EnvHost = "GODOT_MCP_HOST";
+
+        /// <summary>Supplies the bearer token (routed to cloud or custom token by active mode).</summary>
+        public const string EnvToken = "GODOT_MCP_TOKEN";
+
+        /// <summary>Forces the connection mode (<c>Cloud</c> / <c>Custom</c>, case-insensitive).</summary>
+        public const string EnvConnectionMode = "GODOT_MCP_CONNECTION_MODE";
+
+        // --- Defaults. ---
+
+        /// <summary>Base URL of the hosted cloud server. The <c>/mcp</c> hub path is appended by <see cref="ResolveCloudUrl"/>.</summary>
+        public const string DefaultCloudBaseUrl = "https://ai-game.dev";
+
+        /// <summary>The MCP hub path appended to the cloud base URL.</summary>
+        public const string CloudHubPath = "/mcp";
+
+        /// <summary>Default custom-mode host when nothing is configured (local dev server convention).</summary>
+        public const string DefaultCustomHost = "http://localhost:8080";
+
+        // --- Serialized backing fields. ---
+
+        /// <summary>
+        /// Backing field for the custom-mode server URL. Serialized as <c>host</c>.
+        /// Use <see cref="Host"/> for the active connection URL (which routes through Cloud mode).
+        /// </summary>
+        [JsonPropertyName("host")]
+        public string CustomHost { get; set; } = DefaultCustomHost;
+
+        /// <summary>Backing field for the custom-mode bearer token. Serialized as <c>token</c>.</summary>
+        [JsonPropertyName("token")]
+        public string? CustomToken { get; set; }
+
+        /// <summary>Backing field for the cloud-mode bearer token. Serialized as <c>cloudToken</c>.</summary>
+        [JsonPropertyName("cloudToken")]
+        public string? CloudToken { get; set; }
+
+        /// <summary>The configured connection mode (overridable by <see cref="EnvConnectionMode"/> via <see cref="ResolveActiveMode"/>).</summary>
+        [JsonPropertyName("connectionMode")]
+        public GodotMcpConnectionMode ConnectionMode { get; set; } = GodotMcpConnectionMode.Cloud;
+
+        /// <summary>
+        /// The effective connection mode after applying the <see cref="EnvConnectionMode"/> override.
+        /// Never serialized — recomputed from the env each access so a process-level override always wins.
+        /// </summary>
+        [JsonIgnore]
+        public GodotMcpConnectionMode ActiveMode => ResolveActiveMode(ConnectionMode);
+
+        /// <summary>
+        /// Active connection URL based on <see cref="ActiveMode"/>:
+        /// the resolved cloud URL in Cloud mode, otherwise the custom host.
+        /// The setter writes through to <see cref="CustomHost"/> (custom mode is the only writable host).
+        /// </summary>
+        [JsonIgnore]
+        public override string Host
+        {
+            get => ActiveMode == GodotMcpConnectionMode.Cloud ? ResolveCloudUrl() : ResolveCustomHost();
+            set => CustomHost = value;
+        }
+
+        /// <summary>
+        /// Active bearer token based on <see cref="ActiveMode"/>. In Cloud mode the cloud token (env-overridable);
+        /// in Custom mode the custom token (env-overridable). The setter mirrors the getter so a generic
+        /// <c>Token = ...</c> assignment lands on the field that matches the active mode.
+        /// </summary>
+        [JsonIgnore]
+        public override string? Token
+        {
+            get => ActiveMode == GodotMcpConnectionMode.Cloud ? ResolveCloudToken() : ResolveCustomToken();
+            set
+            {
+                if (ActiveMode == GodotMcpConnectionMode.Cloud)
+                    CloudToken = value;
+                else
+                    CustomToken = value;
+            }
+        }
+
+        public GodotMcpConfig()
+        {
+            // Auto-reconnect / backoff are handled by the reused McpPlugin SignalR client when
+            // KeepConnected is true (it drives a FixedRetryPolicy on the underlying HubConnection).
+            // We do not reimplement transport — we just opt into staying connected.
+            KeepConnected = true;
+            GenerateSkillFiles = false;
+        }
+
+        // --- Pure resolution helpers (unit-testable; no Godot / SignalR dependency). ---
+
+        /// <summary>
+        /// Resolve the active connection mode, letting <see cref="EnvConnectionMode"/> override the configured value.
+        /// An unrecognized/empty env value falls through to <paramref name="configured"/>.
+        /// </summary>
+        public static GodotMcpConnectionMode ResolveActiveMode(GodotMcpConnectionMode configured)
+        {
+            var raw = ReadEnv(EnvConnectionMode);
+            if (string.IsNullOrWhiteSpace(raw))
+                return configured;
+
+            if (Enum.TryParse<GodotMcpConnectionMode>(raw.Trim(), ignoreCase: true, out var parsed))
+                return parsed;
+
+            return configured;
+        }
+
+        /// <summary>
+        /// Resolve the cloud BASE url (no hub path), applying the <see cref="EnvCloudUrl"/> override.
+        /// Invalid / non-http(s) overrides fall back to <see cref="DefaultCloudBaseUrl"/>. A trailing
+        /// <c>/mcp</c> is stripped so <see cref="ResolveCloudUrl"/> never produces <c>/mcp/mcp</c>.
+        /// </summary>
+        public static string ResolveCloudBaseUrl()
+        {
+            var raw = ReadEnv(EnvCloudUrl);
+            if (string.IsNullOrWhiteSpace(raw))
+                return DefaultCloudBaseUrl;
+
+            var normalized = raw.Trim().Trim('"').TrimEnd('/');
+
+            if (!Uri.TryCreate(normalized, UriKind.Absolute, out var uri) ||
+                (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+            {
+                return DefaultCloudBaseUrl;
+            }
+
+            if (normalized.EndsWith(CloudHubPath, StringComparison.OrdinalIgnoreCase))
+                normalized = normalized[..^CloudHubPath.Length];
+
+            return normalized;
+        }
+
+        /// <summary>Resolve the full cloud connection URL (base + <see cref="CloudHubPath"/>).</summary>
+        public static string ResolveCloudUrl() => ResolveCloudBaseUrl() + CloudHubPath;
+
+        /// <summary>
+        /// Resolve the active custom-mode host, applying the <see cref="EnvHost"/> override.
+        /// </summary>
+        public string ResolveCustomHost()
+        {
+            var raw = ReadEnv(EnvHost);
+            if (!string.IsNullOrWhiteSpace(raw))
+                return raw!.Trim().Trim('"');
+
+            return string.IsNullOrWhiteSpace(CustomHost) ? DefaultCustomHost : CustomHost;
+        }
+
+        /// <summary>Resolve the active cloud token, applying the <see cref="EnvToken"/> override.</summary>
+        public string? ResolveCloudToken()
+        {
+            var raw = ReadEnv(EnvToken);
+            return string.IsNullOrWhiteSpace(raw) ? CloudToken : raw!.Trim();
+        }
+
+        /// <summary>Resolve the active custom token, applying the <see cref="EnvToken"/> override.</summary>
+        public string? ResolveCustomToken()
+        {
+            var raw = ReadEnv(EnvToken);
+            return string.IsNullOrWhiteSpace(raw) ? CustomToken : raw!.Trim();
+        }
+
+        static string? ReadEnv(string name) => Environment.GetEnvironmentVariable(name);
+    }
+}

--- a/addons/godot_mcp/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConnection.cs
@@ -1,0 +1,141 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using com.IvanMurzak.Godot.MCP.Reflection;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet;
+using Godot;
+using McpVersion = com.IvanMurzak.McpPlugin.Common.Version;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// Owns the lifecycle of the reused <c>com.IvanMurzak.McpPlugin</c> SignalR client for the
+    /// Godot editor plugin. The Godot analog of Unity-MCP's <c>UnityMcpPlugin.BuildMcpPlugin</c> +
+    /// <c>Connect</c> path, condensed to the single-instance editor case.
+    ///
+    /// <para>
+    /// Responsibilities:
+    /// <list type="bullet">
+    ///   <item>Build the <see cref="Reflector"/> with the Godot type converters
+    ///   (<see cref="GodotReflectorFactory"/>).</item>
+    ///   <item>Build an <see cref="IMcpPlugin"/> via <see cref="McpPluginBuilder"/>, scanning the
+    ///   addon assembly for <c>[AiToolType]</c>/<c>[AiTool]</c> methods (the <c>ping</c> tool today).</item>
+    ///   <item>Apply the resolved <see cref="GodotMcpConfig"/> (Cloud/Custom host + bearer token).</item>
+    ///   <item>Connect. Auto-reconnect/backoff is handled inside the McpPlugin client when
+    ///   <see cref="ConnectionConfig.KeepConnected"/> is true — NOT reimplemented here.</item>
+    /// </list>
+    /// </para>
+    ///
+    /// This type is editor-only (<c>#if TOOLS</c>): it instantiates the SignalR client and is driven
+    /// by <see cref="GodotMcpPlugin"/>'s tree lifecycle.
+    /// </summary>
+    public sealed class GodotMcpConnection : IDisposable
+    {
+        /// <summary>Plugin version reported to the server in the MCP handshake.</summary>
+        public const string PluginVersion = "0.1.0";
+
+        readonly GodotMcpConfig _config;
+        IMcpPlugin? _plugin;
+
+        /// <summary>The active config (resolved Host/Token/mode are read live off this).</summary>
+        public GodotMcpConfig Config => _config;
+
+        /// <summary>The built plugin instance, or null before <see cref="Start"/> / after <see cref="Dispose"/>.</summary>
+        public IMcpPlugin? Plugin => _plugin;
+
+        public GodotMcpConnection(GodotMcpConfig? config = null)
+        {
+            _config = config ?? new GodotMcpConfig();
+        }
+
+        /// <summary>
+        /// Build the plugin (reflector + tool scan + config) and initiate the connection. Idempotent:
+        /// a second call while a plugin already exists is a no-op. The connect itself is fire-and-forget
+        /// from the editor's perspective — the McpPlugin client manages (re)connection in the background.
+        /// </summary>
+        public void Start()
+        {
+            if (_plugin != null)
+            {
+                GD.Print("[Godot-MCP] connection already started; ignoring duplicate Start().");
+                return;
+            }
+
+            Reflector reflector = GodotReflectorFactory.CreateDefaultReflector();
+
+            var version = new McpVersion
+            {
+                Api = com.IvanMurzak.McpPlugin.Common.Consts.ApiVersion,
+                Plugin = PluginVersion,
+                Environment = $"Godot {Engine.GetVersionInfo()["string"]}"
+            };
+
+            // Scan THIS addon assembly for [AiToolType]/[AiTool] (the ping tool, and future families).
+            Assembly addonAssembly = typeof(GodotMcpConnection).Assembly;
+
+            var builder = new McpPluginBuilder(version)
+                .SetConfig(_config)
+                .WithToolsFromAssembly(addonAssembly)
+                .WithPromptsFromAssembly(addonAssembly)
+                .WithResourcesFromAssembly(addonAssembly);
+
+            _plugin = builder.Build(reflector);
+
+            var mode = _config.ActiveMode;
+            var host = _config.Host;
+            GD.Print($"[Godot-MCP] connecting (mode={mode}, host={host}) ...");
+
+            // Fire-and-forget connect; KeepConnected drives reconnection in the client.
+            _ = ConnectAsync();
+        }
+
+        async Task ConnectAsync()
+        {
+            var plugin = _plugin;
+            if (plugin == null)
+                return;
+
+            try
+            {
+                var ok = await plugin.Connect();
+                if (ok)
+                    GD.Print("[Godot-MCP] connected.");
+                else
+                    GD.PushWarning("[Godot-MCP] initial connect returned false; client will keep retrying if KeepConnected.");
+            }
+            catch (Exception ex)
+            {
+                GD.PushError($"[Godot-MCP] connect failed: {ex.Message}");
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_plugin != null)
+            {
+                try
+                {
+                    _plugin.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    GD.PushError($"[Godot-MCP] error disposing connection: {ex.Message}");
+                }
+                _plugin = null;
+            }
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/GodotMcpPlugin.cs
+++ b/addons/godot_mcp/GodotMcpPlugin.cs
@@ -10,6 +10,7 @@
 #if TOOLS
 #nullable enable
 using Godot;
+using com.IvanMurzak.Godot.MCP.Connection;
 using com.IvanMurzak.Godot.MCP.MainThreadDispatch;
 
 namespace com.IvanMurzak.Godot.MCP
@@ -21,9 +22,9 @@ namespace com.IvanMurzak.Godot.MCP
     ///
     /// On load it installs the editor main-thread dispatcher (the Godot analog of Unity's
     /// <c>MainThread.Instance.Run</c>) so downstream tool handlers can marshal Godot API calls
-    /// onto the main thread. The MCP connection to ai-game.dev (SignalR client via
-    /// com.IvanMurzak.McpPlugin) is intentionally NOT wired up here — that is a separate
-    /// downstream task.
+    /// onto the main thread, then boots the MCP connection (SignalR client via
+    /// com.IvanMurzak.McpPlugin) to the configured server (cloud ai-game.dev by default, or a
+    /// custom override) and registers the addon's MCP tools.
     /// </summary>
     [Tool]
     public partial class GodotMcpPlugin : EditorPlugin
@@ -31,6 +32,7 @@ namespace com.IvanMurzak.Godot.MCP
         const string DispatcherNodeName = "GodotMcpMainThreadDispatcher";
 
         MainThreadDispatcher? _dispatcher;
+        GodotMcpConnection? _connection;
 
         public override void _EnterTree()
         {
@@ -43,10 +45,29 @@ namespace com.IvanMurzak.Godot.MCP
             GodotMainThread.Install();
 
             GD.Print("[Godot-MCP] plugin loaded");
+
+            // Boot the MCP connection (after the dispatcher is installed so tool handlers can marshal
+            // onto the main thread). Reuses the McpPlugin SignalR client + bearer auth; mode/URL/token
+            // come from GodotMcpConfig (env-overridable). Failures here must not break plugin load.
+            try
+            {
+                _connection = new GodotMcpConnection();
+                _connection.Start();
+            }
+            catch (System.Exception ex)
+            {
+                GD.PushError($"[Godot-MCP] failed to start MCP connection: {ex.Message}");
+            }
         }
 
         public override void _ExitTree()
         {
+            if (_connection != null)
+            {
+                _connection.Dispose();
+                _connection = null;
+            }
+
             if (_dispatcher != null)
             {
                 _dispatcher.QueueFree();

--- a/addons/godot_mcp/Tools/Tool_Ping.cs
+++ b/addons/godot_mcp/Tools/Tool_Ping.cs
@@ -1,0 +1,52 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.ComponentModel;
+using com.IvanMurzak.McpPlugin;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// Lightweight readiness/connectivity probe. The single tool that proves the end-to-end
+    /// MCP path (editor boot → SignalR connect → tool dispatch → structured result) is wired up,
+    /// before any engine-driving tool families are added. The Godot analog of a plain echo/pong tool.
+    ///
+    /// <para>
+    /// This is engine-runtime logic with no Godot editor API surface, so it intentionally lives
+    /// OUTSIDE <c>#if TOOLS</c> — it is discovered by the McpPlugin assembly scanner and returns a
+    /// pure-managed value, needing no main-thread marshalling.
+    /// </para>
+    /// </summary>
+    [AiToolType]
+    public partial class Tool_Ping
+    {
+        public const string PingToolId = "ping";
+
+        [AiTool
+        (
+            PingToolId,
+            Title = "Ping",
+            ReadOnlyHint = true,
+            IdempotentHint = true,
+            OpenWorldHint = false
+        )]
+        [Description("Lightweight readiness probe for the Godot-MCP connection. Returns the input " +
+            "'message' echoed back, or 'pong' when omitted. Useful for verifying SignalR connectivity " +
+            "end-to-end after the editor plugin connects to the MCP server.")]
+        public string Ping
+        (
+            [Description("Optional message to echo back. When null or empty, the tool returns 'pong'.")]
+            string? message = null
+        )
+        {
+            return string.IsNullOrEmpty(message) ? "pong" : message;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Boot the reused `com.IvanMurzak.McpPlugin` SignalR client from the editor plugin (`GodotMcpPlugin._EnterTree`, after the main-thread dispatcher install): build the Godot reflector (`GodotReflectorFactory`), build the plugin (scanning the addon assembly for `[AiTool]`), and connect. Transport is NOT reimplemented.
- `GodotMcpConfig` (extends McpPlugin's `ConnectionConfig`): Cloud/Custom mode (Cloud default), default cloud URL `https://ai-game.dev/mcp`, `GODOT_MCP_*` env overrides, mode-aware cloud-vs-custom bearer-token selection. `KeepConnected=true` delegates auto-reconnect/backoff to the reused client.
- A single `ping` `[AiTool]` (echo/pong) proves the path.
- gitignore `*.uid` (carried follow-up): Godot 4.4+ editor `.cs.uid` artifacts that tripped PR #3's Gate A.

## Test plan
- [x] `dotnet build Godot-MCP.sln -c Debug` — 0 errors.
- [x] `dotnet test Godot-MCP.Tests` — 41/41 pass (22 new: mode/URL/token resolution + ping contract; pure-managed, no server).
- [x] Headless Godot 4.5.1 build of the testbed against this worktree's addon — C# compiles, plugin lifecycle runs.
- [ ] Live connect + `ping` round-trip through a server — **pending operator**. The headless editor-boot smoke surfaces a pre-existing `ReflectorNet` editor-runtime assembly-load error that ALSO reproduces on `main` (PR #3 code), independent of this change; a full live round-trip needs a running MCP server + that editor-ALC resolution resolved. Runbook in the iteration handoff.

Closes #4