### PR TITLE
ci: tag-triggered addon-zip release workflow + RELEASING.md

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,116 @@
+# ┌──────────────────────────────────────────────────────────────────┐
+# │  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+# │  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+# │  Copyright (c) 2026 Ivan Murzak                                  │
+# │  Licensed under the Apache License, Version 2.0.                 │
+# │  See the LICENSE file in the project root for more information.  │
+# └──────────────────────────────────────────────────────────────────┘
+#
+# Tag-triggered release: builds + tests the solution for sanity, packages the
+# addons/godot_mcp/ folder into a versioned zip, and publishes a GitHub Release
+# with that zip attached + auto-generated notes.
+#
+# Triggers:
+#   - push of a tag matching `v*` (e.g. `v0.1.0`)  -> builds, zips, AND publishes
+#     the GitHub Release.
+#   - workflow_dispatch (manual)                   -> DRY RUN: builds + zips and
+#     uploads the zip only as a workflow ARTIFACT. The publish step is guarded by
+#     `if: startsWith(github.ref, 'refs/tags/')`, so a dispatch run NEVER creates a
+#     Release. There is intentionally NO `push: branches` trigger — a merge to main
+#     must not cut a release. A `v*` tag push is the one and only publish path.
+
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch: # manual dry-run: build + zip + upload artifact, no Release
+
+# Least-privilege: only the release job needs to write the GitHub Release.
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: build, zip addon, publish release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      # Sanity build + test. Mirrors ci.yml so a tag on a red commit fails loudly
+      # before any zip/Release is produced. Godot.NET.Sdk is a NuGet SDK, so no
+      # Godot binary is needed here.
+      - name: Restore
+        run: dotnet restore Godot-MCP.sln
+
+      - name: Build
+        run: dotnet build Godot-MCP.sln --configuration Debug --no-restore
+
+      - name: Test
+        run: dotnet test Godot-MCP.Tests/Godot-MCP.Tests.csproj --configuration Debug --no-build --verbosity normal
+
+      # Resolve the release version. On a tag push this is the tag name with any
+      # leading `v` stripped (v0.1.0 -> 0.1.0). On a manual dispatch (no tag)
+      # fall back to the plugin.cfg version + a `-dryrun` suffix so the artifact
+      # name is unambiguous and never collides with a real release asset.
+      - name: Resolve version
+        id: version
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            version="${GITHUB_REF_NAME#v}"
+          else
+            cfg_version="$(grep -E '^version=' addons/godot_mcp/plugin.cfg | head -n1 | sed -E 's/^version="?([^"]*)"?.*/\1/')"
+            version="${cfg_version}-dryrun"
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Resolved release version: ${version}"
+
+      # Package only the addon SOURCE folder (the deliverable — Godot has no
+      # compiled artifact to ship). Exclude dev cruft so the zip is install-clean.
+      - name: Package addon zip
+        id: package
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+          zip_name="godot-mcp-addon-${version}.zip"
+          # Zip the addons/ tree so the archive expands to addons/godot_mcp/...,
+          # which drops straight into a consumer project's res:// root.
+          zip -r "${zip_name}" addons/godot_mcp \
+            -x '*.uid' \
+            -x '*.import' \
+            -x '*/bin/*' \
+            -x '*/obj/*' \
+            -x '*/.godot/*'
+          echo "zip_name=${zip_name}" >> "$GITHUB_OUTPUT"
+          echo "Created ${zip_name}:"
+          unzip -l "${zip_name}"
+
+      # DRY-RUN path (workflow_dispatch, no tag): upload the zip as an artifact so
+      # the packaging can be inspected without publishing. Never runs on a tag.
+      - name: Upload addon zip as artifact (dry run)
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.package.outputs.zip_name }}
+          path: ${{ steps.package.outputs.zip_name }}
+
+      # PUBLISH path (tag push only): create the GitHub Release with the zip
+      # attached and auto-generated notes. Guarded so the dispatch dry-run never
+      # reaches it.
+      - name: Create GitHub Release
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: ${{ steps.package.outputs.zip_name }}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,121 @@
+# Releasing Godot-MCP
+
+How a new version of the **Godot-MCP** addon is built, published, and distributed.
+
+The single distribution channel is the **addon source folder** (`addons/godot_mcp/`), shipped
+two ways from the same artifact:
+
+1. a **GitHub Release** with a versioned `godot-mcp-addon-<version>.zip` attached, and
+2. a **Godot Asset Library** entry that points at that repository/version.
+
+Godot-MCP does **not** publish any NuGet package of its own — see [NuGet](#nuget-decision) below.
+
+---
+
+## How to cut a release
+
+The release is fully automated by [`.github/workflows/release.yml`](../.github/workflows/release.yml),
+which fires **only on a `v*` tag push**. Merging to `main` does NOT cut a release.
+
+1. **Bump the addon version.** Edit the `version` field in
+   [`addons/godot_mcp/plugin.cfg`](../addons/godot_mcp/plugin.cfg) to the new semver
+   (e.g. `version="0.2.0"`). This is the canonical version source for the addon. Commit it to `main`
+   through the normal PR flow.
+2. **Tag the release commit.** Once the version bump is on `main`, create and push a matching tag
+   prefixed with `v`:
+
+   ```bash
+   git tag v0.2.0
+   git push origin v0.2.0
+   ```
+
+   > The tag name (`v0.2.0`) is what names the GitHub Release; the workflow strips the leading `v`
+   > for the zip filename (`godot-mcp-addon-0.2.0.zip`). Keep the tag's semver in lockstep with the
+   > `plugin.cfg` `version` you bumped in step 1.
+
+3. **The workflow runs.** On the tag push, `release.yml`:
+   - restores + builds + tests `Godot-MCP.sln` (sanity gate — a tag on a red commit fails here
+     before anything is published);
+   - zips `addons/godot_mcp/` into `godot-mcp-addon-<version>.zip`, excluding dev cruft
+     (`*.uid`, `*.import`, `bin/`, `obj/`, `.godot/`);
+   - creates the **GitHub Release** named after the tag, with the zip attached and
+     auto-generated release notes (`generate_release_notes: true`).
+
+4. **Verify.** Check the new Release at
+   `https://github.com/IvanMurzak/Godot-MCP/releases/tag/v0.2.0` and confirm the zip asset is
+   attached and the notes look right.
+
+### Dry run (no publish)
+
+To exercise the build + zip without publishing a Release, trigger the workflow manually
+(`workflow_dispatch`, e.g. via *Actions → release → Run workflow*). The manual path builds and zips
+exactly as the tag path does, but uploads the zip as a **workflow artifact** only — the
+Release-publish step is guarded by `if: startsWith(github.ref, 'refs/tags/')`, so a dispatch run
+**never** creates a Release. Download the artifact from the run summary to inspect the package.
+
+---
+
+## Godot Asset Library submission (metadata — manual, Ivan-gated)
+
+The Godot Asset Library is the discoverable in-editor channel (*AssetLib* tab). Submission is a
+**manual web-form step** performed by the maintainer at
+<https://godotengine.org/asset-library/> after a GitHub Release exists. It is **not** automated and
+**not** performed by this pipeline. The metadata below is prepared so the form can be filled in
+quickly; nothing here submits anything.
+
+| Field | Value |
+| --- | --- |
+| **Asset name** | Godot-MCP |
+| **Category** | Tools |
+| **Godot version** | 4.3+ (C#/.NET mono edition) |
+| **Repository host** | GitHub |
+| **Repository URL** | `https://github.com/IvanMurzak/Godot-MCP` |
+| **Version** | the semver just released (e.g. `0.2.0`) — match `plugin.cfg` / the `v*` tag |
+| **Version string / commit** | the released tag's commit (the Asset Library entry points at a specific commit or the release download) |
+| **Download / commit** | the `v<semver>` tag commit on `main` (Asset Library can reference the tagged commit; the GitHub Release zip is the human download) |
+| **License** | Apache-2.0 (matches [`LICENSE`](../LICENSE) and the `plugin.cfg` author) |
+| **Icon** | a 128×128 PNG/SVG icon. **NONE ships in `addons/godot_mcp/` today** — add one (e.g. `addons/godot_mcp/icon.png`) before the first Asset Library submission and reference its raw GitHub URL in the form. |
+| **Short description** | "Model Context Protocol (MCP) integration for the Godot Editor. AI tools in C#, cloud-connected to ai-game.dev." (matches `plugin.cfg` `description`) |
+| **Long description** | The Godot counterpart of Unity-MCP: a C# editor addon that exposes Godot Editor operations (nodes, scenes, resources, scripts, screenshots, editor state, reflection) as **AI Tools** over an MCP server. See [`README.md`](../README.md) for the full tool family list and install steps. **Important install note for consumers:** because Godot compiles every `.cs` under the project into one assembly, the consumer's `.csproj` must declare the two NuGet `PackageReference`s the addon needs (`com.IvanMurzak.ReflectorNet` 5.3.1, `com.IvanMurzak.McpPlugin` 6.5.5) — surface this in the submission so installers aren't surprised by a compile error. |
+
+After the form is submitted, a Godot Asset Library moderator reviews and approves the entry; later
+versions are pushed as edits to the same entry (bump the version + point at the new tag).
+
+---
+
+## NuGet decision
+
+**Godot-MCP does NOT publish its own NuGet package.** It *consumes* two upstream packages from
+nuget.org as `PackageReference`s, pinned and owned by the upstream release pipelines (never bumped
+in this repo):
+
+| Package | Version | Role |
+| --- | --- | --- |
+| `com.IvanMurzak.ReflectorNet` | `5.3.1` | reflection / serialization core |
+| `com.IvanMurzak.McpPlugin` | `6.5.5` | MCP plugin client (transitively pulls `McpPlugin.Common` + `ReflectorNet`) |
+
+The addon **source folder** — distributed via the GitHub Release zip and the Godot Asset Library
+entry — is the **sole** distribution channel for Godot-MCP. There is no new package ID to claim and
+no NuGet publish secret to configure; `release.yml` contains **no** `dotnet pack` / `dotnet nuget
+push` step, by design. (This is the deliberate difference from the sibling `ReflectorNet` /
+`MCP-Plugin-dotnet` repos, whose `deploy.yml` workflows DO push NuGet packages — those repos ARE the
+upstream publishers; Godot-MCP is only a consumer.)
+
+---
+
+## GATES — what requires the maintainer (Ivan)
+
+Every action below is intentionally **out of scope for automation / agents** and must be performed
+by the maintainer:
+
+- **The first `v*` tag / first Release.** No agent cuts a tag or runs `gh release create`. The
+  maintainer pushes the `v<semver>` tag; `release.yml` then runs on its own.
+- **Each subsequent release tag.** Same — bumping `plugin.cfg` lands via PR, but the tag that
+  actually publishes is pushed by the maintainer.
+- **Godot Asset Library submission (and version edits).** A manual web-form step at
+  <https://godotengine.org/asset-library/>, never automated.
+- **Adding the addon icon** required by the Asset Library form (none ships today).
+- **Any future NuGet publishing** — new package IDs, `dotnet nuget push` steps, or NuGet
+  publish secrets / trusted-publishing config. None exist today and none should be added without an
+  explicit maintainer decision (the current model is consume-only; see
+  [NuGet decision](#nuget-decision)).


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml`: tag-triggered (`v*` push only) addon-zip GitHub Release. Builds + tests for sanity, zips `addons/godot_mcp/` (excluding `*.uid`/`*.import`/`bin`/`obj`/`.godot`), publishes via `softprops/action-gh-release@v2` with auto-generated notes. `workflow_dispatch` gives a dry-run that uploads the zip as an artifact only (publish step guarded by `if: startsWith(github.ref, 'refs/tags/')`). Least-privilege `permissions: contents: write`. No `push: branches` trigger — a merge never cuts a release.
- Add `docs/RELEASING.md`: tag/release flow, Godot Asset Library submission metadata (prepared, manual + Ivan-gated), consume-only NuGet decision (no package published here), and a GATES section of maintainer-only actions.
- No NuGet publish step / secret / tag was added or fired. Author-only change.

## Test plan
- [x] `dotnet build Godot-MCP.sln -c Debug` — 0 errors
- [x] `dotnet test Godot-MCP.Tests` — 192 passed, 0 failed
- [x] `release.yml` YAML validated (safe_load); triggers = `push.tags:[v*]` + `workflow_dispatch`, no `push.branches`; release step guarded by `refs/tags/`
- [x] `ci.yml` unaffected (docs/workflow-only change)

Closes #20