### PR TITLE
feat: screenshot tools (editor viewport / camera / isolated node render to PNG)

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -72,6 +72,11 @@
          not here. -->
     <Compile Include="..\addons\godot_mcp\Data\ScriptInfo.cs" Link="Source\ScriptInfo.cs" />
     <Compile Include="..\addons\godot_mcp\Tools\ScriptLang.cs" Link="Source\ScriptLang.cs" />
+    <!-- Screenshot tool family — pure-managed pieces only (no Godot native types, no #if TOOLS): the
+         size-cap clamping, framing trig, view-direction table, and hex-color parse. The editor-driving
+         handlers (Tool_Screenshot.*.cs) are #if TOOLS and encode a real Godot Image, so they are verified
+         via the headless/windowed Godot smoke (test.md Suite 3), not here. -->
+    <Compile Include="..\addons\godot_mcp\Tools\ScreenshotMath.cs" Link="Source\ScreenshotMath.cs" />
   </ItemGroup>
 
 </Project>

--- a/Godot-MCP.Tests/ScreenshotMathTests.cs
+++ b/Godot-MCP.Tests/ScreenshotMathTests.cs
@@ -163,6 +163,48 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Equal(6f, d, 3);
         }
 
+        // ---- BracketClipPlanes -------------------------------------------------------------------
+
+        [Fact]
+        public void BracketClipPlanes_ObjectAlwaysWithinRange()
+        {
+            // Camera 100 units out from a radius-10 object: the object spans depths [90, 110]. The returned
+            // planes must bracket that whole span.
+            var (near, far) = ScreenshotMath.BracketClipPlanes(100f, 10f, userNear: 0.05f, userFar: 4000f);
+            Assert.True(near <= 90f, $"near {near} must be <= object front face 90");
+            Assert.True(far >= 110f, $"far {far} must be >= object back face 110");
+            Assert.True(near > 0f);
+            Assert.True(far > near);
+        }
+
+        [Fact]
+        public void BracketClipPlanes_OnlyLoosensCallerPlanes()
+        {
+            // A wide user range already brackets the object → it must be honored unchanged (only loosened).
+            var (near, far) = ScreenshotMath.BracketClipPlanes(50f, 5f, userNear: 0.01f, userFar: 10000f);
+            Assert.Equal(0.01f, near, 5);
+            Assert.Equal(10000f, far, 1);
+        }
+
+        [Fact]
+        public void BracketClipPlanes_LargeObjectSmallFar_GrowsFar()
+        {
+            // A big object with a too-small user far: far must grow to clear the back face (~210), not stay 100.
+            var (near, far) = ScreenshotMath.BracketClipPlanes(200f, 100f, userNear: 0.05f, userFar: 100f);
+            Assert.True(far >= 300f, $"far {far} must clear the back face ~300");
+            Assert.True(near > 0f);
+        }
+
+        [Fact]
+        public void BracketClipPlanes_NearStaysPositive_ForCloseLargeObject()
+        {
+            // Object front face would be negative (distance < radius): near must floor at a small positive.
+            var (near, far) = ScreenshotMath.BracketClipPlanes(5f, 20f, userNear: 0.05f, userFar: 10f);
+            Assert.True(near > 0f, $"near {near} must stay positive");
+            Assert.True(far > near, $"far {far} must exceed near {near}");
+            Assert.True(float.IsFinite(near) && float.IsFinite(far));
+        }
+
         // ---- GetViewDirectionAndUp ---------------------------------------------------------------
 
         [Theory]

