### PR TITLE
feat: scene + node tools (create/find/modify/reparent/duplicate/delete, scene open/save/create)

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -48,6 +48,15 @@
          no Godot native types — so it is unit-testable in this plain-xUnit host. -->
     <Compile Include="..\addons\godot_mcp\Connection\GodotMcpAssemblyResolver.cs" Link="Source\GodotMcpAssemblyResolver.cs" />
     <Compile Include="..\addons\godot_mcp\Tools\Tool_Ping.cs" Link="Source\Tool_Ping.cs" />
+    <!-- Scene/Node tool family — pure-managed pieces only (no Godot native types, no #if TOOLS):
+         structured result models, the property-patch model, the path normalizer, and the ambient
+         reflector accessor. The editor-driving tool methods (Tool_Node.*.cs / Tool_Scene.*.cs) are
+         #if TOOLS and verified via the headless Godot smoke (test.md Suite 3), not here. -->
+    <Compile Include="..\addons\godot_mcp\Data\NodeData.cs" Link="Source\NodeData.cs" />
+    <Compile Include="..\addons\godot_mcp\Data\SceneData.cs" Link="Source\SceneData.cs" />
+    <Compile Include="..\addons\godot_mcp\Data\NodePropertyPatch.cs" Link="Source\NodePropertyPatch.cs" />
+    <Compile Include="..\addons\godot_mcp\Tools\NodePathNormalizer.cs" Link="Source\NodePathNormalizer.cs" />
+    <Compile Include="..\addons\godot_mcp\Reflection\GodotMcpReflector.cs" Link="Source\GodotMcpReflector.cs" />
   </ItemGroup>
 
 </Project>

--- a/Godot-MCP.Tests/SceneNodeToolTests.cs
+++ b/Godot-MCP.Tests/SceneNodeToolTests.cs
@@ -159,6 +159,14 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         [InlineData("Player/Weapon", "Main", "Player/Weapon")]
         // Whitespace is trimmed.
         [InlineData("  Main/Player  ", "Main", "Player")]
+        // Bare slash and bare '/root/' (no segment after the prefix) normalize to empty — ResolveNode
+        // then treats empty as the edited root (documented degenerate-input behavior).
+        [InlineData("/", "Main", "")]
+        [InlineData("/root/", "Main", "")]
+        // A root NAME that is a PREFIX of (not equal to) the first segment must NOT be stripped: root
+        // "Main" + "MainMenu/X" keeps "MainMenu/X" (the trailing-'/' guard prevents a prefix false-match).
+        [InlineData("MainMenu/X", "Main", "MainMenu/X")]
+        [InlineData("/root/MainMenu/X", "Main", "MainMenu/X")]
         public void NodePathNormalizer_Normalizes(string raw, string rootName, string expected)
         {
             Assert.Equal(expected, NodePathNormalizer.Normalize(raw, rootName));

--- a/Godot-MCP.Tests/SceneNodeToolTests.cs
+++ b/Godot-MCP.Tests/SceneNodeToolTests.cs
@@ -1,0 +1,210 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Collections.Generic;
+using System.Text.Json;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.Godot.MCP.Reflection;
+using com.IvanMurzak.Godot.MCP.Tools;
+using com.IvanMurzak.ReflectorNet;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pure-managed coverage for the scene/node tool family: the structured result models
+    /// (<see cref="NodeData"/>, <see cref="SceneData"/>), the property-patch model
+    /// (<see cref="NodePropertyPatch"/>), the scene-tree path normalizer
+    /// (<see cref="NodePathNormalizer"/>), and the ambient reflector accessor
+    /// (<see cref="GodotMcpReflector"/>). None of these touch a live Godot SceneTree, so they run in the
+    /// plain xUnit host with no Godot binary. The editor-driving handlers themselves (<c>#if TOOLS</c>)
+    /// are verified by the headless Godot smoke (test.md Suite 3).
+    /// </summary>
+    public class SceneNodeToolTests
+    {
+        // ---- NodeData ----------------------------------------------------------------------------
+
+        [Fact]
+        public void NodeData_Serializes_WithExpectedJsonNames()
+        {
+            var data = new NodeData
+            {
+                InstanceId = 42ul,
+                Name = "Player",
+                Path = "/root/Main/Player",
+                Type = "CharacterBody3D",
+                ScriptResourcePath = "res://player.gd",
+                ChildCount = 2,
+            };
+
+            var json = JsonSerializer.Serialize(data);
+
+            Assert.Contains("\"instanceId\"", json);
+            Assert.Contains("\"name\"", json);
+            Assert.Contains("\"path\"", json);
+            Assert.Contains("\"type\"", json);
+            Assert.Contains("\"scriptResourcePath\"", json);
+            Assert.Contains("\"childCount\"", json);
+
+            var restored = JsonSerializer.Deserialize<NodeData>(json);
+            Assert.NotNull(restored);
+            Assert.Equal(42ul, restored!.InstanceId);
+            Assert.Equal("Player", restored.Name);
+            Assert.Equal("CharacterBody3D", restored.Type);
+            Assert.Equal("res://player.gd", restored.ScriptResourcePath);
+            Assert.Equal(2, restored.ChildCount);
+            Assert.Null(restored.Children);
+        }
+
+        [Fact]
+        public void NodeData_RoundTrips_WithChildrenHierarchy()
+        {
+            var data = new NodeData
+            {
+                Name = "Main",
+                Type = "Node",
+                ChildCount = 1,
+                Children = new List<NodeData>
+                {
+                    new NodeData { Name = "Child", Type = "Node2D", ChildCount = 0 },
+                },
+            };
+
+            var json = JsonSerializer.Serialize(data);
+            var restored = JsonSerializer.Deserialize<NodeData>(json);
+
+            Assert.NotNull(restored);
+            Assert.NotNull(restored!.Children);
+            Assert.Single(restored.Children!);
+            Assert.Equal("Child", restored.Children![0].Name);
+            Assert.Equal("Node2D", restored.Children[0].Type);
+        }
+
+        // ---- SceneData ---------------------------------------------------------------------------
+
+        [Fact]
+        public void SceneData_Serializes_WithExpectedJsonNames()
+        {
+            var data = new SceneData
+            {
+                ResourcePath = "res://levels/level_1.tscn",
+                RootName = "Level1",
+                RootInstanceId = 7ul,
+                IsActive = true,
+            };
+
+            var json = JsonSerializer.Serialize(data);
+
+            Assert.Contains("\"resourcePath\"", json);
+            Assert.Contains("\"rootName\"", json);
+            Assert.Contains("\"rootInstanceId\"", json);
+            Assert.Contains("\"isActive\"", json);
+
+            var restored = JsonSerializer.Deserialize<SceneData>(json);
+            Assert.NotNull(restored);
+            Assert.Equal("res://levels/level_1.tscn", restored!.ResourcePath);
+            Assert.Equal("Level1", restored.RootName);
+            Assert.Equal(7ul, restored.RootInstanceId);
+            Assert.True(restored.IsActive);
+        }
+
+        [Fact]
+        public void SceneData_AllowsNullPath_ForUnsavedScene()
+        {
+            var data = new SceneData { ResourcePath = null, RootName = "New", IsActive = true };
+            var json = JsonSerializer.Serialize(data);
+            var restored = JsonSerializer.Deserialize<SceneData>(json);
+            Assert.NotNull(restored);
+            Assert.Null(restored!.ResourcePath);
+            Assert.Equal("New", restored.RootName);
+        }
+
+        // ---- NodePropertyPatch -------------------------------------------------------------------
+
+        [Fact]
+        public void NodePropertyPatch_RoundTrips_PathAndName()
+        {
+            var patch = new NodePropertyPatch { Path = "position/[0]" };
+            var json = JsonSerializer.Serialize(patch);
+
+            Assert.Contains("\"path\"", json);
+            Assert.Contains("\"value\"", json);
+
+            var restored = JsonSerializer.Deserialize<NodePropertyPatch>(json);
+            Assert.NotNull(restored);
+            Assert.Equal("position/[0]", restored!.Path);
+        }
+
+        // ---- NodePathNormalizer ------------------------------------------------------------------
+
+        [Theory]
+        // Absolute '/root/<Root>/...' forms reduce to a root-relative child path.
+        [InlineData("/root/Main/Player", "Main", "Player")]
+        [InlineData("/root/Main/Player/Weapon", "Main", "Player/Weapon")]
+        // Leading single slash is stripped.
+        [InlineData("/Main/Player", "Main", "Player")]
+        // Root-prefixed (no /root/) forms strip the root segment.
+        [InlineData("Main/Player", "Main", "Player")]
+        // The root segment alone resolves to '.' (the root itself).
+        [InlineData("/root/Main", "Main", ".")]
+        [InlineData("Main", "Main", ".")]
+        // A path that does not name the root is left root-relative as-is.
+        [InlineData("Player/Weapon", "Main", "Player/Weapon")]
+        // Whitespace is trimmed.
+        [InlineData("  Main/Player  ", "Main", "Player")]
+        public void NodePathNormalizer_Normalizes(string raw, string rootName, string expected)
+        {
+            Assert.Equal(expected, NodePathNormalizer.Normalize(raw, rootName));
+        }
+
+        [Fact]
+        public void NodePathNormalizer_HandlesNullAndEmpty()
+        {
+            Assert.Equal(string.Empty, NodePathNormalizer.Normalize(string.Empty, "Main"));
+            Assert.Equal(string.Empty, NodePathNormalizer.Normalize(null!, "Main"));
+        }
+
+        // ---- GodotMcpReflector -------------------------------------------------------------------
+
+        [Fact]
+        public void GodotMcpReflector_GetOrCreate_FallsBack_WhenNoCurrent()
+        {
+            var saved = GodotMcpReflector.Current;
+            try
+            {
+                GodotMcpReflector.Current = null;
+                var reflector = GodotMcpReflector.GetOrCreate();
+                Assert.NotNull(reflector);
+                // The fallback is NOT cached into Current (the connection remains the sole owner).
+                Assert.Null(GodotMcpReflector.Current);
+            }
+            finally
+            {
+                GodotMcpReflector.Current = saved;
+            }
+        }
+
+        [Fact]
+        public void GodotMcpReflector_GetOrCreate_ReturnsCurrent_WhenSet()
+        {
+            var saved = GodotMcpReflector.Current;
+            try
+            {
+                var mine = new Reflector();
+                GodotMcpReflector.Current = mine;
+                Assert.Same(mine, GodotMcpReflector.GetOrCreate());
+            }
+            finally
+            {
+                GodotMcpReflector.Current = saved;
+            }
+        }
+    }
+}

--- a/addons/godot_mcp/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConnection.cs
@@ -48,6 +48,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
         readonly GodotMcpConfig _config;
         IMcpPlugin? _plugin;
+        Reflector? _publishedReflector;
 
         /// <summary>The active config (resolved Host/Token/mode are read live off this).</summary>
         public GodotMcpConfig Config => _config;
@@ -74,6 +75,11 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             }
 
             Reflector reflector = GodotReflectorFactory.CreateDefaultReflector();
