### PR TITLE
build(deps): bump com.IvanMurzak.McpPlugin 6.5.5 → 6.7.0

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -30,7 +30,7 @@
          com.IvanMurzak.McpPlugin is needed because GodotMcpConfig extends its ConnectionConfig and
          Tool_Ping uses its [AiTool]/[AiToolType] attributes — both pure-managed and CI-friendly. -->
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.1" />
-    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="6.5.5" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="6.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Godot-MCP.csproj
+++ b/Godot-MCP.csproj
@@ -17,7 +17,7 @@
   -->
   <ItemGroup>
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.1" />
-    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="6.5.5" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="6.7.0" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
## Summary
- Bump `com.IvanMurzak.McpPlugin` `6.5.5` → `6.7.0` in both `Godot-MCP.csproj` and `Godot-MCP.Tests/Godot-MCP.Tests.csproj`.
- `com.IvanMurzak.ReflectorNet` stays at `5.3.1` (already satisfies what McpPlugin 6.7.0 requires).
- Manual consumer-pin bump: Godot-MCP is not covered by the MCP-Plugin-dotnet release pipeline's consumer-bump steps. v6.7.0 carries the csharp-sdk 1.4.0 update, but Godot-MCP consumes the CLIENT package (no `ModelContextProtocol` dependency), so no source migration was needed.

## Test plan
- [x] `dotnet restore` + `dotnet build Godot-MCP.sln --configuration Debug --no-restore` — clean (0 warnings, 0 errors)
- [x] `dotnet test Godot-MCP.Tests/Godot-MCP.Tests.csproj` — 192/192 pass

Closes #22