--- a/Godot-MCP.Tests/ScreenshotMathTests.cs
+++ b/Godot-MCP.Tests/ScreenshotMathTests.cs
@@ -1,0 +1,242 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using com.IvanMurzak.Godot.MCP.Tools;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pure-managed coverage for the screenshot tool family's math/validation helper
+    /// (<see cref="ScreenshotMath"/>): dimension validation, transport-cap clamping (aspect preserved),
+    /// framing validation, the camera-distance trig, the view-direction table, and hex-color parsing. None
+    /// of this touches a live Godot rendering device, so it runs in the plain xUnit host with no Godot
+    /// binary. The editor-driving handlers themselves (<c>Tool_Screenshot.*.cs</c>, behind <c>#if TOOLS</c>)
+    /// — which read back and PNG-encode a real Godot <c>Image</c> — are verified by the headless/windowed
+    /// Godot smoke (test.md Suite 3), since image encoding needs the Godot runtime.
+    /// </summary>
+    public class ScreenshotMathTests
+    {
+        // ---- ValidateDimensions ------------------------------------------------------------------
+
+        [Theory]
+        [InlineData(1, 1, true)]
+        [InlineData(1920, 1080, true)]
+        [InlineData(ScreenshotMath.MaxDimension, ScreenshotMath.MaxDimension, true)]
+        [InlineData(0, 100, false)]
+        [InlineData(100, 0, false)]
+        [InlineData(-1, 100, false)]
+        [InlineData(ScreenshotMath.MaxDimension + 1, 100, false)]
+        [InlineData(100, ScreenshotMath.MaxDimension + 1, false)]
+        public void ValidateDimensions_EnforcesBounds(int width, int height, bool expectedValid)
+        {
+            var valid = ScreenshotMath.ValidateDimensions(width, height, out var error);
+            Assert.Equal(expectedValid, valid);
+            if (expectedValid)
+                Assert.Null(error);
+            else
+                Assert.False(string.IsNullOrEmpty(error));
+        }
+
+        // ---- ClampToTransportLimit ---------------------------------------------------------------
+
+        [Fact]
+        public void ClampToTransportLimit_WithinCap_ReturnsUnchanged()
+        {
+            var (w, h) = ScreenshotMath.ClampToTransportLimit(1920, 1080);
+            Assert.Equal(1920, w);
+            Assert.Equal(1080, h);
+        }
+
+        [Fact]
+        public void ClampToTransportLimit_AtCap_ReturnsUnchanged()
+        {
+            var (w, h) = ScreenshotMath.ClampToTransportLimit(
+                ScreenshotMath.MaxScreenshotDimension, ScreenshotMath.MaxScreenshotDimension);
+            Assert.Equal(ScreenshotMath.MaxScreenshotDimension, w);
+            Assert.Equal(ScreenshotMath.MaxScreenshotDimension, h);
+        }
+
+        [Fact]
+        public void ClampToTransportLimit_OversizedLandscape_ScalesLongestEdgeToCap_PreservesAspect()
+        {
+            // 8000x4000 (2:1) -> longest edge clamped to the cap, aspect preserved.
+            var (w, h) = ScreenshotMath.ClampToTransportLimit(8000, 4000);
+            Assert.Equal(ScreenshotMath.MaxScreenshotDimension, w);
+            Assert.Equal(ScreenshotMath.MaxScreenshotDimension / 2, h);
+        }
+
+        [Fact]
+        public void ClampToTransportLimit_OversizedPortrait_ScalesLongestEdgeToCap_PreservesAspect()
+        {
+            var (w, h) = ScreenshotMath.ClampToTransportLimit(4000, 8000);
+            Assert.Equal(ScreenshotMath.MaxScreenshotDimension / 2, w);
+            Assert.Equal(ScreenshotMath.MaxScreenshotDimension, h);
+        }
+
+        [Fact]
+        public void ClampToTransportLimit_ExtremeAspect_FloorsShortEdgeAtOne()
+        {
+            // A 1-px-tall band scaled down must never collapse the short edge to 0.
+            var (w, h) = ScreenshotMath.ClampToTransportLimit(16000, 1);
+            Assert.Equal(ScreenshotMath.MaxScreenshotDimension, w);
+            Assert.True(h >= 1);
+        }
+
+        // ---- ValidateFraming ---------------------------------------------------------------------
+
+        [Theory]
+        [InlineData(60f, 0.05f, 1000f, 1.2f, true)]
+        [InlineData(ScreenshotMath.MinFieldOfView, 0.05f, 1000f, 1.2f, true)]
+        [InlineData(ScreenshotMath.MaxFieldOfView, 0.05f, 1000f, 1.2f, true)]
+        // fov out of range
+        [InlineData(0f, 0.05f, 1000f, 1.2f, false)]
+        [InlineData(180f, 0.05f, 1000f, 1.2f, false)]
+        // near must be > 0
+        [InlineData(60f, 0f, 1000f, 1.2f, false)]
+        [InlineData(60f, -1f, 1000f, 1.2f, false)]
+        // far must be > near
+        [InlineData(60f, 10f, 10f, 1.2f, false)]
+        [InlineData(60f, 10f, 5f, 1.2f, false)]
+        // padding out of range
+        [InlineData(60f, 0.05f, 1000f, 0f, false)]
+        [InlineData(60f, 0.05f, 1000f, 1000f, false)]
+        public void ValidateFraming_EnforcesRanges(float fov, float near, float far, float padding, bool expectedValid)
+        {
+            var valid = ScreenshotMath.ValidateFraming(fov, near, far, padding, out var error);
+            Assert.Equal(expectedValid, valid);
+            if (!expectedValid)
+                Assert.False(string.IsNullOrEmpty(error));
+        }
+
+        [Fact]
+        public void ValidateFraming_RejectsNonFinite()
+        {
+            Assert.False(ScreenshotMath.ValidateFraming(float.NaN, 0.05f, 1000f, 1.2f, out _));
+            Assert.False(ScreenshotMath.ValidateFraming(60f, float.PositiveInfinity, 1000f, 1.2f, out _));
+            Assert.False(ScreenshotMath.ValidateFraming(60f, 0.05f, float.NaN, 1.2f, out _));
+            Assert.False(ScreenshotMath.ValidateFraming(60f, 0.05f, 1000f, float.PositiveInfinity, out _));
+        }
+
+        // ---- ComputeCameraDistance ---------------------------------------------------------------
+
+        [Fact]
+        public void ComputeCameraDistance_LargerRadius_YieldsLargerDistance()
+        {
+            var near = ScreenshotMath.ComputeCameraDistance(1f, 60f, 1.0f);
+            var far = ScreenshotMath.ComputeCameraDistance(2f, 60f, 1.0f);
+            Assert.True(far > near);
+            // Distance is linear in radius for a fixed fov/padding.
+            Assert.Equal(near * 2f, far, 3);
+        }
+
+        [Fact]
+        public void ComputeCameraDistance_MorePadding_YieldsLargerDistance()
+        {
+            var tight = ScreenshotMath.ComputeCameraDistance(1f, 60f, 1.0f);
+            var loose = ScreenshotMath.ComputeCameraDistance(1f, 60f, 1.5f);
+            Assert.True(loose > tight);
+            Assert.Equal(tight * 1.5f, loose, 3);
+        }
+
+        [Fact]
+        public void ComputeCameraDistance_ZeroRadius_StillFinitePositive()
+        {
+            var d = ScreenshotMath.ComputeCameraDistance(0f, 60f, 1.2f);
+            Assert.True(d > 0f);
+            Assert.True(float.IsFinite(d));
+        }
+
+        [Fact]
+        public void ComputeCameraDistance_KnownFov_MatchesTrig()
+        {
+            // For fov=60deg, half-angle=30deg, sin(30)=0.5 => distance = radius*padding / 0.5 = 2*radius*padding.
+            var d = ScreenshotMath.ComputeCameraDistance(3f, 60f, 1.0f);
+            Assert.Equal(6f, d, 3);
+        }
+
+        // ---- GetViewDirectionAndUp ---------------------------------------------------------------
+
+        [Theory]
+        [InlineData(ScreenshotView.Front, 0f, 0f, -1f)]
+        [InlineData(ScreenshotView.Back, 0f, 0f, 1f)]
+        [InlineData(ScreenshotView.Left, -1f, 0f, 0f)]
+        [InlineData(ScreenshotView.Right, 1f, 0f, 0f)]
+        [InlineData(ScreenshotView.Top, 0f, 1f, 0f)]
+        [InlineData(ScreenshotView.Bottom, 0f, -1f, 0f)]
+        public void GetViewDirectionAndUp_ReturnsExpectedDirection(ScreenshotView view, float dx, float dy, float dz)
+        {
+            var (dir, up) = ScreenshotMath.GetViewDirectionAndUp(view);
+            Assert.Equal(dx, dir.x, 5);
+            Assert.Equal(dy, dir.y, 5);
+            Assert.Equal(dz, dir.z, 5);
+
+            // The up vector must not be parallel to the view direction (else LookAt is degenerate). For
+            // top/bottom the up is forward (Z); for the lateral views it is world up (Y).
+            var dot = dir.x * up.x + dir.y * up.y + dir.z * up.z;
+            Assert.Equal(0f, dot, 5);
+        }
+
+        // ---- TryParseHtmlColor -------------------------------------------------------------------
+
+        [Fact]
+        public void TryParseHtmlColor_SixDigit_Parses()
+        {
+            Assert.True(ScreenshotMath.TryParseHtmlColor("#404040", out var c));
+            Assert.Equal(0x40 / 255f, c.r, 5);
+            Assert.Equal(0x40 / 255f, c.g, 5);
+            Assert.Equal(0x40 / 255f, c.b, 5);
+            Assert.Equal(1f, c.a, 5);
+        }
+
+        [Fact]
+        public void TryParseHtmlColor_NoHash_Parses()
+        {
+            Assert.True(ScreenshotMath.TryParseHtmlColor("FF0000", out var c));
+            Assert.Equal(1f, c.r, 5);
+            Assert.Equal(0f, c.g, 5);
+            Assert.Equal(0f, c.b, 5);
+        }
+
+        [Fact]
+        public void TryParseHtmlColor_EightDigit_ParsesAlpha()
+        {
+            Assert.True(ScreenshotMath.TryParseHtmlColor("#00FF0080", out var c));
+            Assert.Equal(0f, c.r, 5);
+            Assert.Equal(1f, c.g, 5);
+            Assert.Equal(0f, c.b, 5);
+            Assert.Equal(0x80 / 255f, c.a, 5);
+        }
+
+        [Fact]
+        public void TryParseHtmlColor_ThreeDigitShorthand_Parses()
+        {
+            // '#FFF' -> white (each nibble doubled).
+            Assert.True(ScreenshotMath.TryParseHtmlColor("#FFF", out var c));
+            Assert.Equal(1f, c.r, 5);
+            Assert.Equal(1f, c.g, 5);
+            Assert.Equal(1f, c.b, 5);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("#GGGGGG")]   // non-hex digits
+        [InlineData("#12345")]    // wrong length (5)
+        [InlineData("#1234567")]  // wrong length (7)
+        [InlineData("notacolor")]
+        public void TryParseHtmlColor_Invalid_ReturnsFalse(string? hex)
+        {
+            Assert.False(ScreenshotMath.TryParseHtmlColor(hex, out _));
+        }
+    }
+}

--- a/addons/godot_mcp/Tools/ScreenshotMath.cs
+++ b/addons/godot_mcp/Tools/ScreenshotMath.cs
@@ -183,6 +183,45 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         }
 
         /// <summary>
+        /// Bracket the camera clip planes around the object the isolated render just framed, so the object's
+        /// depth span — a sphere of <paramref name="boundsRadius"/> centered <paramref name="cameraDistance"/>
+        /// in front of the camera — always lies inside [near, far]. Without this, a large object (or a small
+        /// user-supplied far) can leave the framed target OUTSIDE the clip range, producing an empty /
+        /// background-only PNG that the tool still reports as success.
+        ///
+        /// <para>
+        /// The object spans depths [cameraDistance - r, cameraDistance + r] (with a small margin <c>k</c>).
+        /// Near is shrunk toward — never below — that front face (floored positive so the perspective matrix
+        /// stays valid); far is grown to at least clear the back face. The caller's near/far act as the
+        /// tightest defaults: they are only loosened, never tightened, so an explicit wide range is honored.
+        /// Pure (no Godot types) → unit-testable.
+        /// </para>
+        /// </summary>
+        public static (float near, float far) BracketClipPlanes(float cameraDistance, float boundsRadius, float userNear, float userFar)
+        {
+            // Margin so the object's silhouette is not clipped exactly at the planes.
+            const float k = 1.05f;
+            var span = Math.Max(0f, boundsRadius) * k;
+
+            // Front face of the object, floored to a small positive value (near must be > 0 for perspective).
+            var frontFace = Math.Max(1e-4f, cameraDistance - span);
+            // Back face of the object.
+            var backFace = cameraDistance + span;
+
+            // Only loosen the caller's planes: near may move closer (smaller), far may move farther (larger).
+            var near = Math.Min(userNear, frontFace);
+            var far = Math.Max(userFar, backFace);
+
+            // Guarantee a valid, non-degenerate range even for pathological inputs.
+            if (near <= 0f)
+                near = 1e-4f;
+            if (far <= near)
+                far = near + Math.Max(span * 2f, 1e-3f);
+
+            return (near, far);
+        }
+
+        /// <summary>
         /// Parse a '#RGB' / '#RRGGBB' / '#RRGGBBAA' hex color into normalized (r,g,b,a) floats in [0,1].
         /// Returns false on a malformed string. Pure — does NOT construct Godot's <c>Color</c> (which would pull
         /// a native dependency); the editor handler converts the tuple to a <c>Color</c>. A leading '#' is

