### PR TITLE
feat: editor introspection tools (editor/play state, console/logs, selection, reflection method find/call)

### DIFF
--- a/Godot-MCP.Tests/EditorReflectionToolTests.cs
+++ b/Godot-MCP.Tests/EditorReflectionToolTests.cs
@@ -1,0 +1,316 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Linq;
+using System.Text.Json;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.Godot.MCP.Tools;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pure-managed coverage for the editor-introspection tool family (issue #16): the in-memory
+    /// <see cref="GodotLogCollector"/> (the only piece with non-trivial logic — bounded FIFO ring buffer,
+    /// newest-first query, severity / time-window filtering, stack-trace strip) and the result models
+    /// (<see cref="LogEntry"/>, <see cref="EditorStateData"/>, <see cref="SelectionData"/>). None of these
+    /// touch a live Godot editor, so they run in the plain xUnit host with no Godot binary. The
+    /// editor-driving handlers themselves — <c>Tool_Editor.*.cs</c> (play state), <c>Tool_Editor.Selection.*.cs</c>
+    /// (selection), and the editor effect of <c>Tool_Console.*</c> / <c>Tool_Reflection.*</c> — are verified
+    /// by the headless Godot smoke (test.md Suite 3).
+    /// </summary>
+    public class EditorReflectionToolTests
+    {
+        // ---- GodotLogCollector: append / query ordering ------------------------------------------
+
+        [Fact]
+        public void Query_ReturnsNewestFirst()
+        {
+            var c = new GodotLogCollector();
+            var t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            c.Append(new LogEntry(GodotLogType.Log, "first", t0));
+            c.Append(new LogEntry(GodotLogType.Log, "second", t0.AddSeconds(1)));
+            c.Append(new LogEntry(GodotLogType.Log, "third", t0.AddSeconds(2)));
+
+            var result = c.Query();
+
+            Assert.Equal(3, result.Length);
+            Assert.Equal("third", result[0].Message);
+            Assert.Equal("second", result[1].Message);
+            Assert.Equal("first", result[2].Message);
+        }
+
+        [Fact]
+        public void Query_MaxEntries_CapsToMostRecent()
+        {
+            var c = new GodotLogCollector();
+            var t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            for (int i = 0; i < 5; i++)
+                c.Append(new LogEntry(GodotLogType.Log, $"m{i}", t0.AddSeconds(i)));
+
+            var result = c.Query(maxEntries: 2);
+
+            Assert.Equal(2, result.Length);
+            Assert.Equal("m4", result[0].Message);
+            Assert.Equal("m3", result[1].Message);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-5)]
+        public void Query_NonPositiveMaxEntries_ClampedToOne(int maxEntries)
+        {
+            var c = new GodotLogCollector();
+            var t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            c.Append(new LogEntry(GodotLogType.Log, "a", t0));
+            c.Append(new LogEntry(GodotLogType.Log, "b", t0.AddSeconds(1)));
+
+            var result = c.Query(maxEntries: maxEntries);
+
+            Assert.Single(result);
+            Assert.Equal("b", result[0].Message);
+        }
+
+        // ---- GodotLogCollector: severity filter --------------------------------------------------
+
+        [Fact]
+        public void Query_LogTypeFilter_RestrictsToSeverity()
+        {
+            var c = new GodotLogCollector();
+            var t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            c.Append(new LogEntry(GodotLogType.Log, "info", t0));
+            c.Append(new LogEntry(GodotLogType.Warning, "warn", t0.AddSeconds(1)));
+            c.Append(new LogEntry(GodotLogType.Error, "err", t0.AddSeconds(2)));
+
+            var errors = c.Query(logTypeFilter: GodotLogType.Error);
+            Assert.Single(errors);
+            Assert.Equal("err", errors[0].Message);
+
+            var warnings = c.Query(logTypeFilter: GodotLogType.Warning);
+            Assert.Single(warnings);
+            Assert.Equal("warn", warnings[0].Message);
+
+            var all = c.Query();
+            Assert.Equal(3, all.Length);
+        }
+
+        // ---- GodotLogCollector: time window ------------------------------------------------------
+
+        [Fact]
+        public void Query_LastMinutes_FiltersByWindow()
+        {
+            var c = new GodotLogCollector();
+            var now = DateTime.UtcNow;
+            c.Append(new LogEntry(GodotLogType.Log, "old", now.AddMinutes(-30)));
+            c.Append(new LogEntry(GodotLogType.Log, "recent", now.AddMinutes(-1)));
+
+            var result = c.Query(lastMinutes: 5);
+
+            Assert.Single(result);
+            Assert.Equal("recent", result[0].Message);
+        }
+
+        [Fact]
+        public void Query_LastMinutesZero_ReturnsAll()
+        {
+            var c = new GodotLogCollector();
+            var now = DateTime.UtcNow;
+            c.Append(new LogEntry(GodotLogType.Log, "old", now.AddHours(-2)));
+            c.Append(new LogEntry(GodotLogType.Log, "recent", now));
+
+            var result = c.Query(lastMinutes: 0);
+
+            Assert.Equal(2, result.Length);
+        }
+
+        // ---- GodotLogCollector: stack-trace strip ------------------------------------------------
+
+        [Fact]
+        public void Query_IncludeStackTraceFalse_StripsStackTrace()
+        {
+            var c = new GodotLogCollector();
+            var t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            c.Append(new LogEntry(GodotLogType.Error, "boom", t0, stackTrace: "at Foo()\nat Bar()"));
+
+            var stripped = c.Query(includeStackTrace: false);
+            Assert.Single(stripped);
+            Assert.Null(stripped[0].StackTrace);
+
+            var kept = c.Query(includeStackTrace: true);
+            Assert.Single(kept);
+            Assert.Equal("at Foo()\nat Bar()", kept[0].StackTrace);
+        }
+
+        // ---- GodotLogCollector: bounded ring buffer ----------------------------------------------
+
+        [Fact]
+        public void Append_BeyondCapacity_EvictsOldest()
+        {
+            var c = new GodotLogCollector();
+            var t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+            // One past capacity: the very first entry must be evicted.
+            for (int i = 0; i < GodotLogCollector.Capacity + 1; i++)
+                c.Append(new LogEntry(GodotLogType.Log, $"m{i}", t0.AddSeconds(i)));
+
+            Assert.Equal(GodotLogCollector.Capacity, c.Count);
+
+            // Newest is the last appended; the evicted "m0" must be gone even when asking for everything.
+            var all = c.Query(maxEntries: GodotLogCollector.Capacity);
+            Assert.Equal($"m{GodotLogCollector.Capacity}", all[0].Message);
+            Assert.DoesNotContain(all, e => e.Message == "m0");
+        }
+
+        // ---- GodotLogCollector: clear ------------------------------------------------------------
+
+        [Fact]
+        public void Clear_EmptiesBuffer()
+        {
+            var c = new GodotLogCollector();
+            c.Append(GodotLogType.Log, "x");
+            Assert.Equal(1, c.Count);
+
+            c.Clear();
+
+            Assert.Equal(0, c.Count);
+            Assert.Empty(c.Query());
+        }
+
+        // ---- GodotLogCollector: Append convenience overload + null guard -------------------------
+
+        [Fact]
+        public void Append_PartsOverload_StampsNowUtc()
+        {
+            var c = new GodotLogCollector();
+            var before = DateTime.UtcNow.AddSeconds(-1);
+            c.Append(GodotLogType.Warning, "hello", stackTrace: "trace");
+            var after = DateTime.UtcNow.AddSeconds(1);
+
+            var e = Assert.Single(c.Query(includeStackTrace: true));
+            Assert.Equal(GodotLogType.Warning, e.LogType);
+            Assert.Equal("hello", e.Message);
+            Assert.Equal("trace", e.StackTrace);
+            Assert.InRange(e.Timestamp, before, after);
+        }
+
+        [Fact]
+        public void Append_Null_IsIgnored()
+        {
+            var c = new GodotLogCollector();
+            c.Append((LogEntry)null!);
+            Assert.Equal(0, c.Count);
+        }
+
+        // ---- GetOrCreate fallback ----------------------------------------------------------------
+
+        [Fact]
+        public void GetOrCreate_WhenCurrentNull_ReturnsAndCachesFresh()
+        {
+            var saved = GodotLogCollector.Current;
+            try
+            {
+                GodotLogCollector.Current = null;
+                var first = GodotLogCollector.GetOrCreate();
+                Assert.NotNull(first);
+                // Caches into Current, so a second call returns the SAME instance.
+                Assert.Same(first, GodotLogCollector.GetOrCreate());
+                Assert.Same(first, GodotLogCollector.Current);
+            }
+            finally
+            {
+                GodotLogCollector.Current = saved;
+            }
+        }
+
+        // ---- Models: serialization round-trips ---------------------------------------------------
+
+        [Fact]
+        public void LogEntry_RoundTripsJson()
+        {
+            var t0 = new DateTime(2026, 3, 4, 12, 0, 0, DateTimeKind.Utc);
+            var entry = new LogEntry(GodotLogType.Error, "kaput", t0, "at X()");
+
+            var json = JsonSerializer.Serialize(entry);
+            var back = JsonSerializer.Deserialize<LogEntry>(json);
+
+            Assert.NotNull(back);
+            Assert.Equal(GodotLogType.Error, back!.LogType);
+            Assert.Equal("kaput", back.Message);
+            Assert.Equal("at X()", back.StackTrace);
+            Assert.Equal(t0, back.Timestamp);
+
+            // Property names use the camelCase JSON contract.
+            Assert.Contains("\"logType\"", json);
+            Assert.Contains("\"stackTrace\"", json);
+        }
+
+        [Fact]
+        public void EditorStateData_RoundTripsJson()
+        {
+            var data = new EditorStateData
+            {
+                IsPlaying = true,
+                PlayingScene = "res://main.tscn",
+                EditorVersion = "4.5.1.stable.mono",
+            };
+
+            var json = JsonSerializer.Serialize(data);
+            var back = JsonSerializer.Deserialize<EditorStateData>(json);
+
+            Assert.NotNull(back);
+            Assert.True(back!.IsPlaying);
+            Assert.Equal("res://main.tscn", back.PlayingScene);
+            Assert.Equal("4.5.1.stable.mono", back.EditorVersion);
+            Assert.Contains("\"isPlaying\"", json);
+            Assert.Contains("\"playingScene\"", json);
+            Assert.Contains("\"editorVersion\"", json);
+        }
+
+        [Fact]
+        public void SelectionData_RoundTripsJson_WithNodes()
+        {
+            var data = new SelectionData
+            {
+                Nodes =
+                {
+                    new NodeData { InstanceId = 10, Name = "A", Path = "/root/A", Type = "Node2D" },
+                    new NodeData { InstanceId = 20, Name = "B", Path = "/root/B", Type = "Sprite2D" },
+                },
+            };
+            data.Count = data.Nodes.Count;
+            data.ActiveNode = data.Nodes.Last();
+
+            var json = JsonSerializer.Serialize(data);
+            var back = JsonSerializer.Deserialize<SelectionData>(json);
+
+            Assert.NotNull(back);
+            Assert.Equal(2, back!.Count);
+            Assert.Equal(2, back.Nodes.Count);
+            Assert.Equal("A", back.Nodes[0].Name);
+            Assert.NotNull(back.ActiveNode);
+            Assert.Equal("B", back.ActiveNode!.Name);
+            Assert.Contains("\"activeNode\"", json);
+        }
+
+        [Fact]
+        public void SelectionData_Empty_HasNullActiveAndZeroCount()
+        {
+            var data = new SelectionData();
+            var json = JsonSerializer.Serialize(data);
+            var back = JsonSerializer.Deserialize<SelectionData>(json);
+
+            Assert.NotNull(back);
+            Assert.Empty(back!.Nodes);
+            Assert.Null(back.ActiveNode);
+            Assert.Equal(0, back.Count);
+        }
+    }
+}

