### PR TITLE
fix: load ReflectorNet/McpPlugin at Godot editor runtime (live runtime blocker)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,149 @@
+# CLAUDE.md — Godot-MCP
+
+Godot **editor addon** (`addons/godot_mcp/`) backed by a `Godot.NET.Sdk` C# project. A `[Tool]`
+`EditorPlugin` (`GodotMcpPlugin`) boots on editor load, installs the main-thread dispatcher, builds a
+`Reflector` with Godot type converters, and connects to an MCP server (cloud `ai-game.dev` by default,
+or a custom local server) over the reused `com.IvanMurzak.McpPlugin` SignalR client. The MCP/reflection
+stack is **not forked** — it is consumed from nuget.org as `PackageReference`s and the pins are owned by
+the upstream release pipelines (never bump them here).
+
+## Build / test
+
+```bash
+dotnet restore Godot-MCP.sln
+dotnet build  Godot-MCP.sln --configuration Debug --no-restore   # 0 errors required (CI gate)
+dotnet test   Godot-MCP.Tests/Godot-MCP.Tests.csproj --configuration Debug --no-build   # 0 failures
+```
+
+`Godot.NET.Sdk` is a NuGet SDK, so **no Godot binary is needed to build or unit-test**. The xUnit
+project compiles a CI-friendly subset of the addon sources directly (it never `ProjectReference`s the
+game project). Only **pure-managed** Godot types are unit-testable here — Godot types that wrap a native
+object (`NodePath`, `Node`, `Resource`, `SceneTree`) call `godotsharp_*` P/Invoke on construction and
+crash the test host with `AccessViolationException` when no Godot native lib is loaded; verify those via
+the headless Godot smoke instead.
+
+## Editor-runtime assembly loading (the dependency-resolution fix)
+
+> If you are adding tool families or any code that touches a NuGet dependency at editor runtime, read
+> this — it is why the plugin can load `ReflectorNet`/`McpPlugin` in the editor at all.
+
+**The Godot gotcha.** Godot loads the project's compiled assembly into the **default**
+`AssemblyLoadContext`, but does **not** teach that context how to find the project's NuGet dependency
+graph. The CLR default probing looks only beside the host binary (Godot's own folder) and in the shared
+framework; it does **not** read the project's `*.deps.json`, and — unlike a normal `dotnet` app launch —
+Godot does **not** emit a `*.runtimeconfig.dev.json` (which would carry the NuGet global-packages probing
+paths) next to the built assembly. So the first time editor-plugin code touches a type from a dependency
+that was not copied beside the project assembly, the runtime throws:
+
+```
+System.IO.FileNotFoundException: Could not load file or assembly 'ReflectorNet, Version=5.3.1.0, ...'
+```
+
+This is a known, long-standing Godot limitation for C# addons with external dependencies
+(godotengine/godot-proposals#9074, godotengine/godot#112701).
+
+**The fix** lives in `addons/godot_mcp/Connection/GodotMcpAssemblyResolver.cs`. It hooks
+`AssemblyLoadContext.Default.Resolving` and answers the misses itself, per assembly name, in order:
+
+1. **Same-directory probe** — `<name>.dll` next to the project assembly (covers consumers who copy deps
+   into the output dir via `<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>`).
+2. **`*.deps.json` + NuGet global-packages probe** — parse the project's `*.deps.json` to learn each
+   library's `{package}/{version}` and runtime-asset relative path (`lib/net8.0/ReflectorNet.dll`), then
+   locate the file under the NuGet global packages folder (`NUGET_PACKAGES` env, else
+   `~/.nuget/packages`). **This is the strategy that actually carries in the Godot editor**, where no
+   dev.json probing config exists.
+3. **`AssemblyDependencyResolver`** — best-effort last try; it resolves RID-specific assets when a
+   sibling dev.json/runtimeconfig is present (a plain `dotnet` host), and returns empty in the editor.
+
+Two non-obvious constraints make it work:
+
+- **It is installed from a `[ModuleInitializer]`, not from `_EnterTree`.** Godot instantiates the
+  `EditorPlugin` *type* (whose fields/usings reference the NuGet-dependency types) before any plugin
+  method body runs, so installing the hook inside `_EnterTree` is too late — type load already triggers
+  the failing resolution. The module initializer runs when the assembly's module is first loaded, before
+  any type is constructed, and references only BCL types so it cannot itself fault.
+- **In the editor, `Assembly.Location` is empty** (Godot byte-loads the project assembly). The resolver
+  reconstructs the anchor path from `AppContext.BaseDirectory + <AssemblyName>.dll` (Godot points
+  `BaseDirectory` at `.godot/mono/temp/bin/<cfg>/`, where the `*.deps.json` sits).
+
+The resolver is pure-BCL and unit-tested (`Godot-MCP.Tests/AssemblyResolverTests.cs`): the test project
+itself references the same packages, so its sibling `*.deps.json` exercises the same resolution path with
+no Godot binary.
+
+## Consumer-install story (how an end user's Godot project gets the deps)
+
+A consumer installs the addon by placing `addons/godot_mcp/` in their Godot C# project and enabling it in
+*Project → Project Settings → Plugins*. Because Godot compiles **every** `.cs` under the project into one
+assembly, the addon's C# only compiles if the **consumer's `.csproj` declares the same NuGet
+`PackageReference`s** the addon depends on:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.1" />
+  <PackageReference Include="com.IvanMurzak.McpPlugin"   Version="6.5.5" />
+</ItemGroup>
+```
+
+With those references present, `dotnet restore` populates the consumer's NuGet cache and the build emits a
+`*.deps.json` describing the graph — which is exactly what `GodotMcpAssemblyResolver` reads at editor
+runtime to locate the DLLs. **No manual DLL copying is required**; the resolver finds them in the NuGet
+global packages folder. (A consumer who prefers self-contained output can instead set
+`<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>` so the DLLs land beside the project
+assembly — strategy 1 above then covers them.) These reference instructions should be surfaced in the
+addon's user-facing README / install docs as the family grows.
+
+## Testbed runbook (headless live-verification)
+
+The infra repo's `Godot-Test-Project/` (plain folder, analog of `Unity-Test-Project/`) wires the addon via
+a directory junction `addons/godot_mcp → <Godot-MCP>/addons/godot_mcp` and pins the same NuGet packages.
+Binary: `Godot_v4.5.1-stable_mono_win64_console.exe` (the `_console` variant surfaces `GD.Print`).
+
+**Clean editor-boot smoke** (proves the assembly-load fix):
+
+```bash
+# (worktree verification) repoint the junction to the worktree addon, then restore it afterwards:
+#   New-Item -ItemType Junction -Path addons\godot_mcp -Target <worktree>\Godot-MCP\addons\godot_mcp
+GODOT=.../Godot_v4.5.1-stable_mono_win64_console.exe
+"$GODOT" --headless --path <infra>/Godot-Test-Project --build-solutions --quit   # builds C#
+"$GODOT" --headless --path <infra>/Godot-Test-Project --editor --quit            # boots editor
+# Expect: "[Godot-MCP] plugin loaded", a stream of "[Godot-MCP] resolved '<dep>' -> <nuget-cache-path>",
+#         and NO FileNotFoundException. If the testbed shows a stale assembly, wipe
+#         .godot/mono/temp/{obj,bin} and rebuild (Godot's incremental build can miss junction edits).
+```
+
+**Live connect + ping** (proves the end-to-end MCP path) against a local server:
+
+```bash
+# 1) Start a local MCP server (MCP-Plugin-dotnet DemoWebApp). Default Authorization=none (no token).
+cd <infra>/MCP-Plugin-dotnet/DemoWebApp
+dotnet run -c Release -- port=5300 client-transport=streamableHttp        # /help returns 200 when up
+
+# 2) Boot the editor in Custom mode pointed at it (the plugin connects to <host>/hub/mcp-server):
+export GODOT_MCP_CONNECTION_MODE=Custom
+export GODOT_MCP_HOST=http://localhost:5300
+# (GODOT_MCP_TOKEN only needed if the server is started with authorization=required)
+"$GODOT" --headless --path <infra>/Godot-Test-Project --editor --quit-after 600000   # hold connected
+# Expect: "[Godot-MCP] connecting (mode=Custom, host=http://localhost:5300) ..." then
+#         "[Godot-MCP] connected.". Server log shows "Version handshake successful. Plugin: 0.1.0".
+
+# 3) While connected, invoke the ping tool via the server's direct-tool-call API:
+curl -s -X POST http://localhost:5300/api/tools/ping -H "Content-Type: application/json" -d '{}'
+#   -> {"status":"success","structured":{"result":"pong"}}
+curl -s -X POST http://localhost:5300/api/tools/ping -H "Content-Type: application/json" \
+     -d '{"message":"hello-godot"}'
+#   -> {"status":"success","structured":{"result":"hello-godot"}}
+```
+
+This exact runbook was executed for issue #6 and observed green (clean boot + `pong`).
+
+## Conventions
+
+- Root namespace `com.IvanMurzak.Godot.MCP` (reverse-domain, matches Unity-MCP / McpPlugin). New types
+  nest under folder-matching namespaces.
+- Every `.cs` starts with the ASCII-art Apache-2.0 header (copy from a neighbouring file).
+- Editor-only code lives behind `#if TOOLS`. Engine-runtime logic that is pure-managed (config, tools,
+  the assembly resolver) stays outside `#if TOOLS` so it is CI-unit-testable.
+- All Godot API calls from tool handlers marshal onto the editor main thread via the dispatcher; never
+  touch `Node`/`Resource`/`EditorInterface` off-thread.
+- Commits: `<type>(<scope>): <description>`; reference issues with `Closes #N`. Never `git add -A`; never
+  bump the reused NuGet pins; never commit `bin/`/`obj/`/`.godot/`/`*.uid`.

--- a/Godot-MCP.Tests/AssemblyResolverTests.cs
+++ b/Godot-MCP.Tests/AssemblyResolverTests.cs
@@ -1,0 +1,107 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.IO;
+using System.Reflection;
+using com.IvanMurzak.Godot.MCP.Connection;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the editor-runtime NuGet-dependency resolution logic in
+    /// <see cref="GodotMcpAssemblyResolver"/>. This is the exact mechanism that lets the Godot editor
+    /// find ReflectorNet/McpPlugin at runtime (where Godot's default AssemblyLoadContext otherwise
+    /// throws <c>FileNotFoundException</c> because it does not probe the project's <c>*.deps.json</c>).
+    ///
+    /// <para>
+    /// We seed the resolver from THIS test assembly's location: the test project itself
+    /// <c>PackageReference</c>s <c>com.IvanMurzak.ReflectorNet</c> and <c>com.IvanMurzak.McpPlugin</c>,
+    /// so its sibling <c>*.deps.json</c> describes the same dependency graph the addon assembly has.
+    /// Pure-BCL, no Godot native types — CI-friendly (no Godot binary needed).
+    /// </para>
+    /// </summary>
+    public class AssemblyResolverTests
+    {
+        static string TestAssemblyPath => typeof(AssemblyResolverTests).Assembly.Location;
+
+        [Theory]
+        [InlineData("ReflectorNet")]
+        [InlineData("McpPlugin")]
+        [InlineData("McpPlugin.Common")]
+        public void ResolvePath_ResolvesTransitiveNuGetDependency_ViaDepsJson(string simpleName)
+        {
+            // Re-seed the deps.json resolver from the test assembly (idempotent Install() may have
+            // already pinned a different anchor in another test run, so go through the seam directly).
+            GodotMcpAssemblyResolver.Install(TestAssemblyPath);
+
+            var resolved = GodotMcpAssemblyResolver.ResolvePath(new AssemblyName(simpleName));
+
+            Assert.False(string.IsNullOrEmpty(resolved), $"expected a resolved path for '{simpleName}'");
+            Assert.True(File.Exists(resolved), $"resolved path should exist on disk: {resolved}");
+            Assert.Equal(simpleName + ".dll", Path.GetFileName(resolved));
+        }
+
+        [Fact]
+        public void ResolvePath_ReturnsNull_ForUnknownAssembly()
+        {
+            GodotMcpAssemblyResolver.Install(TestAssemblyPath);
+
+            var resolved = GodotMcpAssemblyResolver.ResolvePath(
+                new AssemblyName("Definitely.Not.A.Real.Assembly.Name.42"));
+
+            Assert.True(string.IsNullOrEmpty(resolved));
+        }
+
+        [Theory]
+        [InlineData("ReflectorNet")]
+        [InlineData("McpPlugin")]
+        [InlineData("McpPlugin.Common")]
+        public void BuildDepsJsonIndex_MapsAssembliesToExistingNuGetCachePaths(string simpleName)
+        {
+            // This is the strategy that actually carries in the Godot editor, where no
+            // *.runtimeconfig.dev.json (NuGet probing paths) is emitted next to the project assembly,
+            // so AssemblyDependencyResolver returns empty. The deps.json index resolves package
+            // {id}/{version}/{relative} against the NuGet global packages folder directly.
+            var depsJsonPath = Path.ChangeExtension(TestAssemblyPath, ".deps.json");
+            Assert.True(File.Exists(depsJsonPath), $"test deps.json should exist: {depsJsonPath}");
+
+            var index = GodotMcpAssemblyResolver.BuildDepsJsonIndex(depsJsonPath);
+
+            Assert.NotNull(index);
+            Assert.True(index!.TryGetValue(simpleName, out var path),
+                $"deps.json index should contain '{simpleName}'");
+            Assert.True(File.Exists(path), $"indexed path should exist on disk: {path}");
+            Assert.Equal(simpleName + ".dll", Path.GetFileName(path));
+        }
+
+        [Fact]
+        public void BuildDepsJsonIndex_ReturnsNull_ForMissingFile()
+        {
+            var index = GodotMcpAssemblyResolver.BuildDepsJsonIndex(
+                Path.Combine(Path.GetTempPath(), "definitely-missing.deps.json"));
+
+            Assert.Null(index);
+        }
+
+        [Fact]
+        public void Install_IsIdempotent_DoesNotThrowOnRepeatedCalls()
+        {
+            // Multiple installs (plugin toggled off/on, domain reload) must be safe.
+            GodotMcpAssemblyResolver.Install(TestAssemblyPath);
+            GodotMcpAssemblyResolver.Install(TestAssemblyPath);
+            GodotMcpAssemblyResolver.Install();
+
+            // Still resolves after repeated installs.
+            var resolved = GodotMcpAssemblyResolver.ResolvePath(new AssemblyName("ReflectorNet"));
+            Assert.False(string.IsNullOrEmpty(resolved));
+        }
+    }
+}