--- a/addons/godot_mcp/Tools/ScreenshotMath.cs
+++ b/addons/godot_mcp/Tools/ScreenshotMath.cs
@@ -1,0 +1,253 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.ComponentModel;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// Camera angle (relative to a target node's bounding box) for the isolated render. The Godot analog
+    /// of Unity-MCP's <c>Tool_Screenshot.CameraView</c>. Lives in the pure-managed helper (no Godot native
+    /// types) so it can be referenced from the xUnit host.
+    /// </summary>
+    public enum ScreenshotView
+    {
+        [Description("Camera faces the object's front (-Z). Standard front view.")]
+        Front,
+        [Description("Camera faces the object's rear (+Z).")]
+        Back,
+        [Description("Camera faces the object's left (-X).")]
+        Left,
+        [Description("Camera faces the object's right (+X).")]
+        Right,
+        [Description("Camera looks down at the object from above (+Y).")]
+        Top,
+        [Description("Camera looks up at the object from below (-Y).")]
+        Bottom,
+    }
+
+    /// <summary>
+    /// Background fill for the isolated render's <c>SubViewport</c>.
+    /// </summary>
+    public enum ScreenshotBackground
+    {
+        [Description("Flat color defined by backgroundColor (hex string). SubViewport is opaque.")]
+        SolidColor,
+        [Description("Alpha-zero background for compositing (SubViewport.TransparentBg = true). PNG carries alpha.")]
+        Transparent,
+    }
+
+    /// <summary>
+    /// Pure-managed math/validation shared by the screenshot tool family. Extracted from the editor-only
+    /// (<c>#if TOOLS</c>) handlers — mirroring <see cref="NodePathNormalizer"/> / <see cref="ResPathNormalizer"/>
+    /// — so the transport-cap clamping, the bounds-to-camera-distance computation, the view-direction table,
+    /// and the hex-color parse (the parts most prone to off-by-one / aspect-ratio bugs) are unit-testable in
+    /// the plain xUnit host with NO live Godot rendering. None of this touches a Godot native type.
+    /// </summary>
+    public static class ScreenshotMath
+    {
+        /// <summary>
+        /// Longest output edge allowed on any single screenshot, in pixels. Godot's <c>Image.SavePngToBuffer</c>
+        /// PNG travels back to the AI as image content inside a JSON envelope over the McpPlugin transport,
+        /// which caps a single message. An overly large capture produces a PNG that exceeds that cap and is
+        /// dropped in transit. 3840 (true 4K) leaves comfortable headroom while staying well above what the
+        /// model's vision actually consumes (images are downsampled to ~1568 px on the longest edge before the
+        /// model sees them), so extra resolution past ~4K only inflates the payload. Mirrors the Unity plugin's
+        /// <c>MaxScreenshotDimension</c>.
+        /// </summary>
+        public const int MaxScreenshotDimension = 3840;
+
+        /// <summary>Smallest accepted output edge, in pixels.</summary>
+        public const int MinDimension = 1;
+
+        /// <summary>Largest dimension a caller may request before transport clamping kicks in.</summary>
+        public const int MaxDimension = 16384;
+
+        public const float MinFieldOfView = 1f;
+        public const float MaxFieldOfView = 179f;
+        public const float MinPadding = 0.01f;
+        public const float MaxPadding = 100f;
+        public const float MaxNearClip = 1000f;
+        public const float MaxFarClip = 1e6f;
+
+        /// <summary>
+        /// Validate a requested width/height pair. Returns false and sets <paramref name="error"/> when either
+        /// dimension is &lt; <see cref="MinDimension"/> or &gt; <see cref="MaxDimension"/>. Pure; no clamping.
+        /// </summary>
+        public static bool ValidateDimensions(int width, int height, out string? error)
+        {
+            if (width < MinDimension || height < MinDimension)
+            {
+                error = $"Width and height must be >= {MinDimension}. Got {width}x{height}.";
+                return false;
+            }
+            if (width > MaxDimension || height > MaxDimension)
+            {
+                error = $"Width and height must be <= {MaxDimension} pixels. Got {width}x{height}.";
+                return false;
+            }
+            error = null;
+            return true;
+        }
+
+        /// <summary>
+        /// Scale (width, height) so the longest edge is at most <see cref="MaxScreenshotDimension"/>, preserving
+        /// aspect ratio. Returns the input unchanged when already within the limit. Each axis floors at 1 px.
+        /// Mirrors the Unity plugin's <c>ClampToTransportLimit</c>.
+        /// </summary>
+        public static (int width, int height) ClampToTransportLimit(int width, int height)
+        {
+            var longest = Math.Max(width, height);
+            if (longest <= MaxScreenshotDimension)
+                return (width, height);
+
+            var scale = (float)MaxScreenshotDimension / longest;
+            return (Math.Max(1, (int)Math.Round(width * scale)),
+                    Math.Max(1, (int)Math.Round(height * scale)));
+        }
+
+        /// <summary>
+        /// Validate the camera framing parameters for the isolated render. Returns false + an error string when
+        /// any value is non-finite or out of range. Pure (no Godot types).
+        /// </summary>
+        public static bool ValidateFraming(float fieldOfView, float nearClip, float farClip, float padding, out string? error)
+        {
+            if (!IsFinite(fieldOfView) || fieldOfView < MinFieldOfView || fieldOfView > MaxFieldOfView)
+            {
+                error = $"fieldOfView must be finite and between {MinFieldOfView} and {MaxFieldOfView} degrees. Got {fieldOfView}.";
+                return false;
+            }
+            if (!IsFinite(padding) || padding < MinPadding || padding > MaxPadding)
+            {
+                error = $"padding must be finite and between {MinPadding} and {MaxPadding}. Got {padding}.";
+                return false;
+            }
+            if (!IsFinite(nearClip) || nearClip <= 0f || nearClip > MaxNearClip)
+            {
+                error = $"nearClipPlane must be finite and in (0, {MaxNearClip}]. Got {nearClip}.";
+                return false;
+            }
+            if (!IsFinite(farClip) || farClip <= nearClip || farClip > MaxFarClip)
+            {
+                error = $"farClipPlane must be finite, > nearClipPlane ({nearClip}), and <= {MaxFarClip}. Got {farClip}.";
+                return false;
+            }
+            error = null;
+            return true;
+        }
+
+        /// <summary>
+        /// Unit view direction (the offset from the bounding-box center toward the camera) and the camera's
+        /// up vector for a given <see cref="ScreenshotView"/>. Returned as plain (x,y,z) float triples so the
+        /// table is testable without constructing Godot's <c>Vector3</c> (a struct, but kept out of the pure
+        /// helper to avoid any GodotSharp dependency leaking into the math unit tests).
+        /// </summary>
+        public static ((float x, float y, float z) direction, (float x, float y, float z) up) GetViewDirectionAndUp(ScreenshotView view)
+        {
+            return view switch
+            {
+                ScreenshotView.Front  => ((0f, 0f, -1f), (0f, 1f, 0f)),
+                ScreenshotView.Back   => ((0f, 0f, 1f),  (0f, 1f, 0f)),
+                ScreenshotView.Left   => ((-1f, 0f, 0f), (0f, 1f, 0f)),
+                ScreenshotView.Right  => ((1f, 0f, 0f),  (0f, 1f, 0f)),
+                ScreenshotView.Top    => ((0f, 1f, 0f),  (0f, 0f, 1f)),
+                ScreenshotView.Bottom => ((0f, -1f, 0f), (0f, 0f, 1f)),
+                _                     => ((0f, 0f, -1f), (0f, 1f, 0f)),
+            };
+        }
+
+        /// <summary>
+        /// Distance the camera must sit from the bounding-box center so a sphere of the given
+        /// <paramref name="boundsRadius"/> fits the vertical field of view, scaled by <paramref name="padding"/>
+        /// (1.0 = tight fit, 1.5 = 50% extra margin). A near-zero radius floors at 0.05 so a point/empty target
+        /// still yields a sane finite distance. Pure trig.
+        /// </summary>
+        public static float ComputeCameraDistance(float boundsRadius, float fieldOfViewDegrees, float padding)
+        {
+            if (boundsRadius < 0.0001f)
+                boundsRadius = 0.05f;
+
+            var fovRad = fieldOfViewDegrees * 0.5f * (float)(Math.PI / 180.0);
+            var sin = (float)Math.Sin(fovRad);
+            if (sin < 1e-6f)
+                sin = 1e-6f;
+            return (boundsRadius * padding) / sin;
+        }
+
+        /// <summary>
+        /// Parse a '#RGB' / '#RRGGBB' / '#RRGGBBAA' hex color into normalized (r,g,b,a) floats in [0,1].
+        /// Returns false on a malformed string. Pure — does NOT construct Godot's <c>Color</c> (which would pull
+        /// a native dependency); the editor handler converts the tuple to a <c>Color</c>. A leading '#' is
+        /// optional. Mirrors Godot's own '#'-hex acceptance without the native parse.
+        /// </summary>
+        public static bool TryParseHtmlColor(string? hex, out (float r, float g, float b, float a) color)
+        {
+            color = (0f, 0f, 0f, 1f);
+            if (string.IsNullOrWhiteSpace(hex))
+                return false;
+
+            var s = hex!.Trim();
+            if (s.StartsWith("#", StringComparison.Ordinal))
+                s = s.Substring(1);
+
+            // Accept 3 (RGB), 6 (RRGGBB), or 8 (RRGGBBAA) hex digits.
+            if (s.Length != 3 && s.Length != 6 && s.Length != 8)
+                return false;
+
+            foreach (var c in s)
+            {
+                var isHex = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+                if (!isHex)
+                    return false;
+            }
+
+            float r, g, b, a = 1f;
+            if (s.Length == 3)
+            {
+                r = Hex1(s[0]);
+                g = Hex1(s[1]);
+                b = Hex1(s[2]);
+            }
+            else
+            {
+                r = Hex2(s, 0);
+                g = Hex2(s, 2);
+                b = Hex2(s, 4);
+                if (s.Length == 8)
+                    a = Hex2(s, 6);
+            }
+
+            color = (r, g, b, a);
+            return true;
+        }
+
+        static float Hex1(char c)
+        {
+            var v = HexVal(c);
+            // '#RGB' shorthand: each nibble is doubled (e.g. 'F' -> 0xFF).
+            return (v * 16 + v) / 255f;
+        }
+
+        static float Hex2(string s, int i)
+        {
+            return (HexVal(s[i]) * 16 + HexVal(s[i + 1])) / 255f;
+        }
+
+        static int HexVal(char c)
+        {
+            if (c >= '0' && c <= '9') return c - '0';
+            if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+            return c - 'A' + 10;
+        }
+
+        static bool IsFinite(float v) => !float.IsNaN(v) && !float.IsInfinity(v);
+    }
+}