--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -77,6 +77,17 @@
          handlers (Tool_Screenshot.*.cs) are #if TOOLS and encode a real Godot Image, so they are verified
          via the headless/windowed Godot smoke (test.md Suite 3), not here. -->
     <Compile Include="..\addons\godot_mcp\Tools\ScreenshotMath.cs" Link="Source\ScreenshotMath.cs" />
+    <!-- Editor introspection tool family (editor-state / console-logs / selection / reflection) —
+         pure-managed pieces only (no Godot native types, no #if TOOLS): the structured result models,
+         the log severity enum, and the in-memory log collector. The editor-driving handlers
+         (Tool_Editor.*.cs / Tool_Editor.Selection.*.cs) are #if TOOLS and verified via the headless
+         Godot smoke (test.md Suite 3); the console/reflection tool handlers (Tool_Console.*.cs /
+         Tool_Reflection.*.cs) live outside #if TOOLS but their editor effect is a Suite-3 concern —
+         here we unit-test the collector + models. -->
+    <Compile Include="..\addons\godot_mcp\Data\EditorStateData.cs" Link="Source\EditorStateData.cs" />
+    <Compile Include="..\addons\godot_mcp\Data\LogEntry.cs" Link="Source\LogEntry.cs" />
+    <Compile Include="..\addons\godot_mcp\Data\SelectionData.cs" Link="Source\SelectionData.cs" />
+    <Compile Include="..\addons\godot_mcp\Tools\GodotLogCollector.cs" Link="Source\GodotLogCollector.cs" />
   </ItemGroup>
 
 </Project>

--- a/addons/godot_mcp/Data/EditorStateData.cs
+++ b/addons/godot_mcp/Data/EditorStateData.cs
@@ -1,0 +1,54 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.Godot.MCP.Data
+{
+    /// <summary>
+    /// Structured snapshot of the Godot editor's run/play state — the Godot analog of Unity-MCP's
+    /// <c>EditorStatsData</c>. Where Unity exposes a single in-editor "playmode" toggle
+    /// (<c>EditorApplication.isPlaying</c>), Godot's editor launches the game in a SEPARATE OS process
+    /// (<see cref="global::Godot.EditorInterface.PlayMainScene"/> /
+    /// <see cref="global::Godot.EditorInterface.StopPlayingScene"/>); this model captures whether such a
+    /// run is currently active (<see cref="IsPlaying"/>), the <c>res://</c> path of the scene being run
+    /// (<see cref="PlayingScene"/>), and the editor's version string. Godot has no editor-side "paused"
+    /// or "compiling" play state to mirror, so those Unity fields have no analog here.
+    ///
+    /// Pure-managed (no Godot API surface, no <c>#if TOOLS</c>), so it is unit-testable in the plain
+    /// xUnit host. The editor handler fills it from <see cref="global::Godot.EditorInterface"/> on the
+    /// main thread.
+    /// </summary>
+    [System.Serializable]
+    [Description("Snapshot of the Godot editor run/play state: whether a play-run is active, the res:// " +
+        "path of the scene being run (if any), and the editor version string.")]
+    public class EditorStateData
+    {
+        [JsonInclude, JsonPropertyName("isPlaying")]
+        [Description("True when the editor is currently running a scene in a separate game process " +
+            "(EditorInterface.IsPlayingScene()).")]
+        public bool IsPlaying { get; set; } = false;
+
+        [JsonInclude, JsonPropertyName("playingScene")]
+        [Description("res:// path of the scene currently being run, or null when not playing " +
+            "(EditorInterface.GetPlayingScene()).")]
+        public string? PlayingScene { get; set; } = null;
+
+        [JsonInclude, JsonPropertyName("editorVersion")]
+        [Description("Godot editor version string, e.g. '4.5.1.stable.mono' (Engine.GetVersionInfo()['string']).")]
+        public string EditorVersion { get; set; } = string.Empty;
+
+        public EditorStateData() { }
+
+        public override string ToString()
+            => $"Editor play={IsPlaying} scene='{PlayingScene ?? "(none)"}' version='{EditorVersion}'";
+    }
+}

--- a/addons/godot_mcp/Data/LogEntry.cs
+++ b/addons/godot_mcp/Data/LogEntry.cs
@@ -1,0 +1,79 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.Godot.MCP.Data
+{
+    /// <summary>
+    /// Severity of a captured editor log line — the Godot analog of Unity's <c>UnityEngine.LogType</c>.
+    /// Godot's logging surface (<c>GD.Print</c> / <c>GD.PushWarning</c> / <c>GD.PushError</c>) collapses
+    /// to three levels, so this enum mirrors them rather than Unity's five (Unity's Assert/Exception have
+    /// no distinct Godot counterpart).
+    /// </summary>
+    [Description("Severity of a captured editor log line: Log, Warning, or Error.")]
+    public enum GodotLogType
+    {
+        [Description("Informational message (GD.Print).")]
+        Log = 0,
+        [Description("Warning message (GD.PushWarning).")]
+        Warning = 1,
+        [Description("Error message (GD.PushError).")]
+        Error = 2,
+    }
+
+    /// <summary>
+    /// One captured editor log line — the Godot analog of Unity-MCP's <c>LogEntry</c>. Holds the
+    /// severity, message text, a timestamp, and an optional stack trace. Produced by
+    /// <see cref="Tools.GodotLogCollector"/> and returned by the <c>console-get-logs</c> tool.
+    ///
+    /// Pure-managed (no Godot API surface, no <c>#if TOOLS</c>), so it is unit-testable in the plain
+    /// xUnit host.
+    /// </summary>
+    [System.Serializable]
+    [Description("A captured Godot editor log line: severity, message, timestamp, and optional stack trace.")]
+    public class LogEntry
+    {
+        [JsonInclude, JsonPropertyName("logType")]
+        [Description("Severity of the log line (Log / Warning / Error).")]
+        public GodotLogType LogType { get; set; } = GodotLogType.Log;
+
+        [JsonInclude, JsonPropertyName("message")]
+        [Description("The log message text.")]
+        public string Message { get; set; } = string.Empty;
+
+        [JsonInclude, JsonPropertyName("timestamp")]
+        [Description("UTC timestamp when the line was captured.")]
+        public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+
+        [JsonInclude, JsonPropertyName("stackTrace")]
+        [Description("Optional stack trace associated with the line; null when none was captured.")]
+        public string? StackTrace { get; set; } = null;
+
+        public LogEntry() { }
+
+        public LogEntry(GodotLogType logType, string message, DateTime timestamp, string? stackTrace = null)
+        {
+            LogType = logType;
+            Message = message ?? string.Empty;
+            Timestamp = timestamp;
+            StackTrace = string.IsNullOrEmpty(stackTrace) ? null : stackTrace;
+        }
+
+        public override string ToString() => ToString(includeStackTrace: false);
+
+        public string ToString(bool includeStackTrace)
+            => includeStackTrace && !string.IsNullOrEmpty(StackTrace)
+                ? $"{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{LogType}] {Message}\nStack Trace:\n{StackTrace}"
+                : $"{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{LogType}] {Message}";
+    }
+}

--- a/addons/godot_mcp/Data/SelectionData.cs
+++ b/addons/godot_mcp/Data/SelectionData.cs
@@ -1,0 +1,52 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.Godot.MCP.Data
+{
+    /// <summary>
+    /// Structured snapshot of the Godot editor's current node selection — the Godot analog of Unity-MCP's
+    /// <c>SelectionData</c>. Godot's <see cref="global::Godot.EditorSelection"/> selects scene-tree
+    /// <see cref="global::Godot.Node"/>s only (there is no Unity-style asset-GUID / Transform / Component
+    /// distinction), so this model carries a flat list of selected nodes plus a convenience pointer to the
+    /// "active" one (Godot has no first-class active-object concept; the LAST selected node is reported as
+    /// active, matching how the editor inspector tracks the most-recently-clicked node).
+    ///
+    /// Pure-managed (no Godot API surface, no <c>#if TOOLS</c>): each selected node is captured as a
+    /// <see cref="NodeData"/> (built on the main thread from the live node), so the model touches no Godot
+    /// native object once constructed and is unit-testable in the plain xUnit host.
+    /// </summary>
+    [System.Serializable]
+    [Description("Snapshot of the Godot editor node selection: the selected nodes and the active (last-" +
+        "selected) node, each as structured NodeData.")]
+    public class SelectionData
+    {
+        [JsonInclude, JsonPropertyName("nodes")]
+        [Description("All currently-selected scene-tree nodes, in selection order.")]
+        public List<NodeData> Nodes { get; set; } = new();
+
+        [JsonInclude, JsonPropertyName("activeNode")]
+        [Description("The active (last-selected) node, or null when the selection is empty. Godot has no " +
+            "first-class active-object concept; the last selected node is reported here.")]
+        public NodeData? ActiveNode { get; set; } = null;
+
+        [JsonInclude, JsonPropertyName("count")]
+        [Description("Number of selected nodes.")]
+        public int Count { get; set; } = 0;
+
+        public SelectionData() { }
+
+        public override string ToString()
+            => $"Selection count={Count} active='{ActiveNode?.Name ?? "(none)"}'";
+    }
+}

--- a/addons/godot_mcp/GodotMcpPlugin.cs
+++ b/addons/godot_mcp/GodotMcpPlugin.cs
@@ -12,7 +12,9 @@
 using System.Runtime.CompilerServices;
 using Godot;
 using com.IvanMurzak.Godot.MCP.Connection;
+using com.IvanMurzak.Godot.MCP.Data;
 using com.IvanMurzak.Godot.MCP.MainThreadDispatch;
+using com.IvanMurzak.Godot.MCP.Tools;
 
 namespace com.IvanMurzak.Godot.MCP
 {
@@ -37,6 +39,12 @@ namespace com.IvanMurzak.Godot.MCP
 
         public override void _EnterTree()
         {
+            // Install the process-wide log collector first so every lifecycle line below (resolver
+            // probes, plugin-loaded, connection state) is captured for the 'console-get-logs' tool.
+            // Godot's C# API exposes no global managed log hook, so the collector is fed explicitly by
+            // the plugin's own logging path (Log/LogWarning/LogError helpers) — see GodotLogCollector.
+            GodotLogCollector.Current = new GodotLogCollector();
+
             // FIRST: teach the editor's default AssemblyLoadContext how to find the addon's transitive
             // NuGet dependency assemblies (ReflectorNet / McpPlugin / ...). Godot does not probe the
             // project's *.deps.json, so without this hook the first touch of a NuGet-dependency type
@@ -44,7 +52,7 @@ namespace com.IvanMurzak.Godot.MCP
             // installing it here does NOT prematurely load the very assemblies it resolves — it must
             // run before any code path (BootMcp below) reaches a NuGet-dependency type. See
             // GodotMcpAssemblyResolver for the full rationale.
-            GodotMcpAssemblyResolver.Log = msg => GD.Print(msg);
+            GodotMcpAssemblyResolver.Log = msg => Log(msg);
             GodotMcpAssemblyResolver.Install();
 
             // Pump for off-thread → main-thread work. Added as a child of this EditorPlugin Node so it
@@ -55,9 +63,33 @@ namespace com.IvanMurzak.Godot.MCP
             // Route ReflectorNet's MainThread.Instance through the dispatcher.
             GodotMainThread.Install();
 
-            GD.Print("[Godot-MCP] plugin loaded");
+            Log("[Godot-MCP] plugin loaded");
 
             BootMcp();
+        }
+
+        /// <summary>
+        /// Print an informational lifecycle line to the Godot output AND capture it into the
+        /// <see cref="GodotLogCollector"/> so it is retrievable via the <c>console-get-logs</c> tool.
+        /// </summary>
+        static void Log(string message)
+        {
+            GD.Print(message);
+            GodotLogCollector.Current?.Append(GodotLogType.Log, message);
+        }
+
+        /// <summary>Warning-level analog of <see cref="Log"/>.</summary>
+        static void LogWarning(string message)
+        {
+            GD.PushWarning(message);
+            GodotLogCollector.Current?.Append(GodotLogType.Warning, message);
+        }
+
+        /// <summary>Error-level analog of <see cref="Log"/>.</summary>
+        static void LogError(string message)
+        {
+            GD.PushError(message);
+            GodotLogCollector.Current?.Append(GodotLogType.Error, message);
         }
 
         /// <summary>
@@ -77,7 +109,7 @@ namespace com.IvanMurzak.Godot.MCP
             }
             catch (System.Exception ex)
             {
-                GD.PushError($"[Godot-MCP] failed to start MCP connection: {ex.Message}");
+                LogError($"[Godot-MCP] failed to start MCP connection: {ex.Message}");
             }
         }
 