--- a/Godot-MCP.Tests/AssemblyResolverTests.cs
+++ b/Godot-MCP.Tests/AssemblyResolverTests.cs
@@ -38,8 +38,11 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         [InlineData("McpPlugin.Common")]
         public void ResolvePath_ResolvesTransitiveNuGetDependency_ViaDepsJson(string simpleName)
         {
-            // Re-seed the deps.json resolver from the test assembly (idempotent Install() may have
-            // already pinned a different anchor in another test run, so go through the seam directly).
+            // Ensure the resolver is installed and seeded from the test assembly's sibling deps.json.
+            // NOTE: Install() latches on the first call (the _installed flag), so this is the seeding
+            // call only if no prior test installed it first; otherwise it is a no-op and the resolver is
+            // already seeded from the test assembly (every test in this class anchors on TestAssemblyPath,
+            // so the seeded anchor is the same either way).
             GodotMcpAssemblyResolver.Install(TestAssemblyPath);
 
             var resolved = GodotMcpAssemblyResolver.ResolvePath(new AssemblyName(simpleName));
@@ -102,6 +105,29 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             // Still resolves after repeated installs.
             var resolved = GodotMcpAssemblyResolver.ResolvePath(new AssemblyName("ReflectorNet"));
             Assert.False(string.IsNullOrEmpty(resolved));
+        }
+
+        [Fact]
+        public void Install_LatchesOnFirstCall_SecondInstallWithDifferentAnchorIsNoOp()
+        {
+            // Proves the idempotency latch behaviorally (rather than merely "does not throw"): once the
+            // resolver is installed, a SECOND Install() seeded from a DIFFERENT (here, deliberately
+            // bogus) anchor must NOT re-seed or change resolution behavior — the _installed latch makes
+            // the second call a no-op, so the original (good) seeding stays in effect. If the latch ever
+            // regressed and the resolver re-seeded from this bogus anchor, ResolvePath would stop finding
+            // the real dependency and this test would fail.
+            GodotMcpAssemblyResolver.Install(TestAssemblyPath);
+
+            var before = GodotMcpAssemblyResolver.ResolvePath(new AssemblyName("ReflectorNet"));
+            Assert.False(string.IsNullOrEmpty(before), "precondition: resolver must resolve ReflectorNet after the seeding install");
+
+            // A path that does not exist and has no sibling deps.json. If this re-seeded the resolver,
+            // strategies 1 and 2 would lose their good probe dir / deps.json index.
+            var bogusAnchor = Path.Combine(Path.GetTempPath(), "godot-mcp-nonexistent-anchor", "Bogus.dll");
+            GodotMcpAssemblyResolver.Install(bogusAnchor);
+
+            var after = GodotMcpAssemblyResolver.ResolvePath(new AssemblyName("ReflectorNet"));
+            Assert.Equal(before, after);
         }
     }
 }