--- a/addons/godot_mcp/Tools/Tool_Screenshot.Camera.cs
+++ b/addons/godot_mcp/Tools/Tool_Screenshot.Camera.cs
@@ -84,21 +84,31 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 World3D = source.GetWorld3D(),
             };
 
-            var cloneCamera = new Camera3D
+            // The caller owns the SubViewport's lifetime: construction below (native property reads on the
+            // source camera) can throw before the render runs, so freeing must cover construction too — not
+            // just the render. RenderSubViewportToPng only hosts/un-hosts; this finally frees on every path.
+            try
             {
-                GlobalTransform = source.GlobalTransform,
-                Projection = source.Projection,
-                Fov = source.Fov,
-                Size = source.Size,
-                Near = source.Near,
-                Far = source.Far,
-                KeepAspect = source.KeepAspect,
-                Current = true,
-            };
-            subViewport.AddChild(cloneCamera);
+                var cloneCamera = new Camera3D
+                {
+                    GlobalTransform = source.GlobalTransform,
+                    Projection = source.Projection,
+                    Fov = source.Fov,
+                    Size = source.Size,
+                    Near = source.Near,
+                    Far = source.Far,
+                    KeepAspect = source.KeepAspect,
+                    Current = true,
+                };
+                subViewport.AddChild(cloneCamera);
 
-            return RenderSubViewportToPng(subViewport,
-                caption: $"Camera3D '{source.Name}' screenshot ({width}x{height})");
+                return RenderSubViewportToPng(subViewport,
+                    caption: $"Camera3D '{source.Name}' screenshot ({width}x{height})");
+            }
+            finally
+            {
+                FreeOffscreenViewport(subViewport);
+            }
         }
 
         // Render the camera's 2D world into an off-screen SubViewport that shares World2D and applies the
@@ -118,34 +128,45 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 World2D = world2D,
             };
 
-            // Center the requested camera position in the output: translate the canvas so the camera's
-            // global position maps to the middle of the output, scaled by the camera zoom.
-            var zoom = source.Zoom;
-            if (zoom.X == 0f) zoom.X = 1f;
-            if (zoom.Y == 0f) zoom.Y = 1f;
-            var center = source.GetTargetPosition();
-            var canvasTransform = new Transform2D(0f, zoom, 0f,
-                new Vector2(width, height) * 0.5f - center * zoom);
-            subViewport.CanvasTransform = canvasTransform;
+            // The caller owns the SubViewport's lifetime: the canvas-transform construction below reads
+            // native camera state (zoom / center) and can throw, so free on every path including a throw
+            // before the render. RenderSubViewportToPng only hosts/un-hosts.
+            try
+            {
+                // Center the requested camera framing in the output: translate the canvas so the camera's
+                // on-screen center maps to the middle of the output, scaled by the camera zoom.
+                // GetScreenCenterPosition() is the actual screen center (post-smoothing), unlike
+                // GetTargetPosition() which returns the pre-smoothing drag target.
+                var zoom = source.Zoom;
+                if (zoom.X == 0f) zoom.X = 1f;
+                if (zoom.Y == 0f) zoom.Y = 1f;
+                var center = source.GetScreenCenterPosition();
+                var canvasTransform = new Transform2D(0f, zoom, 0f,
+                    new Vector2(width, height) * 0.5f - center * zoom);
+                subViewport.CanvasTransform = canvasTransform;
 
-            return RenderSubViewportToPng(subViewport,
-                caption: $"Camera2D '{source.Name}' screenshot ({width}x{height})");
+                return RenderSubViewportToPng(subViewport,
+                    caption: $"Camera2D '{source.Name}' screenshot ({width}x{height})");
+            }
+            finally
+            {
+                FreeOffscreenViewport(subViewport);
+            }
         }
 
         // Shared off-screen render: parent the SubViewport into the editor tree (so it gets a rendering
-        // device), force a draw, read back + encode, and always free the temporary nodes. MUST run on the
-        // main thread.
+        // device), force a draw, read back + encode. The CALLER owns the SubViewport's lifetime and frees
+        // it (via FreeOffscreenViewport) in its own finally — this only hosts/un-hosts it so a throw during
+        // construction (before this is even reached) is still covered by the caller. MUST run on the main
+        // thread.
         static ResponseCallTool RenderSubViewportToPng(SubViewport subViewport, string caption)
         {
             // The SubViewport needs a parent in the live tree to allocate a render target. The editor's
             // base control is a stable, always-present host; the SubViewport renders off-screen (it is not
-            // a visible child of any editor panel) and is removed before the call returns.
+            // a visible child of any editor panel) and is un-hosted before the call returns.
             var host = EditorInterface.Singleton.GetBaseControl();
             if (host == null)
-            {
-                subViewport.QueueFree();
                 return ResponseCallTool.Error("Editor base control is unavailable; cannot host the off-screen render.");
-            }
 
             try
             {
@@ -168,10 +189,22 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             }
             finally
             {
+                // Un-host only; the caller's finally QueueFree's the SubViewport (and its descendants).
                 if (subViewport.GetParent() != null)
                     subViewport.GetParent().RemoveChild(subViewport);
-                subViewport.QueueFree();
             }
+        }
+
+        // Free an off-screen SubViewport and its descendants. Idempotent-safe to call from the caller's
+        // finally on every path (including a throw before the SubViewport was ever hosted): un-hosts it if
+        // still parented, then QueueFree's the whole subtree exactly once. MUST run on the main thread.
+        static void FreeOffscreenViewport(SubViewport subViewport)
+        {
+            if (subViewport == null || !GodotObject.IsInstanceValid(subViewport))
+                return;
+            if (subViewport.GetParent() != null)
+                subViewport.GetParent().RemoveChild(subViewport);
+            subViewport.QueueFree();
         }
     }
 }

