### PR TITLE
feat: script tools (read/create/update/delete C# + GDScript, attach script to node)

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -66,6 +66,12 @@
     <Compile Include="..\addons\godot_mcp\Data\ResourceInfo.cs" Link="Source\ResourceInfo.cs" />
     <Compile Include="..\addons\godot_mcp\Data\ResourceFindResult.cs" Link="Source\ResourceFindResult.cs" />
     <Compile Include="..\addons\godot_mcp\Tools\ResPathNormalizer.cs" Link="Source\ResPathNormalizer.cs" />
+    <!-- Script tool family — pure-managed pieces only (no Godot native types, no #if TOOLS): the
+         structured result model and the language/path helper. The editor-driving handlers
+         (Tool_Script.*.cs) are #if TOOLS and verified via the headless Godot smoke (test.md Suite 3),
+         not here. -->
+    <Compile Include="..\addons\godot_mcp\Data\ScriptInfo.cs" Link="Source\ScriptInfo.cs" />
+    <Compile Include="..\addons\godot_mcp\Tools\ScriptLang.cs" Link="Source\ScriptLang.cs" />
   </ItemGroup>
 
 </Project>

--- a/Godot-MCP.Tests/ScriptToolTests.cs
+++ b/Godot-MCP.Tests/ScriptToolTests.cs
@@ -1,0 +1,169 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Text.Json;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.Godot.MCP.Tools;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pure-managed coverage for the script tool family: the <see cref="ScriptInfo"/> result model and the
+    /// <see cref="ScriptLang_"/> extension/path helper. Neither touches a live Godot scripting runtime, so
+    /// they run in the plain xUnit host with no Godot binary. The editor-driving handlers themselves
+    /// (<c>Tool_Script.*.cs</c>, behind <c>#if TOOLS</c>) — including the GDScript parse check and the C#
+    /// build settle — are verified by the headless Godot smoke (test.md Suite 3).
+    /// </summary>
+    public class ScriptToolTests
+    {
+        // ---- ScriptLang_.TryGetLang / IsScriptExtension ------------------------------------------
+
+        [Theory]
+        [InlineData("res://scripts/Enemy.cs", true, ScriptLang.CSharp)]
+        [InlineData("res://scripts/player.gd", true, ScriptLang.GDScript)]
+        // Case-insensitive extension match.
+        [InlineData("res://scripts/Enemy.CS", true, ScriptLang.CSharp)]
+        [InlineData("res://scripts/Player.GD", true, ScriptLang.GDScript)]
+        // Non-script extensions.
+        [InlineData("res://scenes/main.tscn", false, ScriptLang.CSharp)]
+        [InlineData("res://materials/wood.tres", false, ScriptLang.CSharp)]
+        [InlineData("res://notes.txt", false, ScriptLang.CSharp)]
+        public void TryGetLang_DetectsByExtension(string path, bool expected, ScriptLang expectedLang)
+        {
+            var ok = ScriptLang_.TryGetLang(path, out var lang);
+            Assert.Equal(expected, ok);
+            Assert.Equal(expected, ScriptLang_.IsScriptExtension(path));
+            if (ok)
+                Assert.Equal(expectedLang, lang);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void TryGetLang_EmptyOrNull_ReturnsFalse(string? path)
+        {
+            Assert.False(ScriptLang_.TryGetLang(path, out _));
+            Assert.False(ScriptLang_.IsScriptExtension(path));
+        }
+
+        [Theory]
+        [InlineData(ScriptLang.CSharp, ".cs")]
+        [InlineData(ScriptLang.GDScript, ".gd")]
+        public void ExtensionFor_ReturnsCanonicalExtension(ScriptLang lang, string expected)
+        {
+            Assert.Equal(expected, ScriptLang_.ExtensionFor(lang));
+        }
+
+        // ---- ScriptLang_.RequireScriptResPath ----------------------------------------------------
+
+        [Fact]
+        public void RequireScriptResPath_AcceptsCSharp_TrimsWhitespace_DetectsLang()
+        {
+            var p = ScriptLang_.RequireScriptResPath("  res://scripts/Enemy.cs  ", "scriptPath", out var lang);
+            Assert.Equal("res://scripts/Enemy.cs", p);
+            Assert.Equal(ScriptLang.CSharp, lang);
+        }
+
+        [Fact]
+        public void RequireScriptResPath_AcceptsGDScript()
+        {
+            var p = ScriptLang_.RequireScriptResPath("res://player.gd", "scriptPath", out var lang);
+            Assert.Equal("res://player.gd", p);
+            Assert.Equal(ScriptLang.GDScript, lang);
+        }
+
+        [Fact]
+        public void RequireScriptResPath_Rejects_NonScriptExtension()
+        {
+            // It is a valid res:// file path, but not a .cs/.gd — must be rejected with a language-specific
+            // message (the shared ResPathNormalizer would have accepted it).
+            var ex = Assert.Throws<ArgumentException>(
+                () => ScriptLang_.RequireScriptResPath("res://scenes/main.tscn", "scriptPath", out _));
+            Assert.Contains(".cs", ex.Message);
+            Assert.Contains(".gd", ex.Message);
+        }
+
+        [Fact]
+        public void RequireScriptResPath_Rejects_NonResPath()
+        {
+            Assert.Throws<ArgumentException>(
+                () => ScriptLang_.RequireScriptResPath("/abs/Enemy.cs", "scriptPath", out _));
+            Assert.Throws<ArgumentException>(
+                () => ScriptLang_.RequireScriptResPath("user://Enemy.cs", "scriptPath", out _));
+        }
+
+        [Fact]
+        public void RequireScriptResPath_Rejects_DirectoryAndBareScheme()
+        {
+            // Directory (trailing slash) and the bare 'res://' root are not files — rejected by the shared
+            // res:// guards before the extension check runs.
+            Assert.Throws<ArgumentException>(
+                () => ScriptLang_.RequireScriptResPath("res://scripts/", "scriptPath", out _));
+            Assert.Throws<ArgumentException>(
+                () => ScriptLang_.RequireScriptResPath("res://", "scriptPath", out _));
+            Assert.Throws<ArgumentException>(
+                () => ScriptLang_.RequireScriptResPath(null, "scriptPath", out _));
+        }
+
+        [Fact]
+        public void RequireScriptResPath_Rejects_ParentTraversalSegment()
+        {
+            // The shared '..' guard applies — res://a/../a/b.cs must be rejected so path-equality guards hold.
+            var ex = Assert.Throws<ArgumentException>(
+                () => ScriptLang_.RequireScriptResPath("res://a/../a/Enemy.cs", "scriptPath", out _));
+            Assert.Contains("..", ex.Message);
+        }
+
+        // ---- ScriptInfo serialization ------------------------------------------------------------
+
+        [Fact]
+        public void ScriptInfo_Serializes_WithExpectedJsonNames()
+        {
+            var info = new ScriptInfo
+            {
+                ResourcePath = "res://scripts/player.gd",
+                Language = "GDScript",
+                Content = "extends Node\n",
+                LineCount = 2,
+                Status = "Script read.",
+            };
+
+            var json = JsonSerializer.Serialize(info);
+            Assert.Contains("\"resourcePath\"", json);
+            Assert.Contains("\"language\"", json);
+            Assert.Contains("\"content\"", json);
+            Assert.Contains("\"lineCount\"", json);
+            Assert.Contains("\"status\"", json);
+
+            var restored = JsonSerializer.Deserialize<ScriptInfo>(json);
+            Assert.NotNull(restored);
+            Assert.Equal("res://scripts/player.gd", restored!.ResourcePath);
+            Assert.Equal("GDScript", restored.Language);
+            Assert.Equal("extends Node\n", restored.Content);
+            Assert.Equal(2, restored.LineCount);
+            Assert.Equal("Script read.", restored.Status);
+        }
+
+        [Fact]
+        public void ScriptInfo_IdentityOnly_AllowsNullContentAndStatus()
+        {
+            var info = new ScriptInfo { ResourcePath = "res://scripts/Enemy.cs", Language = "CSharp" };
+            var json = JsonSerializer.Serialize(info);
+            var restored = JsonSerializer.Deserialize<ScriptInfo>(json);
+
+            Assert.NotNull(restored);
+            Assert.Null(restored!.Content);
+            Assert.Null(restored.Status);
+            Assert.Equal(0, restored.LineCount);
+        }
+    }
+}

--- a/addons/godot_mcp/Data/ScriptInfo.cs
+++ b/addons/godot_mcp/Data/ScriptInfo.cs
@@ -1,0 +1,63 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.Godot.MCP.Data
+{
+    /// <summary>
+    /// Identity + content record for a script file on disk — returned by <c>script-read</c> and as the
+    /// confirmation payload of <c>script-create</c>/<c>script-update</c>/<c>script-delete</c>/
+    /// <c>script-attach-to-node</c>. Carries the script's <c>res://</c> path, its language
+    /// (<c>"CSharp"</c>/<c>"GDScript"</c>), and — for reads — the file content + a short status note about
+    /// any triggered compile/reload. The Godot analog of the Unity-MCP <c>script-read</c> / <c>script-
+    /// update-or-create</c> result (both languages, since Godot is dual-language).
+    ///
+    /// <para>
+    /// Pure-managed (no Godot API surface, no <c>#if TOOLS</c>), so it is unit-testable in the plain xUnit
+    /// host. The editor-side handlers fill <see cref="Content"/> only for reads and <see cref="Status"/>
+    /// with the settle/reload outcome.
+    /// </para>
+    /// </summary>
+    [System.Serializable]
+    [Description("Identity + (for reads) content of a script file: its res:// path, language, optional " +
+        "content, and a status note about any triggered compile/reload.")]
+    public class ScriptInfo
+    {
+        [JsonInclude, JsonPropertyName("resourcePath")]
+        [Description("res:// path of the script file, e.g. 'res://scripts/player.gd' or 'res://scripts/Enemy.cs'.")]
+        public string ResourcePath { get; set; } = string.Empty;
+
+        [JsonInclude, JsonPropertyName("language")]
+        [Description("Script language: 'CSharp' for a .cs file, 'GDScript' for a .gd file.")]
+        public string Language { get; set; } = string.Empty;
+
+        [JsonInclude, JsonPropertyName("content")]
+        [Description("The script's text content. Populated by 'script-read'; null on the write/delete/attach " +
+            "confirmation payloads (which echo identity only).")]
+        public string? Content { get; set; } = null;
+
+        [JsonInclude, JsonPropertyName("lineCount")]
+        [Description("Number of lines in 'content' when present (the read slice's line count), else 0.")]
+        public int LineCount { get; set; } = 0;
+
+        [JsonInclude, JsonPropertyName("status")]
+        [Description("Short human-readable status note, e.g. 'Script created; build settled.' or 'Script " +
+            "read.'. For C# writes/deletes this records the bounded compile/reload settle outcome; null when " +
+            "no status applies.")]
+        public string? Status { get; set; } = null;
+
+        public ScriptInfo() { }
+
+        public override string ToString()
+            => $"Script '{ResourcePath}' ({Language}){(Status != null ? $" — {Status}" : string.Empty)}";
+    }
+}

--- a/addons/godot_mcp/Tools/ScriptLang.cs
+++ b/addons/godot_mcp/Tools/ScriptLang.cs
@@ -1,0 +1,101 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// Godot's two first-class scripting languages, distinguished by file extension. <see cref="CSharp"/>
+    /// (<c>.cs</c>) compiles into the project assembly (a build/reload is needed before a freshly-added
+    /// type is usable); <see cref="GDScript"/> (<c>.gd</c>) is interpreted and re-parsed on load.
+    /// </summary>
+    public enum ScriptLang
+    {
+        CSharp,
+        GDScript,
+    }
+
+    /// <summary>
+    /// Pure-string helpers shared by the script tool family (<c>script-*</c>): extension → language
+    /// detection and <c>res://</c> script-path validation. Extracted from the editor-only
+    /// (<c>#if TOOLS</c>) handlers — like <see cref="ResPathNormalizer"/> / <see cref="NodePathNormalizer"/>
+    /// — so the extension/validation logic is unit-testable in the plain xUnit host with no live Godot
+    /// scripting runtime.
+    ///
+    /// <para>
+    /// A "script" here is a source file Godot recognizes as a <see cref="global::Godot.Script"/>: a C#
+    /// (<c>.cs</c>) or GDScript (<c>.gd</c>) file under <c>res://</c>. The editor-side handlers additionally
+    /// re-use <see cref="ResPathNormalizer.RequireResFilePath"/> for the shared <c>res://</c> + <c>..</c>
+    /// + bare-scheme guards; this class layers the language-specific extension contract on top.
+    /// </para>
+    /// </summary>
+    public static class ScriptLang_
+    {
+        public const string CSharpExtension = ".cs";
+        public const string GDScriptExtension = ".gd";
+
+        /// <summary>
+        /// True when <paramref name="path"/> ends with a recognized script extension (<c>.cs</c> or
+        /// <c>.gd</c>), case-insensitively. Does NOT validate the <c>res://</c> scheme — pair with
+        /// <see cref="ResPathNormalizer.IsResPath"/> / <see cref="RequireScriptResPath"/> for that.
+        /// </summary>
+        public static bool IsScriptExtension(string? path)
+            => TryGetLang(path, out _);
+
+        /// <summary>
+        /// Resolve a script file path to its <see cref="ScriptLang"/> by extension. Returns false (and
+        /// <paramref name="lang"/> = <see cref="ScriptLang.CSharp"/> as an unused default) when the path
+        /// has no recognized script extension.
+        /// </summary>
+        public static bool TryGetLang(string? path, out ScriptLang lang)
+        {
+            lang = ScriptLang.CSharp;
+            if (string.IsNullOrEmpty(path))
+                return false;
+
+            if (path!.EndsWith(CSharpExtension, StringComparison.OrdinalIgnoreCase))
+            {
+                lang = ScriptLang.CSharp;
+                return true;
+            }
+            if (path.EndsWith(GDScriptExtension, StringComparison.OrdinalIgnoreCase))
+            {
+                lang = ScriptLang.GDScript;
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// The canonical lowercase extension (including the leading dot) for a language.
+        /// </summary>
+        public static string ExtensionFor(ScriptLang lang)
+            => lang == ScriptLang.GDScript ? GDScriptExtension : CSharpExtension;
+
+        /// <summary>
+        /// Validate that <paramref name="path"/> is a <c>res://</c> script file path (a file under
+        /// <c>res://</c>, not the bare root or a directory, with no <c>..</c> segment, ending in
+        /// <c>.cs</c>/<c>.gd</c>), throwing <see cref="ArgumentException"/> (with
+        /// <paramref name="paramName"/>) otherwise. Returns the trimmed path and its detected language on
+        /// success. Layers the script-extension contract on top of
+        /// <see cref="ResPathNormalizer.RequireResFilePath"/> so the two share one set of res:// guards.
+        /// </summary>
+        public static string RequireScriptResPath(string? path, string paramName, out ScriptLang lang)
+        {
+            var p = ResPathNormalizer.RequireResFilePath(path, paramName);
+            if (!TryGetLang(p, out lang))
+                throw new ArgumentException(
+                    $"Script path must end with '{CSharpExtension}' (C#) or '{GDScriptExtension}' (GDScript); got '{path}'.",
+                    paramName);
+            return p;
+        }
+    }
+}

--- a/addons/godot_mcp/Tools/Tool_Script.AttachToNode.cs
+++ b/addons/godot_mcp/Tools/Tool_Script.AttachToNode.cs
@@ -31,26 +31,23 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         [Description("Attach a script (C# '.cs' or GDScript '.gd') to a Node in the currently edited Godot " +
             "scene — the Godot analog of adding a MonoBehaviour to a GameObject. Identify the target with " +
             "'nodeRef' (instanceId preferred, else scene-tree path) and the script with 'scriptPath' (a " +
-            "res:// script file that must exist). Pass an empty/null 'scriptPath' to DETACH (clear) the " +
-            "node's script. The script resource is loaded and set via Node.SetScript; the scene is marked " +
+            "res:// script file that must exist). Pass an empty/whitespace/null 'scriptPath' to DETACH (clear) " +
+            "the node's script. The script resource is loaded and set via Node.SetScript; the scene is marked " +
             "unsaved (persist with '" + Tool_Scene.SceneSaveToolId + "'). Returns the script's structured " +
             "ScriptInfo on attach, or an identity record with a 'detached' status on clear.")]
         public ScriptInfo AttachToNode
         (
             [Description("Reference to the target Node (instanceId preferred, else scene-tree path).")]
             NodeRef nodeRef,
-            [Description("res:// path of the script to attach, ending in '.cs' or '.gd'. Pass empty/null to " +
-                "DETACH the node's current script.")]
+            [Description("res:// path of the script to attach, ending in '.cs' or '.gd'. Pass " +
+                "empty/whitespace/null to DETACH the node's current script.")]
             string? scriptPath = null
         )
         {
-            if (nodeRef == null)
-                throw new ArgumentNullException(nameof(nodeRef));
-            if (!nodeRef.IsValid(out var refError))
-                throw new ArgumentException(refError, nameof(nodeRef));
-
             return MainThread.Instance.Run(() =>
             {
+                // ResolveNode validates the ref (null / invalid / not-found) and returns a single consistent
+                // structured failure, matching the other Tool_Node handlers — no redundant top-level pre-check.
                 var node = Tool_Node.ResolveNode(nodeRef, out var error)
                     ?? throw new Exception(error ?? $"Node by {nodeRef} not found.");
 

--- a/addons/godot_mcp/Tools/Tool_Script.AttachToNode.cs
+++ b/addons/godot_mcp/Tools/Tool_Script.AttachToNode.cs
@@ -1,0 +1,93 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Script
+    {
+        public const string ScriptAttachToNodeToolId = "script-attach-to-node";
+
+        [AiTool
+        (
+            ScriptAttachToNodeToolId,
+            Title = "Script / Attach To Node",
+            IdempotentHint = true
+        )]
+        [Description("Attach a script (C# '.cs' or GDScript '.gd') to a Node in the currently edited Godot " +
+            "scene — the Godot analog of adding a MonoBehaviour to a GameObject. Identify the target with " +
+            "'nodeRef' (instanceId preferred, else scene-tree path) and the script with 'scriptPath' (a " +
+            "res:// script file that must exist). Pass an empty/null 'scriptPath' to DETACH (clear) the " +
+            "node's script. The script resource is loaded and set via Node.SetScript; the scene is marked " +
+            "unsaved (persist with '" + Tool_Scene.SceneSaveToolId + "'). Returns the script's structured " +
+            "ScriptInfo on attach, or an identity record with a 'detached' status on clear.")]
+        public ScriptInfo AttachToNode
+        (
+            [Description("Reference to the target Node (instanceId preferred, else scene-tree path).")]
+            NodeRef nodeRef,
+            [Description("res:// path of the script to attach, ending in '.cs' or '.gd'. Pass empty/null to " +
+                "DETACH the node's current script.")]
+            string? scriptPath = null
+        )
+        {
+            if (nodeRef == null)
+                throw new ArgumentNullException(nameof(nodeRef));
+            if (!nodeRef.IsValid(out var refError))
+                throw new ArgumentException(refError, nameof(nodeRef));
+
+            return MainThread.Instance.Run(() =>
+            {
+                var node = Tool_Node.ResolveNode(nodeRef, out var error)
+                    ?? throw new Exception(error ?? $"Node by {nodeRef} not found.");
+
+                // Detach mode: clear the script. SetScript(default) assigns a nil Variant, removing the script.
+                if (string.IsNullOrWhiteSpace(scriptPath))
+                {
+                    node.SetScript(default);
+                    EditorInterface.Singleton.MarkSceneAsUnsaved();
+                    return new ScriptInfo
+                    {
+                        ResourcePath = string.Empty,
+                        Language = string.Empty,
+                        Status = $"Script detached from node '{node.Name}'.",
+                    };
+                }
+
+                var resPath = ScriptLang_.RequireScriptResPath(scriptPath, nameof(scriptPath), out var lang);
+
+                if (!ResourceLoader.Exists(resPath))
+                    throw new ArgumentException(
+                        $"No script resource exists at '{resPath}'. Create it with '{ScriptCreateToolId}' first " +
+                        "(and, for a new C# type, rebuild the project so the script compiles).", nameof(scriptPath));
+
+                var script = ResourceLoader.Load<Script>(resPath)
+                    ?? throw new ArgumentException(
+                        $"Resource at '{resPath}' is not a Godot Script.", nameof(scriptPath));
+
+                node.SetScript(script);
+
+                // Mark unsaved so the script assignment persists when the scene is saved (the assignment is
+                // serialized into the .tscn). We do NOT save here — saving is an explicit, separate step
+                // (Tool_Scene.Save) so the caller controls when the scene is written.
+                EditorInterface.Singleton.MarkSceneAsUnsaved();
+
+                return ToScriptInfo(resPath, lang, $"Script attached to node '{node.Name}'.");
+            });
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Script.Create.cs
+++ b/addons/godot_mcp/Tools/Tool_Script.Create.cs
@@ -1,0 +1,68 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Script
+    {
+        public const string ScriptCreateToolId = "script-create";
+
+        [AiTool
+        (
+            ScriptCreateToolId,
+            Title = "Script / Create"
+        )]
+        [Description("Create a NEW Godot script file (C# '.cs' or GDScript '.gd') under res:// with the " +
+            "provided source. Fails if a file already exists at the path — use '" + ScriptUpdateToolId +
+            "' to overwrite. GDScript content is syntax-validated before write (invalid '.gd' is rejected and " +
+            "nothing is written); C# is accepted as-is (no in-editor compiler) and the post-write build settle " +
+            "surfaces compile errors. Missing parent directories are created. For a '.cs' file the editor " +
+            "filesystem reimports and BOUNDED-settles before returning (a project rebuild then loads the new " +
+            "type); a '.gd' file only needs a filesystem update. Returns a structured ScriptInfo.")]
+        public ScriptInfo Create
+        (
+            [Description("res:// path for the new script, ending in '.cs' (C#) or '.gd' (GDScript), e.g. " +
+                "'res://scripts/Enemy.cs' or 'res://scripts/player.gd'.")]
+            string scriptPath,
+            [Description("Source code for the new script file.")]
+            string content
+        )
+        {
+            if (content == null)
+                throw new ArgumentNullException(nameof(content));
+
+            return MainThread.Instance.Run(() =>
+            {
+                var resPath = ScriptLang_.RequireScriptResPath(scriptPath, nameof(scriptPath), out var lang);
+
+                // Guard on the file on disk (like Tool_Resource.Create): an existing file is never silently
+                // clobbered by 'create' — that is what 'update' is for.
+                if (FileAccess.FileExists(resPath))
+                    throw new ArgumentException(
+                        $"A file already exists at '{resPath}'. Use '{ScriptUpdateToolId}' to overwrite it, " +
+                        $"or '{ScriptDeleteToolId}' to remove it first.", nameof(scriptPath));
+
+                if (!ValidateSyntax(content, lang, out var syntaxError))
+                    throw new ArgumentException(syntaxError, nameof(content));
+
+                return WriteScript(resPath, lang, content, "created");
+            });
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Script.Delete.cs
+++ b/addons/godot_mcp/Tools/Tool_Script.Delete.cs
@@ -1,0 +1,83 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Script
+    {
+        public const string ScriptDeleteToolId = "script-delete";
+
+        [AiTool
+        (
+            ScriptDeleteToolId,
+            Title = "Script / Delete",
+            DestructiveHint = true
+        )]
+        [Description("Delete a Godot script file (C# '.cs' or GDScript '.gd') from the res:// filesystem. " +
+            "Fails if no file exists at the path. The script's identity (path, language) is captured BEFORE " +
+            "deletion and returned for confirmation. The file is removed with DirAccess, along with its " +
+            "Godot '.uid' sidecar when present, then the editor filesystem is rescanned and (for a '.cs' file) " +
+            "BOUNDED-settles. WARNING: nodes/resources referencing the deleted script will break — verify " +
+            "with '" + ScriptReadToolId + "' first. Returns a structured ScriptInfo.")]
+        public ScriptInfo Delete
+        (
+            [Description("res:// path of the script file to delete, ending in '.cs' or '.gd'.")]
+            string scriptPath
+        )
+        {
+            return MainThread.Instance.Run(() =>
+            {
+                var resPath = ScriptLang_.RequireScriptResPath(scriptPath, nameof(scriptPath), out var lang);
+
+                if (!FileAccess.FileExists(resPath))
+                    throw new ArgumentException($"No script file exists at '{resPath}'.", nameof(scriptPath));
+
+                var rmErr = DirAccess.RemoveAbsolute(resPath);
+                if (rmErr != Error.Ok)
+                    throw new Exception($"Failed to delete '{resPath}': {rmErr}.");
+
+                // From here the script file is already gone. This is a MULTI-FILE op (script + '.uid'
+                // sidecar): if the sidecar removal throws below, the script itself is still deleted. Refresh
+                // in 'finally' regardless so the editor index drops the removed entry even on partial failure.
+                string status;
+                try
+                {
+                    // Godot 4.3+ emits a '.uid' sidecar next to a script; remove it too when present so no
+                    // orphaned uid file is left behind (the analog of Unity's '.meta').
+                    var uidPath = resPath + ".uid";
+                    if (FileAccess.FileExists(uidPath))
+                    {
+                        var rmUidErr = DirAccess.RemoveAbsolute(uidPath);
+                        if (rmUidErr != Error.Ok)
+                            throw new Exception(
+                                $"Inconsistent state: script '{resPath}' was deleted but its '.uid' sidecar " +
+                                $"'{uidPath}' failed to remove ({rmUidErr}). The script itself is already gone; " +
+                                "remove the orphaned sidecar manually.");
+                    }
+                }
+                finally
+                {
+                    status = RefreshAndSettle(resPath, lang, removed: true);
+                }
+
+                return ToScriptInfo(resPath, lang, $"Script deleted; {status}");
+            });
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Script.Delete.cs
+++ b/addons/godot_mcp/Tools/Tool_Script.Delete.cs
@@ -52,30 +52,27 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                     throw new Exception($"Failed to delete '{resPath}': {rmErr}.");
 
                 // From here the script file is already gone. This is a MULTI-FILE op (script + '.uid'
-                // sidecar): if the sidecar removal throws below, the script itself is still deleted. Refresh
-                // in 'finally' regardless so the editor index drops the removed entry even on partial failure.
-                string status;
-                try
+                // sidecar): the PRIMARY delete already succeeded, so a failure to remove the SECONDARY sidecar
+                // is a degraded (not failed) outcome — we report it as a warning in the status rather than
+                // throwing a transport error (mirrors resource-move/delete's "primary op succeeded, secondary
+                // degraded" principle). Refresh regardless so the editor index drops the removed entry.
+                string? sidecarWarning = null;
+
+                // Godot 4.3+ emits a '.uid' sidecar next to a script; remove it too when present so no
+                // orphaned uid file is left behind (the analog of Unity's '.meta').
+                var uidPath = resPath + ".uid";
+                if (FileAccess.FileExists(uidPath))
                 {
-                    // Godot 4.3+ emits a '.uid' sidecar next to a script; remove it too when present so no
-                    // orphaned uid file is left behind (the analog of Unity's '.meta').
-                    var uidPath = resPath + ".uid";
-                    if (FileAccess.FileExists(uidPath))
-                    {
-                        var rmUidErr = DirAccess.RemoveAbsolute(uidPath);
-                        if (rmUidErr != Error.Ok)
-                            throw new Exception(
-                                $"Inconsistent state: script '{resPath}' was deleted but its '.uid' sidecar " +
-                                $"'{uidPath}' failed to remove ({rmUidErr}). The script itself is already gone; " +
-                                "remove the orphaned sidecar manually.");
-                    }
-                }
-                finally
-                {
-                    status = RefreshAndSettle(resPath, lang, removed: true);
+                    var rmUidErr = DirAccess.RemoveAbsolute(uidPath);
+                    if (rmUidErr != Error.Ok)
+                        sidecarWarning =
+                            $" WARNING: the script was deleted but its '.uid' sidecar '{uidPath}' failed to " +
+                            $"remove ({rmUidErr}) — orphaned, manual cleanup may be needed.";
                 }
 
-                return ToScriptInfo(resPath, lang, $"Script deleted; {status}");
+                var status = RefreshAndSettle(resPath, lang, removed: true);
+
+                return ToScriptInfo(resPath, lang, $"Script deleted; {status}{sidecarWarning}");
             });
         }
     }

--- a/addons/godot_mcp/Tools/Tool_Script.Read.cs
+++ b/addons/godot_mcp/Tools/Tool_Script.Read.cs
@@ -1,0 +1,96 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Script
+    {
+        public const string ScriptReadToolId = "script-read";
+
+        [AiTool
+        (
+            ScriptReadToolId,
+            Title = "Script / Read",
+            ReadOnlyHint = true,
+            IdempotentHint = true
+        )]
+        [Description("Read a Godot script file (C# '.cs' or GDScript '.gd') under res:// and return its " +
+            "content + metadata (res:// path, language, line count). Supports an optional 1-based " +
+            "'lineFrom'/'lineTo' slice for partial reads (indices are clamped — out-of-range values read " +
+            "at-most the whole file). Pair with '" + ScriptUpdateToolId + "'/'" + ScriptCreateToolId +
+            "' to write back. The file is read with Godot's FileAccess so it works on any res:// path " +
+            "(imported or not). Returns a structured ScriptInfo.")]
+        public ScriptInfo Read
+        (
+            [Description("res:// path of the script to read, e.g. 'res://scripts/player.gd' or " +
+                "'res://scripts/Enemy.cs'. Must end in '.cs' or '.gd'.")]
+            string scriptPath,
+            [Description("1-based start line of the slice (default 1). Clamped into range.")]
+            int lineFrom = 1,
+            [Description("1-based inclusive end line of the slice (default -1 = end of file). Clamped into range.")]
+            int lineTo = -1
+        )
+        {
+            return MainThread.Instance.Run(() =>
+            {
+                var resPath = ScriptLang_.RequireScriptResPath(scriptPath, nameof(scriptPath), out var lang);
+
+                if (!FileAccess.FileExists(resPath))
+                    throw new System.IO.FileNotFoundException($"No script file exists at '{resPath}'.", resPath);
+
+                using var file = FileAccess.Open(resPath, FileAccess.ModeFlags.Read);
+                if (file == null)
+                    throw new Exception($"Failed to open '{resPath}' for reading: {FileAccess.GetOpenError()}.");
+
+                var text = file.GetAsText();
+
+                // Slice [lineFrom..lineTo] (inclusive, 1-based), clamping like Unity-MCP's script-read so an
+                // out-of-range request is forgiving (reads at-most the whole file). Split on '\n' after
+                // normalizing CRLF so a Windows-authored file slices by logical line, not by raw bytes.
+                var lines = text.Replace("\r\n", "\n").Replace("\r", "\n").Split('\n');
+
+                var from = lineFrom;
+                var to = lineTo;
+                if (from < 1 || from > lines.Length)
+                    from = 1;
+                if (to == -1 || to > lines.Length)
+                    to = lines.Length;
+                if (to < 1)
+                    to = lines.Length;
+                if (from > to)
+                    from = to;
+
+                var startIndex = from - 1;
+                var count = to - from + 1;
+                var slice = new string[count];
+                Array.Copy(lines, startIndex, slice, 0, count);
+                var content = string.Join("\n", slice);
+
+                return new ScriptInfo
+                {
+                    ResourcePath = resPath,
+                    Language = lang.ToString(),
+                    Content = content,
+                    LineCount = count,
+                    Status = "Script read.",
+                };
+            });
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Script.Update.cs
+++ b/addons/godot_mcp/Tools/Tool_Script.Update.cs
@@ -1,0 +1,68 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Script
+    {
+        public const string ScriptUpdateToolId = "script-update";
+
+        [AiTool
+        (
+            ScriptUpdateToolId,
+            Title = "Script / Update",
+            DestructiveHint = true,
+            IdempotentHint = true
+        )]
+        [Description("Overwrite an EXISTING Godot script file (C# '.cs' or GDScript '.gd') under res:// with " +
+            "the provided source. Fails if no file exists at the path — use '" + ScriptCreateToolId + "' to " +
+            "create one. GDScript content is syntax-validated before write (invalid '.gd' is rejected and the " +
+            "existing file is left untouched); C# is accepted as-is (no in-editor compiler) and the post-write " +
+            "build settle surfaces compile errors. For a '.cs' file the editor filesystem reimports and " +
+            "BOUNDED-settles before returning (a project rebuild then loads the changed type); a '.gd' file " +
+            "only needs a filesystem update so the editor re-parses it. Use '" + ScriptReadToolId + "' to " +
+            "inspect the current content first. Returns a structured ScriptInfo.")]
+        public ScriptInfo Update
+        (
+            [Description("res:// path of the existing script to overwrite, ending in '.cs' or '.gd'.")]
+            string scriptPath,
+            [Description("New source code to write (replaces the file's entire content).")]
+            string content
+        )
+        {
+            if (content == null)
+                throw new ArgumentNullException(nameof(content));
+
+            return MainThread.Instance.Run(() =>
+            {
+                var resPath = ScriptLang_.RequireScriptResPath(scriptPath, nameof(scriptPath), out var lang);
+
+                if (!FileAccess.FileExists(resPath))
+                    throw new ArgumentException(
+                        $"No script file exists at '{resPath}'. Use '{ScriptCreateToolId}' to create it.",
+                        nameof(scriptPath));
+
+                if (!ValidateSyntax(content, lang, out var syntaxError))
+                    throw new ArgumentException(syntaxError, nameof(content));
+
+                return WriteScript(resPath, lang, content, "updated");
+            });
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Script.cs
+++ b/addons/godot_mcp/Tools/Tool_Script.cs
@@ -125,6 +125,16 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         /// builds via out-of-band MSBuild), so it is accepted as-is and the post-write build settle is what
         /// surfaces real compile errors. Returns true when the content is acceptable; on a GDScript parse
         /// failure returns false and sets <paramref name="error"/>. Main-thread only (touches GDScript).
+        ///
+        /// <para>
+        /// LIMITATION (parse-only): the throwaway <see cref="GDScript.Reload"/> probe can return a non-Ok
+        /// Error for reasons that are NOT a syntax error — e.g. the source <c>extends</c> a project type,
+        /// declares a <c>class_name</c>, or <c>preload(...)</c>s a resource that the standalone probe cannot
+        /// resolve. Hard-rejecting on those would falsely block a syntactically-valid <c>.gd</c> that merely
+        /// references project state. So we ONLY hard-reject an actual parse/syntax error
+        /// (<see cref="Error.ParseError"/>); any other non-Ok Reload result is treated as ACCEPTED
+        /// best-effort (parallel to the C# path) and the real load is left to the editor's full re-parse.
+        /// </para>
         /// </summary>
         static bool ValidateSyntax(string content, ScriptLang lang, out string? error)
         {
@@ -133,10 +143,12 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 return true; // C#: no cheap in-editor check; the build settle is the real gate.
 
             // Feed the source into a throwaway GDScript instance and reload it. Reload() parses + compiles the
-            // source and returns a non-Ok Error on a syntax/parse failure, without writing anything to disk.
+            // source; a genuine syntax error surfaces as Error.ParseError. Other non-Ok results (a resolution
+            // failure against project state the standalone probe can't see — extends/class_name/preload) are
+            // NOT syntax errors, so we accept them best-effort rather than misclassify them as a parse failure.
             var probe = new GDScript { SourceCode = content };
             var err = probe.Reload(keepState: false);
-            if (err != Error.Ok)
+            if (err == Error.ParseError)
             {
                 error = $"GDScript failed to parse ({err}). Fix the syntax and retry.";
                 return false;

--- a/addons/godot_mcp/Tools/Tool_Script.cs
+++ b/addons/godot_mcp/Tools/Tool_Script.cs
@@ -1,0 +1,177 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.Threading;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// Script tool family (<c>script-*</c>) — the Godot analog of Unity-MCP's <c>Tool_Script</c>, covering
+    /// BOTH of Godot's first-class scripting languages: C# (<c>.cs</c>) and GDScript (<c>.gd</c>). Each tool
+    /// method lives in its own partial-class file (Read / Create / Update / Delete / AttachToNode) and
+    /// drives the Godot editor's script + filesystem pipeline through the main-thread dispatcher.
+    ///
+    /// <para>
+    /// Godot ↔ Unity mapping: a Godot <see cref="Script"/> file on disk ↔ a Unity <c>MonoScript</c>
+    /// <c>.cs</c>; <c>script-read</c>/<c>script-update-or-create</c>/<c>script-delete</c> map 1:1; attaching a
+    /// script to a node (<c>node.SetScript</c>) ↔ Unity's "add a MonoBehaviour component". The key
+    /// difference from Unity: Godot has no Roslyn <c>script-execute</c> (Unity compiles + runs arbitrary C#
+    /// at runtime), so dynamic code-execution is intentionally out of scope here — this family is file CRUD
+    /// + attach only.
+    /// </para>
+    ///
+    /// <para>
+    /// Compile/reload discipline: a freshly-written or deleted <c>.cs</c> only takes effect after the project
+    /// assembly is rebuilt — so the C# write/delete handlers reimport through the editor filesystem and
+    /// BOUNDED-settle (mirroring <see cref="Tool_FileSystem"/>'s reimport settle loop) before returning, so a
+    /// follow-up tool sees a consistent state. A <c>.gd</c> file is interpreted and re-parsed on load, so it
+    /// needs only a filesystem update, not a build.
+    /// </para>
+    ///
+    /// Editor-only (<c>#if TOOLS</c>): the handlers touch <see cref="EditorInterface"/> and live
+    /// <see cref="Script"/>/<see cref="Node"/> objects. The pure-managed pieces
+    /// (<see cref="Data.ScriptInfo"/>, <see cref="ScriptLang_"/>, <see cref="ResPathNormalizer"/>) live
+    /// outside this guard and are unit-tested.
+    /// </summary>
+    [AiToolType]
+    public partial class Tool_Script
+    {
+        // Shared bounded-settle tunables for a C# rebuild, mirroring Tool_FileSystem.Reimport. The
+        // MainThread dispatcher already runs us on the editor main thread, so a short Thread.Sleep yields
+        // without re-entrancy issues.
+        const int SettleSleepMs = 25;
+        const int SettleMaxWaits = 200;   // 200 * 25ms = 5s settle ceiling
+
+        /// <summary>
+        /// Make a freshly-written/removed script visible to the editor filesystem and, for C#, drain any
+        /// resulting import/build scan (bounded). A <c>.gd</c> file is interpreted, so it only needs the
+        /// filesystem to learn about it; a <c>.cs</c> file changes the compiled assembly, so we reimport it
+        /// and wait for the editor's filesystem scan to settle. Returns a short status note. Main-thread only.
+        /// </summary>
+        static string RefreshAndSettle(string resPath, ScriptLang lang, bool removed)
+        {
+            var efs = EditorInterface.Singleton.GetResourceFilesystem();
+            if (efs == null)
+                return "Editor resource filesystem unavailable; change written but not reimported.";
+
+            // GDScript: interpreted, no build. A full filesystem scan picks up an add/remove; a single-file
+            // update just needs UpdateFile so the editor re-reads it.
+            if (lang == ScriptLang.GDScript)
+            {
+                if (removed)
+                    efs.Scan();
+                else
+                    efs.UpdateFile(resPath);
+                return removed ? "GDScript removed; filesystem rescanned." : "GDScript written; filesystem updated.";
+            }
+
+            // C#: the assembly must pick up the change. Reimport the specific file (add/update) or rescan
+            // (remove), then bound-wait for the editor filesystem scan to settle so a follow-up tool sees a
+            // consistent state. We do NOT block on the actual MSBuild here — Godot rebuilds the C# assembly
+            // out-of-band (on focus / explicit Build) and a headless editor may never run it; settling the
+            // filesystem scan is the bounded, reliable signal we can observe.
+            if (removed)
+            {
+                efs.Scan();
+            }
+            else
+            {
+                efs.ReimportFiles(new[] { resPath });
+            }
+
+            var waits = 0;
+            while (efs.IsScanning() && waits < SettleMaxWaits)
+            {
+                Thread.Sleep(SettleSleepMs);
+                waits++;
+            }
+
+            var settled = !efs.IsScanning();
+            var verb = removed ? "removed" : "written";
+            return settled
+                ? $"C# script {verb}; filesystem settled (rebuild the project to load the new assembly)."
+                : $"C# script {verb}; filesystem still scanning after {SettleMaxWaits * SettleSleepMs}ms " +
+                  $"(progress={efs.GetScanningProgress():0.00}).";
+        }
+
+        /// <summary>
+        /// Build a <see cref="ScriptInfo"/> identity record (no content). Main-thread-agnostic — operates on
+        /// already-captured strings.
+        /// </summary>
+        static ScriptInfo ToScriptInfo(string resPath, ScriptLang lang, string? status = null)
+            => new ScriptInfo
+            {
+                ResourcePath = resPath,
+                Language = lang.ToString(),
+                Status = status,
+            };
+
+        /// <summary>
+        /// Best-effort pre-write syntax validation. For GDScript we can actually compile-check the source via
+        /// <see cref="GDScript.Reload"/> on a parser-fed instance, so an obviously-broken <c>.gd</c> is
+        /// rejected before it touches disk. For C# there is no in-editor compiler we can reach cheaply (Godot
+        /// builds via out-of-band MSBuild), so it is accepted as-is and the post-write build settle is what
+        /// surfaces real compile errors. Returns true when the content is acceptable; on a GDScript parse
+        /// failure returns false and sets <paramref name="error"/>. Main-thread only (touches GDScript).
+        /// </summary>
+        static bool ValidateSyntax(string content, ScriptLang lang, out string? error)
+        {
+            error = null;
+            if (lang != ScriptLang.GDScript)
+                return true; // C#: no cheap in-editor check; the build settle is the real gate.
+
+            // Feed the source into a throwaway GDScript instance and reload it. Reload() parses + compiles the
+            // source and returns a non-Ok Error on a syntax/parse failure, without writing anything to disk.
+            var probe = new GDScript { SourceCode = content };
+            var err = probe.Reload(keepState: false);
+            if (err != Error.Ok)
+            {
+                error = $"GDScript failed to parse ({err}). Fix the syntax and retry.";
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Write <paramref name="content"/> to <paramref name="resPath"/> (creating parent directories as
+        /// needed — Godot's FileAccess does NOT auto-create them), then refresh + bounded-settle. Main-thread
+        /// only. Caller is responsible for the create-vs-update existence precondition.
+        /// </summary>
+        static ScriptInfo WriteScript(string resPath, ScriptLang lang, string content, string verb)
+        {
+            // FileAccess.Open(...Write) does not create missing parent directories — make them first so a
+            // nested target (e.g. 'res://scripts/ai/Brain.cs') works, mirroring Tool_Resource.Create.
+            var slash = resPath.LastIndexOf('/');
+            var targetDir = slash >= 0 ? resPath.Substring(0, slash + 1) : ResPathNormalizer.ResScheme;
+            if (!DirAccess.DirExistsAbsolute(targetDir))
+            {
+                var mkErr = DirAccess.MakeDirRecursiveAbsolute(targetDir);
+                if (mkErr != Error.Ok)
+                    throw new Exception($"Failed to create target directory '{targetDir}': {mkErr}.");
+            }
+
+            using (var file = FileAccess.Open(resPath, FileAccess.ModeFlags.Write))
+            {
+                if (file == null)
+                    throw new Exception($"Failed to open '{resPath}' for writing: {FileAccess.GetOpenError()}.");
+                file.StoreString(content);
+            }
+
+            var status = RefreshAndSettle(resPath, lang, removed: false);
+            return ToScriptInfo(resPath, lang, $"Script {verb}; {status}");
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Add the `script-*` tool family (third after scene/node #9 and resource/fs #11), covering Godot's two first-class scripting languages — C# (`.cs`) and GDScript (`.gd`).
- Tools: `script-read` (content + metadata, line-slice), `script-create`/`script-update` (create-rejects-existing / update-requires-existing; GDScript syntax-validated before write, C# accepted as-is with a post-write build settle), `script-delete` (file + `.uid` sidecar, rescan/settle), `script-attach-to-node` (set/clear a node's script, persisted into the saved `.tscn`).
- Reuses `ResPathNormalizer` (res:// + `..` + bare-scheme guards) via a new `ScriptLang_` helper, `NodeRef`/`Tool_Node.ResolveNode`, and a structured `ScriptInfo` result model. Dynamic code-execute intentionally out of scope (no Godot Roslyn analog).

## Test plan
- [x] `dotnet build Godot-MCP.sln -c Debug` — 0 errors.
- [x] `dotnet test Godot-MCP.Tests` — 125/125 pass (19 new pure-managed cases for `ScriptLang_` + `ScriptInfo`).
- [x] Live headless verification (Godot 4.5.1 mono testbed + local MCP server, Custom mode): all 5 tools registered + ping; create/read/update/delete for both `.cs` and `.gd`; GDScript syntax rejection leaves the file untouched; create-collision and update-nonexistent guards; C# create/delete drive the compile-settle path; `script-attach-to-node` set `scriptResourcePath` on the live node and persisted `script = ExtResource("res://scripts/player.gd")` into the saved `.tscn`; detach cleared it; no orphaned `.uid` sidecars after delete.

Closes #12