@@ -95,7 +127,11 @@ namespace com.IvanMurzak.Godot.MCP
                 _dispatcher = null;
             }
 
-            GD.Print("[Godot-MCP] plugin unloaded");
+            Log("[Godot-MCP] plugin unloaded");
+
+            // Release the collector so a stale buffer does not outlive this plugin instance (a fresh one
+            // is installed on the next _EnterTree).
+            GodotLogCollector.Current = null;
         }
     }
 }

--- a/addons/godot_mcp/Tools/GodotLogCollector.cs
+++ b/addons/godot_mcp/Tools/GodotLogCollector.cs
@@ -1,0 +1,128 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using com.IvanMurzak.Godot.MCP.Data;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// In-memory, bounded ring-buffer of captured editor log lines — the Godot analog of Unity-MCP's
+    /// <c>UnityLogCollector</c>. Unity subscribes to <c>Application.logMessageReceivedThreaded</c> to
+    /// capture EVERY engine log line; Godot's C# API exposes NO such global managed log hook (it is a
+    /// long-standing engine gap — there is no managed <c>OS.add_logger</c> / log-received signal in 4.x).
+    /// So this collector is fed explicitly by the plugin's own logging path (the <c>GD.Print</c> /
+    /// <c>GD.PushWarning</c> / <c>GD.PushError</c> wrapper installed at editor boot), giving the
+    /// <c>console-get-logs</c> tool a faithful, queryable record of the Godot-MCP plugin's own editor
+    /// activity even though the broader editor console cannot be tapped from managed code.
+    ///
+    /// <para>
+    /// Thread-safe (a single lock guards the buffer): <see cref="Append"/> may be called from any thread
+    /// the plugin logs on, while <see cref="Query"/> reads from the tool dispatch thread. Bounded by
+    /// <see cref="Capacity"/> — once full, the oldest line is dropped (FIFO), so memory never grows
+    /// without bound during a long editor session.
+    /// </para>
+    ///
+    /// Pure-managed (no Godot API surface, no <c>#if TOOLS</c>), so it is unit-testable in the plain
+    /// xUnit host.
+    /// </summary>
+    public sealed class GodotLogCollector
+    {
+        /// <summary>Maximum number of retained log lines before the oldest is evicted (FIFO).</summary>
+        public const int Capacity = 1000;
+
+        readonly object _gate = new();
+        readonly Queue<LogEntry> _entries = new(Capacity);
+
+        /// <summary>
+        /// Process-wide collector used by the plugin's logging path and read by the <c>console-*</c>
+        /// tools. Assigned once at editor boot; tools fall back to a fresh empty collector via
+        /// <see cref="GetOrCreate"/> when the plugin has not booted (e.g. a direct unit call), so the
+        /// tool layer never hard-depends on the editor lifecycle.
+        /// </summary>
+        public static GodotLogCollector? Current { get; set; }
+
+        /// <summary>Return <see cref="Current"/> when set, otherwise a fresh empty collector.</summary>
+        public static GodotLogCollector GetOrCreate() => Current ??= new GodotLogCollector();
+
+        /// <summary>Append a captured line, evicting the oldest when at <see cref="Capacity"/>.</summary>
+        public void Append(LogEntry entry)
+        {
+            if (entry == null)
+                return;
+
+            lock (_gate)
+            {
+                if (_entries.Count >= Capacity)
+                    _entries.Dequeue();
+                _entries.Enqueue(entry);
+            }
+        }
+
+        /// <summary>Convenience overload: capture a line from its parts (timestamp defaults to now-UTC).</summary>
+        public void Append(GodotLogType logType, string message, string? stackTrace = null)
+            => Append(new LogEntry(logType, message, DateTime.UtcNow, stackTrace));
+
+        /// <summary>Drop all retained log lines.</summary>
+        public void Clear()
+        {
+            lock (_gate)
+            {
+                _entries.Clear();
+            }
+        }
+
+        /// <summary>Current number of retained log lines.</summary>
+        public int Count
+        {
+            get { lock (_gate) { return _entries.Count; } }
+        }
+
+        /// <summary>
+        /// Query the retained lines, newest-first, mirroring Unity-MCP's <c>LogCollector.Query</c>
+        /// semantics: optional severity filter, optional last-N-minutes window, stack-trace strip, and a
+        /// <paramref name="maxEntries"/> cap applied AFTER ordering (so the cap keeps the most recent
+        /// lines). Returns a fresh array of copies so the caller can serialize off the lock.
+        /// </summary>
+        public LogEntry[] Query(
+            int maxEntries = 100,
+            GodotLogType? logTypeFilter = null,
+            bool includeStackTrace = false,
+            int lastMinutes = 0)
+        {
+            if (maxEntries < 1)
+                maxEntries = 1;
+
+            DateTime? cutoff = lastMinutes > 0 ? DateTime.UtcNow.AddMinutes(-lastMinutes) : null;
+
+            lock (_gate)
+            {
+                IEnumerable<LogEntry> q = _entries;
+
+                if (logTypeFilter.HasValue)
+                    q = q.Where(e => e.LogType == logTypeFilter.Value);
+
+                if (cutoff.HasValue)
+                    q = q.Where(e => e.Timestamp >= cutoff.Value);
+
+                // Newest-first, then cap. The buffer is FIFO (oldest at head), so reverse to get newest-first.
+                return q
+                    .Reverse()
+                    .Take(maxEntries)
+                    .Select(e => includeStackTrace
+                        ? new LogEntry(e.LogType, e.Message, e.Timestamp, e.StackTrace)
+                        : new LogEntry(e.LogType, e.Message, e.Timestamp, stackTrace: null))
+                    .ToArray();
+            }
+        }
+    }
+}