--- a/addons/godot_mcp/Tools/Tool_Screenshot.Camera.cs
+++ b/addons/godot_mcp/Tools/Tool_Screenshot.Camera.cs
@@ -1,0 +1,178 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Screenshot
+    {
+        public const string ScreenshotCameraToolId = "screenshot-camera";
+
+        [AiTool
+        (
+            ScreenshotCameraToolId,
+            Title = "Screenshot / Camera",
+            ReadOnlyHint = true,
+            IdempotentHint = true,
+            OpenWorldHint = false
+        )]
+        [Description("Capture a screenshot from a specific Camera3D (or Camera2D) in the edited scene and " +
+            "return it as a PNG image for direct LLM inspection. Identify the camera with 'nodeRef' " +
+            "(instanceId preferred, else a scene-tree path). The camera's own world is rendered into a " +
+            "temporary off-screen SubViewport at the requested 'width'x'height', so the editor's live " +
+            "selection/camera is left untouched. Output edges are capped to keep the response transportable. " +
+            "NOTE: rendering needs a real GPU — a Godot launched with '--headless' yields an empty image, " +
+            "surfaced here as a structured error rather than a blank PNG.")]
+        public ResponseCallTool ScreenshotCamera
+        (
+            [Description("Reference to the camera Node (Camera3D or Camera2D) to capture from " +
+                "(instanceId preferred, else scene-tree path).")]
+            NodeRef nodeRef,
+            [Description("Output width in pixels. Default 1920. Must be > 0 and within the dimension cap.")]
+            int width = 1920,
+            [Description("Output height in pixels. Default 1080. Must be > 0 and within the dimension cap.")]
+            int height = 1080
+        )
+        {
+            if (!ScreenshotMath.ValidateDimensions(width, height, out var dimError))
+                return ResponseCallTool.Error(dimError!);
+
+            // Clamp the requested size to the transport limit up front so the off-screen SubViewport is
+            // allocated at the final size (cheaper than rendering large then downscaling).
+            (width, height) = ScreenshotMath.ClampToTransportLimit(width, height);
+
+            return MainThread.Instance.Run(() =>
+            {
+                var node = Tool_Node.ResolveNode(nodeRef, out var resolveError);
+                if (node == null)
+                    return ResponseCallTool.Error(resolveError ?? $"Camera node {nodeRef} not found.");
+
+                if (node is Camera3D camera3D)
+                    return CaptureCamera3D(camera3D, width, height);
+                if (node is Camera2D camera2D)
+                    return CaptureCamera2D(camera2D, width, height);
+
+                return ResponseCallTool.Error(
+                    $"Node {nodeRef} is a '{node.GetClass()}', not a Camera3D or Camera2D.");
+            });
+        }
+
+        // Render the camera's 3D world into an off-screen SubViewport via a temporary clone camera, so the
+        // editor's own current camera / selection is never disturbed. MUST run on the main thread.
+        static ResponseCallTool CaptureCamera3D(Camera3D source, int width, int height)
+        {
+            var subViewport = new SubViewport
+            {
+                Size = new Vector2I(width, height),
+                RenderTargetUpdateMode = SubViewport.UpdateMode.Always,
+                // Share the source camera's world so the same scene content is visible.
+                World3D = source.GetWorld3D(),
+            };
+
+            var cloneCamera = new Camera3D
+            {
+                GlobalTransform = source.GlobalTransform,
+                Projection = source.Projection,
+                Fov = source.Fov,
+                Size = source.Size,
+                Near = source.Near,
+                Far = source.Far,
+                KeepAspect = source.KeepAspect,
+                Current = true,
+            };
+            subViewport.AddChild(cloneCamera);
+
+            return RenderSubViewportToPng(subViewport,
+                caption: $"Camera3D '{source.Name}' screenshot ({width}x{height})");
+        }
+
+        // Render the camera's 2D world into an off-screen SubViewport that shares World2D and applies the
+        // source camera's transform as the SubViewport's canvas transform (so the same framing is captured).
+        static ResponseCallTool CaptureCamera2D(Camera2D source, int width, int height)
+        {
+            var sourceViewport = source.GetViewport();
+            var world2D = sourceViewport?.GetWorld2D();
+            if (world2D == null)
+                return ResponseCallTool.Error(
+                    $"Camera2D '{source.Name}' is not inside a viewport with a World2D; cannot capture.");
+
+            var subViewport = new SubViewport
+            {
+                Size = new Vector2I(width, height),
+                RenderTargetUpdateMode = SubViewport.UpdateMode.Always,
+                World2D = world2D,
+            };
+
+            // Center the requested camera position in the output: translate the canvas so the camera's
+            // global position maps to the middle of the output, scaled by the camera zoom.
+            var zoom = source.Zoom;
+            if (zoom.X == 0f) zoom.X = 1f;
+            if (zoom.Y == 0f) zoom.Y = 1f;
+            var center = source.GetTargetPosition();
+            var canvasTransform = new Transform2D(0f, zoom, 0f,
+                new Vector2(width, height) * 0.5f - center * zoom);
+            subViewport.CanvasTransform = canvasTransform;
+
+            return RenderSubViewportToPng(subViewport,
+                caption: $"Camera2D '{source.Name}' screenshot ({width}x{height})");
+        }
+
+        // Shared off-screen render: parent the SubViewport into the editor tree (so it gets a rendering
+        // device), force a draw, read back + encode, and always free the temporary nodes. MUST run on the
+        // main thread.
+        static ResponseCallTool RenderSubViewportToPng(SubViewport subViewport, string caption)
+        {
+            // The SubViewport needs a parent in the live tree to allocate a render target. The editor's
+            // base control is a stable, always-present host; the SubViewport renders off-screen (it is not
+            // a visible child of any editor panel) and is removed before the call returns.
+            var host = EditorInterface.Singleton.GetBaseControl();
+            if (host == null)
+            {
+                subViewport.QueueFree();
+                return ResponseCallTool.Error("Editor base control is unavailable; cannot host the off-screen render.");
+            }
+
+            try
+            {
+                host.AddChild(subViewport);
+
+                // The SubViewport renders into its target across the next draw. A SINGLE force-draw issued
+                // immediately after AddChild can read back BEFORE the off-screen target has the scene content
+                // (empirically: the first draw yields the clear color only). The SubViewport is created with
+                // UpdateMode.Always, and two force-draws let the content land before the synchronous
+                // read-back below.
+                RenderingServer.ForceDraw();
+                RenderingServer.ForceDraw();
+
+                var png = EncodeViewportPng(subViewport, flipY: false, out var error);
+                if (png == null)
+                    return ResponseCallTool.Error(error ?? "Failed to read back the camera render.");
+
+                return ResponseCallTool.Image(png, McpPlugin.Common.Consts.MimeType.ImagePng,
+                    $"{caption} ({png.Length} bytes PNG)");
+            }
+            finally
+            {
+                if (subViewport.GetParent() != null)
+                    subViewport.GetParent().RemoveChild(subViewport);
+                subViewport.QueueFree();
+            }
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Screenshot.Isolated.cs
+++ b/addons/godot_mcp/Tools/Tool_Screenshot.Isolated.cs
@@ -123,6 +123,26 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             // hosts/un-hosts; this finally QueueFree's the SubViewport and all temp children on every path.
             try
             {
+                // The OwnWorld3D SubViewport otherwise clears to Godot's DEFAULT environment color, ignoring
+                // the requested SolidColor hex. For the SolidColor path, install a WorldEnvironment whose
+                // Environment clears the background to the parsed color so the produced PNG actually shows the
+                // requested background. (Transparent stays driven by TransparentBg above and gets no
+                // WorldEnvironment.) The WorldEnvironment is a child of the SubViewport, so
+                // FreeOffscreenViewport's subtree QueueFree frees it along with the clone/camera/light.
+                if (background == ScreenshotBackground.SolidColor &&
+                    ScreenshotMath.TryParseHtmlColor(backgroundColorHex, out var bg))
+                {
+                    var worldEnvironment = new WorldEnvironment
+                    {
+                        Environment = new global::Godot.Environment
+                        {
+                            BackgroundMode = global::Godot.Environment.BGMode.Color,
+                            BackgroundColor = new Color(bg.r, bg.g, bg.b, bg.a),
+                        },
+                    };
+                    subViewport.AddChild(worldEnvironment);
+                }
+
                 // Duplicate so we can recenter at the origin without mutating the real node's transform.
                 // Scripts are deliberately NOT duplicated: a static off-screen render needs no behavior, and
                 // including them would run the clones' _EnterTree/_Ready on AddChild — observable side

--- a/addons/godot_mcp/Tools/Tool_Screenshot.Isolated.cs
+++ b/addons/godot_mcp/Tools/Tool_Screenshot.Isolated.cs
@@ -1,0 +1,202 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Screenshot
+    {
+        public const string ScreenshotIsolatedToolId = "screenshot-isolated";
+
+        [AiTool
+        (
+            ScreenshotIsolatedToolId,
+            Title = "Screenshot / Isolated Node",
+            ReadOnlyHint = true,
+            IdempotentHint = true,
+            OpenWorldHint = false
+        )]
+        [Description("Render a target Node3D in ISOLATION (only the target is visible, in its own world) " +
+            "from a chosen camera angle, framed automatically to its bounding box, lit by a default " +
+            "directional light, and return the result as a PNG image for direct LLM inspection. Identify " +
+            "the target with 'nodeRef'. Choose the view with 'cameraView' (Front/Back/Left/Right/Top/Bottom). " +
+            "Pick a 'background' (SolidColor or Transparent) and, for SolidColor, a hex 'backgroundColor'. " +
+            "The target is rendered via a temporary off-screen copy, so the edited scene is never mutated. " +
+            "Output is a square 'resolution'x'resolution' PNG, capped to keep the response transportable. " +
+            "NOTE: rendering needs a real GPU — a Godot launched with '--headless' yields an empty image, " +
+            "surfaced here as a structured error rather than a blank PNG.")]
+        public ResponseCallTool ScreenshotIsolated
+        (
+            [Description("Reference to the target Node3D to render in isolation (instanceId preferred, else path).")]
+            NodeRef nodeRef,
+            [Description("Camera angle relative to the target's bounding box. Default: Front.")]
+            ScreenshotView cameraView = ScreenshotView.Front,
+            [Description("Background mode for the render: SolidColor (default) or Transparent.")]
+            ScreenshotBackground background = ScreenshotBackground.SolidColor,
+            [Description("Hex background color (e.g. '#404040'). Used only when background is SolidColor.")]
+            string backgroundColor = "#404040",
+            [Description("Camera vertical field of view in degrees. Default: 60.")]
+            float fieldOfView = 60f,
+            [Description("Near clip plane distance. Default: 0.05.")]
+            float nearClipPlane = 0.05f,
+            [Description("Far clip plane distance. Default: 4000.")]
+            float farClipPlane = 4000f,
+            [Description("Framing multiplier around the object. 1.0 = tight fit, 1.5 = 50% extra space. Default: 1.2.")]
+            float padding = 1.2f,
+            [Description("Output image resolution in pixels (width = height). Default: 512.")]
+            int resolution = 512
+        )
+        {
+            if (resolution < ScreenshotMath.MinDimension || resolution > ScreenshotMath.MaxDimension)
+                return ResponseCallTool.Error(
+                    $"resolution must be between {ScreenshotMath.MinDimension} and {ScreenshotMath.MaxDimension}. Got {resolution}.");
+
+            if (!ScreenshotMath.ValidateFraming(fieldOfView, nearClipPlane, farClipPlane, padding, out var framingError))
+                return ResponseCallTool.Error(framingError!);
+
+            // A single square view; clamp to the transport cap.
+            (resolution, _) = ScreenshotMath.ClampToTransportLimit(resolution, resolution);
+
+            var resolvedBackgroundColor = backgroundColor ?? "#404040";
+            if (background == ScreenshotBackground.SolidColor &&
+                !ScreenshotMath.TryParseHtmlColor(resolvedBackgroundColor, out _))
+            {
+                return ResponseCallTool.Error(
+                    $"Invalid backgroundColor '{resolvedBackgroundColor}'. Expected '#RGB', '#RRGGBB', or '#RRGGBBAA'.");
+            }
+
+            return MainThread.Instance.Run(() =>
+            {
+                var node = Tool_Node.ResolveNode(nodeRef, out var resolveError);
+                if (node == null)
+                    return ResponseCallTool.Error(resolveError ?? $"Target node {nodeRef} not found.");
+
+                if (node is not Node3D node3D)
+                    return ResponseCallTool.Error(
+                        $"Node {nodeRef} is a '{node.GetClass()}', not a Node3D. screenshot-isolated renders 3D nodes only.");
+
+                return CaptureIsolated(node3D, cameraView, background, resolvedBackgroundColor,
+                    fieldOfView, nearClipPlane, farClipPlane, padding, resolution);
+            });
+        }
+
+        static ResponseCallTool CaptureIsolated(
+            Node3D target,
+            ScreenshotView view,
+            ScreenshotBackground background,
+            string backgroundColorHex,
+            float fov,
+            float near,
+            float far,
+            float padding,
+            int resolution)
+        {
+            // Own-world SubViewport => only what we add below is visible: a copy of the target plus a light.
+            // The live edited scene is never touched (we render a Duplicate, in a fresh World3D).
+            var subViewport = new SubViewport
+            {
+                Size = new Vector2I(resolution, resolution),
+                RenderTargetUpdateMode = SubViewport.UpdateMode.Always,
+                OwnWorld3D = true,
+                TransparentBg = background == ScreenshotBackground.Transparent,
+            };
+
+            // Duplicate so we can recenter at the origin without mutating the real node's transform.
+            var clone = (Node3D)target.Duplicate((int)(Node.DuplicateFlags.Signals | Node.DuplicateFlags.Groups | Node.DuplicateFlags.Scripts));
+            clone.Transform = Transform3D.Identity;
+            subViewport.AddChild(clone);
+
+            var bounds = ComputeAabb(clone);
+            var radius = bounds.Size.Length() * 0.5f;
+            var distance = ScreenshotMath.ComputeCameraDistance(radius, fov, padding);
+
+            var (dir, up) = ScreenshotMath.GetViewDirectionAndUp(view);
+            var dirVec = new Vector3(dir.x, dir.y, dir.z);
+            var upVec = new Vector3(up.x, up.y, up.z);
+            var center = bounds.GetCenter();
+            var camPos = center + dirVec * distance;
+
+            var camera = new Camera3D
+            {
+                Projection = Camera3D.ProjectionType.Perspective,
+                Fov = fov,
+                Near = near,
+                Far = far,
+                Current = true,
+            };
+            subViewport.AddChild(camera);
+            camera.LookAtFromPosition(camPos, center, upVec);
+
+            // Default lighting: a single directional light along the view direction so the visible face
+            // is lit regardless of the scene's own lights (which are not present in the isolated world).
+            var light = new DirectionalLight3D
+            {
+                LightEnergy = 1.0f,
+                LightColor = Colors.White,
+            };
+            subViewport.AddChild(light);
+            light.LookAtFromPosition(camPos, center, upVec);
+
+            return RenderSubViewportToPng(subViewport,
+                caption: $"Isolated render of '{target.Name}' ({view}, {resolution}x{resolution}, background={background})");
+        }
+
+        // Aggregate the world-space AABB of every VisualInstance3D in the subtree (the clone's, already at
+        // the origin). Falls back to a small unit box when the target has no visual geometry so the camera
+        // still gets a sane finite framing distance.
+        static Aabb ComputeAabb(Node3D root)
+        {
+            var initialised = false;
+            var bounds = new Aabb();
+
+            foreach (var vi in CollectVisualInstances(root))
+            {
+                var local = vi.GetAabb();
+                // Transform the instance-local AABB into the root's space via the instance's global transform.
+                var worldAabb = vi.GlobalTransform * local;
+                if (!initialised)
+                {
+                    bounds = worldAabb;
+                    initialised = true;
+                }
+                else
+                {
+                    bounds = bounds.Merge(worldAabb);
+                }
+            }
+
+            if (!initialised || bounds.Size.LengthSquared() < 1e-8f)
+                bounds = new Aabb(Vector3.Zero, Vector3.One * 0.1f);
+
+            return bounds;
+        }
+
+        static IEnumerable<VisualInstance3D> CollectVisualInstances(Node node)
+        {
+            if (node is VisualInstance3D vi)
+                yield return vi;
+            foreach (var child in node.GetChildren(includeInternal: false))
+            {
+                foreach (var nested in CollectVisualInstances(child))
+                    yield return nested;
+            }
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Screenshot.Isolated.cs
+++ b/addons/godot_mcp/Tools/Tool_Screenshot.Isolated.cs
@@ -117,44 +117,62 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 TransparentBg = background == ScreenshotBackground.Transparent,
             };
 
-            // Duplicate so we can recenter at the origin without mutating the real node's transform.
-            var clone = (Node3D)target.Duplicate((int)(Node.DuplicateFlags.Signals | Node.DuplicateFlags.Groups | Node.DuplicateFlags.Scripts));
-            clone.Transform = Transform3D.Identity;
-            subViewport.AddChild(clone);
-
-            var bounds = ComputeAabb(clone);
-            var radius = bounds.Size.Length() * 0.5f;
-            var distance = ScreenshotMath.ComputeCameraDistance(radius, fov, padding);
-
-            var (dir, up) = ScreenshotMath.GetViewDirectionAndUp(view);
-            var dirVec = new Vector3(dir.x, dir.y, dir.z);
-            var upVec = new Vector3(up.x, up.y, up.z);
-            var center = bounds.GetCenter();
-            var camPos = center + dirVec * distance;
-
-            var camera = new Camera3D
+            // The caller owns the SubViewport's lifetime: every construction step below (Duplicate, AABB
+            // walk, the LookAtFromPosition calls — which THROW on a degenerate eye/target/up) can throw
+            // before the render runs, so freeing must wrap construction too. RenderSubViewportToPng only
+            // hosts/un-hosts; this finally QueueFree's the SubViewport and all temp children on every path.
+            try
             {
-                Projection = Camera3D.ProjectionType.Perspective,
-                Fov = fov,
-                Near = near,
-                Far = far,
-                Current = true,
-            };
-            subViewport.AddChild(camera);
-            camera.LookAtFromPosition(camPos, center, upVec);
+                // Duplicate so we can recenter at the origin without mutating the real node's transform.
+                // Scripts are deliberately NOT duplicated: a static off-screen render needs no behavior, and
+                // including them would run the clones' _EnterTree/_Ready on AddChild — observable side
+                // effects that contradict this tool's ReadOnlyHint=true.
+                var clone = (Node3D)target.Duplicate((int)(Node.DuplicateFlags.Signals | Node.DuplicateFlags.Groups));
+                clone.Transform = Transform3D.Identity;
+                subViewport.AddChild(clone);
 
-            // Default lighting: a single directional light along the view direction so the visible face
-            // is lit regardless of the scene's own lights (which are not present in the isolated world).
-            var light = new DirectionalLight3D
+                var bounds = ComputeAabb(clone);
+                var radius = bounds.Size.Length() * 0.5f;
+                var distance = ScreenshotMath.ComputeCameraDistance(radius, fov, padding);
+
+                // Bracket the clip planes around the framed object so it never falls outside [near, far]
+                // (which would render an empty/background-only image and report it as a successful capture).
+                (near, far) = ScreenshotMath.BracketClipPlanes(distance, radius, near, far);
+
+                var (dir, up) = ScreenshotMath.GetViewDirectionAndUp(view);
+                var dirVec = new Vector3(dir.x, dir.y, dir.z);
+                var upVec = new Vector3(up.x, up.y, up.z);
+                var center = bounds.GetCenter();
+                var camPos = center + dirVec * distance;
+
+                var camera = new Camera3D
+                {
+                    Projection = Camera3D.ProjectionType.Perspective,
+                    Fov = fov,
+                    Near = near,
+                    Far = far,
+                    Current = true,
+                };
+                subViewport.AddChild(camera);
+                camera.LookAtFromPosition(camPos, center, upVec);
+
+                // Default lighting: a single directional light along the view direction so the visible face
+                // is lit regardless of the scene's own lights (which are not present in the isolated world).
+                var light = new DirectionalLight3D
+                {
+                    LightEnergy = 1.0f,
+                    LightColor = Colors.White,
+                };
+                subViewport.AddChild(light);
+                light.LookAtFromPosition(camPos, center, upVec);
+
+                return RenderSubViewportToPng(subViewport,
+                    caption: $"Isolated render of '{target.Name}' ({view}, {resolution}x{resolution}, background={background})");
+            }
+            finally
             {
-                LightEnergy = 1.0f,
-                LightColor = Colors.White,
-            };
-            subViewport.AddChild(light);
-            light.LookAtFromPosition(camPos, center, upVec);
-
-            return RenderSubViewportToPng(subViewport,
-                caption: $"Isolated render of '{target.Name}' ({view}, {resolution}x{resolution}, background={background})");
+                FreeOffscreenViewport(subViewport);
+            }
         }
 
         // Aggregate the world-space AABB of every VisualInstance3D in the subtree (the clone's, already at

--- a/addons/godot_mcp/Tools/Tool_Screenshot.Viewport.cs
+++ b/addons/godot_mcp/Tools/Tool_Screenshot.Viewport.cs
@@ -1,0 +1,72 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System.ComponentModel;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Screenshot
+    {
+        public const string ScreenshotViewportToolId = "screenshot-viewport";
+
+        [AiTool
+        (
+            ScreenshotViewportToolId,
+            Title = "Screenshot / Editor Viewport",
+            ReadOnlyHint = true,
+            IdempotentHint = true,
+            OpenWorldHint = false
+        )]
+        [Description("Capture the Godot editor's main viewport (the 3D or 2D editing surface) and return it " +
+            "as a PNG image for direct LLM inspection. Set 'mode' to '3d' (default) for the 3D editor " +
+            "viewport or '2d' for the 2D editor viewport. The longest output edge is capped to keep the " +
+            "response transportable; oversized captures are scaled down (aspect preserved). NOTE: the " +
+            "viewport must have a live GPU render — a Godot launched with '--headless' has no rendering " +
+            "device and yields an empty image, which surfaces here as a structured error rather than a " +
+            "blank PNG.")]
+        public ResponseCallTool ScreenshotViewport
+        (
+            [Description("Which editor viewport to capture: '3d' (the 3D editor surface, default) or '2d' " +
+                "(the 2D editor surface). Case-insensitive.")]
+            string mode = "3d"
+        )
+        {
+            var normalizedMode = (mode ?? "3d").Trim().ToLowerInvariant();
+            if (normalizedMode != "3d" && normalizedMode != "2d")
+                return ResponseCallTool.Error($"mode must be '3d' or '2d'. Got '{mode}'.");
+
+            return MainThread.Instance.Run(() =>
+            {
+                // GetEditorViewport3D/2D return the editor's SubViewport (a Viewport). On a GPU-backed
+                // editor these hold the live editing render; under --headless they read back empty, which
+                // EncodeViewportPng reports as a structured error.
+                Viewport? viewport = normalizedMode == "2d"
+                    ? EditorInterface.Singleton.GetEditorViewport2D()
+                    : EditorInterface.Singleton.GetEditorViewport3D(0);
+
+                if (viewport == null)
+                    return ResponseCallTool.Error($"Editor {normalizedMode} viewport is unavailable.");
+
+                var png = EncodeViewportPng(viewport, flipY: false, out var error);
+                if (png == null)
+                    return ResponseCallTool.Error(error ?? "Failed to capture the editor viewport.");
+
+                return ResponseCallTool.Image(png, McpPlugin.Common.Consts.MimeType.ImagePng,
+                    $"Editor {normalizedMode} viewport screenshot ({png.Length} bytes PNG)");
+            });
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Screenshot.cs
+++ b/addons/godot_mcp/Tools/Tool_Screenshot.cs
@@ -81,23 +81,6 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             return EncodePng(image, out error);
         }
 
-        /// <summary>
-        /// Encode an already-CPU-resident <see cref="Image"/> to a PNG byte buffer. Resizes to the transport
-        /// cap first. MUST be called on the main thread. Returns null + an error if the encode produces no
-        /// bytes.
-        /// </summary>
-        internal static byte[]? EncodeImagePng(Image image, out string? error)
-        {
-            error = null;
-            if (image.IsEmpty() || image.GetWidth() <= 0 || image.GetHeight() <= 0)
-            {
-                error = "Captured image is empty (no GPU render was produced).";
-                return null;
-            }
-            ResizeToTransportLimit(image);
-            return EncodePng(image, out error);
-        }
-
         static byte[]? EncodePng(Image image, out string? error)
         {
             error = null;

--- a/addons/godot_mcp/Tools/Tool_Screenshot.cs
+++ b/addons/godot_mcp/Tools/Tool_Screenshot.cs
@@ -1,0 +1,125 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using com.IvanMurzak.McpPlugin;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// Screenshot tool family (<c>screenshot-*</c>) — the Godot analog of Unity-MCP's
+    /// <c>Tool_Screenshot</c>. Captures the editor viewport, a specific camera, or an isolated node render
+    /// and returns the result as a PNG image the LLM can inspect directly.
+    ///
+    /// <para>
+    /// Each tool method lives in its own partial-class file (Viewport / Camera / Isolated) and drives the
+    /// Godot rendering API on the editor main thread via the dispatcher. PNG bytes travel back through the
+    /// SAME McpPlugin image-content path Unity uses — <see cref="McpPlugin.Common.Model.ResponseCallTool.Image"/>
+    /// with the <c>image/png</c> MIME type — so the framework's structured image envelope carries the
+    /// capture; we never hand-roll a base64 string field.
+    /// </para>
+    ///
+    /// <para>
+    /// Editor-only (<c>#if TOOLS</c>): every handler touches <see cref="EditorInterface"/>, live
+    /// <see cref="Viewport"/>/<see cref="Camera3D"/>/<see cref="SubViewport"/> objects, and the
+    /// <see cref="RenderingServer"/> — none of which exists in a plain (non-editor) build. The pure-managed
+    /// pieces (size-cap clamping, the bounds→distance trig, the view-direction table, hex-color parse) live
+    /// in <see cref="ScreenshotMath"/> outside this guard and are unit-tested. The image-encoding of a real
+    /// <see cref="Image"/> needs the Godot runtime, so it is verified by the headless/windowed live smoke,
+    /// not by xUnit (see the profile's <c>test.md</c> Suite 3).
+    /// </para>
+    /// </summary>
+    [AiToolType]
+    public partial class Tool_Screenshot
+    {
+        /// <summary>
+        /// Read a viewport's color buffer back to CPU, optionally correct the GPU Y-flip, resize to the
+        /// transport cap if needed, and encode a PNG. MUST be called on the editor main thread. Returns the
+        /// PNG bytes, or null + an error message when the viewport texture has no GPU-rendered image yet
+        /// (the headless / no-GPU case — see the family doc).
+        ///
+        /// <para>
+        /// Godot's <see cref="ViewportTexture"/> is GPU-resident; <see cref="Texture2D.GetImage"/> performs
+        /// the CPU read-back. On a GPU-rendered target the rows arrive already upright (Godot's
+        /// <c>GetImage</c> accounts for the API origin), so <paramref name="flipY"/> defaults to false; pass
+        /// true only for a source you have empirically confirmed comes back inverted.
+        /// </para>
+        /// </summary>
+        internal static byte[]? EncodeViewportPng(Viewport viewport, bool flipY, out string? error)
+        {
+            error = null;
+
+            var texture = viewport.GetTexture();
+            if (texture == null)
+            {
+                error = "Viewport has no texture (the viewport is not rendering to a target).";
+                return null;
+            }
+
+            var image = texture.GetImage();
+            if (image == null || image.IsEmpty() || image.GetWidth() <= 0 || image.GetHeight() <= 0)
+            {
+                error = "Viewport texture read back an empty image — the viewport produced no GPU render " +
+                    "(common under '--headless', which has no rendering device). Run the capture in a " +
+                    "windowed editor with a real GPU.";
+                return null;
+            }
+
+            if (flipY)
+                image.FlipY();
+
+            ResizeToTransportLimit(image);
+
+            return EncodePng(image, out error);
+        }
+
+        /// <summary>
+        /// Encode an already-CPU-resident <see cref="Image"/> to a PNG byte buffer. Resizes to the transport
+        /// cap first. MUST be called on the main thread. Returns null + an error if the encode produces no
+        /// bytes.
+        /// </summary>
+        internal static byte[]? EncodeImagePng(Image image, out string? error)
+        {
+            error = null;
+            if (image.IsEmpty() || image.GetWidth() <= 0 || image.GetHeight() <= 0)
+            {
+                error = "Captured image is empty (no GPU render was produced).";
+                return null;
+            }
+            ResizeToTransportLimit(image);
+            return EncodePng(image, out error);
+        }
+
+        static byte[]? EncodePng(Image image, out string? error)
+        {
+            error = null;
+            var bytes = image.SavePngToBuffer();
+            if (bytes == null || bytes.Length == 0)
+            {
+                error = "PNG encode produced no bytes.";
+                return null;
+            }
+            return bytes;
+        }
+
+        /// <summary>
+        /// Scale the image in place so its longest edge is within <see cref="ScreenshotMath.MaxScreenshotDimension"/>,
+        /// preserving aspect ratio. No-op when already within the limit.
+        /// </summary>
+        static void ResizeToTransportLimit(Image image)
+        {
+            var (w, h) = ScreenshotMath.ClampToTransportLimit(image.GetWidth(), image.GetHeight());
+            if (w != image.GetWidth() || h != image.GetHeight())
+                image.Resize(w, h, Image.Interpolation.Bilinear);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Adds the **screenshot** tool family (`screenshot-viewport` / `screenshot-camera` / `screenshot-isolated`) as `[AiToolType]`/`[AiTool]` partial classes — the fourth family after scene/node (#9), resource/fs (#11), script (#13).
- PNG bytes return through the **same McpPlugin image-content path Unity uses** (`ResponseCallTool.Image` + `image/png`), not a hand-rolled base64 field. Output edges are capped to the transport limit (3840 px, aspect preserved).
- Pure-managed math/validation (`ScreenshotMath`) is unit-tested in the plain xUnit host; the editor-only (`#if TOOLS`) handlers that encode a real Godot `Image` are verified via the headless/windowed Godot smoke (Godot 4.3 editor API only; NuGet pins frozen).

## Tools
- `screenshot-viewport` — capture the editor 3D or 2D viewport (`EditorInterface.GetEditorViewport3D/2D` → `Viewport.GetTexture().GetImage()`).
- `screenshot-camera` — render a specific `Camera3D`/`Camera2D` (by `NodeRef`, via `Tool_Node.ResolveNode`) into an off-screen `SubViewport` sharing the source camera's world; the edited scene is never mutated.
- `screenshot-isolated` — render a target `Node3D` in its own `World3D` (true isolation) from a chosen angle (Front/Back/Left/Right/Top/Bottom), auto-framed to its AABB with a default directional light; SolidColor or Transparent background.

## Test plan
- [x] Suite 1 — `dotnet build Godot-MCP.sln -c Debug` (0 errors, CI parity).
- [x] Suite 2 — `dotnet test Godot-MCP.Tests` (0 failures; 171 total, incl. new `ScreenshotMath` coverage: clamping, framing validation, distance trig, view table, hex parse).
- [x] Headless render caveat verified **empirically**: `--headless` Godot yields an EMPTY image (no GPU render); the tools surface this as a structured error, not a blank PNG.
- [x] Render mechanism (SubViewport + `RenderingServer.ForceDraw` + `GetTexture().GetImage()` + `SavePngToBuffer`) validated on a real GPU (windowed, Vulkan/RTX 4090): a non-empty, **non-uniform** 256×256 RGB PNG was produced and independently decoded (10 distinct sampled colors).
- [ ] **Operator follow-up**: end-to-end drive of the three MCP tools in a live windowed editor with an open 3D scene, through an MCP client (the DemoWebApp exposes only the SignalR hub, no `/api/tools/<name>` REST endpoint, so the in-editor tool round-trip is operator-only).

Closes #14