--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -44,6 +44,9 @@
          compile and run in this plain-xUnit host. GodotMcpConnection.cs is editor-only (#if TOOLS) and
          instantiates the SignalR client; it is verified via the headless Godot smoke, not here. -->
     <Compile Include="..\addons\godot_mcp\Connection\GodotMcpConfig.cs" Link="Source\GodotMcpConfig.cs" />
+    <!-- Editor-runtime NuGet-dependency resolver. Pure-BCL (System.Runtime.Loader), no #if TOOLS,
+         no Godot native types — so it is unit-testable in this plain-xUnit host. -->
+    <Compile Include="..\addons\godot_mcp\Connection\GodotMcpAssemblyResolver.cs" Link="Source\GodotMcpAssemblyResolver.cs" />
     <Compile Include="..\addons\godot_mcp\Tools\Tool_Ping.cs" Link="Source\Tool_Ping.cs" />
   </ItemGroup>
 

--- a/addons/godot_mcp/Connection/GodotMcpAssemblyResolver.cs
+++ b/addons/godot_mcp/Connection/GodotMcpAssemblyResolver.cs
@@ -65,11 +65,31 @@ namespace com.IvanMurzak.Godot.MCP.Connection
     /// hook that runs before Godot instantiates the <c>EditorPlugin</c> type (whose field/using
     /// references would otherwise fault during type load, before any plugin method body runs).
     /// </para>
+    ///
+    /// <para>
+    /// <b>Known limitation (not implemented).</b> Strategy 2 probes only the NuGet <i>global</i> packages
+    /// folder (<c>NUGET_PACKAGES</c> env, else <c>~/.nuget/packages</c>). It does NOT consult NuGet
+    /// <i>fallback</i> package folders — <c>DOTNET_NUGET_FALLBACK_PACKAGES</c> / the SDK's
+    /// <c>NuGetFallbackFolder</c> / the <c>additionalProbingPaths</c> a <c>*.deps.json</c> may declare —
+    /// which some enterprise/CI caches rely on. If a dependency lives only in a fallback folder and not
+    /// the global cache, strategy 2 misses it and the resolve falls through to strategy 3. This is a
+    /// follow-up; for the supported consumer story (a normal <c>dotnet restore</c> into the global cache)
+    /// it does not arise.
+    /// </para>
     /// </summary>
     public static class GodotMcpAssemblyResolver
     {
         static readonly object _gate = new object();
         static bool _installed;
+
+        // Load-bearing concurrency invariant for the three cached fields below: they are seeded under
+        // _gate inside Install() BEFORE the Resolving hook is subscribed, and Install() runs its seeding
+        // body exactly once (the _installed latch makes every later call a no-op — it never re-seeds).
+        // Because of that one-time, publish-before-subscribe ordering, the Resolving hook
+        // (OnResolving → ResolvePath) reads these WITHOUT taking _gate and is still safe: by the time any
+        // resolve can fire, the fields are fully written and never mutated again. A future edit that
+        // re-seeds these post-install (or seeds them after subscribing) would break this and introduce a
+        // data race — take _gate there if you ever do.
         static AssemblyDependencyResolver? _depsResolver;
         static string? _probeDirectory;
         static Dictionary<string, string>? _depsJsonAssemblyPaths;
@@ -219,7 +239,12 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             if (string.IsNullOrEmpty(simpleName))
                 return null;
 
-            // 1) Same-directory probe (copied-beside-the-assembly deployments).
+            // 1) Same-directory probe (copied-beside-the-assembly deployments). This trusts the
+            //    filename: it returns <probeDir>/<simpleName>.dll if it exists, WITHOUT checking the
+            //    file's assembly version against assemblyName.Version. That is intentional — for
+            //    copy-local deploys the build already vetted which version landed beside the assembly,
+            //    so the on-disk DLL is authoritative. (Version skew there would be a build problem, not
+            //    something this runtime probe should second-guess.)
             var dir = _probeDirectory;
             if (!string.IsNullOrEmpty(dir))
             {
@@ -352,7 +377,20 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         {
             var path = ResolvePath(assemblyName);
             if (string.IsNullOrEmpty(path))
+            {
+                // Fail-soft: every strategy missed. Returning null lets the CLR continue its own
+                // resolution (and ultimately throw FileNotFoundException as it normally would), but a
+                // bare FileNotFoundException gives the consumer no clue WHY. The most common cause is
+                // version/cache skew — the *.deps.json lists a {package}/{version} whose folder is not
+                // in the NuGet cache (e.g. restore never ran, or a different pin), so strategy 2 finds
+                // nothing. Surface that here so it is diagnosable from the editor log.
+                Log?.Invoke(
+                    $"[Godot-MCP] could not resolve '{assemblyName.Name}' via same-dir probe / " +
+                    $"deps.json+NuGet-cache / AssemblyDependencyResolver — the CLR will now throw if " +
+                    $"this assembly is required. Check that 'dotnet restore' populated the NuGet cache " +
+                    $"for the version pinned in *.deps.json (probe dir: {_probeDirectory}).");
                 return null;
+            }
 
             try
             {

--- a/addons/godot_mcp/Connection/GodotMcpAssemblyResolver.cs
+++ b/addons/godot_mcp/Connection/GodotMcpAssemblyResolver.cs
@@ -1,0 +1,370 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+using System.Text.Json;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// Resolves the addon's transitive NuGet dependency assemblies (ReflectorNet, McpPlugin,
+    /// McpPlugin.Common, and their own transitive deps such as R3 and the SignalR client) at
+    /// <b>Godot editor runtime</b>.
+    ///
+    /// <para>
+    /// <b>Why this exists.</b> Godot loads the project's compiled assembly into the default
+    /// <see cref="AssemblyLoadContext"/>, but does NOT teach that context how to find the project's
+    /// NuGet dependency graph. The CLR's default resolution probes only the host (Godot's own folder)
+    /// and the shared framework — it does NOT read the project's <c>*.deps.json</c>, and (unlike a
+    /// normal <c>dotnet</c> app launch) Godot does not emit a <c>*.runtimeconfig.dev.json</c> carrying
+    /// the NuGet global-packages probing paths next to the built assembly. So the moment editor-plugin
+    /// code touches a type from a dependency that was not copied beside the project assembly, the JIT
+    /// throws <c>System.IO.FileNotFoundException: Could not load file or assembly 'ReflectorNet, ...'</c>.
+    /// This is a long-standing Godot C# gotcha for addons with external dependencies
+    /// (see godotengine/godot-proposals#9074, godotengine/godot#112701).
+    /// </para>
+    ///
+    /// <para>
+    /// <b>How it fixes it.</b> We hook <see cref="AssemblyLoadContext.Resolving"/> on the default
+    /// context and answer the misses ourselves. Per missed assembly name, in order:
+    /// <list type="number">
+    ///   <item><b>Same-directory probe</b> — <c>&lt;name&gt;.dll</c> next to the project assembly.
+    ///   Covers consumers who copy deps into the output dir
+    ///   (<c>&lt;CopyLocalLockFileAssemblies&gt;true&lt;/CopyLocalLockFileAssemblies&gt;</c>).</item>
+    ///   <item><b><c>*.deps.json</c> + NuGet global-packages probe</b> — parse the project's
+    ///   <c>*.deps.json</c> to learn each library's <c>{package}/{version}</c> and the runtime asset's
+    ///   relative path (<c>lib/net8.0/ReflectorNet.dll</c>), then locate the file under the NuGet
+    ///   global packages folder (<c>NUGET_PACKAGES</c> env or <c>~/.nuget/packages</c>). This is the
+    ///   decisive path in the Godot editor, where no dev.json probing config exists. It is fully
+    ///   consumer-portable: any project that <c>PackageReference</c>s these libraries gets a
+    ///   <c>*.deps.json</c> and the DLLs in its own NuGet cache.</item>
+    ///   <item><b><see cref="AssemblyDependencyResolver"/></b> — used as a best-effort first try when a
+    ///   sibling dev.json/runtimeconfig IS present (e.g. a plain <c>dotnet</c> host), since it also
+    ///   handles runtime-specific (RID) assets. It returns empty in the Godot editor (no dev.json), so
+    ///   strategy 2 is what actually carries there.</item>
+    /// </list>
+    /// All hits load via <see cref="AssemblyLoadContext.LoadFromAssemblyPath"/> into the default
+    /// context so the loaded assembly satisfies the original reference.
+    /// </para>
+    ///
+    /// <para>
+    /// The hook references ONLY BCL types, so installing it does not itself trigger a load of the very
+    /// assemblies it resolves. It is installed by a <see cref="ModuleInitializerAttribute"/> — the only
+    /// hook that runs before Godot instantiates the <c>EditorPlugin</c> type (whose field/using
+    /// references would otherwise fault during type load, before any plugin method body runs).
+    /// </para>
+    /// </summary>
+    public static class GodotMcpAssemblyResolver
+    {
+        static readonly object _gate = new object();
+        static bool _installed;
+        static AssemblyDependencyResolver? _depsResolver;
+        static string? _probeDirectory;
+        static Dictionary<string, string>? _depsJsonAssemblyPaths;
+
+        /// <summary>
+        /// Installs the resolver as early as physically possible. A module initializer runs once when
+        /// the CLR loads THIS assembly's module — BEFORE any type in the assembly is constructed or any
+        /// method JIT-compiled. That matters: Godot instantiates the <c>EditorPlugin</c> type (whose
+        /// fields/usings reference the NuGet-dependency types) before the plugin's <c>_EnterTree</c>
+        /// body would run, so installing from inside <c>_EnterTree</c> is too late — type load already
+        /// triggers the failing resolution. The module initializer wins that race and references only
+        /// BCL types, so it cannot itself fault on a missing dependency.
+        /// </summary>
+        [ModuleInitializer]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Usage", "CA2255:The 'ModuleInitializer' attribute should not be used in libraries",
+            Justification = "This assembly is host-loaded application code (a Godot editor-plugin " +
+                "assembly), not a reusable library. The module initializer is the only hook that runs " +
+                "before Godot instantiates the EditorPlugin type, which is required to install the " +
+                "dependency resolver before the failing assembly load occurs.")]
+        internal static void ModuleInit()
+        {
+            try
+            {
+                Install(ResolveAnchorAssemblyPath());
+            }
+            catch
+            {
+                // Never let a module initializer throw — that would fail the whole assembly load.
+            }
+        }
+
+        /// <summary>
+        /// Optional sink for diagnostic lines (e.g. <c>GD.Print</c>). The resolver stays free of Godot
+        /// API references so it remains pure-BCL and unit-testable; the editor plugin passes a
+        /// Godot-aware logger in. Null is fine (silent). Note: the module initializer installs the hook
+        /// before any plugin code sets this, so installation itself is silent; resolutions that happen
+        /// after the plugin sets <see cref="Log"/> are surfaced.
+        /// </summary>
+        public static Action<string>? Log { get; set; }
+
+        /// <summary>
+        /// Determine the on-disk path of the project/addon assembly whose sibling <c>*.deps.json</c>
+        /// describes the dependency graph. In the Godot editor the assembly's
+        /// <see cref="Assembly.Location"/> is EMPTY (Godot loads the project assembly from a byte
+        /// stream), so we synthesize the path from <see cref="AppContext.BaseDirectory"/> (which Godot
+        /// points at the build output dir, e.g. <c>.godot/mono/temp/bin/&lt;cfg&gt;/</c>) plus the
+        /// assembly's simple name.
+        /// </summary>
+        static string ResolveAnchorAssemblyPath()
+        {
+            var asm = typeof(GodotMcpAssemblyResolver).Assembly;
+
+            var location = asm.Location;
+            if (!string.IsNullOrEmpty(location) && File.Exists(location))
+                return location;
+
+            var name = asm.GetName().Name;
+            if (!string.IsNullOrEmpty(name))
+            {
+                var candidate = Path.Combine(AppContext.BaseDirectory, name + ".dll");
+                if (File.Exists(candidate))
+                    return candidate;
+            }
+
+            // Last resort: any *.deps.json in the base dir anchors the resolver; pair it with its dll.
+            try
+            {
+                foreach (var deps in Directory.EnumerateFiles(AppContext.BaseDirectory, "*.deps.json"))
+                {
+                    var dll = deps.Substring(0, deps.Length - ".deps.json".Length) + ".dll";
+                    if (File.Exists(dll))
+                        return dll;
+                }
+            }
+            catch
+            {
+                // ignore — fall through to empty
+            }
+
+            return string.Empty;
+        }
+
+        /// <summary>
+        /// Install the default-context resolving hook. Idempotent — safe to call more than once (plugin
+        /// toggled off/on, domain reload). Seeds all three resolution strategies from
+        /// <paramref name="anchorAssemblyPath"/> (the project assembly whose sibling <c>*.deps.json</c>
+        /// describes the graph).
+        /// </summary>
+        public static void Install()
+        {
+            Install(ResolveAnchorAssemblyPath());
+        }
+
+        /// <summary>
+        /// Test/seam-friendly overload: install seeded from an explicit anchor assembly path (the path
+        /// whose sibling <c>*.deps.json</c> describes the dependency graph).
+        /// </summary>
+        /// <param name="anchorAssemblyPath">
+        /// Absolute path to an assembly that has a sibling <c>*.deps.json</c>. May be empty; in that
+        /// case only the directory-probe fallback is available, seeded from
+        /// <see cref="AppContext.BaseDirectory"/>.
+        /// </param>
+        public static void Install(string anchorAssemblyPath)
+        {
+            lock (_gate)
+            {
+                if (_installed)
+                    return;
+
+                if (!string.IsNullOrEmpty(anchorAssemblyPath) && File.Exists(anchorAssemblyPath))
+                {
+                    _probeDirectory = Path.GetDirectoryName(anchorAssemblyPath);
+
+                    try
+                    {
+                        _depsResolver = new AssemblyDependencyResolver(anchorAssemblyPath);
+                    }
+                    catch (Exception ex)
+                    {
+                        Log?.Invoke($"[Godot-MCP] AssemblyDependencyResolver unavailable: {ex.Message}");
+                        _depsResolver = null;
+                    }
+
+                    var depsJsonPath = Path.ChangeExtension(anchorAssemblyPath, ".deps.json");
+                    _depsJsonAssemblyPaths = BuildDepsJsonIndex(depsJsonPath);
+                }
+
+                if (string.IsNullOrEmpty(_probeDirectory))
+                    _probeDirectory = AppContext.BaseDirectory;
+
+                AssemblyLoadContext.Default.Resolving += OnResolving;
+                _installed = true;
+
+                Log?.Invoke($"[Godot-MCP] assembly resolver installed (probe dir: {_probeDirectory}).");
+            }
+        }
+
+        /// <summary>
+        /// Resolve a single assembly name to an existing file path. Exposed for unit testing; returns
+        /// null when no strategy finds a file (the CLR then continues its own resolution / throws as it
+        /// normally would).
+        /// </summary>
+        public static string? ResolvePath(AssemblyName assemblyName)
+        {
+            var simpleName = assemblyName.Name;
+            if (string.IsNullOrEmpty(simpleName))
+                return null;
+
+            // 1) Same-directory probe (copied-beside-the-assembly deployments).
+            var dir = _probeDirectory;
+            if (!string.IsNullOrEmpty(dir))
+            {
+                var candidate = Path.Combine(dir, simpleName + ".dll");
+                if (File.Exists(candidate))
+                    return candidate;
+            }
+
+            // 2) deps.json + NuGet global-packages probe (the path that works in the Godot editor).
+            var index = _depsJsonAssemblyPaths;
+            if (index != null && index.TryGetValue(simpleName, out var fromDeps) && File.Exists(fromDeps))
+                return fromDeps;
+
+            // 3) AssemblyDependencyResolver (best-effort; carries RID-specific assets when a dev.json
+            //    probing config is present — e.g. a plain dotnet host).
+            var depsResolver = _depsResolver;
+            if (depsResolver != null)
+            {
+                try
+                {
+                    var resolved = depsResolver.ResolveAssemblyToPath(assemblyName);
+                    if (!string.IsNullOrEmpty(resolved) && File.Exists(resolved))
+                        return resolved;
+                }
+                catch
+                {
+                    // ignore — nothing more to try
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Parse a <c>*.deps.json</c> into a map of <c>assembly-simple-name → absolute file path</c>,
+        /// resolving each runtime asset against the NuGet global packages folder. Returns null when the
+        /// file is absent/unreadable (callers then rely on the other strategies). Public for unit tests.
+        /// </summary>
+        public static Dictionary<string, string>? BuildDepsJsonIndex(string depsJsonPath)
+        {
+            if (string.IsNullOrEmpty(depsJsonPath) || !File.Exists(depsJsonPath))
+                return null;
+
+            var packageRoots = GetNuGetPackageRoots();
+            var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            try
+            {
+                using var doc = JsonDocument.Parse(File.ReadAllText(depsJsonPath));
+                if (!doc.RootElement.TryGetProperty("targets", out var targets))
+                    return map;
+
+                foreach (var target in targets.EnumerateObject())
+                {
+                    foreach (var library in target.Value.EnumerateObject())
+                    {
+                        // library.Name is "Package/Version" (e.g. "com.IvanMurzak.ReflectorNet/5.3.1").
+                        var slash = library.Name.IndexOf('/');
+                        if (slash <= 0)
+                            continue;
+
+                        var packageId = library.Name.Substring(0, slash);
+                        var version = library.Name.Substring(slash + 1);
+
+                        if (!library.Value.TryGetProperty("runtime", out var runtime))
+                            continue;
+
+                        foreach (var asset in runtime.EnumerateObject())
+                        {
+                            // asset.Name is the relative runtime path, e.g. "lib/net8.0/ReflectorNet.dll".
+                            var relative = asset.Name;
+                            if (!relative.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                                continue;
+
+                            var assemblySimpleName = Path.GetFileNameWithoutExtension(relative);
+                            if (string.IsNullOrEmpty(assemblySimpleName) || map.ContainsKey(assemblySimpleName))
+                                continue;
+
+                            var absolute = LocateInPackageRoots(packageRoots, packageId, version, relative);
+                            if (!string.IsNullOrEmpty(absolute))
+                                map[assemblySimpleName] = absolute!;
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                return map.Count > 0 ? map : null;
+            }
+
+            return map;
+        }
+
+        static string? LocateInPackageRoots(IReadOnlyList<string> packageRoots, string packageId, string version, string relativeRuntimePath)
+        {
+            // NuGet lays packages out lower-cased: <root>/<id.lower>/<version.lower>/<relative>.
+            var idLower = packageId.ToLowerInvariant();
+            var versionLower = version.ToLowerInvariant();
+            var relativeNative = relativeRuntimePath.Replace('/', Path.DirectorySeparatorChar);
+
+            foreach (var root in packageRoots)
+            {
+                if (string.IsNullOrEmpty(root))
+                    continue;
+
+                var candidate = Path.Combine(root, idLower, versionLower, relativeNative);
+                if (File.Exists(candidate))
+                    return candidate;
+            }
+
+            return null;
+        }
+
+        static IReadOnlyList<string> GetNuGetPackageRoots()
+        {
+            var roots = new List<string>();
+
+            var env = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+            if (!string.IsNullOrEmpty(env))
+                roots.Add(env);
+
+            var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            if (!string.IsNullOrEmpty(userProfile))
+                roots.Add(Path.Combine(userProfile, ".nuget", "packages"));
+
+            return roots;
+        }
+
+        static Assembly? OnResolving(AssemblyLoadContext context, AssemblyName assemblyName)
+        {
+            var path = ResolvePath(assemblyName);
+            if (string.IsNullOrEmpty(path))
+                return null;
+
+            try
+            {
+                var loaded = AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
+                Log?.Invoke($"[Godot-MCP] resolved '{assemblyName.Name}' -> {path}");
+                return loaded;
+            }
+            catch (Exception ex)
+            {
+                Log?.Invoke($"[Godot-MCP] failed to load '{assemblyName.Name}' from {path}: {ex.Message}");
+                return null;
+            }
+        }
+    }
+}

--- a/addons/godot_mcp/GodotMcpPlugin.cs
+++ b/addons/godot_mcp/GodotMcpPlugin.cs
@@ -9,6 +9,7 @@
 */
 #if TOOLS
 #nullable enable
+using System.Runtime.CompilerServices;
 using Godot;
 using com.IvanMurzak.Godot.MCP.Connection;
 using com.IvanMurzak.Godot.MCP.MainThreadDispatch;
@@ -36,6 +37,16 @@ namespace com.IvanMurzak.Godot.MCP
 
         public override void _EnterTree()
         {
+            // FIRST: teach the editor's default AssemblyLoadContext how to find the addon's transitive
+            // NuGet dependency assemblies (ReflectorNet / McpPlugin / ...). Godot does not probe the
+            // project's *.deps.json, so without this hook the first touch of a NuGet-dependency type
+            // throws FileNotFoundException at runtime. The resolver references only BCL types, so
+            // installing it here does NOT prematurely load the very assemblies it resolves — it must
+            // run before any code path (BootMcp below) reaches a NuGet-dependency type. See
+            // GodotMcpAssemblyResolver for the full rationale.
+            GodotMcpAssemblyResolver.Log = msg => GD.Print(msg);
+            GodotMcpAssemblyResolver.Install();
+
             // Pump for off-thread → main-thread work. Added as a child of this EditorPlugin Node so it
             // lives in the editor SceneTree and gets _Process ticks for the lifetime of the plugin.
             _dispatcher = new MainThreadDispatcher { Name = DispatcherNodeName };
@@ -46,9 +57,19 @@ namespace com.IvanMurzak.Godot.MCP
 
             GD.Print("[Godot-MCP] plugin loaded");
 
-            // Boot the MCP connection (after the dispatcher is installed so tool handlers can marshal
-            // onto the main thread). Reuses the McpPlugin SignalR client + bearer auth; mode/URL/token
-            // come from GodotMcpConfig (env-overridable). Failures here must not break plugin load.
+            BootMcp();
+        }
+
+        /// <summary>
+        /// Boot the MCP connection. Isolated in its own non-inlined method so the JIT does not resolve
+        /// the NuGet-dependency types it references until AFTER <see cref="GodotMcpAssemblyResolver"/>
+        /// has been installed by <see cref="_EnterTree"/>. (Type references are resolved when a method
+        /// is JIT-compiled; keeping this out of <c>_EnterTree</c> guarantees the resolver wins the race.)
+        /// Failures here must not break plugin load — the catch keeps the editor usable.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void BootMcp()
+        {
             try
             {
                 _connection = new GodotMcpConnection();


### PR DESCRIPTION
## Summary
- The Godot editor's default `AssemblyLoadContext` does not probe the project's `*.deps.json`, and Godot emits no `*.runtimeconfig.dev.json` (NuGet probing paths) beside the built assembly — so the first editor-runtime touch of a transitive NuGet dep threw `FileNotFoundException: Could not load file or assembly 'ReflectorNet, Version=5.3.1.0'`, leaving the plugin non-functional past its boot log.
- Adds `GodotMcpAssemblyResolver` — a pure-BCL `AssemblyLoadContext.Default.Resolving` hook installed from a `[ModuleInitializer]` (the only point early enough; `EditorPlugin` type load faults before `_EnterTree` would run). It resolves misses via same-dir probe → `*.deps.json` + NuGet global-packages lookup (the strategy that carries in the editor) → `AssemblyDependencyResolver` fallback. Works for the testbed **and** any consumer project that `PackageReference`s the same libs.
- NuGet pins unchanged (frozen). Documents the fix, consumer-install story, and headless testbed runbook in `CLAUDE.md`.

## Verification (observed, headless — Godot 4.5.1 mono)
- Clean editor boot: `[Godot-MCP] plugin loaded` + `[Godot-MCP] resolved '<dep>' -> <nuget-cache-path>` for the whole graph, **no FileNotFoundException**.
- Live connect (Custom mode → local MCP-Plugin-dotnet DemoWebApp on `:5300`): `[Godot-MCP] connected.`; server log `Version handshake successful. Plugin: 0.1.0, API: 2.0.0, Environment: Godot 4.5.1-stable`.
- Live `ping` round-trip: `POST /api/tools/ping {}` → `{"status":"success","structured":{"result":"pong"}}`; with a message → echoes it back.

## Test plan
- [x] `dotnet build Godot-MCP.sln -c Debug` — 0 errors / 0 warnings.
- [x] `dotnet test Godot-MCP.Tests` — 60 passed (9 new pure-BCL resolver tests).
- [x] Headless editor clean-boot + live connect + `ping`→`pong` (above).

Closes #6