--- a/addons/godot_mcp/Tools/Tool_Console.ClearLogs.cs
+++ b/addons/godot_mcp/Tools/Tool_Console.ClearLogs.cs
@@ -1,0 +1,35 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.ComponentModel;
+using com.IvanMurzak.McpPlugin;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Console
+    {
+        public const string ConsoleClearLogsToolId = "console-clear-logs";
+
+        [AiTool
+        (
+            ConsoleClearLogsToolId,
+            Title = "Console / Clear Logs",
+            DestructiveHint = true,
+            IdempotentHint = true
+        )]
+        [Description("Clear the captured Godot-MCP log cache (read by 'console-get-logs'). Useful for " +
+            "isolating logs to a specific action by clearing the slate first. NOTE: Godot's C# API exposes " +
+            "no managed hook to clear the editor's own Output panel, so (unlike Unity's analog) this clears " +
+            "only the MCP-side cache, not the Godot editor console window.")]
+        public void ClearLogs(string? nothing = null)
+        {
+            GodotLogCollector.GetOrCreate().Clear();
+        }
+    }
+}

--- a/addons/godot_mcp/Tools/Tool_Console.GetLogs.cs
+++ b/addons/godot_mcp/Tools/Tool_Console.GetLogs.cs
@@ -1,0 +1,60 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Console
+    {
+        public const string ConsoleGetLogsToolId = "console-get-logs";
+
+        [AiTool
+        (
+            ConsoleGetLogsToolId,
+            Title = "Console / Get Logs",
+            ReadOnlyHint = true,
+            IdempotentHint = true,
+            OpenWorldHint = false
+        )]
+        [Description("Retrieve captured Godot-MCP editor log lines, newest-first. The Godot analog of " +
+            "Unity's 'console-get-logs'. NOTE: Godot's C# API exposes no global log hook, so this returns " +
+            "the plugin's own captured editor activity (not the entire Godot editor console).\n" +
+            "Inputs:\n" +
+            "  - 'maxEntries' (default 100, min 1): caps the returned array (most-recent lines kept).\n" +
+            "  - 'logTypeFilter' (default null = all): restrict to Log / Warning / Error.\n" +
+            "  - 'includeStackTrace' (default false): include stack-trace strings.\n" +
+            "  - 'lastMinutes' (default 0 = all): only lines captured in the last N minutes.")]
+        public LogEntry[] GetLogs
+        (
+            [Description("Maximum number of log entries to return. Minimum 1, default 100.")]
+            int maxEntries = 100,
+            [Description("Filter by severity (Log / Warning / Error). Null means all severities.")]
+            GodotLogType? logTypeFilter = null,
+            [Description("Include stack traces in the output. Default false.")]
+            bool includeStackTrace = false,
+            [Description("Return logs from the last N minutes. 0 returns all available logs. Default 0.")]
+            int lastMinutes = 0
+        )
+        {
+            if (maxEntries < 1)
+                throw new ArgumentException($"maxEntries must be >= 1; got {maxEntries}.", nameof(maxEntries));
+
+            var collector = GodotLogCollector.GetOrCreate();
+            return collector.Query(
+                maxEntries: maxEntries,
+                logTypeFilter: logTypeFilter,
+                includeStackTrace: includeStackTrace,
+                lastMinutes: lastMinutes);
+        }
+    }
+}

