### PR TITLE
feat: resource + filesystem tools (browse res://, find/get/create/modify/move/delete, reimport)

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -57,6 +57,15 @@
     <Compile Include="..\addons\godot_mcp\Data\NodePropertyPatch.cs" Link="Source\NodePropertyPatch.cs" />
     <Compile Include="..\addons\godot_mcp\Tools\NodePathNormalizer.cs" Link="Source\NodePathNormalizer.cs" />
     <Compile Include="..\addons\godot_mcp\Reflection\GodotMcpReflector.cs" Link="Source\GodotMcpReflector.cs" />
+    <!-- Resource/FileSystem tool family — pure-managed pieces only (no Godot native types, no #if TOOLS):
+         the structured result models and the res:// path normalizer. The editor-driving handlers
+         (Tool_Resource.*.cs / Tool_FileSystem.*.cs) are #if TOOLS and verified via the headless Godot
+         smoke (test.md Suite 3), not here. -->
+    <Compile Include="..\addons\godot_mcp\Data\FileSystemEntry.cs" Link="Source\FileSystemEntry.cs" />
+    <Compile Include="..\addons\godot_mcp\Data\FileSystemListing.cs" Link="Source\FileSystemListing.cs" />
+    <Compile Include="..\addons\godot_mcp\Data\ResourceInfo.cs" Link="Source\ResourceInfo.cs" />
+    <Compile Include="..\addons\godot_mcp\Data\ResourceFindResult.cs" Link="Source\ResourceFindResult.cs" />
+    <Compile Include="..\addons\godot_mcp\Tools\ResPathNormalizer.cs" Link="Source\ResPathNormalizer.cs" />
   </ItemGroup>
 
 </Project>

--- a/Godot-MCP.Tests/ResourceFsToolTests.cs
+++ b/Godot-MCP.Tests/ResourceFsToolTests.cs
@@ -1,0 +1,220 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.Godot.MCP.Tools;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pure-managed coverage for the resource/filesystem tool family: the structured result models
+    /// (<see cref="FileSystemEntry"/>, <see cref="FileSystemListing"/>, <see cref="ResourceInfo"/>,
+    /// <see cref="ResourceFindResult"/>) and the res:// path normalizer (<see cref="ResPathNormalizer"/>).
+    /// None of these touch a live Godot filesystem, so they run in the plain xUnit host with no Godot
+    /// binary. The editor-driving handlers themselves (<c>#if TOOLS</c>) are verified by the headless
+    /// Godot smoke (test.md Suite 3).
+    /// </summary>
+    public class ResourceFsToolTests
+    {
+        // ---- FileSystemEntry / FileSystemListing -------------------------------------------------
+
+        [Fact]
+        public void FileSystemEntry_Serializes_WithExpectedJsonNames()
+        {
+            var entry = new FileSystemEntry
+            {
+                Name = "wood.tres",
+                Path = "res://materials/wood.tres",
+                IsDirectory = false,
+                ResourceType = "StandardMaterial3D",
+                Uid = "uid://abc123",
+            };
+
+            var json = JsonSerializer.Serialize(entry);
+
+            Assert.Contains("\"name\"", json);
+            Assert.Contains("\"path\"", json);
+            Assert.Contains("\"isDirectory\"", json);
+            Assert.Contains("\"resourceType\"", json);
+            Assert.Contains("\"uid\"", json);
+
+            var restored = JsonSerializer.Deserialize<FileSystemEntry>(json);
+            Assert.NotNull(restored);
+            Assert.Equal("wood.tres", restored!.Name);
+            Assert.Equal("res://materials/wood.tres", restored.Path);
+            Assert.False(restored.IsDirectory);
+            Assert.Equal("StandardMaterial3D", restored.ResourceType);
+            Assert.Equal("uid://abc123", restored.Uid);
+        }
+
+        [Fact]
+        public void FileSystemEntry_Directory_AllowsNullTypeAndUid()
+        {
+            var entry = new FileSystemEntry { Name = "materials", Path = "res://materials/", IsDirectory = true };
+            var json = JsonSerializer.Serialize(entry);
+            var restored = JsonSerializer.Deserialize<FileSystemEntry>(json);
+
+            Assert.NotNull(restored);
+            Assert.True(restored!.IsDirectory);
+            Assert.Null(restored.ResourceType);
+            Assert.Null(restored.Uid);
+        }
+
+        [Fact]
+        public void FileSystemListing_RoundTrips_WithEntries()
+        {
+            var listing = new FileSystemListing
+            {
+                Path = "res://",
+                DirectoryCount = 1,
+                FileCount = 1,
+                Entries = new List<FileSystemEntry>
+                {
+                    new FileSystemEntry { Name = "materials", Path = "res://materials/", IsDirectory = true },
+                    new FileSystemEntry { Name = "icon.svg", Path = "res://icon.svg", IsDirectory = false, ResourceType = "Texture2D" },
+                },
+            };
+
+            var json = JsonSerializer.Serialize(listing);
+            Assert.Contains("\"path\"", json);
+            Assert.Contains("\"directoryCount\"", json);
+            Assert.Contains("\"fileCount\"", json);
+            Assert.Contains("\"entries\"", json);
+
+            var restored = JsonSerializer.Deserialize<FileSystemListing>(json);
+            Assert.NotNull(restored);
+            Assert.Equal("res://", restored!.Path);
+            Assert.Equal(1, restored.DirectoryCount);
+            Assert.Equal(1, restored.FileCount);
+            Assert.Equal(2, restored.Entries.Count);
+            Assert.True(restored.Entries[0].IsDirectory);
+            Assert.Equal("Texture2D", restored.Entries[1].ResourceType);
+        }
+
+        // ---- ResourceInfo / ResourceFindResult ---------------------------------------------------
+
+        [Fact]
+        public void ResourceInfo_Serializes_WithExpectedJsonNames()
+        {
+            var info = new ResourceInfo
+            {
+                ResourcePath = "res://materials/wood.tres",
+                Uid = "uid://abc123",
+                Type = "StandardMaterial3D",
+            };
+
+            var json = JsonSerializer.Serialize(info);
+            Assert.Contains("\"resourcePath\"", json);
+            Assert.Contains("\"uid\"", json);
+            Assert.Contains("\"type\"", json);
+
+            var restored = JsonSerializer.Deserialize<ResourceInfo>(json);
+            Assert.NotNull(restored);
+            Assert.Equal("res://materials/wood.tres", restored!.ResourcePath);
+            Assert.Equal("uid://abc123", restored.Uid);
+            Assert.Equal("StandardMaterial3D", restored.Type);
+        }
+
+        [Fact]
+        public void ResourceInfo_AllowsNullUidAndType()
+        {
+            var info = new ResourceInfo { ResourcePath = "res://x.tres" };
+            var json = JsonSerializer.Serialize(info);
+            var restored = JsonSerializer.Deserialize<ResourceInfo>(json);
+            Assert.NotNull(restored);
+            Assert.Null(restored!.Uid);
+            Assert.Null(restored.Type);
+        }
+
+        [Fact]
+        public void ResourceFindResult_RoundTrips_CountAndResources()
+        {
+            var result = new ResourceFindResult
+            {
+                Count = 2,
+                Resources = new List<ResourceInfo>
+                {
+                    new ResourceInfo { ResourcePath = "res://a.tres", Type = "Resource" },
+                    new ResourceInfo { ResourcePath = "res://b.tres", Type = "Curve" },
+                },
+            };
+
+            var json = JsonSerializer.Serialize(result);
+            Assert.Contains("\"count\"", json);
+            Assert.Contains("\"resources\"", json);
+
+            var restored = JsonSerializer.Deserialize<ResourceFindResult>(json);
+            Assert.NotNull(restored);
+            Assert.Equal(2, restored!.Count);
+            Assert.Equal(2, restored.Resources.Count);
+            Assert.Equal("res://a.tres", restored.Resources[0].ResourcePath);
+            Assert.Equal("Curve", restored.Resources[1].Type);
+        }
+
+        // ---- ResPathNormalizer.NormalizeDir ------------------------------------------------------
+
+        [Theory]
+        // Empty/null/'res://' all map to the project root.
+        [InlineData(null, "res://")]
+        [InlineData("", "res://")]
+        [InlineData("res://", "res://")]
+        // A directory path gets a trailing slash.
+        [InlineData("res://materials", "res://materials/")]
+        [InlineData("res://materials/", "res://materials/")]
+        // Nested.
+        [InlineData("res://a/b/c", "res://a/b/c/")]
+        // Whitespace trimmed.
+        [InlineData("  res://materials  ", "res://materials/")]
+        public void NormalizeDir_Normalizes(string? raw, string expected)
+        {
+            Assert.Equal(expected, ResPathNormalizer.NormalizeDir(raw));
+        }
+
+        [Fact]
+        public void NormalizeDir_Rejects_NonResPath()
+        {
+            Assert.Throws<ArgumentException>(() => ResPathNormalizer.NormalizeDir("/abs/path"));
+            Assert.Throws<ArgumentException>(() => ResPathNormalizer.NormalizeDir("user://x"));
+        }
+
+        // ---- ResPathNormalizer.IsResPath / RequireResFilePath ------------------------------------
+
+        [Theory]
+        [InlineData("res://x.tres", true)]
+        [InlineData("res://", true)]
+        [InlineData("user://x", false)]
+        [InlineData("/abs", false)]
+        [InlineData("", false)]
+        [InlineData(null, false)]
+        public void IsResPath_Detects(string? path, bool expected)
+        {
+            Assert.Equal(expected, ResPathNormalizer.IsResPath(path));
+        }
+
+        [Fact]
+        public void RequireResFilePath_AcceptsResFile_TrimsWhitespace()
+        {
+            Assert.Equal("res://materials/wood.tres",
+                ResPathNormalizer.RequireResFilePath("  res://materials/wood.tres  ", "p"));
+        }
+
+        [Fact]
+        public void RequireResFilePath_Rejects_NonResAndDirectory()
+        {
+            Assert.Throws<ArgumentException>(() => ResPathNormalizer.RequireResFilePath("/abs/x.tres", "p"));
+            Assert.Throws<ArgumentException>(() => ResPathNormalizer.RequireResFilePath("res://materials/", "p"));
+            Assert.Throws<ArgumentException>(() => ResPathNormalizer.RequireResFilePath(null, "p"));
+        }
+    }
+}

--- a/Godot-MCP.Tests/ResourceFsToolTests.cs
+++ b/Godot-MCP.Tests/ResourceFsToolTests.cs
@@ -216,5 +216,31 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Throws<ArgumentException>(() => ResPathNormalizer.RequireResFilePath("res://materials/", "p"));
             Assert.Throws<ArgumentException>(() => ResPathNormalizer.RequireResFilePath(null, "p"));
         }