+
+            // Publish the connection's reflector as the ambient one so tool handlers (e.g. node-modify)
+            // share the exact converter set registered here instead of building their own.
+            GodotMcpReflector.Current = reflector;
+            _publishedReflector = reflector;
 
             var version = new McpVersion
             {
@@ -123,6 +129,12 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
         public void Dispose()
         {
+            // Clear the ambient reflector if it is the one we published, so a stale instance does not
+            // outlive the connection that owned it.
+            if (ReferenceEquals(GodotMcpReflector.Current, _publishedReflector))
+                GodotMcpReflector.Current = null;
+            _publishedReflector = null;
+
             if (_plugin != null)
             {
                 try

--- a/addons/godot_mcp/Data/NodeData.cs
+++ b/addons/godot_mcp/Data/NodeData.cs
@@ -1,0 +1,73 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.Godot.MCP.Data
+{
+    /// <summary>
+    /// Structured, engine-agnostic snapshot of a Godot <see cref="global::Godot.Node"/> returned by the
+    /// node tool family (the Godot analog of Unity-MCP's <c>GameObjectData</c>). Holds no live
+    /// <see cref="global::Godot.Node"/> handle — it is built on the main thread from a resolved node and
+    /// then serialized off the main thread, so it touches no Godot native object once constructed.
+    ///
+    /// <para>
+    /// Godot has no Unity-style <c>Component</c> concept: a node IS its type plus its built-in properties
+    /// plus an optional attached script. So <see cref="Type"/> carries the node's class name (e.g.
+    /// <c>"Node3D"</c>) and <see cref="ScriptResourcePath"/> carries the <c>res://</c> path of the
+    /// attached script if any — together they model what a Unity GameObject would express as a list of
+    /// components.
+    /// </para>
+    ///
+    /// Pure-managed (no Godot API surface, no <c>#if TOOLS</c>), so it is unit-testable in the plain
+    /// xUnit host.
+    /// </summary>
+    [System.Serializable]
+    [Description("Structured snapshot of a Godot Node: identity (instanceId/name/path), type, optional " +
+        "attached-script path, child count, and optional children.")]
+    public class NodeData
+    {
+        [JsonInclude, JsonPropertyName("instanceId")]
+        [Description("Instance id of the Node (Godot GodotObject.GetInstanceId()). Stable identity within the session.")]
+        public ulong InstanceId { get; set; } = 0;
+
+        [JsonInclude, JsonPropertyName("name")]
+        [Description("Node name (the last segment of its scene-tree path).")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonInclude, JsonPropertyName("path")]
+        [Description("Absolute scene-tree path of the Node, e.g. '/root/Main/Player'.")]
+        public string Path { get; set; } = string.Empty;
+
+        [JsonInclude, JsonPropertyName("type")]
+        [Description("Godot class name of the Node, e.g. 'Node3D', 'Sprite2D'. The Godot analog of a Unity component set.")]
+        public string Type { get; set; } = string.Empty;
+
+        [JsonInclude, JsonPropertyName("scriptResourcePath")]
+        [Description("res:// path of the script attached to the Node, or null when no script is attached.")]
+        public string? ScriptResourcePath { get; set; } = null;
+
+        [JsonInclude, JsonPropertyName("childCount")]
+        [Description("Number of direct children of the Node (excluding internal children).")]
+        public int ChildCount { get; set; } = 0;
+
+        [JsonInclude, JsonPropertyName("children")]
+        [Description("Direct/recursive children, populated only when a hierarchy depth > 0 was requested. " +
+            "Null when no hierarchy was requested.")]
+        public List<NodeData>? Children { get; set; } = null;
+
+        public NodeData() { }
+
+        public override string ToString()
+            => $"Node '{Name}' ({Type}) instanceId={InstanceId} path='{Path}'";
+    }
+}

--- a/addons/godot_mcp/Data/NodePropertyPatch.cs
+++ b/addons/godot_mcp/Data/NodePropertyPatch.cs
@@ -1,0 +1,42 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+using com.IvanMurzak.ReflectorNet.Model;
+
+namespace com.IvanMurzak.Godot.MCP.Data
+{
+    /// <summary>
+    /// A single path-scoped property patch consumed by <c>node-modify</c> and routed through
+    /// ReflectorNet's <c>Reflector.TryModifyAt(ref obj, path, SerializedMember value, ...)</c>. The Godot
+    /// analog of Unity-MCP's per-GameObject path-patch entry, narrowed to a plain <c>{path, value}</c>
+    /// pair where <see cref="Value"/> is a ReflectorNet <see cref="SerializedMember"/> describing the new
+    /// value at <see cref="Path"/>.
+    ///
+    /// Pure data (no Godot API), so it (de)serializes off the main thread and is unit-testable in the
+    /// plain xUnit host.
+    /// </summary>
+    [System.Serializable]
+    [Description("A path-scoped property patch: 'path' locates the member, 'value' carries the new value " +
+        "as a ReflectorNet SerializedMember. Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'.")]
+    public class NodePropertyPatch
+    {
+        [JsonInclude, JsonPropertyName("path")]
+        [Description("Path to the member to modify. Syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. Leading '#/' is stripped.")]
+        public string Path { get; set; } = string.Empty;
+
+        [JsonInclude, JsonPropertyName("value")]
+        [Description("New value for the member, as a ReflectorNet SerializedMember.")]
+        public SerializedMember? Value { get; set; } = null;
+
+        public NodePropertyPatch() { }
+    }
+}

--- a/addons/godot_mcp/Data/SceneData.cs
+++ b/addons/godot_mcp/Data/SceneData.cs
@@ -1,0 +1,52 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.Godot.MCP.Data
+{
+    /// <summary>
+    /// Shallow, structured snapshot of an open Godot scene (the Godot analog of Unity-MCP's
+    /// <c>SceneDataShallow</c>). A Godot "scene" is a <see cref="global::Godot.PackedScene"/> on disk
+    /// whose instanced root <see cref="global::Godot.Node"/> is edited in the editor; this model
+    /// captures the scene's <c>res://</c> path, root-node identity, and whether it is the editor's
+    /// currently-edited (active) scene.
+    ///
+    /// Pure-managed (no Godot API surface, no <c>#if TOOLS</c>), so it is unit-testable in the plain
+    /// xUnit host.
+    /// </summary>
+    [System.Serializable]
+    [Description("Shallow snapshot of an open Godot scene: res:// path, root-node name/instanceId, and " +
+        "whether it is the editor's active (edited) scene.")]
+    public class SceneData
+    {
+        [JsonInclude, JsonPropertyName("resourcePath")]
+        [Description("res:// path of the scene's .tscn file, or null for an unsaved/new scene.")]
+        public string? ResourcePath { get; set; } = null;
+
+        [JsonInclude, JsonPropertyName("rootName")]
+        [Description("Name of the scene's root Node, or null when the scene has no root yet.")]
+        public string? RootName { get; set; } = null;
+
+        [JsonInclude, JsonPropertyName("rootInstanceId")]
+        [Description("Instance id of the scene's root Node (0 when no root / not currently instanced in the editor).")]
+        public ulong RootInstanceId { get; set; } = 0;
+
+        [JsonInclude, JsonPropertyName("isActive")]
+        [Description("True when this scene is the editor's currently-edited (active) scene.")]
+        public bool IsActive { get; set; } = false;
+
+        public SceneData() { }
+
+        public override string ToString()
+            => $"Scene '{ResourcePath ?? "(unsaved)"}' root='{RootName}' active={IsActive}";
+    }
+}

--- a/addons/godot_mcp/Reflection/GodotMcpReflector.cs
+++ b/addons/godot_mcp/Reflection/GodotMcpReflector.cs
@@ -1,0 +1,50 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using com.IvanMurzak.ReflectorNet;
+
+namespace com.IvanMurzak.Godot.MCP.Reflection
+{
+    /// <summary>
+    /// Ambient accessor for the process-wide <see cref="Reflector"/> that the MCP connection built
+    /// (with the Godot type converters registered). The Godot analog of Unity-MCP's
+    /// <c>UnityMcpPluginEditor.Instance.Reflector</c>.
+    ///
+    /// <para>
+    /// Tool handlers that need a reflector at call time — e.g. <c>node-modify</c>, which routes through
+    /// <c>Reflector.TryModify</c>/<c>TryModifyAt</c>/<c>TryPatch</c> — read <see cref="Current"/> rather
+    /// than constructing a fresh reflector, so they share the exact converter set the connection
+    /// registered. <see cref="GodotMcpConnection.Start"/> assigns <see cref="Current"/> when it builds
+    /// the plugin reflector; if a handler runs before a connection exists (e.g. a direct unit call),
+    /// <see cref="GetOrCreate"/> falls back to a freshly-built default reflector so the tool layer never
+    /// hard-depends on the editor lifecycle.
+    /// </para>
+    ///
+    /// This is engine-runtime code (no Godot editor API, no <c>#if TOOLS</c>), so it is unit-testable in
+    /// the plain xUnit host.
+    /// </summary>
+    public static class GodotMcpReflector
+    {
+        /// <summary>
+        /// The reflector the active connection built, or <c>null</c> before <see cref="GodotMcpConnection.Start"/>
+        /// has run / after the connection was disposed.
+        /// </summary>
+        public static Reflector? Current { get; set; }
+
+        /// <summary>
+        /// Return <see cref="Current"/> when set, otherwise a freshly-built default reflector (with the
+        /// Godot converters registered). Never returns <c>null</c>, so tool handlers can call it without
+        /// a null-guard. Does NOT cache the fallback into <see cref="Current"/> — the connection remains
+        /// the single owner of the shared instance.
+        /// </summary>
+        public static Reflector GetOrCreate()
+            => Current ?? GodotReflectorFactory.CreateDefaultReflector();
+    }
+}

--- a/addons/godot_mcp/Tools/NodePathNormalizer.cs
+++ b/addons/godot_mcp/Tools/NodePathNormalizer.cs
@@ -1,0 +1,57 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// Pure-string normalization of a user-supplied scene-tree path into a form resolvable against the
+    /// edited-scene root via <c>Node.GetNodeOrNull</c>. Extracted from <c>Tool_Node</c> (which is
+    /// editor-only, <c>#if TOOLS</c>) so the path logic — the part most prone to off-by-one slash bugs —
+    /// is unit-testable in the plain xUnit host without a live Godot scene tree.
+    ///
+    /// <para>
+    /// Godot's editor SceneTree window roots open scenes under <c>/root/</c>; the edited scene's own root
+    /// is a child of that window. <c>GetNodeOrNull</c> on the edited root resolves paths RELATIVE to the
+    /// root (it does not resolve the root itself). So this normalizer strips a leading <c>/root/</c> or
+    /// <c>/</c>, and — when the remaining path names the root segment — reduces it to <c>"."</c> (meaning
+    /// "the root itself") or strips the root segment so the remainder is root-relative.
+    /// </para>
+    /// </summary>
+    public static class NodePathNormalizer
+    {
+        /// <summary>
+        /// Normalize <paramref name="rawPath"/> against an edited root named <paramref name="editedRootName"/>.
+        /// Returns <c>"."</c> when the path denotes the root itself, or a root-relative child path otherwise.
+        /// </summary>
+        public static string Normalize(string rawPath, string editedRootName)
+        {
+            var path = (rawPath ?? string.Empty).Trim();
+
+            // Strip a leading '/root/' (the SceneTree window) — the edited scene root is a child of it.
+            const string rootPrefix = "/root/";
+            if (path.StartsWith(rootPrefix, StringComparison.Ordinal))
+                path = path.Substring(rootPrefix.Length);
+            else if (path.StartsWith("/", StringComparison.Ordinal))
+                path = path.Substring(1);
+
+            // If the path now starts with the edited root's own name, strip that segment so the remainder
+            // is relative to the root (GetNodeOrNull resolves children, not the root itself).
+            if (path == editedRootName)
+                return ".";
+            var rootSlash = editedRootName + "/";
+            if (path.StartsWith(rootSlash, StringComparison.Ordinal))
+                path = path.Substring(rootSlash.Length);
+
+            return path;
+        }
+    }
+}

--- a/addons/godot_mcp/Tools/NodePathNormalizer.cs
+++ b/addons/godot_mcp/Tools/NodePathNormalizer.cs
@@ -31,6 +31,12 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         /// <summary>
         /// Normalize <paramref name="rawPath"/> against an edited root named <paramref name="editedRootName"/>.
         /// Returns <c>"."</c> when the path denotes the root itself, or a root-relative child path otherwise.
+        /// <para>
+        /// Note: a bare <c>"/"</c> or <c>"/root/"</c> (no segment after the prefix) normalizes to the empty
+        /// string. <c>ResolveNode</c> treats an empty/<c>"."</c> result as the edited scene root, so these
+        /// degenerate inputs resolve to the root rather than erroring — callers that pass a bare slash get
+        /// the root, by design.
+        /// </para>
         /// </summary>
         public static string Normalize(string rawPath, string editedRootName)
         {

--- a/addons/godot_mcp/Tools/Tool_Node.Create.cs
+++ b/addons/godot_mcp/Tools/Tool_Node.Create.cs
@@ -55,9 +55,10 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 var root = EditorInterface.Singleton.GetEditedSceneRoot()
                     ?? throw new Exception("No scene is currently being edited; open or create a scene first.");
 
-                // Resolve the parent (default: edited scene root).
+                // Resolve the parent (default: edited scene root). An explicit parentNodeRef must resolve
+                // (and throws when it does not) — only a genuinely-null ref falls back to the scene root.
                 Node parent = root;
-                if (parentNodeRef != null && parentNodeRef.IsValid(out _))
+                if (parentNodeRef != null)
                 {
                     parent = ResolveNode(parentNodeRef, out var parentError)
                         ?? throw new ArgumentException(parentError ?? "Parent node not found.", nameof(parentNodeRef));

--- a/addons/godot_mcp/Tools/Tool_Node.Create.cs
+++ b/addons/godot_mcp/Tools/Tool_Node.Create.cs
@@ -1,0 +1,130 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Node
+    {
+        public const string NodeCreateToolId = "node-create";
+
+        [AiTool
+        (
+            NodeCreateToolId,
+            Title = "Node / Create"
+        )]
+        [Description("Create a new Node in the currently edited Godot scene and return its structured data. " +
+            "Three creation modes (choose exactly one):\n" +
+            "  1. Empty/typed — pass 'typeClassName' (a Godot class like 'Node3D', 'Sprite2D', 'Node'). " +
+            "Defaults to 'Node' when omitted.\n" +
+            "  2. Instanced scene — pass 'instanceScenePath' (a res:// path to a .tscn/.scn PackedScene); " +
+            "the scene is instanced and added as a child.\n" +
+            "When both are supplied, 'instanceScenePath' wins. " +
+            "Optionally pass 'parentNodeRef' to parent the new Node (defaults to the edited scene root) and " +
+            "'name' to rename it. The new Node's owner is set to the edited scene root so it is saved with the scene.")]
+        public NodeData Create
+        (
+            [Description("Name for the new Node. When omitted, Godot's default name for the type is used.")]
+            string? name = null,
+            [Description("Godot class name to instantiate (e.g. 'Node3D', 'Sprite2D', 'Node'). Used when " +
+                "'instanceScenePath' is not provided. Defaults to 'Node'.")]
+            string? typeClassName = null,
+            [Description("res:// path to a PackedScene (.tscn/.scn) to instance as the new Node. Takes " +
+                "precedence over 'typeClassName' when both are supplied.")]
+            string? instanceScenePath = null,
+            [Description("Reference to the parent Node. When omitted, the Node is parented to the edited scene root.")]
+            NodeRef? parentNodeRef = null
+        )
+        {
+            return MainThread.Instance.Run(() =>
+            {
+                var root = EditorInterface.Singleton.GetEditedSceneRoot()
+                    ?? throw new Exception("No scene is currently being edited; open or create a scene first.");
+
+                // Resolve the parent (default: edited scene root).
+                Node parent = root;
+                if (parentNodeRef != null && parentNodeRef.IsValid(out _))
+                {
+                    parent = ResolveNode(parentNodeRef, out var parentError)
+                        ?? throw new ArgumentException(parentError ?? "Parent node not found.", nameof(parentNodeRef));
+                }
+
+                // Build the node: instanced scene takes precedence over typed instantiation.
+                Node node;
+                if (!string.IsNullOrEmpty(instanceScenePath))
+                {
+                    if (!ResourceLoader.Exists(instanceScenePath))
+                        throw new ArgumentException($"No resource exists at '{instanceScenePath}'.", nameof(instanceScenePath));
+
+                    var packed = ResourceLoader.Load<PackedScene>(instanceScenePath)
+                        ?? throw new ArgumentException($"Resource at '{instanceScenePath}' is not a PackedScene.", nameof(instanceScenePath));
+
+                    node = packed.Instantiate()
+                        ?? throw new Exception($"Failed to instantiate PackedScene '{instanceScenePath}'.");
+                }
+                else
+                {
+                    var className = string.IsNullOrEmpty(typeClassName) ? "Node" : typeClassName!;
+                    if (!ClassDB.ClassExists(className))
+                        throw new ArgumentException($"Unknown Godot class '{className}'.", nameof(typeClassName));
+                    if (!ClassDB.CanInstantiate(className))
+                        throw new ArgumentException($"Godot class '{className}' cannot be instantiated (abstract/virtual).", nameof(typeClassName));
+
+                    var instance = ClassDB.Instantiate(className).As<Node>()
+                        ?? throw new ArgumentException($"Godot class '{className}' did not instantiate to a Node.", nameof(typeClassName));
+                    node = instance;
+                }
+
+                if (!string.IsNullOrEmpty(name))
+                    node.Name = name;
+
+                parent.AddChild(node);
+
+                // Owner must be the edited scene root for the node (and its sub-tree) to be persisted on save.
+                node.Owner = root;
+                SetOwnerRecursive(node, root);
+
+                EditorInterface.Singleton.MarkSceneAsUnsaved();
+                EditorInterface.Singleton.EditNode(node);
+
+                return ToNodeData(node);
+            });
+        }
+
+        /// <summary>
+        /// Set the scene-root owner on a node's descendants so an instanced sub-tree is saved inline with
+        /// the scene. Skips descendants that already have an owner (e.g. nodes internal to an instanced
+        /// PackedScene that should remain owned by their own scene). Main-thread only.
+        /// </summary>
+        static void SetOwnerRecursive(Node node, Node owner)
+        {
+            var count = node.GetChildCount(includeInternal: false);
+            for (int i = 0; i < count; i++)
+            {
+                var child = node.GetChild(i, includeInternal: false);
+                if (child == null)
+                    continue;
+                if (child.Owner == null)
+                {
+                    child.Owner = owner;
+                    SetOwnerRecursive(child, owner);
+                }
+            }
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Node.Delete.cs
+++ b/addons/godot_mcp/Tools/Tool_Node.Delete.cs
@@ -1,0 +1,69 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Node
+    {
+        public const string NodeDeleteToolId = "node-delete";
+
+        [AiTool
+        (
+            NodeDeleteToolId,
+            Title = "Node / Delete"
+        )]
+        [Description("Delete a Node (and all of its children) from the currently edited Godot scene. " +
+            "Identify the Node with 'nodeRef'. The Node is removed from its parent and freed immediately " +
+            "(synchronous free, required for editor-mode edits). Returns the deleted Node's identity " +
+            "(instanceId, name, path) for confirmation.")]
+        public NodeData Delete
+        (
+            [Description("Reference to the Node to delete (instanceId preferred, else scene-tree path).")]
+            NodeRef nodeRef
+        )
+        {
+            return MainThread.Instance.Run(() =>
+            {
+                var root = EditorInterface.Singleton.GetEditedSceneRoot()
+                    ?? throw new Exception("No scene is currently being edited.");
+
+                var node = ResolveNode(nodeRef, out var error)
+                    ?? throw new ArgumentException(error ?? "Node not found.", nameof(nodeRef));
+
+                if (node == root)
+                    throw new ArgumentException("Cannot delete the scene root Node; close or replace the scene instead.", nameof(nodeRef));
+
+                // Snapshot identity BEFORE freeing — the live handle is invalid afterwards.
+                var deleted = ToNodeData(node);
+
+                var parent = node.GetParent();
+                parent?.RemoveChild(node);
+
+                // Editor-mode deletes must be immediate (QueueFree defers to the next idle frame, which
+                // never ticks deterministically under a headless/tool-driven flow). Node.Free() frees the
+                // node and its whole sub-tree synchronously.
+                node.Free();
+
+                EditorInterface.Singleton.MarkSceneAsUnsaved();
+
+                return deleted;
+            });
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Node.Duplicate.cs
+++ b/addons/godot_mcp/Tools/Tool_Node.Duplicate.cs
@@ -1,0 +1,75 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Node
+    {
+        public const string NodeDuplicateToolId = "node-duplicate";
+
+        [AiTool
+        (
+            NodeDuplicateToolId,
+            Title = "Node / Duplicate"
+        )]
+        [Description("Duplicate a Node (and its whole sub-tree) in the currently edited Godot scene via " +
+            "Godot's Node.Duplicate, adding the copy as a sibling under the same parent. Identify the source " +
+            "with 'nodeRef'. Optionally pass 'name' to rename the duplicate. Returns the new Node's structured data.")]
+        public NodeData Duplicate
+        (
+            [Description("Reference to the Node to duplicate (instanceId preferred, else scene-tree path).")]
+            NodeRef nodeRef,
+            [Description("Optional name for the duplicate. When omitted, Godot assigns a unique sibling name.")]
+            string? name = null
+        )
+        {
+            return MainThread.Instance.Run(() =>
+            {
+                var root = EditorInterface.Singleton.GetEditedSceneRoot()
+                    ?? throw new Exception("No scene is currently being edited.");
+
+                var node = ResolveNode(nodeRef, out var error)
+                    ?? throw new ArgumentException(error ?? "Node not found.", nameof(nodeRef));
+
+                if (node == root)
+                    throw new ArgumentException("Cannot duplicate the scene root Node.", nameof(nodeRef));
+
+                var parent = node.GetParent()
+                    ?? throw new Exception($"Node '{node.Name}' has no parent; cannot place a duplicate.");
+
+                var duplicate = node.Duplicate()
+                    ?? throw new Exception($"Failed to duplicate Node '{node.Name}'.");
+
+                if (!string.IsNullOrEmpty(name))
+                    duplicate.Name = name;
+
+                parent.AddChild(duplicate);
+
+                // Own the duplicate (and its sub-tree) by the scene root so it persists on save.
+                duplicate.Owner = root;
+                SetOwnerRecursive(duplicate, root);
+
+                EditorInterface.Singleton.MarkSceneAsUnsaved();
+                EditorInterface.Singleton.EditNode(duplicate);
+
+                return ToNodeData(duplicate);
+            });
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Node.Find.cs
+++ b/addons/godot_mcp/Tools/Tool_Node.Find.cs
@@ -1,0 +1,61 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Node
+    {
+        public const string NodeFindToolId = "node-find";
+
+        [AiTool
+        (
+            NodeFindToolId,
+            Title = "Node / Find",
+            ReadOnlyHint = true,
+            IdempotentHint = true,
+            OpenWorldHint = false
+        )]
+        [Description("Find a Node in the currently edited Godot scene by instance id or scene-tree path " +
+            "and return its structured data (instanceId, name, path, type, attached script, child count). " +
+            "Provide a 'nodeRef' identifying the Node (instanceId is preferred; a path like " +
+            "'/root/Main/Player' or 'Main/Player' is resolved relative to the edited scene root). " +
+            "Set 'hierarchyDepth' > 0 to include children: 1 = direct children, 2 = grandchildren, etc.")]
+        public NodeData? Find
+        (
+            [Description("Reference to the Node to find (instanceId preferred, else scene-tree path).")]
+            NodeRef nodeRef,
+            [Description("Depth of children to include. 0 = the target Node only; 1 = one layer of children; etc.")]
+            int hierarchyDepth = 0
+        )
+        {
+            if (hierarchyDepth < 0)
+                throw new ArgumentException("hierarchyDepth must be >= 0.", nameof(hierarchyDepth));
+
+            return MainThread.Instance.Run(() =>
+            {
+                var node = ResolveNode(nodeRef, out var error);
+                if (error != null)
+                    throw new Exception(error);
+                if (node == null)
+                    return null;
+
+                return ToNodeData(node, hierarchyDepth);
+            });
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Node.Find.cs
+++ b/addons/godot_mcp/Tools/Tool_Node.Find.cs
@@ -33,7 +33,9 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             "and return its structured data (instanceId, name, path, type, attached script, child count). " +
             "Provide a 'nodeRef' identifying the Node (instanceId is preferred; a path like " +
             "'/root/Main/Player' or 'Main/Player' is resolved relative to the edited scene root). " +
-            "Set 'hierarchyDepth' > 0 to include children: 1 = direct children, 2 = grandchildren, etc.")]
+            "Set 'hierarchyDepth' > 0 to include children: 1 = direct children, 2 = grandchildren, etc. " +
+            "A node that cannot be resolved (bad ref, no edited scene, path not found) yields a structured " +
+            "error, not a null result.")]
         public NodeData? Find
         (
             [Description("Reference to the Node to find (instanceId preferred, else scene-tree path).")]
@@ -47,11 +49,12 @@ namespace com.IvanMurzak.Godot.MCP.Tools
 
             return MainThread.Instance.Run(() =>
             {
+                // ResolveNode sets 'error' on every null return (bad ref, no edited scene, path not found),
+                // so a null node always comes with an error here — surfaced as a structured error rather
+                // than a soft-null result (see the tool description). There is no error-free null case.
                 var node = ResolveNode(nodeRef, out var error);
-                if (error != null)
-                    throw new Exception(error);
                 if (node == null)
-                    return null;
+                    throw new Exception(error ?? $"Node by {nodeRef} not found.");
 
                 return ToNodeData(node, hierarchyDepth);
             });

--- a/addons/godot_mcp/Tools/Tool_Node.Modify.cs
+++ b/addons/godot_mcp/Tools/Tool_Node.Modify.cs
@@ -77,11 +77,22 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 object? objToModify = node;
                 var anyChange = false;
 
-                // 1) JSON Merge Patch.
+                // ReflectorNet's TryPatch/TryModifyAt are documented to accumulate errors into 'logs' and
+                // never throw, but a malformed patch could still surface an exception from a converter or
+                // navigation edge case. Wrap each patch-surface call so a bad entry degrades to a logged
+                // skip instead of aborting MainThread.Run and leaving the scene half-modified + not marked.
+                // 1) JSON Merge Patch (applied first).
                 if (hasJsonPatch)
                 {
-                    if (reflector.TryPatch(ref objToModify, jsonPatch!, logs: logs))
-                        anyChange = true;
+                    try
+                    {
+                        if (reflector.TryPatch(ref objToModify, jsonPatch!, logs: logs))
+                            anyChange = true;
+                    }
+                    catch (Exception ex)
+                    {
+                        logs.Error($"jsonPatch threw and was skipped: {ex.Message}");
+                    }
                 }
 
                 // 2) Path patches.
@@ -100,9 +111,27 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                             logs.Error($"{nameof(pathPatches)}[{i}] ('{patch.Path}') with null value skipped.");
                             continue;
                         }
-                        if (reflector.TryModifyAt(ref objToModify, patch.Path, patch.Value, logs: logs))
-                            anyChange = true;
+                        try
+                        {
+                            if (reflector.TryModifyAt(ref objToModify, patch.Path, patch.Value, logs: logs))
+                                anyChange = true;
+                        }
+                        catch (Exception ex)
+                        {
+                            logs.Error($"{nameof(pathPatches)}[{i}] ('{patch.Path}') threw and was skipped: {ex.Message}");
+                        }
                     }
+                }
+
+                // 'objToModify' is passed by ref: a patch may reassign it to a fresh boxed instance (e.g. a
+                // '$type' replacement) instead of mutating the live node in place. Node is a reference type,
+                // so in-place writes hit the editor's node — but if the ref diverged, the live node was NOT
+                // updated, so reporting success + marking unsaved would be a silent no-op. Guard against it.
+                if (anyChange && !ReferenceEquals(objToModify, node))
+                {
+                    logs.Error("Modification produced a new instance instead of mutating the live Node in " +
+                        "place (the editor Node was not updated); the scene was left unchanged.");
+                    return logs;
                 }
 
                 if (anyChange)

--- a/addons/godot_mcp/Tools/Tool_Node.Modify.cs
+++ b/addons/godot_mcp/Tools/Tool_Node.Modify.cs
@@ -1,0 +1,118 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.Godot.MCP.Reflection;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Model;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Node
+    {
+        public const string NodeModifyToolId = "node-modify";
+
+        [AiTool
+        (
+            NodeModifyToolId,
+            Title = "Node / Modify",
+            IdempotentHint = true
+        )]
+        [Description("Modify properties of a Node in the currently edited Godot scene via ReflectorNet. " +
+            "Identify the Node with 'nodeRef'. Two modification surfaces (supply at least one; both may be " +
+            "combined, applied jsonPatch first then pathPatches):\n" +
+            "  1. 'pathPatches' — list of {path, value} entries routed through Reflector.TryModifyAt for " +
+            "atomic per-path modification. Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', " +
+            "'dictField/[key]'.\n" +
+            "  2. 'jsonPatch' — a JSON Merge Patch (RFC 7396) string routed through Reflector.TryPatch.\n" +
+            "Returns a log of what was changed and what was ignored.")]
+        public Logs Modify
+        (
+            [Description("Reference to the Node to modify (instanceId preferred, else scene-tree path).")]
+            NodeRef nodeRef,
+            [Description("Optional list of path-scoped patches routed through Reflector.TryModifyAt. " +
+                "Each entry is a {path, value}. Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'.")]
+            List<NodePropertyPatch>? pathPatches = null,
+            [Description("Optional JSON Merge Patch (RFC 7396) applied via Reflector.TryPatch.")]
+            string? jsonPatch = null
+        )
+        {
+            var hasPathPatches = pathPatches != null && pathPatches.Count > 0;
+            var hasJsonPatch = !string.IsNullOrWhiteSpace(jsonPatch);
+
+            if (!hasPathPatches && !hasJsonPatch)
+                throw new ArgumentException(
+                    $"At least one of '{nameof(pathPatches)}' or '{nameof(jsonPatch)}' is required.");
+
+            return MainThread.Instance.Run(() =>
+            {
+                var logs = new Logs();
+
+                var node = ResolveNode(nodeRef, out var error);
+                if (error != null)
+                {
+                    logs.Error(error);
+                    return logs;
+                }
+                if (node == null)
+                {
+                    logs.Error($"Node by {nodeRef} not found.");
+                    return logs;
+                }
+
+                var reflector = GodotMcpReflector.GetOrCreate();
+                object? objToModify = node;
+                var anyChange = false;
+
+                // 1) JSON Merge Patch.
+                if (hasJsonPatch)
+                {
+                    if (reflector.TryPatch(ref objToModify, jsonPatch!, logs: logs))
+                        anyChange = true;
+                }
+
+                // 2) Path patches.
+                if (hasPathPatches)
+                {
+                    for (int i = 0; i < pathPatches!.Count; i++)
+                    {
+                        var patch = pathPatches[i];
+                        if (patch == null || string.IsNullOrEmpty(patch.Path))
+                        {
+                            logs.Error($"{nameof(pathPatches)}[{i}] with empty path skipped.");
+                            continue;
+                        }
+                        if (patch.Value == null)
+                        {
+                            logs.Error($"{nameof(pathPatches)}[{i}] ('{patch.Path}') with null value skipped.");
+                            continue;
+                        }
+                        if (reflector.TryModifyAt(ref objToModify, patch.Path, patch.Value, logs: logs))
+                            anyChange = true;
+                    }
+                }
+
+                if (anyChange)
+                    EditorInterface.Singleton.MarkSceneAsUnsaved();
+                else
+                    logs.Warning("No modifications were made.");
+
+                return logs;
+            });
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Node.SetParent.cs
+++ b/addons/godot_mcp/Tools/Tool_Node.SetParent.cs
@@ -1,0 +1,91 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Node
+    {
+        public const string NodeSetParentToolId = "node-set-parent";
+
+        [AiTool
+        (
+            NodeSetParentToolId,
+            Title = "Node / Set Parent",
+            IdempotentHint = true
+        )]
+        [Description("Reparent a Node under a new parent in the currently edited Godot scene, preserving " +
+            "its global transform by default (Godot's Node.Reparent). Identify the moving Node with " +
+            "'nodeRef' and the destination with 'newParentNodeRef'. Set 'keepGlobalTransform' to false to " +
+            "keep the Node's local transform instead. Returns the reparented Node's updated structured data.")]
+        public NodeData SetParent
+        (
+            [Description("Reference to the Node to reparent (instanceId preferred, else scene-tree path).")]
+            NodeRef nodeRef,
+            [Description("Reference to the new parent Node.")]
+            NodeRef newParentNodeRef,
+            [Description("When true (default), preserve the Node's global transform across the reparent. " +
+                "When false, keep its local transform.")]
+            bool keepGlobalTransform = true
+        )
+        {
+            return MainThread.Instance.Run(() =>
+            {
+                var root = EditorInterface.Singleton.GetEditedSceneRoot()
+                    ?? throw new Exception("No scene is currently being edited.");
+
+                var node = ResolveNode(nodeRef, out var error)
+                    ?? throw new ArgumentException(error ?? "Node not found.", nameof(nodeRef));
+
+                var newParent = ResolveNode(newParentNodeRef, out var parentError)
+                    ?? throw new ArgumentException(parentError ?? "New parent Node not found.", nameof(newParentNodeRef));
+
+                if (node == root)
+                    throw new ArgumentException("Cannot reparent the scene root Node.", nameof(nodeRef));
+                if (node == newParent)
+                    throw new ArgumentException("Cannot reparent a Node under itself.", nameof(newParentNodeRef));
+                if (IsAncestorOf(node, newParent))
+                    throw new ArgumentException("Cannot reparent a Node under one of its own descendants.", nameof(newParentNodeRef));
+
+                node.Reparent(newParent, keepGlobalTransform: keepGlobalTransform);
+
+                // Preserve scene persistence: the reparented sub-tree must still be owned by the scene root.
+                if (node.Owner == null)
+                    node.Owner = root;
+                SetOwnerRecursive(node, root);
+
+                EditorInterface.Singleton.MarkSceneAsUnsaved();
+
+                return ToNodeData(node);
+            });
+        }
+
+        /// <summary>True when <paramref name="ancestor"/> is an ancestor of <paramref name="candidate"/>.</summary>
+        static bool IsAncestorOf(Node ancestor, Node candidate)
+        {
+            var cursor = candidate.GetParent();
+            while (cursor != null)
+            {
+                if (cursor == ancestor)
+                    return true;
+                cursor = cursor.GetParent();
+            }
+            return false;
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Node.cs
+++ b/addons/godot_mcp/Tools/Tool_Node.cs
@@ -1,0 +1,155 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// Node tool family (<c>node-*</c>) — the Godot analog of Unity-MCP's <c>Tool_GameObject</c>. Each
+    /// tool method lives in its own partial-class file (Find / Create / Modify / SetParent / Duplicate /
+    /// Delete) and drives the Godot editor scene tree via <see cref="EditorInterface"/> through the
+    /// main-thread dispatcher.
+    ///
+    /// <para>
+    /// Godot ↔ Unity mapping: <c>Node</c> ↔ <c>GameObject</c>; a node's class name + attached script
+    /// ↔ a GameObject's component set; <c>EditorInterface.GetEditedSceneRoot()</c> ↔ the active scene
+    /// root. Node identity is resolved from a <see cref="Data.NodeRef"/> (instance id preferred, then
+    /// scene-tree path) by <see cref="ResolveNode"/>.
+    /// </para>
+    ///
+    /// Editor-only (<c>#if TOOLS</c>): the handlers touch <see cref="EditorInterface"/> and live
+    /// <see cref="Node"/> objects, neither of which exists in a plain (non-editor) build. The pure-managed
+    /// pieces (the <see cref="NodeData"/>/<see cref="NodeRef"/> models, validation) live outside this
+    /// guard and are unit-tested.
+    /// </summary>
+    [AiToolType]
+    public partial class Tool_Node
+    {
+        /// <summary>
+        /// Resolve a <see cref="Data.NodeRef"/> to a live <see cref="Node"/> in the editor scene tree.
+        /// Must be called on the main thread. Returns null and sets <paramref name="error"/> on any
+        /// failure (invalid ref, no edited scene, instance id not a Node, path not found).
+        ///
+        /// Resolution order mirrors <see cref="Data.NodeRef"/>'s declared priority: instance id first
+        /// (stable identity), then scene-tree path (which can shift as the tree mutates). A path is
+        /// resolved relative to the edited-scene root; a leading '/root/' or '/' is tolerated by
+        /// stripping it down to the path under the edited root, and the special path "." (or the root's
+        /// own name) resolves to the root itself.
+        /// </summary>
+        internal static Node? ResolveNode(Data.NodeRef? nodeRef, out string? error)
+        {
+            error = null;
+
+            if (nodeRef == null)
+            {
+                error = "nodeRef is null.";
+                return null;
+            }
+            if (!nodeRef.IsValid(out error))
+                return null;
+
+            // 1) Instance id (priority 1).
+            if (nodeRef.InstanceId != 0)
+            {
+                if (!GodotObject.IsInstanceIdValid(nodeRef.InstanceId))
+                {
+                    error = $"No live object with instanceId '{nodeRef.InstanceId}'.";
+                    return null;
+                }
+                var obj = GodotObject.InstanceFromId(nodeRef.InstanceId);
+                if (obj is Node nodeById)
+                    return nodeById;
+
+                error = $"Object with instanceId '{nodeRef.InstanceId}' is not a Node (it is '{obj?.GetClass() ?? "null"}').";
+                return null;
+            }
+
+            // 2) Scene-tree path (priority 2).
+            var root = EditorInterface.Singleton.GetEditedSceneRoot();
+            if (root == null)
+            {
+                error = "No scene is currently being edited; cannot resolve a Node by path.";
+                return null;
+            }
+
+            var path = NormalizePathToEditedRoot(nodeRef.Path!, root);
+
+            if (string.IsNullOrEmpty(path) || path == ".")
+                return root;
+
+            var node = root.GetNodeOrNull(path);
+            if (node == null)
+            {
+                error = $"Node not found at path '{nodeRef.Path}' (resolved relative to edited scene root '{root.Name}').";
+                return null;
+            }
+            return node;
+        }
+
+        /// <summary>
+        /// Reduce an arbitrary user-supplied path to one resolvable against the edited-scene root.
+        /// Accepts absolute forms ('/root/Main/Player'), edited-root-prefixed forms ('Main/Player' where
+        /// 'Main' is the root), and relative forms. Delegates the pure-string transform to
+        /// <see cref="NodePathNormalizer.Normalize"/> (which is unit-tested off the editor).
+        /// </summary>
+        internal static string NormalizePathToEditedRoot(string rawPath, Node editedRoot)
+            => NodePathNormalizer.Normalize(rawPath, editedRoot.Name.ToString());
+
+        /// <summary>
+        /// Build a structured <see cref="NodeData"/> from a live node. When <paramref name="hierarchyDepth"/>
+        /// is &gt; 0, recursively populates <see cref="NodeData.Children"/> up to that depth (0 = the node
+        /// only, children null). Must be called on the main thread.
+        /// </summary>
+        internal static NodeData ToNodeData(Node node, int hierarchyDepth = 0)
+        {
+            var data = new NodeData
+            {
+                InstanceId = node.GetInstanceId(),
+                Name = node.Name.ToString(),
+                Path = node.GetPath().ToString(),
+                Type = node.GetClass(),
+                ScriptResourcePath = GetAttachedScriptPath(node),
+                ChildCount = node.GetChildCount(includeInternal: false),
+            };
+
+            if (hierarchyDepth > 0)
+            {
+                data.Children = new System.Collections.Generic.List<NodeData>(data.ChildCount);
+                var count = node.GetChildCount(includeInternal: false);
+                for (int i = 0; i < count; i++)
+                {
+                    var child = node.GetChild(i, includeInternal: false);
+                    if (child != null)
+                        data.Children.Add(ToNodeData(child, hierarchyDepth - 1));
+                }
+            }
+
+            return data;
+        }
+
+        /// <summary>res:// path of the script attached to <paramref name="node"/>, or null when none.</summary>
+        static string? GetAttachedScriptPath(Node node)
+        {
+            var scriptVariant = node.GetScript();
+            if (scriptVariant.VariantType == Variant.Type.Nil)
+                return null;
+
+            var script = scriptVariant.As<Script>();
+            var resourcePath = script?.ResourcePath;
+            return string.IsNullOrEmpty(resourcePath) ? null : resourcePath;
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Node.cs
+++ b/addons/godot_mcp/Tools/Tool_Node.cs
@@ -127,8 +127,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             if (hierarchyDepth > 0)
             {
                 data.Children = new System.Collections.Generic.List<NodeData>(data.ChildCount);
-                var count = node.GetChildCount(includeInternal: false);
-                for (int i = 0; i < count; i++)
+                for (int i = 0; i < data.ChildCount; i++)
                 {
                     var child = node.GetChild(i, includeInternal: false);
                     if (child != null)

--- a/addons/godot_mcp/Tools/Tool_Scene.Create.cs
+++ b/addons/godot_mcp/Tools/Tool_Scene.Create.cs
@@ -1,0 +1,98 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Scene
+    {
+        public const string SceneCreateToolId = "scene-create";
+
+        [AiTool
+        (
+            SceneCreateToolId,
+            Title = "Scene / Create"
+        )]
+        [Description("Create a new Godot scene asset at a res://*.tscn path and open it as the active scene. " +
+            "A root Node is created (type given by 'rootTypeClassName', default 'Node'), packed into a " +
+            "PackedScene, saved to 'resourcePath', then opened in the editor. Pass 'rootName' to name the " +
+            "root Node. Returns the new scene's structured data. Use 'node-create' to add child nodes afterwards.")]
+        public SceneData Create
+        (
+            [Description("res:// path for the new scene file, ending in '.tscn' (e.g. 'res://levels/level_2.tscn').")]
+            string resourcePath,
+            [Description("Godot class for the scene's root Node (e.g. 'Node', 'Node2D', 'Node3D'). Defaults to 'Node'.")]
+            string? rootTypeClassName = null,
+            [Description("Name for the root Node. Defaults to the type's default name.")]
+            string? rootName = null
+        )
+        {
+            if (string.IsNullOrEmpty(resourcePath))
+                throw new ArgumentException("resourcePath cannot be null or empty.", nameof(resourcePath));
+
+            return MainThread.Instance.Run(() =>
+            {
+                if (!resourcePath.StartsWith("res://", StringComparison.Ordinal))
+                    throw new ArgumentException($"resourcePath must be a 'res://' path; got '{resourcePath}'.", nameof(resourcePath));
+                if (!resourcePath.EndsWith(".tscn", StringComparison.OrdinalIgnoreCase)
+                    && !resourcePath.EndsWith(".scn", StringComparison.OrdinalIgnoreCase))
+                    throw new ArgumentException($"resourcePath must end with '.tscn' or '.scn'; got '{resourcePath}'.", nameof(resourcePath));
+
+                var className = string.IsNullOrEmpty(rootTypeClassName) ? "Node" : rootTypeClassName!;
+                if (!ClassDB.ClassExists(className))
+                    throw new ArgumentException($"Unknown Godot class '{className}'.", nameof(rootTypeClassName));
+                if (!ClassDB.CanInstantiate(className))
+                    throw new ArgumentException($"Godot class '{className}' cannot be instantiated.", nameof(rootTypeClassName));
+
+                var root = ClassDB.Instantiate(className).As<Node>()
+                    ?? throw new ArgumentException($"Godot class '{className}' did not instantiate to a Node.", nameof(rootTypeClassName));
+
+                if (!string.IsNullOrEmpty(rootName))
+                    root.Name = rootName;
+
+                try
+                {
+                    var packed = new PackedScene();
+                    var packErr = packed.Pack(root);
+                    if (packErr != Error.Ok)
+                        throw new Exception($"Failed to pack new scene root: {packErr}.");
+
+                    var saveErr = ResourceSaver.Save(packed, resourcePath);
+                    if (saveErr != Error.Ok)
+                        throw new Exception($"Failed to save new scene to '{resourcePath}': {saveErr}. " +
+                            "Ensure the target directory exists.");
+                }
+                finally
+                {
+                    // The in-memory root was only needed to pack the PackedScene; free it so it does not
+                    // leak. The editor re-instances its own root when the saved scene is opened below.
+                    root.Free();
+                }
+
+                // Make the new asset visible to the editor's resource filesystem, then open it.
+                EditorInterface.Singleton.GetResourceFilesystem().UpdateFile(resourcePath);
+                EditorInterface.Singleton.OpenSceneFromPath(resourcePath);
+
+                var editedRoot = EditorInterface.Singleton.GetEditedSceneRoot()
+                    ?? throw new Exception($"Created '{resourcePath}' but the editor has no edited scene root afterwards.");
+
+                return ToActiveSceneData(editedRoot);
+            });
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Scene.GetData.cs
+++ b/addons/godot_mcp/Tools/Tool_Scene.GetData.cs
@@ -1,0 +1,57 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Scene
+    {
+        public const string SceneGetDataToolId = "scene-get-data";
+
+        [AiTool
+        (
+            SceneGetDataToolId,
+            Title = "Scene / Get Data",
+            ReadOnlyHint = true,
+            IdempotentHint = true,
+            OpenWorldHint = false
+        )]
+        [Description("Get the scene-tree of the currently edited Godot scene as a structured Node hierarchy " +
+            "rooted at the scene's root Node. 'hierarchyDepth' bounds how deep the tree is walked: 0 = the " +
+            "root only, 1 = root + direct children, etc.; -1 walks the entire tree. Each entry carries the " +
+            "Node's instanceId, name, path, type, attached script, and child count.")]
+        public NodeData GetData
+        (
+            [Description("Depth of the scene tree to include. 0 = root only; N > 0 = N layers of children; " +
+                "-1 = the entire tree.")]
+            int hierarchyDepth = -1
+        )
+        {
+            return MainThread.Instance.Run(() =>
+            {
+                var root = EditorInterface.Singleton.GetEditedSceneRoot()
+                    ?? throw new Exception("No scene is currently being edited.");
+
+                // Walk the whole tree when -1 is requested; otherwise honor the explicit bound. A very
+                // large sentinel is used for "unbounded" so Tool_Node.ToNodeData can stay depth-counted.
+                var depth = hierarchyDepth < 0 ? int.MaxValue : hierarchyDepth;
+                return Tool_Node.ToNodeData(root, depth);
+            });
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Scene.ListOpened.cs
+++ b/addons/godot_mcp/Tools/Tool_Scene.ListOpened.cs
@@ -1,0 +1,72 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System.Collections.Generic;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Scene
+    {
+        public const string SceneListOpenedToolId = "scene-list-opened";
+
+        [AiTool
+        (
+            SceneListOpenedToolId,
+            Title = "Scene / List Opened",
+            ReadOnlyHint = true,
+            IdempotentHint = true,
+            OpenWorldHint = false
+        )]
+        [Description("List every scene currently open in the Godot editor as a shallow snapshot " +
+            "(res:// path, and whether it is the active/edited scene). The active scene additionally " +
+            "carries its root Node's name and instanceId. Use 'scene-get-data' for the deep scene-tree view.")]
+        public List<SceneData> ListOpened(string? nothing = null)
+        {
+            return MainThread.Instance.Run(() =>
+            {
+                var result = new List<SceneData>();
+
+                var editedRoot = EditorInterface.Singleton.GetEditedSceneRoot();
+                var activePath = editedRoot?.GetSceneFilePath() ?? string.Empty;
+
+                var openPaths = EditorInterface.Singleton.GetOpenScenes();
+                var sawActive = false;
+
+                foreach (var path in openPaths)
+                {
+                    var isActive = !string.IsNullOrEmpty(activePath) && path == activePath;
+                    if (isActive && editedRoot != null)
+                    {
+                        result.Add(ToActiveSceneData(editedRoot));
+                        sawActive = true;
+                    }
+                    else
+                    {
+                        result.Add(ToOpenSceneData(path, isActive: false));
+                    }
+                }
+
+                // A freshly-created-but-unsaved active scene has no path, so GetOpenScenes() may not list
+                // it; surface it explicitly so the active scene is never missing from the result.
+                if (!sawActive && editedRoot != null)
+                    result.Add(ToActiveSceneData(editedRoot));
+
+                return result;
+            });
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Scene.Open.cs
+++ b/addons/godot_mcp/Tools/Tool_Scene.Open.cs
@@ -1,0 +1,60 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Scene
+    {
+        public const string SceneOpenToolId = "scene-open";
+
+        [AiTool
+        (
+            SceneOpenToolId,
+            Title = "Scene / Open"
+        )]
+        [Description("Open a Godot scene asset (a res://*.tscn / *.scn PackedScene) in the editor and make " +
+            "it the active/edited scene. Pass 'resourcePath' as the res:// path. Returns the opened scene's " +
+            "structured data (the now-active scene). Use 'scene-list-opened' to see all open scenes afterwards.")]
+        public SceneData Open
+        (
+            [Description("res:// path of the scene file to open, e.g. 'res://levels/level_1.tscn'.")]
+            string resourcePath
+        )
+        {
+            if (string.IsNullOrEmpty(resourcePath))
+                throw new ArgumentException("resourcePath cannot be null or empty.", nameof(resourcePath));
+
+            return MainThread.Instance.Run(() =>
+            {
+                if (!resourcePath.StartsWith("res://", StringComparison.Ordinal))
+                    throw new ArgumentException($"resourcePath must be a 'res://' path; got '{resourcePath}'.", nameof(resourcePath));
+                if (!ResourceLoader.Exists(resourcePath))
+                    throw new ArgumentException($"No scene resource exists at '{resourcePath}'.", nameof(resourcePath));
+
+                EditorInterface.Singleton.OpenSceneFromPath(resourcePath);
+
+                var editedRoot = EditorInterface.Singleton.GetEditedSceneRoot();
+                if (editedRoot == null)
+                    throw new Exception($"Opened '{resourcePath}' but the editor has no edited scene root afterwards.");
+
+                return ToActiveSceneData(editedRoot);
+            });
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Scene.Save.cs
+++ b/addons/godot_mcp/Tools/Tool_Scene.Save.cs
@@ -1,0 +1,78 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Scene
+    {
+        public const string SceneSaveToolId = "scene-save";
+
+        [AiTool
+        (
+            SceneSaveToolId,
+            Title = "Scene / Save",
+            IdempotentHint = true
+        )]
+        [Description("Save the currently edited Godot scene. With no 'path', saves back to the scene's " +
+            "existing res:// file (fails if the scene has never been saved — pass a 'path' in that case). " +
+            "With a 'path' (a res://*.tscn), saves the scene to that new location (save-as). Returns the " +
+            "saved scene's structured data.")]
+        public SceneData Save
+        (
+            [Description("Optional res:// destination path ending in '.tscn'/'.scn' for a save-as. When " +
+                "omitted, the scene is saved back to its existing file.")]
+            string? path = null
+        )
+        {
+            return MainThread.Instance.Run(() =>
+            {
+                var editedRoot = EditorInterface.Singleton.GetEditedSceneRoot()
+                    ?? throw new Exception("No scene is currently being edited; nothing to save.");
+
+                if (!string.IsNullOrEmpty(path))
+                {
+                    if (!path!.StartsWith("res://", StringComparison.Ordinal))
+                        throw new ArgumentException($"path must be a 'res://' path; got '{path}'.", nameof(path));
+                    if (!EndsWithSceneExt(path))
+                        throw new ArgumentException($"path must end with '.tscn' or '.scn'; got '{path}'.", nameof(path));
+
+                    EditorInterface.Singleton.SaveSceneAs(path);
+                }
+                else
+                {
+                    var existingPath = editedRoot.GetSceneFilePath();
+                    if (string.IsNullOrEmpty(existingPath))
+                        throw new Exception("The edited scene has never been saved; provide a 'path' to save it for the first time.");
+
+                    var err = EditorInterface.Singleton.SaveScene();
+                    if (err != Error.Ok)
+                        throw new Exception($"Failed to save scene '{existingPath}': {err}.");
+                }
+
+                // Re-read the edited root (SaveSceneAs re-points the scene's file path).
+                var rootAfter = EditorInterface.Singleton.GetEditedSceneRoot() ?? editedRoot;
+                return ToActiveSceneData(rootAfter);
+            });
+        }
+
+        static bool EndsWithSceneExt(string path)
+            => path.EndsWith(".tscn", StringComparison.OrdinalIgnoreCase)
+            || path.EndsWith(".scn", StringComparison.OrdinalIgnoreCase);
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Scene.Save.cs
+++ b/addons/godot_mcp/Tools/Tool_Scene.Save.cs
@@ -51,7 +51,15 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                     if (!EndsWithSceneExt(path))
                         throw new ArgumentException($"path must end with '.tscn' or '.scn'; got '{path}'.", nameof(path));
 
+                    // SaveSceneAs returns void (no Error), so a silent failure (e.g. an unwritable target
+                    // dir) would otherwise be reported as success. Confirm the edited scene's file path now
+                    // points at the requested destination; a mismatch means the save did not land.
                     EditorInterface.Singleton.SaveSceneAs(path);
+
+                    var savedPath = EditorInterface.Singleton.GetEditedSceneRoot()?.GetSceneFilePath();
+                    if (savedPath != path)
+                        throw new Exception(
+                            $"Save-as to '{path}' did not take effect (edited scene path is now '{savedPath ?? "<none>"}').");
                 }
                 else
                 {

--- a/addons/godot_mcp/Tools/Tool_Scene.cs
+++ b/addons/godot_mcp/Tools/Tool_Scene.cs
@@ -1,0 +1,68 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// Scene tool family (<c>scene-*</c>) — the Godot analog of Unity-MCP's <c>Tool_Scene</c>. Each tool
+    /// method lives in its own partial-class file (Open / Save / Create / ListOpened / GetData) and drives
+    /// the Godot editor's scene set via <see cref="EditorInterface"/> through the main-thread dispatcher.
+    ///
+    /// <para>
+    /// Godot ↔ Unity mapping: a Godot scene is a <see cref="PackedScene"/> on disk (<c>res://*.tscn</c>)
+    /// whose instanced root <see cref="Node"/> is what the editor edits. Godot 4.3's editor API exposes
+    /// the open-scene set as a flat list of <c>res://</c> paths (<see cref="EditorInterface.GetOpenScenes"/>)
+    /// plus the single currently-edited root (<see cref="EditorInterface.GetEditedSceneRoot"/>); there is
+    /// no per-open-scene root accessor in 4.3, so <see cref="ListOpened"/> reports paths and flags which
+    /// one is active.
+    /// </para>
+    ///
+    /// Editor-only (<c>#if TOOLS</c>). The pure-managed <see cref="SceneData"/> model lives outside this
+    /// guard and is unit-tested.
+    /// </summary>
+    [AiToolType]
+    public partial class Tool_Scene
+    {
+        /// <summary>
+        /// Build a <see cref="SceneData"/> for the editor's currently-edited scene from its root node.
+        /// Main-thread only. Returns a model with <see cref="SceneData.IsActive"/> set true.
+        /// </summary>
+        internal static SceneData ToActiveSceneData(Node editedRoot)
+        {
+            var path = editedRoot.GetSceneFilePath();
+            return new SceneData
+            {
+                ResourcePath = string.IsNullOrEmpty(path) ? null : path,
+                RootName = editedRoot.Name.ToString(),
+                RootInstanceId = editedRoot.GetInstanceId(),
+                IsActive = true,
+            };
+        }
+
+        /// <summary>
+        /// Build a path-only <see cref="SceneData"/> for an open scene that is NOT the active one (Godot
+        /// 4.3 exposes no root accessor for non-active open scenes). Main-thread only.
+        /// </summary>
+        internal static SceneData ToOpenSceneData(string resourcePath, bool isActive)
+            => new SceneData
+            {
+                ResourcePath = string.IsNullOrEmpty(resourcePath) ? null : resourcePath,
+                RootName = null,
+                RootInstanceId = 0,
+                IsActive = isActive,
+            };
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Adds the **node tool family** (`node-create`/`node-find`/`node-modify`/`node-set-parent`/`node-duplicate`/`node-delete`) and the **scene tool family** (`scene-create`/`scene-open`/`scene-save`/`scene-list-opened`/`scene-get-data`) as `[AiToolType]` partial classes under `addons/godot_mcp/Tools/`, porting Unity-MCP's GameObject/Scene tools to Godot's Node/Scene model.
- All editor API calls marshal onto the editor main thread via the `GodotMainThread` dispatcher and run behind `#if TOOLS` (Godot 4.3 `EditorInterface`). Results are structured ReflectorNet-serialized models (`NodeData`/`SceneData`); `node-modify` routes through `Reflector.TryModifyAt`/`TryPatch` using the connection's shared reflector.
- Mapping: GameObject→Node, Scene→PackedScene + edited-scene root, Component→node class name + attached-script path. Pure-managed pieces (result models, `NodePropertyPatch`, `NodePathNormalizer`, the ambient `GodotMcpReflector` accessor) live outside `#if TOOLS` and are unit-tested.

## Test plan
- [x] `dotnet build Godot-MCP.sln -c Debug` — 0 errors / 0 warnings (CI parity).
- [x] `dotnet test Godot-MCP.Tests` — 77/77 pass (added pure-managed coverage for the models, the path normalizer, and the reflector accessor).
- [x] **Live headless verification** against a local DemoWebApp MCP server (Custom mode) with the Godot 4.5.1 testbed: clean editor boot + connect, then drove `scene-create → node-create → node-find → node-modify (Position) → node-set-parent → node-duplicate → scene-get-data → node-delete → scene-save → scene-open`. Observed each tool's structured result AND the persisted `verify_scene.tscn` faithfully reflecting the tool-driven tree (Player at transform (1,2,3), recursively-duplicated PlayerCopy, HUD reparent + delete).

Closes #8