--- a/addons/godot_mcp/Tools/Tool_Console.cs
+++ b/addons/godot_mcp/Tools/Tool_Console.cs
@@ -1,0 +1,34 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using com.IvanMurzak.McpPlugin;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// Console / log tool family (<c>console-*</c>) — the Godot analog of Unity-MCP's <c>Tool_Console</c>.
+    /// Each tool method lives in its own partial-class file (GetLogs / ClearLogs) and reads/clears the
+    /// process-wide <see cref="GodotLogCollector"/> that the plugin's logging path feeds.
+    ///
+    /// <para>
+    /// Unlike Unity (which taps <c>Application.logMessageReceivedThreaded</c> to capture every engine
+    /// line), Godot's C# API exposes no global managed log hook, so the collector records the plugin's own
+    /// editor activity (<c>GD.Print</c>/<c>GD.PushWarning</c>/<c>GD.PushError</c>) — see
+    /// <see cref="GodotLogCollector"/> for the rationale.
+    /// </para>
+    ///
+    /// This family is engine-runtime logic with no Godot editor-API surface (it only touches the
+    /// pure-managed collector), so it intentionally lives OUTSIDE <c>#if TOOLS</c> — it is discovered by
+    /// the McpPlugin assembly scanner and is unit-testable in the plain xUnit host.
+    /// </summary>
+    [AiToolType]
+    public partial class Tool_Console
+    {
+    }
+}