+
+        [Fact]
+        public void RequireResFilePath_BareScheme_RejectsWithRootSpecificMessage()
+        {
+            // 'res://' passes IsResPath (it IS a res:// path) but names the project root, not a file. The
+            // message must say so accurately rather than the misleading "not a directory".
+            var ex = Assert.Throws<ArgumentException>(() => ResPathNormalizer.RequireResFilePath("res://", "p"));
+            Assert.Contains("project root", ex.Message);
+            Assert.DoesNotContain("not a directory", ex.Message);
+        }
+
+        [Fact]
+        public void RequireResFilePath_Rejects_ParentTraversalSegment()
+        {
+            // A '..' segment would let res://a/../a/b.tres and res://a/b.tres compare unequal while denoting
+            // the same file — reject it so the src==dst path-equality guards hold.
+            var ex = Assert.Throws<ArgumentException>(
+                () => ResPathNormalizer.RequireResFilePath("res://a/../a/b.tres", "p"));
+            Assert.Contains("..", ex.Message);
+        }
+
+        [Fact]
+        public void NormalizeDir_Rejects_ParentTraversalSegment()
+        {
+            Assert.Throws<ArgumentException>(() => ResPathNormalizer.NormalizeDir("res://a/../b"));
+        }
     }
 }

--- a/addons/godot_mcp/Data/FileSystemEntry.cs
+++ b/addons/godot_mcp/Data/FileSystemEntry.cs
@@ -1,0 +1,58 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.Godot.MCP.Data
+{
+    /// <summary>
+    /// One entry in a <c>res://</c> directory listing — either a sub-directory or an importable file.
+    /// The Godot analog of a single row of Unity-MCP's <c>assets-find</c> result, built from Godot's
+    /// <see cref="global::Godot.EditorFileSystemDirectory"/> on the main thread and then serialized off it.
+    ///
+    /// <para>
+    /// Pure-managed (no Godot API surface, no <c>#if TOOLS</c>): it holds plain strings/bools captured
+    /// from the editor filesystem, so it is unit-testable in the plain xUnit host.
+    /// </para>
+    /// </summary>
+    [System.Serializable]
+    [Description("One entry in a res:// directory listing: a sub-directory or a file, with its res:// path, " +
+        "name, kind, and (for files) resource type + uid.")]
+    public class FileSystemEntry
+    {
+        [JsonInclude, JsonPropertyName("name")]
+        [Description("The entry's leaf name (last path segment), e.g. 'wood.tres' or 'materials'.")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonInclude, JsonPropertyName("path")]
+        [Description("Full res:// path of the entry. Directories end with a trailing '/', e.g. 'res://materials/'.")]
+        public string Path { get; set; } = string.Empty;
+
+        [JsonInclude, JsonPropertyName("isDirectory")]
+        [Description("True when this entry is a directory; false when it is a file.")]
+        public bool IsDirectory { get; set; } = false;
+
+        [JsonInclude, JsonPropertyName("resourceType")]
+        [Description("For files: the Godot resource type the importer assigned (e.g. 'PackedScene', " +
+            "'Texture2D', 'Resource'), or null for directories / unimported files.")]
+        public string? ResourceType { get; set; } = null;
+
+        [JsonInclude, JsonPropertyName("uid")]
+        [Description("For files: the resource UID string (e.g. 'uid://abc123') when the file has one, else null. " +
+            "Directories have no uid.")]
+        public string? Uid { get; set; } = null;
+
+        public FileSystemEntry() { }
+
+        public override string ToString()
+            => IsDirectory ? $"[dir] {Path}" : $"[file] {Path} ({ResourceType ?? "?"})";
+    }
+}

--- a/addons/godot_mcp/Data/FileSystemListing.cs
+++ b/addons/godot_mcp/Data/FileSystemListing.cs
@@ -1,0 +1,54 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.Godot.MCP.Data
+{
+    /// <summary>
+    /// Structured result of a <c>filesystem-list</c> call: the listed directory's <c>res://</c> path plus
+    /// its immediate sub-directories and files (each a <see cref="FileSystemEntry"/>). The Godot analog of
+    /// a single-directory <c>assets-find</c> result.
+    ///
+    /// <para>
+    /// Pure-managed (no Godot API surface, no <c>#if TOOLS</c>), so it is unit-testable in the plain xUnit
+    /// host.
+    /// </para>
+    /// </summary>
+    [System.Serializable]
+    [Description("A res:// directory listing: the directory's path, its immediate sub-directories, and its " +
+        "immediate files.")]
+    public class FileSystemListing
+    {
+        [JsonInclude, JsonPropertyName("path")]
+        [Description("res:// path of the listed directory (always ends with '/'), e.g. 'res://' or 'res://materials/'.")]
+        public string Path { get; set; } = string.Empty;
+
+        [JsonInclude, JsonPropertyName("directoryCount")]
+        [Description("Number of immediate sub-directories in this directory.")]
+        public int DirectoryCount { get; set; } = 0;
+
+        [JsonInclude, JsonPropertyName("fileCount")]
+        [Description("Number of immediate files in this directory.")]
+        public int FileCount { get; set; } = 0;
+
+        [JsonInclude, JsonPropertyName("entries")]
+        [Description("Immediate children of the directory (sub-directories first, then files). Each entry " +
+            "carries its res:// path, kind, and — for files — resource type and uid.")]
+        public List<FileSystemEntry> Entries { get; set; } = new();
+
+        public FileSystemListing() { }
+
+        public override string ToString()
+            => $"Listing '{Path}' ({DirectoryCount} dirs, {FileCount} files)";
+    }
+}

--- a/addons/godot_mcp/Data/ResourceFindResult.cs
+++ b/addons/godot_mcp/Data/ResourceFindResult.cs
@@ -1,0 +1,42 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.Godot.MCP.Data
+{
+    /// <summary>
+    /// Structured result of a <c>resource-find</c> call: the list of matching <see cref="ResourceInfo"/>
+    /// hits plus a count. The Godot analog of a multi-hit <c>assets-find</c> response.
+    ///
+    /// <para>
+    /// Pure-managed (no Godot API surface, no <c>#if TOOLS</c>), so it is unit-testable in the plain xUnit
+    /// host.
+    /// </para>
+    /// </summary>
+    [System.Serializable]
+    [Description("Result of resource-find: a count plus the list of matching resources (path/uid/type).")]
+    public class ResourceFindResult
+    {
+        [JsonInclude, JsonPropertyName("count")]
+        [Description("Number of matching resources found.")]
+        public int Count { get; set; } = 0;
+
+        [JsonInclude, JsonPropertyName("resources")]
+        [Description("The matching resources, each with its res:// path, uid, and type.")]
+        public List<ResourceInfo> Resources { get; set; } = new();
+
+        public ResourceFindResult() { }
+
+        public override string ToString() => $"ResourceFindResult ({Count} matches)";
+    }
+}

--- a/addons/godot_mcp/Data/ResourceInfo.cs
+++ b/addons/godot_mcp/Data/ResourceInfo.cs
@@ -1,0 +1,49 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.Godot.MCP.Data
+{
+    /// <summary>
+    /// Lightweight identity record for a resource on disk — returned by <c>resource-find</c> and as the
+    /// confirmation payload of <c>resource-create</c>/<c>resource-move</c>/<c>resource-delete</c>. Carries
+    /// the resource's <c>res://</c> path, its <c>uid://</c> (when assigned), and the Godot type the
+    /// importer recorded for it. The Godot analog of a single <c>assets-find</c> hit (path + GUID + type).
+    ///
+    /// <para>
+    /// Pure-managed (no Godot API surface, no <c>#if TOOLS</c>), so it is unit-testable in the plain xUnit
+    /// host.
+    /// </para>
+    /// </summary>
+    [System.Serializable]
+    [Description("Identity of a resource on disk: its res:// path, uid:// (when assigned), and Godot type.")]
+    public class ResourceInfo
+    {
+        [JsonInclude, JsonPropertyName("resourcePath")]
+        [Description("res:// path of the resource, e.g. 'res://materials/wood.tres'.")]
+        public string ResourcePath { get; set; } = string.Empty;
+
+        [JsonInclude, JsonPropertyName("uid")]
+        [Description("uid:// identifier of the resource (e.g. 'uid://abc123'), or null when the resource has no uid.")]
+        public string? Uid { get; set; } = null;
+
+        [JsonInclude, JsonPropertyName("type")]
+        [Description("Godot type recorded for the resource by the import pipeline (e.g. 'PackedScene', " +
+            "'Texture2D', 'Resource'), or null when unknown.")]
+        public string? Type { get; set; } = null;
+
+        public ResourceInfo() { }
+
+        public override string ToString()
+            => $"Resource '{ResourcePath}' uid='{Uid ?? "(none)"}' type='{Type ?? "(unknown)"}'";
+    }
+}

--- a/addons/godot_mcp/Tools/ResPathNormalizer.cs
+++ b/addons/godot_mcp/Tools/ResPathNormalizer.cs
@@ -46,10 +46,31 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 throw new ArgumentException(
                     $"Directory path must be a '{ResScheme}' path (or empty for the project root); got '{rawPath}'.");
 
+            RejectParentTraversal(path, rawPath, nameof(rawPath));
+
             if (!path.EndsWith("/", StringComparison.Ordinal))
                 path += "/";
 
             return path;
+        }
+
+        /// <summary>
+        /// Reject a '..' path segment so that, e.g., <c>res://a/../a/b.tres</c> and <c>res://a/b.tres</c>
+        /// cannot denote the same file while comparing as unequal strings (which would let a caller bypass a
+        /// string-equality src==dst guard). Bounded by Godot's res:// sandbox so this is not a traversal
+        /// vulnerability — it just locks the path-equality guards. A bare <c>.</c> segment is harmless and
+        /// allowed; only the parent-escape <c>..</c> is rejected.
+        /// </summary>
+        static void RejectParentTraversal(string normalized, string? original, string paramName)
+        {
+            // Split on '/' and look for a literal '..' segment. The 'res://' prefix yields empty segments
+            // ("res:", "", "") which never equal "..", so it is unaffected.
+            foreach (var segment in normalized.Split('/'))
+            {
+                if (segment == "..")
+                    throw new ArgumentException(
+                        $"Path must not contain a '..' parent-directory segment; got '{original}'.", paramName);
+            }
         }
 
         /// <summary>
@@ -68,8 +89,14 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             var p = (path ?? string.Empty).Trim();
             if (!IsResPath(p))
                 throw new ArgumentException($"Path must be a '{ResScheme}' path; got '{path}'.", paramName);
+            // The bare scheme 'res://' is the project root, not a file — give an accurate message rather than
+            // the misleading "not a directory" one the trailing-slash check below would otherwise produce.
+            if (p == ResScheme)
+                throw new ArgumentException(
+                    $"Path must name a file under '{ResScheme}', not the bare project root '{ResScheme}'.", paramName);
             if (p.EndsWith("/", StringComparison.Ordinal))
                 throw new ArgumentException($"Path must be a file path, not a directory; got '{path}'.", paramName);
+            RejectParentTraversal(p, path, paramName);
             return p;
         }
     }

--- a/addons/godot_mcp/Tools/ResPathNormalizer.cs
+++ b/addons/godot_mcp/Tools/ResPathNormalizer.cs
@@ -1,0 +1,76 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// Pure-string validation/normalization of <c>res://</c> paths shared by the filesystem and resource
+    /// tool families. Extracted from the editor-only (<c>#if TOOLS</c>) handlers — like
+    /// <see cref="NodePathNormalizer"/> — so the slash/prefix logic, the part most prone to off-by-one
+    /// bugs, is unit-testable in the plain xUnit host with no live Godot filesystem.
+    ///
+    /// <para>
+    /// Godot addresses every project asset under the <c>res://</c> virtual root and every directory by its
+    /// trailing-slash form (so <c>EditorFileSystem.GetFilesystemPath("res://materials/")</c> resolves the
+    /// directory). These helpers enforce the <c>res://</c> scheme and the directory trailing-slash
+    /// convention without touching any Godot API.
+    /// </para>
+    /// </summary>
+    public static class ResPathNormalizer
+    {
+        public const string ResScheme = "res://";
+
+        /// <summary>
+        /// Normalize a user-supplied directory argument to a Godot <c>res://</c> directory path
+        /// (trailing-slash form). An empty/null/<c>"res://"</c> input maps to the project root
+        /// (<c>"res://"</c>); any other input must be a <c>res://</c> path and is given a trailing slash.
+        /// Throws <see cref="ArgumentException"/> for a non-<c>res://</c> input.
+        /// </summary>
+        public static string NormalizeDir(string? rawPath)
+        {
+            var path = (rawPath ?? string.Empty).Trim();
+
+            if (path.Length == 0 || path == ResScheme)
+                return ResScheme;
+
+            if (!path.StartsWith(ResScheme, StringComparison.Ordinal))
+                throw new ArgumentException(
+                    $"Directory path must be a '{ResScheme}' path (or empty for the project root); got '{rawPath}'.");
+
+            if (!path.EndsWith("/", StringComparison.Ordinal))
+                path += "/";
+
+            return path;
+        }
+
+        /// <summary>
+        /// True when <paramref name="path"/> is a non-empty <c>res://</c> path.
+        /// </summary>
+        public static bool IsResPath(string? path)
+            => !string.IsNullOrEmpty(path) && path!.StartsWith(ResScheme, StringComparison.Ordinal);
+
+        /// <summary>
+        /// Validate that <paramref name="path"/> is a <c>res://</c> file path, throwing
+        /// <see cref="ArgumentException"/> (with <paramref name="paramName"/>) otherwise. Returns the
+        /// trimmed path on success.
+        /// </summary>
+        public static string RequireResFilePath(string? path, string paramName)
+        {
+            var p = (path ?? string.Empty).Trim();
+            if (!IsResPath(p))
+                throw new ArgumentException($"Path must be a '{ResScheme}' path; got '{path}'.", paramName);
+            if (p.EndsWith("/", StringComparison.Ordinal))
+                throw new ArgumentException($"Path must be a file path, not a directory; got '{path}'.", paramName);
+            return p;
+        }
+    }
+}

--- a/addons/godot_mcp/Tools/Tool_FileSystem.List.cs
+++ b/addons/godot_mcp/Tools/Tool_FileSystem.List.cs
@@ -65,7 +65,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                     var subPath = sub.GetPath(); // already a 'res://.../' trailing-slash form
                     listing.Entries.Add(new FileSystemEntry
                     {
-                        Name = TrimTrailingSlash(GetLeafName(subPath)),
+                        Name = GetLeafName(subPath), // GetLeafName already strips the trailing slash
                         Path = subPath,
                         IsDirectory = true,
                     });
@@ -115,8 +115,6 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             var idx = trimmed.LastIndexOf('/');
             return idx < 0 ? trimmed : trimmed.Substring(idx + 1);
         }
-
-        static string TrimTrailingSlash(string s) => s.TrimEnd('/');
     }
 }
 #endif