--- a/addons/godot_mcp/Tools/Tool_Editor.GetState.cs
+++ b/addons/godot_mcp/Tools/Tool_Editor.GetState.cs
@@ -1,0 +1,41 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Editor
+    {
+        public const string EditorApplicationGetStateToolId = "editor-application-get-state";
+
+        [AiTool
+        (
+            EditorApplicationGetStateToolId,
+            Title = "Editor / Application / Get State",
+            ReadOnlyHint = true,
+            IdempotentHint = true,
+            OpenWorldHint = false
+        )]
+        [Description("Return the current run/play state of the Godot editor: whether a scene is currently " +
+            "being run in a separate game process, the res:// path of that scene (if any), and the editor " +
+            "version string. The Godot analog of Unity's 'editor-application-get-state'. Use " +
+            "'editor-application-set-state' to start/stop a play-run.")]
+        public EditorStateData GetState(string? nothing = null)
+        {
+            return MainThread.Instance.Run(() => ToEditorStateData());
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Editor.Selection.Get.cs
+++ b/addons/godot_mcp/Tools/Tool_Editor.Selection.Get.cs
@@ -1,0 +1,42 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Editor_Selection
+    {
+        public const string EditorSelectionGetToolId = "editor-selection-get";
+
+        [AiTool
+        (
+            EditorSelectionGetToolId,
+            Title = "Editor / Selection / Get",
+            ReadOnlyHint = true,
+            IdempotentHint = true,
+            OpenWorldHint = false
+        )]
+        [Description("Get the current node selection in the Godot editor as structured data: the selected " +
+            "scene-tree nodes (each as NodeData with instanceId/name/path/type) and the active (last-" +
+            "selected) node. The Godot analog of Unity's 'editor-selection-get'. Use 'editor-selection-set' " +
+            "to change the selection. Returns an empty selection (count 0, activeNode null) when nothing is " +
+            "selected.")]
+        public SelectionData Get(string? nothing = null)
+        {
+            return MainThread.Instance.Run(() => ToSelectionData());
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Editor.Selection.Set.cs
+++ b/addons/godot_mcp/Tools/Tool_Editor.Selection.Set.cs
@@ -1,0 +1,70 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Editor_Selection
+    {
+        public const string EditorSelectionSetToolId = "editor-selection-set";
+
+        [AiTool
+        (
+            EditorSelectionSetToolId,
+            Title = "Editor / Selection / Set",
+            IdempotentHint = true
+        )]
+        [Description("Set the Godot editor's node selection to the provided nodes (replacing any current " +
+            "selection). The Godot analog of Unity's 'editor-selection-set'. Each entry is a NodeRef " +
+            "(instanceId preferred, else scene-tree path relative to the edited scene root). All refs must " +
+            "resolve to live scene-tree nodes; otherwise the call throws and the selection is left " +
+            "unchanged. Pass an empty list to clear the selection. Use 'editor-selection-get' to inspect " +
+            "the current selection first. Returns the post-change SelectionData.")]
+        public SelectionData Set
+        (
+            [Description("Nodes to select, each identified by instanceId (preferred) or scene-tree path. " +
+                "An empty list clears the selection.")]
+            List<NodeRef> select
+        )
+        {
+            if (select == null)
+                throw new ArgumentNullException(nameof(select));
+
+            return MainThread.Instance.Run(() =>
+            {
+                // Resolve all refs FIRST so a bad ref aborts before we mutate the live selection (all-or-nothing).
+                var resolved = new List<Node>(select.Count);
+                for (int i = 0; i < select.Count; i++)
+                {
+                    var node = Tool_Node.ResolveNode(select[i], out var error);
+                    if (node == null)
+                        throw new Exception($"select[{i}] could not be resolved: {error ?? $"{select[i]} not found."}");
+                    resolved.Add(node);
+                }
+
+                var selection = EditorInterface.Singleton.GetSelection();
+                selection.Clear();
+                foreach (var node in resolved)
+                    selection.AddNode(node);
+
+                return ToSelectionData();
+            });
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Editor.Selection.cs
+++ b/addons/godot_mcp/Tools/Tool_Editor.Selection.cs
@@ -1,0 +1,63 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// Editor selection tool family (<c>editor-selection-*</c>) — the Godot analog of Unity-MCP's
+    /// <c>Tool_Editor_Selection</c>. Each tool method lives in its own partial-class file (Get / Set) and
+    /// drives the editor's node selection via <see cref="EditorSelection"/> (obtained from
+    /// <see cref="EditorInterface.GetSelection"/>) through the main-thread dispatcher.
+    ///
+    /// <para>
+    /// Godot ↔ Unity mapping: Godot's <see cref="EditorSelection"/> selects scene-tree
+    /// <see cref="Node"/>s only — there is no Unity-style asset-GUID / Transform / Component selection
+    /// distinction, and no first-class "active object". So <see cref="SelectionData"/> carries a flat node
+    /// list plus the LAST-selected node as the "active" one (matching how the editor inspector tracks the
+    /// most-recently-clicked node).
+    /// </para>
+    ///
+    /// Editor-only (<c>#if TOOLS</c>). The pure-managed <see cref="SelectionData"/> model lives outside
+    /// this guard and is unit-tested.
+    /// </summary>
+    [AiToolType]
+    public partial class Tool_Editor_Selection
+    {
+        /// <summary>
+        /// Build a <see cref="SelectionData"/> from the editor's current node selection. Main-thread only.
+        /// The active node is reported as the LAST selected node (Godot has no first-class active object).
+        /// </summary>
+        internal static SelectionData ToSelectionData()
+        {
+            var data = new SelectionData();
+
+            var selection = EditorInterface.Singleton.GetSelection();
+            var nodes = selection.GetSelectedNodes();
+
+            foreach (var node in nodes)
+            {
+                if (node == null)
+                    continue;
+                data.Nodes.Add(Tool_Node.ToNodeData(node, hierarchyDepth: 0));
+            }
+
+            data.Count = data.Nodes.Count;
+            data.ActiveNode = data.Nodes.Count > 0 ? data.Nodes[data.Nodes.Count - 1] : null;
+
+            return data;
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Editor.SetState.cs
+++ b/addons/godot_mcp/Tools/Tool_Editor.SetState.cs
@@ -1,0 +1,88 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Editor
+    {
+        public const string EditorApplicationSetStateToolId = "editor-application-set-state";
+
+        [AiTool
+        (
+            EditorApplicationSetStateToolId,
+            Title = "Editor / Application / Set State",
+            IdempotentHint = true
+        )]
+        [Description("Start or stop the Godot editor's play-run. Unlike Unity (an in-editor playmode " +
+            "toggle), Godot launches the game in a SEPARATE process. Use 'editor-application-get-state' to " +
+            "inspect the current state first.\n" +
+            "Inputs:\n" +
+            "  - 'isPlaying' (default false): true starts a run, false stops any active run.\n" +
+            "  - 'scene' (default 'main'): which scene to run when starting — 'main' runs the project's main " +
+            "scene (EditorInterface.PlayMainScene), 'current' runs the currently-edited scene " +
+            "(EditorInterface.PlayCurrentScene), or a res:// path runs that specific scene " +
+            "(EditorInterface.PlayCustomScene). Ignored when 'isPlaying' is false.\n" +
+            "Returns the post-change EditorStateData snapshot.")]
+        public EditorStateData SetState
+        (
+            [Description("If true, start a play-run; if false, stop any active run.")]
+            bool isPlaying = false,
+            [Description("Which scene to run when starting: 'main' (project main scene), 'current' (the " +
+                "currently-edited scene), or a res:// path to a specific .tscn. Ignored when isPlaying is false.")]
+            string scene = "main"
+        )
+        {
+            return MainThread.Instance.Run(() =>
+            {
+                var ei = EditorInterface.Singleton;
+
+                if (!isPlaying)
+                {
+                    ei.StopPlayingScene();
+                    return ToEditorStateData();
+                }
+
+                var which = string.IsNullOrWhiteSpace(scene) ? "main" : scene.Trim();
+
+                if (which.Equals("main", StringComparison.OrdinalIgnoreCase))
+                {
+                    ei.PlayMainScene();
+                }
+                else if (which.Equals("current", StringComparison.OrdinalIgnoreCase))
+                {
+                    var editedRoot = ei.GetEditedSceneRoot();
+                    if (editedRoot == null)
+                        throw new Exception("Cannot run the current scene: no scene is currently being edited.");
+                    ei.PlayCurrentScene();
+                }
+                else
+                {
+                    // Treat anything else as a res:// scene path.
+                    if (!which.StartsWith("res://", StringComparison.Ordinal))
+                        throw new Exception($"'scene' must be 'main', 'current', or a res:// path; got '{scene}'.");
+                    if (!ResourceLoader.Exists(which))
+                        throw new Exception($"Scene not found at '{which}'.");
+                    ei.PlayCustomScene(which);
+                }
+
+                return ToEditorStateData();
+            });
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Editor.cs
+++ b/addons/godot_mcp/Tools/Tool_Editor.cs
@@ -1,0 +1,57 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// Editor application tool family (<c>editor-application-*</c>) — the Godot analog of Unity-MCP's
+    /// <c>Tool_Editor</c>. Each tool method lives in its own partial-class file (GetState / SetState) and
+    /// drives the editor's run/play lifecycle via <see cref="EditorInterface"/> through the main-thread
+    /// dispatcher.
+    ///
+    /// <para>
+    /// Godot ↔ Unity mapping: Unity toggles an IN-editor playmode (<c>EditorApplication.isPlaying</c>);
+    /// Godot launches the game in a SEPARATE OS process via <see cref="EditorInterface.PlayMainScene"/> /
+    /// <see cref="EditorInterface.PlayCurrentScene"/> / <see cref="EditorInterface.PlayCustomScene"/> and
+    /// stops it via <see cref="EditorInterface.StopPlayingScene"/>; <see cref="EditorInterface.IsPlayingScene"/>
+    /// reports whether a run is active. There is no editor-side "paused" / "compiling" play state to mirror,
+    /// so those Unity fields have no Godot analog (see <see cref="EditorStateData"/>).
+    /// </para>
+    ///
+    /// Editor-only (<c>#if TOOLS</c>). The pure-managed <see cref="EditorStateData"/> model lives outside
+    /// this guard and is unit-tested.
+    /// </summary>
+    [AiToolType]
+    public partial class Tool_Editor
+    {
+        /// <summary>
+        /// Build an <see cref="EditorStateData"/> from the live editor. Main-thread only.
+        /// </summary>
+        internal static EditorStateData ToEditorStateData()
+        {
+            var ei = EditorInterface.Singleton;
+            var isPlaying = ei.IsPlayingScene();
+            var playingScene = isPlaying ? ei.GetPlayingScene() : null;
+
+            return new EditorStateData
+            {
+                IsPlaying = isPlaying,
+                PlayingScene = string.IsNullOrEmpty(playingScene) ? null : playingScene,
+                EditorVersion = Engine.GetVersionInfo()["string"].AsString(),
+            };
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Reflection.MethodCall.cs
+++ b/addons/godot_mcp/Tools/Tool_Reflection.MethodCall.cs
@@ -1,0 +1,159 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using com.IvanMurzak.Godot.MCP.Reflection;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet;
+using com.IvanMurzak.ReflectorNet.Model;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Reflection
+    {
+        public const string ReflectionMethodCallToolId = "reflection-method-call";
+
+        [AiTool
+        (
+            ReflectionMethodCallToolId,
+            Title = "Method C# / Call"
+        )]
+        [Description("Call a C# method by reflection — including private methods. The Godot analog of " +
+            "Unity's 'reflection-method-call'. Requires a method schema obtained via " +
+            "'reflection-method-find'. Supports static methods, instance methods (with optional target " +
+            "deserialization), and main-thread / off-thread execution.\n" +
+            "Inputs:\n" +
+            "  - 'targetObject' (optional) — for instance methods; { type, value } where value is " +
+            "deserialized to type. Null for static methods (or to construct a fresh instance).\n" +
+            "  - 'inputParameters' (optional) — list of { type, name, value }; names/types are enhanced " +
+            "against the resolved signature when omitted.\n" +
+            "  - 'executeInMainThread' (default true) — keep true for Godot-API-touching methods; set false " +
+            "only for thread-safe pure logic.")]
+        public SerializedMember MethodCall
+        (
+            [Description("Method filter: Namespace / TypeName / MethodName / InputParameters identifying the method.")]
+            MethodRef filter,
+            [Description("Set true if 'filter.Namespace' is a known full namespace name; otherwise false.")]
+            bool knownNamespace = false,
+            [Description("Minimal match level for 'filter.TypeName' (0 ignore, 1 contains-ic [default], " +
+                "2 contains-cs, 3 starts-ic, 4 starts-cs, 5 equals-ic, 6 equals-cs).")]
+            int typeNameMatchLevel = 1,
+            [Description("Minimal match level for 'filter.MethodName' (0 ignore, 1 contains-ic [default], " +
+                "2 contains-cs, 3 starts-ic, 4 starts-cs, 5 equals-ic, 6 equals-cs).")]
+            int methodNameMatchLevel = 1,
+            [Description("Minimal match level for 'filter.InputParameters' (0 ignore, 1 count matches, " +
+                "2 equals [default]).")]
+            int parametersMatchLevel = 2,
+            [Description("Target object for an instance method ({ type, value }). Null for a static method, " +
+                "or to construct a fresh instance of the declaring type.")]
+            SerializedMember? targetObject = null,
+            [Description("Method input parameters, each { type, name, value }.")]
+            SerializedMemberList? inputParameters = null,
+            [Description("Run the call on the editor main thread. Keep true for Godot-API methods; false " +
+                "for thread-safe pure logic.")]
+            bool executeInMainThread = true
+        )
+        {
+            // Enhance filter with input parameters if the filter carries none.
+            if ((filter.InputParameters?.Count ?? 0) == 0 && (inputParameters?.Count ?? 0) > 0)
+                filter.EnhanceInputParameters(inputParameters);
+
+            var methods = FindMethods(
+                filter: filter,
+                knownNamespace: knownNamespace,
+                typeNameMatchLevel: typeNameMatchLevel,
+                methodNameMatchLevel: methodNameMatchLevel,
+                parametersMatchLevel: parametersMatchLevel).ToList();
+
+            if (methods.Count == 0)
+                throw new Exception($"Method not found.\n{filter}");
+
+            MethodInfo method;
+
+            if (methods.Count > 1)
+            {
+                var isValidParameterTypeName = inputParameters.IsValidTypeNames(
+                    fieldName: nameof(inputParameters),
+                    out _);
+
+                var filtered = isValidParameterTypeName
+                    ? methods.FilterByParameters(inputParameters)
+                    : null;
+
+                if (filtered == null)
+                    throw new Exception(Error.MoreThanOneMethodFound(GodotMcpReflector.GetOrCreate(), methods));
+
+                method = filtered;
+            }
+            else
+            {
+                method = methods.First();
+            }
+
+            inputParameters?.EnhanceNames(method);
+            inputParameters?.EnhanceTypes(method);
+
+            Func<SerializedMember> action = () =>
+            {
+                var reflector = GodotMcpReflector.GetOrCreate();
+                var logger = NullLogger.Instance;
+
+                var dictInputParameters = inputParameters?.ToDictionary(
+                    keySelector: p => p.name ?? throw new InvalidOperationException(
+                        "Input parameter name is null. Please specify 'name' for each input parameter."),
+                    elementSelector: p => reflector.Deserialize(p, logger: logger));
+
+                MethodWrapper methodWrapper;
+
+                if (string.IsNullOrEmpty(targetObject?.typeName))
+                {
+                    // No instance needed — static method (or a fresh instance constructed by the wrapper).
+                    methodWrapper = new MethodWrapper(reflector, logger, method);
+                }
+                else
+                {
+                    var obj = reflector.Deserialize(targetObject!, logger: logger);
+                    if (obj == null)
+                        throw new Exception($"'{nameof(targetObject)}' deserialized instance is null. " +
+                            $"Please specify '{nameof(targetObject)}' properly.");
+
+                    methodWrapper = new MethodWrapper(reflector, logger, targetInstance: obj, methodInfo: method);
+                }
+
+                if (!methodWrapper.VerifyParameters(dictInputParameters, out var error))
+                    throw new Exception(error);
+
+                var task = dictInputParameters != null
+                    ? methodWrapper.InvokeDict(dictInputParameters, CancellationToken.None)
+                    : methodWrapper.Invoke(Array.Empty<object>());
+
+                var result = task.Result;
+                if (result is SerializedMember serializedResult)
+                    return serializedResult;
+
+                return reflector.Serialize(
+                    obj: result,
+                    fallbackType: method.ReturnType,
+                    logger: logger);
+            };
+
+            if (executeInMainThread)
+                return MainThread.Instance.Run(action);
+
+            return action();
+        }
+    }
+}

--- a/addons/godot_mcp/Tools/Tool_Reflection.MethodFind.cs
+++ b/addons/godot_mcp/Tools/Tool_Reflection.MethodFind.cs
@@ -1,0 +1,81 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.ComponentModel;
+using System.Linq;
+using com.IvanMurzak.Godot.MCP.Reflection;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet;
+using com.IvanMurzak.ReflectorNet.Model;
+using com.IvanMurzak.ReflectorNet.Utils;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Reflection
+    {
+        public const string ReflectionMethodFindToolId = "reflection-method-find";
+
+        [AiTool
+        (
+            ReflectionMethodFindToolId,
+            Title = "Method C# / Find",
+            ReadOnlyHint = true,
+            IdempotentHint = true
+        )]
+        [Description("Find C# methods across every loaded assembly by name / declaring-type / parameters — " +
+            "including private methods. The Godot analog of Unity's 'reflection-method-find'. Returns " +
+            "serialized MethodData entries usable as schemas for 'reflection-method-call'.\n" +
+            "Match levels (apply to typeName / MethodName / Parameters):\n" +
+            "  - typeNameMatchLevel / methodNameMatchLevel (default 1 = contains-ignoring-case): " +
+            "0 ignore filter, 1 contains-ic, 2 contains-cs, 3 starts-with-ic, 4 starts-with-cs, 5 equals-ic, " +
+            "6 equals-cs.\n" +
+            "  - parametersMatchLevel (default 0 = ignore filter): 0 ignore, 1 count matches, 2 equals.")]
+        public string MethodFind
+        (
+            [Description("Method filter: Namespace / TypeName / MethodName / InputParameters to match against.")]
+            MethodRef filter,
+            [Description("Set true if 'filter.Namespace' is a known full namespace name; otherwise false.")]
+            bool knownNamespace = false,
+            [Description("Minimal match level for 'filter.TypeName' (0 ignore, 1 contains-ic [default], " +
+                "2 contains-cs, 3 starts-ic, 4 starts-cs, 5 equals-ic, 6 equals-cs).")]
+            int typeNameMatchLevel = 1,
+            [Description("Minimal match level for 'filter.MethodName' (0 ignore, 1 contains-ic [default], " +
+                "2 contains-cs, 3 starts-ic, 4 starts-cs, 5 equals-ic, 6 equals-cs).")]
+            int methodNameMatchLevel = 1,
+            [Description("Minimal match level for 'filter.InputParameters' (0 ignore [default], " +
+                "1 count matches, 2 equals).")]
+            int parametersMatchLevel = 0
+        )
+        {
+            return MainThread.Instance.Run(() =>
+            {
+                var methods = FindMethods(
+                    filter: filter,
+                    knownNamespace: knownNamespace,
+                    typeNameMatchLevel: typeNameMatchLevel,
+                    methodNameMatchLevel: methodNameMatchLevel,
+                    parametersMatchLevel: parametersMatchLevel).ToList();
+
+                if (methods.Count == 0)
+                    return $"[Success] Method not found. With request:\n{filter}";
+
+                var reflector = GodotMcpReflector.GetOrCreate();
+
+                var methodRefs = methods
+                    .Select(method => new MethodData(reflector, method, justRef: false))
+                    .ToList();
+
+                return $@"[Success] Found {methods.Count} method(s):
+```json
+{methodRefs.ToJson(reflector)}
+```";
+            });
+        }
+    }
+}

--- a/addons/godot_mcp/Tools/Tool_Reflection.cs
+++ b/addons/godot_mcp/Tools/Tool_Reflection.cs
@@ -1,0 +1,161 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet;
+using com.IvanMurzak.ReflectorNet.Model;
+using com.IvanMurzak.ReflectorNet.Utils;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// Reflection tool family (<c>reflection-method-*</c>) — the Godot analog of Unity-MCP's
+    /// <c>Tool_Reflection</c>. This family is engine-agnostic: it reuses ReflectorNet's reflection engine
+    /// (<see cref="TypeUtils.AllTypes"/>, <see cref="MethodData"/>, <see cref="MethodWrapper"/>) to find
+    /// and call C# methods (static + instance, public + private) across every loaded assembly. The only
+    /// Godot-specific wiring is the reflector source: it reads <see cref="Reflection.GodotMcpReflector"/>
+    /// (the connection-built reflector with Godot type converters) instead of Unity's
+    /// <c>UnityMcpPluginEditor.Instance.Reflector</c>.
+    ///
+    /// <para>
+    /// No Godot editor-API surface, so it intentionally lives OUTSIDE <c>#if TOOLS</c>. The find/call
+    /// logic is pure-managed and discovered by the McpPlugin assembly scanner. Main-thread marshalling is
+    /// applied per-call (Godot-touching reflected methods need it; thread-safe pure logic can opt out via
+    /// <c>executeInMainThread = false</c>).
+    /// </para>
+    /// </summary>
+    [AiToolType]
+    public partial class Tool_Reflection
+    {
+        static IEnumerable<Type> AllTypes => TypeUtils.AllTypes;
+
+        static int Compare(string original, string value)
+        {
+            if (string.IsNullOrEmpty(original) || string.IsNullOrEmpty(value))
+                return 0;
+
+            if (original.Equals(value, StringComparison.OrdinalIgnoreCase))
+                return original.Equals(value, StringComparison.Ordinal) ? 6 : 5;
+
+            if (original.StartsWith(value, StringComparison.OrdinalIgnoreCase))
+                return original.StartsWith(value, StringComparison.Ordinal) ? 4 : 3;
+
+            if (original.Contains(value, StringComparison.OrdinalIgnoreCase))
+                return original.Contains(value, StringComparison.Ordinal) ? 2 : 1;
+
+            return 0;
+        }
+
+        static int Compare(ParameterInfo[] original, List<MethodRef.Parameter>? value)
+        {
+            if (original == null && value == null)
+                return 2;
+
+            if (original == null || value == null)
+                return 0;
+
+            if (original.Length != value.Count)
+                return 0;
+
+            for (int i = 0; i < original.Length; i++)
+            {
+                var parameter = original[i];
+                var methodRefParameter = value[i];
+
+                if (parameter.Name != methodRefParameter.Name)
+                    return 1;
+
+                if (parameter.ParameterType.IsMatch(methodRefParameter.TypeName) == false)
+                    return 1;
+            }
+
+            return 2;
+        }
+
+        /// <summary>
+        /// Find methods across every loaded assembly matching the <paramref name="filter"/>, with tunable
+        /// match levels for the declaring-type name, the method name, and the parameters. A faithful port
+        /// of Unity-MCP's <c>Tool_Reflection.FindMethods</c> (the logic is engine-agnostic — only the
+        /// reflector source differs, and that is read at the call sites in MethodFind / MethodCall).
+        /// </summary>
+        static IEnumerable<MethodInfo> FindMethods(
+            MethodRef filter,
+            bool knownNamespace = false,
+            int typeNameMatchLevel = 1,
+            int methodNameMatchLevel = 1,
+            int parametersMatchLevel = 2,
+            BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static)
+        {
+            filter.Namespace = filter.Namespace?.Trim()?.Replace("null", string.Empty);
+            if (string.IsNullOrEmpty(filter.TypeName))
+                filter.TypeName = null!;
+
+            var typesEnumerable = AllTypes
+                .Where(type => type.IsVisible)
+                .Where(type => !type.IsInterface)
+                .Where(type => !type.IsAbstract || type.IsSealed)
+                .Where(type => !type.IsGenericTypeDefinition);
+
+            if (knownNamespace)
+                typesEnumerable = typesEnumerable.Where(type => type.Namespace == filter.Namespace);
+
+            if (typeNameMatchLevel > 0 && !string.IsNullOrEmpty(filter.TypeName))
+                typesEnumerable = typesEnumerable
+                    .Select(type => new { Type = type, MatchLevel = Compare(type.Name, filter.TypeName) })
+                    .Where(entry => entry.MatchLevel >= typeNameMatchLevel)
+                    .OrderByDescending(entry => entry.MatchLevel)
+                    .Select(entry => entry.Type);
+
+            var types = typesEnumerable.ToList();
+
+            var methodEnumerable = types
+                .SelectMany(type => type.GetMethods(bindingFlags)
+                    .Where(method => method.DeclaringType == type))
+                .Where(method => method.DeclaringType != null)
+                .Where(method => !method.DeclaringType!.IsAbstract || method.DeclaringType.IsSealed)
+                .Where(method => !method.IsGenericMethodDefinition);
+
+            if (methodNameMatchLevel > 0 && !string.IsNullOrEmpty(filter.MethodName))
+                methodEnumerable = methodEnumerable
+                    .Select(method => new { Method = method, MatchLevel = Compare(method.Name, filter.MethodName) })
+                    .Where(entry => entry.MatchLevel >= methodNameMatchLevel)
+                    .OrderByDescending(entry => entry.MatchLevel)
+                    .Select(entry => entry.Method);
+
+            if (parametersMatchLevel > 0)
+                methodEnumerable = methodEnumerable
+                    .Select(method => new { Method = method, MatchLevel = Compare(method.GetParameters(), filter.InputParameters) })
+                    .Where(entry => entry.MatchLevel >= parametersMatchLevel)
+                    .OrderByDescending(entry => entry.MatchLevel)
+                    .Select(entry => entry.Method);
+
+            return methodEnumerable;
+        }
+
+        public static class Error
+        {
+            public static string MoreThanOneMethodFound(Reflector reflector, List<MethodInfo> methods)
+            {
+                var methodsString = methods
+                    .Select(method => new MethodData(reflector, method, justRef: false))
+                    .ToJson(reflector);
+
+                return @$"Found more than one method. Only single method should be targeted. Please specify the method name more precisely.
+Found {methods.Count} method(s):
+```json
+{methodsString}
+```";
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Ports the final Unity "editor introspection" tool family to Godot (5th/last of the 5 families): **editor-application-get-state/-set-state** (play-run via `EditorInterface.Play{Main,Current,Custom}Scene`/`StopPlayingScene`), **console-get-logs/-clear-logs** (pure-managed bounded `GodotLogCollector` fed by the plugin's `GD.Print/Warning/Error` path — Godot exposes no global managed log hook), **editor-selection-get/-set** (via `EditorSelection`), and **reflection-method-find/-call** (faithful port of ReflectorNet's engine-agnostic find/call, static+instance incl. private, main-thread-aware).
- Structured ReflectorNet-serialized models under `Data/`: `EditorStateData`, `LogEntry`+`GodotLogType`, `SelectionData`. Editor-driving handlers are `#if TOOLS`; pure-managed models + collector compile into the xUnit project.
- Reused NuGet pins unchanged (ReflectorNet 5.3.1, McpPlugin 6.5.5).

## Test plan
- [x] `dotnet build Godot-MCP.sln` — 0 errors, 0 warnings (CI parity).
- [x] `dotnet test Godot-MCP.Tests` — 192 passed (24 new: log-collector FIFO/filter/window/strip + model JSON round-trips).
- [x] Headless Godot 4.5.1 mono smoke: `[Godot-MCP] plugin loaded`, all deps resolve, no `FileNotFoundException`, tool families registered.

Closes #16