--- a/addons/godot_mcp/Tools/Tool_FileSystem.List.cs
+++ b/addons/godot_mcp/Tools/Tool_FileSystem.List.cs
@@ -1,0 +1,122 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_FileSystem
+    {
+        public const string FileSystemListToolId = "filesystem-list";
+
+        [AiTool
+        (
+            FileSystemListToolId,
+            Title = "FileSystem / List",
+            ReadOnlyHint = true,
+            IdempotentHint = true,
+            OpenWorldHint = false
+        )]
+        [Description("Browse the Godot project's res:// filesystem one directory at a time. Pass a 'path' " +
+            "(a res:// directory, e.g. 'res://materials' — a trailing slash is optional); omit it (or pass " +
+            "'res://') to list the project root. Returns the directory's immediate sub-directories and files. " +
+            "Each file entry includes the importer-assigned resource type (e.g. 'PackedScene', 'Texture2D') " +
+            "and uid (when assigned) — read straight from the editor's filesystem index, so no resource is " +
+            "loaded. A non-existent or non-res:// path yields a structured error.")]
+        public FileSystemListing List
+        (
+            [Description("res:// directory to list (a trailing slash is optional). Omit or pass 'res://' for the project root.")]
+            string? path = null
+        )
+        {
+            return MainThread.Instance.Run(() =>
+            {
+                var dirPath = ResPathNormalizer.NormalizeDir(path);
+
+                var efs = EditorInterface.Singleton.GetResourceFilesystem()
+                    ?? throw new Exception("Editor resource filesystem is not available.");
+
+                var dir = efs.GetFilesystemPath(dirPath)
+                    ?? throw new ArgumentException($"Directory '{dirPath}' was not found in the project filesystem.", nameof(path));
+
+                var listing = new FileSystemListing { Path = dirPath };
+
+                // Sub-directories first.
+                var subDirCount = dir.GetSubdirCount();
+                for (int i = 0; i < subDirCount; i++)
+                {
+                    var sub = dir.GetSubdir(i);
+                    if (sub == null)
+                        continue;
+
+                    var subPath = sub.GetPath(); // already a 'res://.../' trailing-slash form
+                    listing.Entries.Add(new FileSystemEntry
+                    {
+                        Name = TrimTrailingSlash(GetLeafName(subPath)),
+                        Path = subPath,
+                        IsDirectory = true,
+                    });
+                }
+
+                // Then files.
+                var fileCount = dir.GetFileCount();
+                for (int i = 0; i < fileCount; i++)
+                {
+                    var filePath = dir.GetFilePath(i);
+                    var fileType = dir.GetFileType(i).ToString(); // GetFileType(int) returns a StringName
+
+                    // Resolve the uid when the importer assigned one (Godot 4.3: ResourceLoader maps res://->uid).
+                    var uidText = GodotUidForPath(filePath);
+                    var uid = string.IsNullOrEmpty(uidText) ? null : uidText;
+
+                    listing.Entries.Add(new FileSystemEntry
+                    {
+                        Name = GetLeafName(filePath),
+                        Path = filePath,
+                        IsDirectory = false,
+                        ResourceType = string.IsNullOrEmpty(fileType) ? null : fileType,
+                        Uid = uid,
+                    });
+                }
+
+                listing.DirectoryCount = subDirCount;
+                listing.FileCount = fileCount;
+                return listing;
+            });
+        }
+
+        /// <summary>
+        /// res:// → uid:// text for a file, or empty when the file has no registered uid. Main-thread only
+        /// (touches <see cref="ResourceLoader"/>). Returns Godot's <c>uid://</c> text form.
+        /// </summary>
+        static string GodotUidForPath(string resPath)
+        {
+            var id = ResourceLoader.GetResourceUid(resPath);
+            return id == ResourceUid.InvalidId ? string.Empty : ResourceUid.IdToText(id);
+        }
+
+        /// <summary>Leaf (last segment) of a res:// path; a trailing slash on a directory path is preserved by the caller.</summary>
+        static string GetLeafName(string resPath)
+        {
+            var trimmed = resPath.TrimEnd('/');
+            var idx = trimmed.LastIndexOf('/');
+            return idx < 0 ? trimmed : trimmed.Substring(idx + 1);
+        }
+
+        static string TrimTrailingSlash(string s) => s.TrimEnd('/');
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_FileSystem.Reimport.cs
+++ b/addons/godot_mcp/Tools/Tool_FileSystem.Reimport.cs
@@ -1,0 +1,96 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Threading;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_FileSystem
+    {
+        public const string FileSystemReimportToolId = "filesystem-reimport";
+
+        [AiTool
+        (
+            FileSystemReimportToolId,
+            Title = "FileSystem / Reimport",
+            IdempotentHint = true
+        )]
+        [Description("Re-scan the Godot project's res:// filesystem and/or reimport specific files, then " +
+            "wait for the import to settle before returning. The Godot analog of Unity's AssetDatabase.Refresh. " +
+            "Two modes:\n" +
+            "  - Pass 'files' (a list of res:// paths) to reimport exactly those files via " +
+            "EditorFileSystem.ReimportFiles — use this after editing a source asset's bytes outside the editor.\n" +
+            "  - Omit 'files' (or pass an empty list) to trigger a full EditorFileSystem.Scan — use this after " +
+            "adding/removing files on disk so Godot picks up the change.\n" +
+            "The call blocks until scanning completes (bounded), so a subsequent resource-find/get-data sees " +
+            "the settled state. Returns a short status string.")]
+        public string Reimport
+        (
+            [Description("Optional list of res:// file paths to reimport. When omitted/empty, a full filesystem scan is run instead.")]
+            List<string>? files = null
+        )
+        {
+            return MainThread.Instance.Run(() =>
+            {
+                var efs = EditorInterface.Singleton.GetResourceFilesystem()
+                    ?? throw new Exception("Editor resource filesystem is not available.");
+
+                var hasFiles = files != null && files.Count > 0;
+
+                string action;
+                if (hasFiles)
+                {
+                    // Validate every path up front so a single bad entry is a clean error, not a partial import.
+                    foreach (var f in files!)
+                    {
+                        var p = ResPathNormalizer.RequireResFilePath(f, nameof(files));
+                        if (!FileAccess.FileExists(p))
+                            throw new ArgumentException($"No file exists at '{p}'.", nameof(files));
+                    }
+
+                    efs.ReimportFiles(files!.ToArray());
+                    action = $"Reimported {files.Count} file(s)";
+                }
+                else
+                {
+                    efs.Scan();
+                    action = "Full filesystem scan";
+                }
+
+                // Settle: Scan() runs the index asynchronously, so poll IsScanning() until it clears (with a
+                // bounded number of short sleeps so a stuck scan cannot hang the tool indefinitely).
+                // ReimportFiles is synchronous, but IsScanning() may still report a tail scan — the same wait
+                // covers both. The MainThread dispatcher already executes us on the editor main thread, so a
+                // short Thread.Sleep here yields without re-entrancy issues.
+                const int maxWaits = 200;          // 200 * 25ms = 5s ceiling
+                const int sleepMs = 25;
+                var waits = 0;
+                while (efs.IsScanning() && waits < maxWaits)
+                {
+                    Thread.Sleep(sleepMs);
+                    waits++;
+                }
+
+                var settled = !efs.IsScanning();
+                return settled
+                    ? $"{action}; filesystem settled."
+                    : $"{action}; filesystem still scanning after {maxWaits * sleepMs}ms (progress={efs.GetScanningProgress():0.00}).";
+            });
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_FileSystem.Reimport.cs
+++ b/addons/godot_mcp/Tools/Tool_FileSystem.Reimport.cs
@@ -51,6 +51,12 @@ namespace com.IvanMurzak.Godot.MCP.Tools
 
                 var hasFiles = files != null && files.Count > 0;
 
+                // Bounded settle loop tunables. The MainThread dispatcher already executes us on the editor
+                // main thread, so a short Thread.Sleep here yields without re-entrancy issues.
+                const int sleepMs = 25;
+                const int maxWaits = 200;          // 200 * 25ms = 5s settle ceiling
+                const int primeWaits = 40;         // 40 * 25ms = 1s ceiling to observe the scan START
+
                 string action;
                 if (hasFiles)
                 {
@@ -64,20 +70,50 @@ namespace com.IvanMurzak.Godot.MCP.Tools
 
                     efs.ReimportFiles(files!.ToArray());
                     action = $"Reimported {files.Count} file(s)";
-                }
-                else
-                {
-                    efs.Scan();
-                    action = "Full filesystem scan";
+
+                    // ReimportFiles is synchronous; only a tail scan (if any) may still be in flight. Do NOT
+                    // prime here — a prime that never observes a scan would falsely report "never started".
+                    // Just drain whatever scan is currently running (bounded).
+                    var tailWaits = 0;
+                    while (efs.IsScanning() && tailWaits < maxWaits)
+                    {
+                        Thread.Sleep(sleepMs);
+                        tailWaits++;
+                    }
+
+                    var tailSettled = !efs.IsScanning();
+                    return tailSettled
+                        ? $"{action}; filesystem settled."
+                        : $"{action}; filesystem still scanning after {maxWaits * sleepMs}ms (progress={efs.GetScanningProgress():0.00}).";
                 }
 
-                // Settle: Scan() runs the index asynchronously, so poll IsScanning() until it clears (with a
-                // bounded number of short sleeps so a stuck scan cannot hang the tool indefinitely).
-                // ReimportFiles is synchronous, but IsScanning() may still report a tail scan — the same wait
-                // covers both. The MainThread dispatcher already executes us on the editor main thread, so a
-                // short Thread.Sleep here yields without re-entrancy issues.
-                const int maxWaits = 200;          // 200 * 25ms = 5s ceiling
-                const int sleepMs = 25;
+                // Full scan. Scan() runs the index ASYNCHRONOUSLY, so IsScanning() can still be false on the
+                // first check (the scan has not begun yet). A naive `while (IsScanning())` would exit
+                // immediately and falsely report "settled" though nothing was indexed — defeating the tool's
+                // purpose. So PRIME first: poll until the scan is observed running at least once (bounded),
+                // and only then poll until it clears.
+                efs.Scan();
+                action = "Full filesystem scan";
+
+                var primed = false;
+                var primePolls = 0;
+                while (primePolls < primeWaits)
+                {
+                    if (efs.IsScanning())
+                    {
+                        primed = true;
+                        break;
+                    }
+                    Thread.Sleep(sleepMs);
+                    primePolls++;
+                }
+
+                if (!primed)
+                    // The scan never started within the prime window. Report it explicitly rather than
+                    // silently claiming "settled" — the caller should not assume the index was refreshed.
+                    return $"{action}; scan did not start within {primeWaits * sleepMs}ms — filesystem may be unchanged or busy (NOT confirmed settled).";
+
+                // Scan observed running; now drain it (bounded).
                 var waits = 0;
                 while (efs.IsScanning() && waits < maxWaits)
                 {

--- a/addons/godot_mcp/Tools/Tool_FileSystem.Reimport.cs
+++ b/addons/godot_mcp/Tools/Tool_FileSystem.Reimport.cs
@@ -60,16 +60,21 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 string action;
                 if (hasFiles)
                 {
-                    // Validate every path up front so a single bad entry is a clean error, not a partial import.
+                    // Validate every path up front so a single bad entry is a clean error, not a partial
+                    // import. Collect the normalized/trimmed paths and reimport THOSE — passing the raw
+                    // 'files' (which may carry surrounding whitespace) would not match a known res:// file
+                    // and ReimportFiles would silently no-op.
+                    var normalized = new List<string>(files!.Count);
                     foreach (var f in files!)
                     {
                         var p = ResPathNormalizer.RequireResFilePath(f, nameof(files));
                         if (!FileAccess.FileExists(p))
                             throw new ArgumentException($"No file exists at '{p}'.", nameof(files));
+                        normalized.Add(p);
                     }
 
-                    efs.ReimportFiles(files!.ToArray());
-                    action = $"Reimported {files.Count} file(s)";
+                    efs.ReimportFiles(normalized.ToArray());
+                    action = $"Reimported {normalized.Count} file(s)";
 
                     // ReimportFiles is synchronous; only a tail scan (if any) may still be in flight. Do NOT
                     // prime here — a prime that never observes a scan would falsely report "never started".

--- a/addons/godot_mcp/Tools/Tool_FileSystem.cs
+++ b/addons/godot_mcp/Tools/Tool_FileSystem.cs
@@ -1,0 +1,40 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using com.IvanMurzak.McpPlugin;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// FileSystem tool family (<c>filesystem-*</c>) — the Godot analog of the read-only "browse the
+    /// project" half of Unity-MCP's <c>Tool_Assets</c> (<c>assets-find</c>). It walks the editor's
+    /// <see cref="EditorFileSystem"/> — the project-aware index of the <c>res://</c> tree — through the
+    /// main-thread dispatcher.
+    ///
+    /// <para>
+    /// Godot ↔ Unity mapping: <see cref="EditorFileSystem"/> ↔ Unity's <c>AssetDatabase</c>; an
+    /// <see cref="EditorFileSystemDirectory"/> ↔ a folder of asset GUIDs; the importer-assigned
+    /// per-file type ↔ a Unity asset's main type. The <see cref="EditorFileSystem"/> already knows each
+    /// file's resource type + uid without loading the resource, so listing is cheap and side-effect-free.
+    /// </para>
+    ///
+    /// Editor-only (<c>#if TOOLS</c>): the handlers touch <see cref="EditorInterface"/> and
+    /// <see cref="EditorFileSystem"/>, neither of which exists in a plain (non-editor) build. The
+    /// pure-managed result models (<see cref="Data.FileSystemEntry"/>/<see cref="Data.FileSystemListing"/>)
+    /// live outside this guard and are unit-tested.
+    /// </summary>
+    [AiToolType]
+    public partial class Tool_FileSystem
+    {
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Resource.Create.cs
+++ b/addons/godot_mcp/Tools/Tool_Resource.Create.cs
@@ -52,7 +52,10 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                     && !resPath.EndsWith(".res", StringComparison.OrdinalIgnoreCase))
                     throw new ArgumentException($"resourcePath must end with '.tres' or '.res'; got '{resourcePath}'.", nameof(resourcePath));
 
-                if (ResourceLoader.Exists(resPath))
+                // Guard on the file on disk (like sibling Move/Delete), not just on a LOADABLE resource:
+                // ResourceLoader.Exists is false for a present-but-unimported / non-resource file, which
+                // ResourceSaver.Save would then silently overwrite.
+                if (FileAccess.FileExists(resPath) || ResourceLoader.Exists(resPath))
                     throw new ArgumentException($"A resource already exists at '{resPath}'. Use '{ResourceModifyToolId}' to change it, " +
                         $"or '{ResourceMoveToolId}'/'{ResourceDeleteToolId}' to relocate/remove it first.", nameof(resourcePath));
 

--- a/addons/godot_mcp/Tools/Tool_Resource.Create.cs
+++ b/addons/godot_mcp/Tools/Tool_Resource.Create.cs
@@ -1,0 +1,92 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Resource
+    {
+        public const string ResourceCreateToolId = "resource-create";
+
+        [AiTool
+        (
+            ResourceCreateToolId,
+            Title = "Resource / Create"
+        )]
+        [Description("Create a new Godot Resource (.tres/.res) on disk. A fresh instance of the Godot class " +
+            "named by 'typeClassName' (e.g. 'StandardMaterial3D', 'Resource', 'Curve') is instantiated, then " +
+            "saved to 'resourcePath' (which must be a res:// path ending in '.tres' or '.res') via " +
+            "ResourceSaver. The editor filesystem is updated so the new asset is importable immediately. " +
+            "Use '" + ResourceModifyToolId + "' afterwards to set its properties. Returns the new resource's " +
+            "identity (res:// path, uid, type).")]
+        public ResourceInfo Create
+        (
+            [Description("res:// path for the new resource file, ending in '.tres' or '.res' (e.g. 'res://materials/wood.tres').")]
+            string resourcePath,
+            [Description("Godot class to instantiate for the resource (must derive from Resource), e.g. " +
+                "'StandardMaterial3D', 'Curve', 'Resource'. Defaults to 'Resource'.")]
+            string? typeClassName = null
+        )
+        {
+            if (string.IsNullOrEmpty(resourcePath))
+                throw new ArgumentException("resourcePath cannot be null or empty.", nameof(resourcePath));
+
+            return MainThread.Instance.Run(() =>
+            {
+                var resPath = ResPathNormalizer.RequireResFilePath(resourcePath, nameof(resourcePath));
+                if (!resPath.EndsWith(".tres", StringComparison.OrdinalIgnoreCase)
+                    && !resPath.EndsWith(".res", StringComparison.OrdinalIgnoreCase))
+                    throw new ArgumentException($"resourcePath must end with '.tres' or '.res'; got '{resourcePath}'.", nameof(resourcePath));
+
+                if (ResourceLoader.Exists(resPath))
+                    throw new ArgumentException($"A resource already exists at '{resPath}'. Use '{ResourceModifyToolId}' to change it, " +
+                        $"or '{ResourceMoveToolId}'/'{ResourceDeleteToolId}' to relocate/remove it first.", nameof(resourcePath));
+
+                var className = string.IsNullOrEmpty(typeClassName) ? "Resource" : typeClassName!;
+                if (!ClassDB.ClassExists(className))
+                    throw new ArgumentException($"Unknown Godot class '{className}'.", nameof(typeClassName));
+                if (!ClassDB.CanInstantiate(className))
+                    throw new ArgumentException($"Godot class '{className}' cannot be instantiated (abstract/virtual).", nameof(typeClassName));
+                if (!ClassDB.IsParentClass(className, "Resource"))
+                    throw new ArgumentException($"Godot class '{className}' does not derive from Resource.", nameof(typeClassName));
+
+                var resource = ClassDB.Instantiate(className).As<Resource>()
+                    ?? throw new ArgumentException($"Godot class '{className}' did not instantiate to a Resource.", nameof(typeClassName));
+
+                // ResourceSaver.Save does NOT create missing parent directories — create them first so a
+                // nested target path (e.g. 'res://materials/wood.tres') works like Unity's CreateAsset.
+                var targetDir = resPath.Substring(0, resPath.LastIndexOf('/') + 1);
+                if (!DirAccess.DirExistsAbsolute(targetDir))
+                {
+                    var mkErr = DirAccess.MakeDirRecursiveAbsolute(targetDir);
+                    if (mkErr != Error.Ok)
+                        throw new Exception($"Failed to create target directory '{targetDir}': {mkErr}.");
+                }
+
+                var saveErr = ResourceSaver.Save(resource, resPath);
+                if (saveErr != Error.Ok)
+                    throw new Exception($"Failed to save new resource to '{resPath}': {saveErr}.");
+
+                // Make the new asset visible to the editor's resource filesystem (no full rescan needed).
+                EditorInterface.Singleton.GetResourceFilesystem()?.UpdateFile(resPath);
+
+                return ToResourceInfo(resPath, resource);
+            });
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Resource.Delete.cs
+++ b/addons/godot_mcp/Tools/Tool_Resource.Delete.cs
@@ -55,17 +55,30 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 if (rmErr != Error.Ok)
                     throw new Exception($"Failed to delete '{resPath}': {rmErr}.");
 
-                // Remove the sidecar '.import' metadata if present.
-                var importPath = resPath + ".import";
-                if (FileAccess.FileExists(importPath))
+                // From here the resource file is already gone. This is a MULTI-FILE op (resource + .import
+                // sidecar): if the sidecar removal throws below, the resource itself is still deleted. Rescan
+                // in a 'finally' regardless so the editor index drops the removed entry even on partial
+                // failure — never leave a stale index pointing at a file that no longer exists.
+                try
                 {
-                    var rmImportErr = DirAccess.RemoveAbsolute(importPath);
-                    if (rmImportErr != Error.Ok)
-                        throw new Exception($"Deleted '{resPath}' but failed to remove its '.import' sidecar '{importPath}': {rmImportErr}.");
+                    // Remove the sidecar '.import' metadata if present.
+                    var importPath = resPath + ".import";
+                    if (FileAccess.FileExists(importPath))
+                    {
+                        var rmImportErr = DirAccess.RemoveAbsolute(importPath);
+                        if (rmImportErr != Error.Ok)
+                            throw new Exception(
+                                $"Inconsistent state: resource '{resPath}' was deleted but its '.import' " +
+                                $"sidecar '{importPath}' failed to remove ({rmImportErr}). The resource itself " +
+                                "is already gone; remove the orphaned sidecar manually.");
+                    }
                 }
-
-                // Rescan so the editor filesystem drops the removed entry.
-                EditorInterface.Singleton.GetResourceFilesystem()?.Scan();
+                finally
+                {
+                    // Rescan so the editor filesystem drops the removed entry — runs even when the sidecar
+                    // removal threw, so the index never lists a resource that no longer exists on disk.
+                    EditorInterface.Singleton.GetResourceFilesystem()?.Scan();
+                }
 
                 return info;
             });

--- a/addons/godot_mcp/Tools/Tool_Resource.Delete.cs
+++ b/addons/godot_mcp/Tools/Tool_Resource.Delete.cs
@@ -1,0 +1,75 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Resource
+    {
+        public const string ResourceDeleteToolId = "resource-delete";
+
+        [AiTool
+        (
+            ResourceDeleteToolId,
+            Title = "Resource / Delete"
+        )]
+        [Description("Delete a resource file from the res:// filesystem. 'resourcePath' must be a res:// file " +
+            "path. The resource's identity (path, uid, type) is captured BEFORE deletion and returned for " +
+            "confirmation. The resource file is removed with DirAccess, along with its sidecar '.import' " +
+            "metadata when present, then the editor filesystem is rescanned. WARNING: other resources holding " +
+            "a hard reference to this file will break — verify with '" + ResourceFindToolId + "' first.")]
+        public ResourceInfo Delete
+        (
+            [Description("res:// path of the resource file to delete.")]
+            string resourcePath
+        )
+        {
+            if (string.IsNullOrEmpty(resourcePath))
+                throw new ArgumentException("resourcePath cannot be null or empty.", nameof(resourcePath));
+
+            return MainThread.Instance.Run(() =>
+            {
+                var resPath = ResPathNormalizer.RequireResFilePath(resourcePath, nameof(resourcePath));
+
+                if (!FileAccess.FileExists(resPath))
+                    throw new ArgumentException($"No file exists at '{resPath}'.", nameof(resourcePath));
+
+                // Snapshot identity BEFORE removing the file (path/uid/type are unrecoverable afterwards).
+                var info = ToResourceInfo(resPath);
+
+                var rmErr = DirAccess.RemoveAbsolute(resPath);
+                if (rmErr != Error.Ok)
+                    throw new Exception($"Failed to delete '{resPath}': {rmErr}.");
+
+                // Remove the sidecar '.import' metadata if present.
+                var importPath = resPath + ".import";
+                if (FileAccess.FileExists(importPath))
+                {
+                    var rmImportErr = DirAccess.RemoveAbsolute(importPath);
+                    if (rmImportErr != Error.Ok)
+                        throw new Exception($"Deleted '{resPath}' but failed to remove its '.import' sidecar '{importPath}': {rmImportErr}.");
+                }
+
+                // Rescan so the editor filesystem drops the removed entry.
+                EditorInterface.Singleton.GetResourceFilesystem()?.Scan();
+
+                return info;
+            });
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Resource.Find.cs
+++ b/addons/godot_mcp/Tools/Tool_Resource.Find.cs
@@ -1,0 +1,163 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Resource
+    {
+        public const string ResourceFindToolId = "resource-find";
+
+        [AiTool
+        (
+            ResourceFindToolId,
+            Title = "Resource / Find",
+            ReadOnlyHint = true,
+            IdempotentHint = true,
+            OpenWorldHint = false
+        )]
+        [Description("Find resources in the Godot project's res:// filesystem. Combine any of:\n" +
+            "  - 'resourcePath' — an exact res:// path to resolve (also accepts a 'uid://' which is mapped " +
+            "to its path).\n" +
+            "  - 'uid' — a 'uid://' identifier to resolve to its res:// path.\n" +
+            "  - 'typeFilter' — a Godot type name (e.g. 'PackedScene', 'Texture2D', 'Resource'); only files " +
+            "whose importer-assigned type equals or derives from it are returned.\n" +
+            "  - 'directory' — a res:// directory to scope the type-filtered scan (defaults to the whole project).\n" +
+            "With 'resourcePath' or 'uid', returns that single resource (a structured error if it does not " +
+            "exist). With 'typeFilter' (and optional 'directory'), recursively scans the editor filesystem " +
+            "and returns every match. Each hit carries res:// path, uid, and type.")]
+        public ResourceFindResult Find
+        (
+            [Description("Optional exact res:// path (or uid://) to resolve to a single resource.")]
+            string? resourcePath = null,
+            [Description("Optional uid:// identifier to resolve to a single resource.")]
+            string? uid = null,
+            [Description("Optional Godot type name to filter by (e.g. 'PackedScene', 'Texture2D'). Matches " +
+                "the file's importer-assigned type, including subclasses.")]
+            string? typeFilter = null,
+            [Description("Optional res:// directory to scope a type-filtered scan. Defaults to the project root.")]
+            string? directory = null
+        )
+        {
+            var hasPath = !string.IsNullOrWhiteSpace(resourcePath);
+            var hasUid = !string.IsNullOrWhiteSpace(uid);
+            var hasType = !string.IsNullOrWhiteSpace(typeFilter);
+
+            if (!hasPath && !hasUid && !hasType)
+                throw new ArgumentException(
+                    $"At least one of '{nameof(resourcePath)}', '{nameof(uid)}', or '{nameof(typeFilter)}' is required.");
+
+            return MainThread.Instance.Run(() =>
+            {
+                var result = new ResourceFindResult();
+                var efs = EditorInterface.Singleton.GetResourceFilesystem()
+                    ?? throw new Exception("Editor resource filesystem is not available.");
+
+                // 1) Direct lookup by uid (mapped to a res:// path).
+                if (hasUid)
+                {
+                    var resolved = ResolveUidToPath(uid!)
+                        ?? throw new ArgumentException($"uid '{uid}' does not resolve to any resource.", nameof(uid));
+                    AddSingle(result, resolved);
+                    return result;
+                }
+
+                // 2) Direct lookup by path (a 'uid://' path is mapped first).
+                if (hasPath)
+                {
+                    var resPath = resourcePath!.StartsWith("uid://", StringComparison.Ordinal)
+                        ? (ResolveUidToPath(resourcePath!) ?? throw new ArgumentException($"uid '{resourcePath}' does not resolve to any resource.", nameof(resourcePath)))
+                        : resourcePath!;
+
+                    if (!ResourceLoader.Exists(resPath))
+                        throw new ArgumentException($"No resource exists at '{resPath}'.", nameof(resourcePath));
+
+                    AddSingle(result, resPath);
+                    return result;
+                }
+
+                // 3) Type-filtered recursive scan over the editor filesystem.
+                var scope = ResPathNormalizer.NormalizeDir(directory);
+                var rootDir = efs.GetFilesystemPath(scope)
+                    ?? throw new ArgumentException($"Directory '{scope}' was not found in the project filesystem.", nameof(directory));
+
+                CollectByType(rootDir, typeFilter!, result.Resources);
+                result.Count = result.Resources.Count;
+                return result;
+            });
+        }
+
+        /// <summary>Add a single resolved path to <paramref name="result"/>. Main-thread only.</summary>
+        static void AddSingle(ResourceFindResult result, string resPath)
+        {
+            result.Resources.Add(ToResourceInfo(resPath));
+            result.Count = result.Resources.Count;
+        }
+
+        /// <summary>uid:// text → res:// path, or null when the uid is unknown. Main-thread only.</summary>
+        static string? ResolveUidToPath(string uidText)
+        {
+            var id = ResourceUid.TextToId(uidText);
+            if (id == ResourceUid.InvalidId || !ResourceUid.HasId(id))
+                return null;
+            var path = ResourceUid.GetIdPath(id);
+            return string.IsNullOrEmpty(path) ? null : path;
+        }
+
+        /// <summary>
+        /// Recursively walk <paramref name="dir"/> collecting every file whose importer-assigned type
+        /// matches <paramref name="typeFilter"/> (exact or subclass via <see cref="ClassDB.IsParentClass"/>).
+        /// Main-thread only.
+        /// </summary>
+        static void CollectByType(EditorFileSystemDirectory dir, string typeFilter, List<ResourceInfo> sink)
+        {
+            var fileCount = dir.GetFileCount();
+            for (int i = 0; i < fileCount; i++)
+            {
+                var fileType = dir.GetFileType(i).ToString();
+                if (TypeMatches(fileType, typeFilter))
+                    sink.Add(ToResourceInfo(dir.GetFilePath(i)));
+            }
+
+            var subCount = dir.GetSubdirCount();
+            for (int i = 0; i < subCount; i++)
+            {
+                var sub = dir.GetSubdir(i);
+                if (sub != null)
+                    CollectByType(sub, typeFilter, sink);
+            }
+        }
+
+        /// <summary>
+        /// True when <paramref name="fileType"/> equals <paramref name="typeFilter"/> or derives from it.
+        /// Uses <see cref="ClassDB.IsParentClass"/> when both are known engine classes; otherwise falls
+        /// back to a case-sensitive equality so custom/script types still match exactly.
+        /// </summary>
+        static bool TypeMatches(string fileType, string typeFilter)
+        {
+            if (string.IsNullOrEmpty(fileType))
+                return false;
+            if (fileType == typeFilter)
+                return true;
+            if (ClassDB.ClassExists(fileType) && ClassDB.ClassExists(typeFilter))
+                return ClassDB.IsParentClass(fileType, typeFilter);
+            return false;
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Resource.Find.cs
+++ b/addons/godot_mcp/Tools/Tool_Resource.Find.cs
@@ -40,7 +40,10 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             "  - 'directory' — a res:// directory to scope the type-filtered scan (defaults to the whole project).\n" +
             "With 'resourcePath' or 'uid', returns that single resource (a structured error if it does not " +
             "exist). With 'typeFilter' (and optional 'directory'), recursively scans the editor filesystem " +
-            "and returns every match. Each hit carries res:// path, uid, and type.")]
+            "and returns every match. Each hit carries res:// path, uid, and type.\n" +
+            "NOTE: 'resourcePath' and 'uid' are mutually exclusive — when both are supplied 'uid' takes " +
+            "precedence and 'resourcePath' is ignored. For a direct path/uid lookup, 'typeFilter' and " +
+            "'directory' are ignored (they only apply to the type-filtered scan).")]
         public ResourceFindResult Find
         (
             [Description("Optional exact res:// path (or uid://) to resolve to a single resource.")]

--- a/addons/godot_mcp/Tools/Tool_Resource.GetData.cs
+++ b/addons/godot_mcp/Tools/Tool_Resource.GetData.cs
@@ -1,0 +1,69 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.Godot.MCP.Reflection;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Model;
+using com.IvanMurzak.ReflectorNet.Utils;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Resource
+    {
+        public const string ResourceGetDataToolId = "resource-get-data";
+
+        [AiTool
+        (
+            ResourceGetDataToolId,
+            Title = "Resource / Get Data",
+            ReadOnlyHint = true,
+            IdempotentHint = true,
+            OpenWorldHint = false
+        )]
+        [Description("Get the serialized data of a Godot Resource (.tres/.res asset) — every serializable " +
+            "property — via ReflectorNet. Identify the resource with 'resourceRef' (a res:// path is " +
+            "preferred; an instance id of an already-loaded resource also works). Use '" + ResourceFindToolId +
+            "' to locate the resource first. Returns a ReflectorNet SerializedMember describing the resource; " +
+            "a resource that cannot be resolved yields a structured error.")]
+        public SerializedMember GetData
+        (
+            [Description("Reference to the resource to read (res:// path preferred, else a loaded instance id).")]
+            ResourceRef resourceRef
+        )
+        {
+            if (resourceRef == null)
+                throw new ArgumentNullException(nameof(resourceRef));
+            if (!resourceRef.IsValid(out var validationError))
+                throw new ArgumentException(validationError, nameof(resourceRef));
+
+            return MainThread.Instance.Run(() =>
+            {
+                var resource = ResolveResource(resourceRef, out var path, out var error);
+                if (resource == null)
+                    throw new Exception(error ?? $"Resource {resourceRef} not found.");
+
+                var reflector = GodotMcpReflector.GetOrCreate();
+                var name = string.IsNullOrEmpty(path)
+                    ? (string.IsNullOrEmpty(resource.ResourceName) ? resource.GetClass() : resource.ResourceName)
+                    : path!;
+
+                return reflector.Serialize(
+                    obj: resource,
+                    name: name,
+                    recursive: true);
+            });
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Resource.Modify.cs
+++ b/addons/godot_mcp/Tools/Tool_Resource.Modify.cs
@@ -1,0 +1,167 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.Godot.MCP.Reflection;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Model;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Resource
+    {
+        public const string ResourceModifyToolId = "resource-modify";
+
+        [AiTool
+        (
+            ResourceModifyToolId,
+            Title = "Resource / Modify",
+            IdempotentHint = true
+        )]
+        [Description("Modify properties of a Godot Resource (.tres/.res asset) via ReflectorNet and save it " +
+            "back to disk. Identify the resource with 'resourceRef' (a res:// path is required — an instance " +
+            "id with no on-disk path cannot be saved). Two modification surfaces (supply at least one; both " +
+            "may be combined, applied jsonPatch first then pathPatches):\n" +
+            "  1. 'pathPatches' — list of {path, value} entries routed through Reflector.TryModifyAt. " +
+            "Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'.\n" +
+            "  2. 'jsonPatch' — a JSON Merge Patch (RFC 7396) string routed through Reflector.TryPatch.\n" +
+            "On success the resource is re-saved with ResourceSaver and the editor filesystem is updated " +
+            "(the .import sidecar is left untouched). Use '" + ResourceGetDataToolId + "' first to inspect " +
+            "the structure. Returns a log of what was changed and what was ignored.")]
+        public Logs Modify
+        (
+            [Description("Reference to the resource to modify (res:// path required; an unsaved instance cannot be persisted).")]
+            ResourceRef resourceRef,
+            [Description("Optional list of path-scoped patches routed through Reflector.TryModifyAt. " +
+                "Each entry is a {path, value}. Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'.")]
+            List<NodePropertyPatch>? pathPatches = null,
+            [Description("Optional JSON Merge Patch (RFC 7396) applied via Reflector.TryPatch.")]
+            string? jsonPatch = null
+        )
+        {
+            var hasPathPatches = pathPatches != null && pathPatches.Count > 0;
+            var hasJsonPatch = !string.IsNullOrWhiteSpace(jsonPatch);
+
+            if (!hasPathPatches && !hasJsonPatch)
+                throw new ArgumentException(
+                    $"At least one of '{nameof(pathPatches)}' or '{nameof(jsonPatch)}' is required.");
+
+            return MainThread.Instance.Run(() =>
+            {
+                var logs = new Logs();
+
+                var resource = ResolveResource(resourceRef, out var path, out var error);
+                if (error != null)
+                {
+                    logs.Error(error);
+                    return logs;
+                }
+                if (resource == null)
+                {
+                    logs.Error($"Resource {resourceRef} not found.");
+                    return logs;
+                }
+                if (string.IsNullOrEmpty(path))
+                {
+                    logs.Error("Resource has no res:// path on disk, so a modification cannot be saved. " +
+                        "Provide a 'resourceRef' with a 'resourcePath'.");
+                    return logs;
+                }
+
+                var reflector = GodotMcpReflector.GetOrCreate();
+                object? objToModify = resource;
+                var anyChange = false;
+
+                // ReflectorNet's TryPatch/TryModifyAt accumulate errors into 'logs' and are documented not to
+                // throw, but a malformed patch could still surface an exception from a converter. Wrap each
+                // patch-surface call so a bad entry degrades to a logged skip instead of aborting and leaving
+                // a half-modified, unsaved resource.
+                // 1) JSON Merge Patch (applied first).
+                if (hasJsonPatch)
+                {
+                    try
+                    {
+                        if (reflector.TryPatch(ref objToModify, jsonPatch!, logs: logs))
+                            anyChange = true;
+                    }
+                    catch (Exception ex)
+                    {
+                        logs.Error($"jsonPatch threw and was skipped: {ex.Message}");
+                    }
+                }
+
+                // 2) Path patches.
+                if (hasPathPatches)
+                {
+                    for (int i = 0; i < pathPatches!.Count; i++)
+                    {
+                        var patch = pathPatches[i];
+                        if (patch == null || string.IsNullOrEmpty(patch.Path))
+                        {
+                            logs.Error($"{nameof(pathPatches)}[{i}] with empty path skipped.");
+                            continue;
+                        }
+                        if (patch.Value == null)
+                        {
+                            logs.Error($"{nameof(pathPatches)}[{i}] ('{patch.Path}') with null value skipped.");
+                            continue;
+                        }
+                        try
+                        {
+                            if (reflector.TryModifyAt(ref objToModify, patch.Path, patch.Value, logs: logs))
+                                anyChange = true;
+                        }
+                        catch (Exception ex)
+                        {
+                            logs.Error($"{nameof(pathPatches)}[{i}] ('{patch.Path}') threw and was skipped: {ex.Message}");
+                        }
+                    }
+                }
+
+                // 'objToModify' is passed by ref: a patch may reassign it to a fresh boxed instance (e.g. a
+                // '$type' replacement) instead of mutating the live resource in place. Resource is a reference
+                // type, so in-place writes hit the loaded resource — but if the ref diverged, the resource we
+                // are about to save was NOT updated, so persisting would write stale data. Guard against it.
+                if (anyChange && !ReferenceEquals(objToModify, resource))
+                {
+                    logs.Error("Modification produced a new instance instead of mutating the loaded Resource " +
+                        "in place; the resource was NOT re-saved.");
+                    return logs;
+                }
+
+                if (!anyChange)
+                {
+                    logs.Warning("No modifications were made; the resource was not re-saved.");
+                    return logs;
+                }
+
+                // Persist via ResourceSaver (NOT a hand-edit of the .tres / .import sidecar) and make the
+                // editor filesystem aware of the change.
+                var saveErr = ResourceSaver.Save(resource, path!);
+                if (saveErr != Error.Ok)
+                {
+                    logs.Error($"Modifications applied in memory but ResourceSaver.Save('{path}') failed: {saveErr}.");
+                    return logs;
+                }
+
+                EditorInterface.Singleton.GetResourceFilesystem()?.UpdateFile(path!);
+                logs.Success($"Resource '{path}' modified and saved.");
+                return logs;
+            });
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Resource.Modify.cs
+++ b/addons/godot_mcp/Tools/Tool_Resource.Modify.cs
@@ -84,6 +84,9 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 var reflector = GodotMcpReflector.GetOrCreate();
                 object? objToModify = resource;
                 var anyChange = false;
+                // Track which surface (if any) reassigned 'objToModify' to a fresh boxed instance, so the
+                // $type-divergence rejection below can name the culprit for debuggability.
+                string? divergedSurface = null;
 
                 // ReflectorNet's TryPatch/TryModifyAt accumulate errors into 'logs' and are documented not to
                 // throw, but a malformed patch could still surface an exception from a converter. Wrap each
@@ -95,7 +98,11 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                     try
                     {
                         if (reflector.TryPatch(ref objToModify, jsonPatch!, logs: logs))
+                        {
                             anyChange = true;
+                            if (divergedSurface == null && !ReferenceEquals(objToModify, resource))
+                                divergedSurface = "jsonPatch";
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -122,7 +129,11 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                         try
                         {
                             if (reflector.TryModifyAt(ref objToModify, patch.Path, patch.Value, logs: logs))
+                            {
                                 anyChange = true;
+                                if (divergedSurface == null && !ReferenceEquals(objToModify, resource))
+                                    divergedSurface = $"pathPatches[{i}] ('{patch.Path}')";
+                            }
                         }
                         catch (Exception ex)
                         {
@@ -137,8 +148,9 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 // are about to save was NOT updated, so persisting would write stale data. Guard against it.
                 if (anyChange && !ReferenceEquals(objToModify, resource))
                 {
-                    logs.Error("Modification produced a new instance instead of mutating the loaded Resource " +
-                        "in place; the resource was NOT re-saved.");
+                    logs.Error($"Modification via {divergedSurface ?? "a patch surface"} produced a new " +
+                        "instance instead of mutating the loaded Resource in place (likely a '$type' " +
+                        "replacement); the resource was NOT re-saved.");
                     return logs;
                 }
 

--- a/addons/godot_mcp/Tools/Tool_Resource.Move.cs
+++ b/addons/godot_mcp/Tools/Tool_Resource.Move.cs
@@ -74,20 +74,31 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 if (moveErr != Error.Ok)
                     throw new Exception($"Failed to move '{src}' to '{dst}': {moveErr}.");
 
-                // Move the sidecar '.import' metadata if it exists (imported assets carry one; .tres usually
-                // do not). Keeping it next to the resource preserves import settings + uid mapping.
-                var srcImport = src + ".import";
-                if (FileAccess.FileExists(srcImport))
+                // From here the resource file is already at 'dst'. This is a MULTI-FILE op (resource +
+                // .import sidecar): if the sidecar rename throws below, the filesystem is left half-moved.
+                // Rescan in a 'finally' regardless so the editor index reflects on-disk reality (resource at
+                // dst) even on a partial failure — never leave a stale index pointing at the old location.
+                try
                 {
-                    var importErr = DirAccess.RenameAbsolute(srcImport, dst + ".import");
-                    if (importErr != Error.Ok)
-                        throw new Exception($"Moved '{src}' but failed to move its '.import' sidecar: {importErr}. " +
-                            "The asset may need a manual reimport.");
+                    // Move the sidecar '.import' metadata if it exists (imported assets carry one; .tres
+                    // usually do not). Keeping it next to the resource preserves import settings + uid mapping.
+                    var srcImport = src + ".import";
+                    if (FileAccess.FileExists(srcImport))
+                    {
+                        var importErr = DirAccess.RenameAbsolute(srcImport, dst + ".import");
+                        if (importErr != Error.Ok)
+                            throw new Exception(
+                                $"Inconsistent state: resource moved to '{dst}' but its '.import' sidecar " +
+                                $"failed to move ('{srcImport}' -> '{dst}.import': {importErr}). A manual " +
+                                "reimport of the moved resource is required to repair the import metadata.");
+                    }
                 }
-
-                // Rescan so the editor filesystem indexes the new location and drops the old one.
-                var efs = EditorInterface.Singleton.GetResourceFilesystem();
-                efs?.Scan();
+                finally
+                {
+                    // Rescan so the editor filesystem indexes the new location and drops the old one — runs
+                    // even when the sidecar move threw, so the index never lies about where the resource is.
+                    EditorInterface.Singleton.GetResourceFilesystem()?.Scan();
+                }
 
                 return ToResourceInfo(dst);
             });

--- a/addons/godot_mcp/Tools/Tool_Resource.Move.cs
+++ b/addons/godot_mcp/Tools/Tool_Resource.Move.cs
@@ -1,0 +1,97 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Resource
+    {
+        public const string ResourceMoveToolId = "resource-move";
+
+        [AiTool
+        (
+            ResourceMoveToolId,
+            Title = "Resource / Move",
+            IdempotentHint = false
+        )]
+        [Description("Move or rename a resource file in the res:// filesystem. Both 'sourcePath' and " +
+            "'destinationPath' must be res:// file paths. The resource file is moved with DirAccess; its " +
+            "sidecar '.import' metadata (when present) is moved alongside it so the import pipeline stays " +
+            "consistent. The editor filesystem is then rescanned so the new location is indexed. Returns the " +
+            "moved resource's identity at its new path. NOTE: hard-coded res:// path references in OTHER " +
+            "resources are not rewritten — prefer addressing assets by uid where stable references matter.")]
+        public ResourceInfo Move
+        (
+            [Description("res:// path of the resource to move (the existing file).")]
+            string sourcePath,
+            [Description("res:// destination path (the new file location/name).")]
+            string destinationPath
+        )
+        {
+            if (string.IsNullOrEmpty(sourcePath))
+                throw new ArgumentException("sourcePath cannot be null or empty.", nameof(sourcePath));
+            if (string.IsNullOrEmpty(destinationPath))
+                throw new ArgumentException("destinationPath cannot be null or empty.", nameof(destinationPath));
+
+            return MainThread.Instance.Run(() =>
+            {
+                var src = ResPathNormalizer.RequireResFilePath(sourcePath, nameof(sourcePath));
+                var dst = ResPathNormalizer.RequireResFilePath(destinationPath, nameof(destinationPath));
+
+                if (src == dst)
+                    throw new ArgumentException("sourcePath and destinationPath are identical.", nameof(destinationPath));
+
+                if (!FileAccess.FileExists(src))
+                    throw new ArgumentException($"No file exists at '{src}'.", nameof(sourcePath));
+                if (FileAccess.FileExists(dst))
+                    throw new ArgumentException($"A file already exists at '{dst}'.", nameof(destinationPath));
+
+                // Ensure the destination directory exists (DirAccess.Rename does not create it).
+                var dstDir = dst.Substring(0, dst.LastIndexOf('/') + 1);
+                if (!DirAccess.DirExistsAbsolute(dstDir))
+                {
+                    var mkErr = DirAccess.MakeDirRecursiveAbsolute(dstDir);
+                    if (mkErr != Error.Ok)
+                        throw new Exception($"Failed to create destination directory '{dstDir}': {mkErr}.");
+                }
+
+                // Move the resource file itself.
+                var moveErr = DirAccess.RenameAbsolute(src, dst);
+                if (moveErr != Error.Ok)
+                    throw new Exception($"Failed to move '{src}' to '{dst}': {moveErr}.");
+
+                // Move the sidecar '.import' metadata if it exists (imported assets carry one; .tres usually
+                // do not). Keeping it next to the resource preserves import settings + uid mapping.
+                var srcImport = src + ".import";
+                if (FileAccess.FileExists(srcImport))
+                {
+                    var importErr = DirAccess.RenameAbsolute(srcImport, dst + ".import");
+                    if (importErr != Error.Ok)
+                        throw new Exception($"Moved '{src}' but failed to move its '.import' sidecar: {importErr}. " +
+                            "The asset may need a manual reimport.");
+                }
+
+                // Rescan so the editor filesystem indexes the new location and drops the old one.
+                var efs = EditorInterface.Singleton.GetResourceFilesystem();
+                efs?.Scan();
+
+                return ToResourceInfo(dst);
+            });
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Resource.cs
+++ b/addons/godot_mcp/Tools/Tool_Resource.cs
@@ -1,0 +1,142 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// Resource tool family (<c>resource-*</c>) — the Godot analog of the resource-mutating half of
+    /// Unity-MCP's <c>Tool_Assets</c> (find / get-data / modify / create / move / delete). Each tool method
+    /// lives in its own partial-class file and drives the Godot editor's resource pipeline
+    /// (<see cref="ResourceLoader"/>/<see cref="ResourceSaver"/>/<see cref="EditorFileSystem"/>) through the
+    /// main-thread dispatcher.
+    ///
+    /// <para>
+    /// Godot ↔ Unity mapping: a Godot <see cref="Resource"/> on disk (<c>.tres</c>/<c>.res</c>) ↔ a Unity
+    /// asset; a <c>res://</c> path / <c>uid://</c> ↔ a Unity asset path / GUID; <see cref="ResourceSaver"/>
+    /// ↔ <c>AssetDatabase.CreateAsset</c>; <see cref="EditorFileSystem.Scan"/>/<c>ReimportFiles</c> ↔
+    /// <c>AssetDatabase.Refresh</c>/<c>ImportAsset</c>. A resource is identified by a
+    /// <see cref="Data.ResourceRef"/> (res:// path preferred, else a loaded instance id) and resolved on
+    /// the main thread by <see cref="ResolveResource"/>.
+    /// </para>
+    ///
+    /// <para>
+    /// Import-pipeline discipline: tools that write to disk go through <see cref="ResourceSaver"/> and the
+    /// editor filesystem (<see cref="EditorFileSystem.UpdateFile"/>), and moves/renames/deletes use
+    /// <see cref="EditorFileSystem"/>-aware operations so Godot's sidecar <c>.import</c> metadata stays
+    /// consistent. The family never hand-edits <c>.import</c> files.
+    /// </para>
+    ///
+    /// Editor-only (<c>#if TOOLS</c>): the handlers touch <see cref="EditorInterface"/> and live
+    /// <see cref="Resource"/> objects. The pure-managed result models
+    /// (<see cref="Data.ResourceInfo"/>/<see cref="Data.ResourceFindResult"/>) and the
+    /// <see cref="ResPathNormalizer"/> live outside this guard and are unit-tested.
+    /// </summary>
+    [AiToolType]
+    public partial class Tool_Resource
+    {
+        /// <summary>
+        /// Resolve a <see cref="Data.ResourceRef"/> to a loaded <see cref="Resource"/> and its
+        /// <c>res://</c> path. Must be called on the main thread. Returns null and sets
+        /// <paramref name="error"/> on any failure (invalid ref, instance id not a Resource, path with no
+        /// resource).
+        ///
+        /// Resolution order mirrors <see cref="Data.ResourceRef"/>'s declared priority: <c>ResourcePath</c>
+        /// first (the stable identity of an on-disk asset), then a loaded <c>InstanceId</c>.
+        /// </summary>
+        internal static Resource? ResolveResource(Data.ResourceRef? resourceRef, out string? path, out string? error)
+        {
+            error = null;
+            path = null;
+
+            if (resourceRef == null)
+            {
+                error = "resourceRef is null.";
+                return null;
+            }
+            if (!resourceRef.IsValid(out error))
+                return null;
+
+            // 1) res:// path (priority 1).
+            if (!string.IsNullOrEmpty(resourceRef.ResourcePath))
+            {
+                var resPath = resourceRef.ResourcePath!;
+                if (!ResourceLoader.Exists(resPath))
+                {
+                    error = $"No resource exists at '{resPath}'.";
+                    return null;
+                }
+
+                var loaded = ResourceLoader.Load(resPath);
+                if (loaded == null)
+                {
+                    error = $"Resource at '{resPath}' failed to load.";
+                    return null;
+                }
+
+                path = resPath;
+                return loaded;
+            }
+
+            // 2) Loaded instance id (priority 2).
+            if (resourceRef.InstanceId != 0)
+            {
+                if (!GodotObject.IsInstanceIdValid(resourceRef.InstanceId))
+                {
+                    error = $"No live object with instanceId '{resourceRef.InstanceId}'.";
+                    return null;
+                }
+                var obj = GodotObject.InstanceFromId(resourceRef.InstanceId);
+                if (obj is Resource resById)
+                {
+                    var rp = resById.ResourcePath;
+                    path = string.IsNullOrEmpty(rp) ? null : rp;
+                    return resById;
+                }
+
+                error = $"Object with instanceId '{resourceRef.InstanceId}' is not a Resource (it is '{obj?.GetClass() ?? "null"}').";
+                return null;
+            }
+
+            error = "resourceRef has neither a resourcePath nor an instanceId.";
+            return null;
+        }
+
+        /// <summary>
+        /// Build a <see cref="Data.ResourceInfo"/> from a resource path (and an optional already-loaded
+        /// resource for the type). Main-thread only (reads <see cref="ResourceLoader"/>/the resource).
+        /// </summary>
+        internal static ResourceInfo ToResourceInfo(string resPath, Resource? loaded = null)
+        {
+            var uidId = ResourceLoader.GetResourceUid(resPath);
+            var uid = uidId == ResourceUid.InvalidId ? null : ResourceUid.IdToText(uidId);
+
+            string? type = loaded?.GetClass();
+            if (string.IsNullOrEmpty(type))
+            {
+                var classFromFs = EditorInterface.Singleton.GetResourceFilesystem()?.GetFileType(resPath);
+                type = string.IsNullOrEmpty(classFromFs) ? null : classFromFs;
+            }
+
+            return new ResourceInfo
+            {
+                ResourcePath = resPath,
+                Uid = uid,
+                Type = type,
+            };
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Adds two `[AiToolType]` tool families under `addons/godot_mcp/Tools/`, the Godot analog of Unity-MCP's `Tool_Assets`:
  - **`filesystem-*`**: `filesystem-list` (browse the `res://` tree via `EditorFileSystem`, with per-file importer type + uid) and `filesystem-reimport` (`Scan()`/`ReimportFiles(...)` with a bounded settle).
  - **`resource-*`**: `resource-find` (by path / `uid://` / type), `resource-get-data` (ReflectorNet-serialized), `resource-modify` (jsonPatch/pathPatches → `ResourceSaver`), `resource-create` (`.tres`/`.res`), `resource-move`, `resource-delete`.
- All Godot API marshalled via the `GodotMainThread` dispatcher; resources resolved through `ResourceRef`; Godot's import pipeline respected (`.import` sidecar moved/removed alongside the resource, rescan after external writes — never hand-edited).
- Pure-managed pieces (`ResPathNormalizer` + the result models) are xUnit-tested; the editor-driving handlers are `#if TOOLS`.

## Test plan
- [x] `dotnet build Godot-MCP.sln` — 0 errors (CI parity).
- [x] `dotnet test Godot-MCP.Tests` — 103 passed, 0 failed (adds `ResourceFsToolTests`, 22 new cases).
- [x] Live headless verification against a real **Godot 4.5.1** editor connected to a local MCP server: `filesystem-list`, `resource-create` (nested path, auto-mkdir), `resource-find` (by type), `resource-get-data` (full `StandardMaterial3D` tree), `resource-modify` (`ResourceName` patch — **confirmed persisted in the on-disk `.tres`**), `resource-move` (uid preserved), `resource-delete`, and `filesystem-reimport` (full + targeted) — all observed with structured results.

Closes #10