### PR TITLE
feat(connection): load GODOT_MCP_* from a project .env file

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -44,6 +44,10 @@
          compile and run in this plain-xUnit host. GodotMcpConnection.cs is editor-only (#if TOOLS) and
          instantiates the SignalR client; it is verified via the headless Godot smoke, not here. -->
     <Compile Include="..\addons\godot_mcp\Connection\GodotMcpConfig.cs" Link="Source\GodotMcpConfig.cs" />
+    <!-- Project-root `.env` loader: pure-managed parser + precedence applier (no Godot native types,
+         no #if TOOLS). The editor wiring (ProjectSettings.GlobalizePath) lives in GodotMcpConnection.cs
+         (#if TOOLS), verified via the headless smoke; the parse/apply core is unit-tested here. -->
+    <Compile Include="..\addons\godot_mcp\Connection\GodotMcpEnvFile.cs" Link="Source\GodotMcpEnvFile.cs" />
     <!-- Editor-runtime NuGet-dependency resolver. Pure-BCL (System.Runtime.Loader), no #if TOOLS,
          no Godot native types — so it is unit-testable in this plain-xUnit host. -->
     <Compile Include="..\addons\godot_mcp\Connection\GodotMcpAssemblyResolver.cs" Link="Source\GodotMcpAssemblyResolver.cs" />

--- a/Godot-MCP.Tests/GodotMcpEnvFileTests.cs
+++ b/Godot-MCP.Tests/GodotMcpEnvFileTests.cs
@@ -1,0 +1,408 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using com.IvanMurzak.Godot.MCP.Connection;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the pure-managed project-root <c>.env</c> layer (<see cref="GodotMcpEnvFile"/>): line
+    /// parsing (comment/blank/quoted/whitespace/unknown-key), the env &gt; file &gt; config &gt; default
+    /// precedence for each key, mode-aware token routing, loopback host → Custom auto-mode, explicit
+    /// mode overriding loopback, and the missing-file no-op. No Godot native types or filesystem-bound
+    /// parser surface — CI-friendly.
+    ///
+    /// <para>
+    /// Tests that exercise the loopback / env-precedence path mutate process env vars, so the class
+    /// shares the <c>env</c> collection with <see cref="GodotMcpConfigTests"/> (no cross-class parallel
+    /// env races) and restores prior values via <see cref="EnvFileScope"/>.
+    /// </para>
+    /// </summary>
+    [Collection("env")]
+    public class GodotMcpEnvFileTests
+    {
+        // --- Parse: line handling ---
+
+        [Fact]
+        public void Parse_KeyValue_IsRecognized()
+        {
+            var values = GodotMcpEnvFile.Parse(new[] { "GODOT_MCP_HOST=http://localhost:5300" });
+            Assert.Equal("http://localhost:5300", values[GodotMcpConfig.EnvHost]);
+        }
+
+        [Fact]
+        public void Parse_SkipsBlankAndCommentLines()
+        {
+            var values = GodotMcpEnvFile.Parse(new[]
+            {
+                "",
+                "   ",
+                "# a comment",
+                "   # indented comment",
+                "GODOT_MCP_TOKEN=tok"
+            });
+            Assert.Single(values);
+            Assert.Equal("tok", values[GodotMcpConfig.EnvToken]);
+        }
+
+        [Theory]
+        [InlineData("GODOT_MCP_TOKEN=\"quoted\"", "quoted")]
+        [InlineData("GODOT_MCP_TOKEN='quoted'", "quoted")]
+        [InlineData("GODOT_MCP_TOKEN=  spaced  ", "spaced")]
+        [InlineData("  GODOT_MCP_TOKEN  =  trim-key  ", "trim-key")]
+        public void Parse_SanitizesWhitespaceAndQuotes(string line, string expected)
+        {
+            var values = GodotMcpEnvFile.Parse(new[] { line });
+            Assert.Equal(expected, values[GodotMcpConfig.EnvToken]);
+        }
+
+        [Fact]
+        public void Parse_IgnoresUnknownKeys()
+        {
+            var values = GodotMcpEnvFile.Parse(new[]
+            {
+                "PATH=/usr/bin",
+                "GODOT_MCP_UNKNOWN=x",
+                "SOME_OTHER=y",
+                "GODOT_MCP_HOST=http://localhost:8080"
+            });
+            Assert.Single(values);
+            Assert.Equal("http://localhost:8080", values[GodotMcpConfig.EnvHost]);
+        }
+
+        [Fact]
+        public void Parse_LineWithoutEquals_IsSkipped()
+        {
+            var values = GodotMcpEnvFile.Parse(new[] { "GODOT_MCP_HOST", "novalue" });
+            Assert.Empty(values);
+        }
+
+        [Fact]
+        public void Parse_BlankValue_IsSkipped()
+        {
+            var values = GodotMcpEnvFile.Parse(new[] { "GODOT_MCP_TOKEN=", "GODOT_MCP_HOST=   " });
+            Assert.Empty(values);
+        }
+
+        [Fact]
+        public void Parse_ValueWithEquals_KeepsRemainder()
+        {
+            // Only the FIRST '=' splits key/value (tokens may contain '=').
+            var values = GodotMcpEnvFile.Parse(new[] { "GODOT_MCP_TOKEN=a=b=c" });
+            Assert.Equal("a=b=c", values[GodotMcpConfig.EnvToken]);
+        }
+
+        [Fact]
+        public void Parse_DuplicateKey_LastWins()
+        {
+            var values = GodotMcpEnvFile.Parse(new[]
+            {
+                "GODOT_MCP_TOKEN=first",
+                "GODOT_MCP_TOKEN=second"
+            });
+            Assert.Equal("second", values[GodotMcpConfig.EnvToken]);
+        }
+
+        [Fact]
+        public void Parse_AllFourRecognizedKeys()
+        {
+            var values = GodotMcpEnvFile.Parse(new[]
+            {
+                "GODOT_MCP_CONNECTION_MODE=Custom",
+                "GODOT_MCP_HOST=http://localhost:5300",
+                "GODOT_MCP_CLOUD_URL=https://staging.ai-game.dev",
+                "GODOT_MCP_TOKEN=tok"
+            });
+            Assert.Equal(4, values.Count);
+            Assert.Equal("Custom", values[GodotMcpConfig.EnvConnectionMode]);
+            Assert.Equal("http://localhost:5300", values[GodotMcpConfig.EnvHost]);
+            Assert.Equal("https://staging.ai-game.dev", values[GodotMcpConfig.EnvCloudUrl]);
+            Assert.Equal("tok", values[GodotMcpConfig.EnvToken]);
+        }
+
+        // --- LoadFile: missing-file no-op ---
+
+        [Fact]
+        public void LoadFile_MissingPath_ReturnsEmpty()
+        {
+            var path = Path.Combine(Path.GetTempPath(), "godot-mcp-no-such-" + Guid.NewGuid().ToString("N") + ".env");
+            Assert.Empty(GodotMcpEnvFile.LoadFile(path));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void LoadFile_NullOrBlankPath_ReturnsEmpty(string? path)
+        {
+            Assert.Empty(GodotMcpEnvFile.LoadFile(path));
+        }
+
+        [Fact]
+        public void LoadFile_RealFile_ParsesContents()
+        {
+            var path = Path.Combine(Path.GetTempPath(), "godot-mcp-" + Guid.NewGuid().ToString("N") + ".env");
+            File.WriteAllText(path,
+                "# project-root .env\nGODOT_MCP_HOST=http://localhost:5300\nGODOT_MCP_TOKEN=\"file-tok\"\n");
+            try
+            {
+                var values = GodotMcpEnvFile.LoadFile(path);
+                Assert.Equal("http://localhost:5300", values[GodotMcpConfig.EnvHost]);
+                Assert.Equal("file-tok", values[GodotMcpConfig.EnvToken]);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        // --- Apply: missing/empty values no-op ---
+
+        [Fact]
+        public void Apply_EmptyValues_IsNoOp()
+        {
+            using var _ = EnvFileScope.ClearAll();
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Cloud, CloudToken = "orig" };
+            GodotMcpEnvFile.Apply(config, new Dictionary<string, string>());
+            Assert.Equal(GodotMcpConnectionMode.Cloud, config.ConnectionMode);
+            Assert.Equal("orig", config.CloudToken);
+        }
+
+        [Fact]
+        public void Apply_NullValues_IsNoOp()
+        {
+            using var _ = EnvFileScope.ClearAll();
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Cloud };
+            var same = GodotMcpEnvFile.Apply(config, null);
+            Assert.Same(config, same);
+        }
+
+        // --- Precedence: file value beats configured field / default ---
+
+        [Fact]
+        public void Apply_FileHost_OverridesConfiguredCustomHost()
+        {
+            using var _ = EnvFileScope.ClearAll();
+            var config = new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Custom,
+                CustomHost = "http://localhost:1111"
+            };
+            GodotMcpEnvFile.Apply(config, Map(GodotMcpConfig.EnvHost, "http://localhost:5300"));
+            Assert.Equal("http://localhost:5300", config.Host);
+        }
+
+        [Fact]
+        public void Apply_FileToken_OverridesConfiguredField_Cloud()
+        {
+            using var _ = EnvFileScope.ClearAll();
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Cloud, CloudToken = "old" };
+            GodotMcpEnvFile.Apply(config, Map(GodotMcpConfig.EnvToken, "file-tok"));
+            Assert.Equal("file-tok", config.Token);
+            Assert.Equal("file-tok", config.CloudToken);
+        }
+
+        // --- Precedence: process env beats file ---
+
+        [Fact]
+        public void EnvHost_Beats_FileHost()
+        {
+            using var _ = EnvFileScope.Set(GodotMcpConfig.EnvHost, "http://localhost:9999");
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Custom };
+            GodotMcpEnvFile.Apply(config, Map(GodotMcpConfig.EnvHost, "http://localhost:5300"));
+            // Env wins live in the getter even though the file value was written to the field.
+            Assert.Equal("http://localhost:9999", config.Host);
+        }
+
+        [Fact]
+        public void EnvToken_Beats_FileToken()
+        {
+            using var _ = EnvFileScope.Set(GodotMcpConfig.EnvToken, "env-tok");
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Cloud };
+            GodotMcpEnvFile.Apply(config, Map(GodotMcpConfig.EnvToken, "file-tok"));
+            Assert.Equal("env-tok", config.Token);
+        }
+
+        [Fact]
+        public void EnvMode_Beats_FileMode()
+        {
+            // File says Cloud, env says Custom → env wins (ActiveMode reads env live).
+            using var _ = EnvFileScope.Set(GodotMcpConfig.EnvConnectionMode, "Custom");
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Cloud };
+            GodotMcpEnvFile.Apply(config, Map(GodotMcpConfig.EnvConnectionMode, "Cloud"));
+            Assert.Equal(GodotMcpConnectionMode.Custom, config.ActiveMode);
+        }
+
+        // --- Default wins when neither env nor file present ---
+
+        [Fact]
+        public void Default_WhenNoEnvNoFile_ConfigValuesIntact()
+        {
+            using var _ = EnvFileScope.ClearAll();
+            var config = new GodotMcpConfig();
+            GodotMcpEnvFile.Apply(config, new Dictionary<string, string>());
+            Assert.Equal(GodotMcpConnectionMode.Cloud, config.ActiveMode);
+            Assert.Equal("https://ai-game.dev/mcp", config.Host);
+        }
+
+        // --- Token mode-routing ---
+
+        [Fact]
+        public void Apply_FileToken_RoutesToCustomToken_InCustomMode()
+        {
+            using var _ = EnvFileScope.ClearAll();
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Custom };
+            GodotMcpEnvFile.Apply(config, Map(GodotMcpConfig.EnvToken, "ctok"));
+            Assert.Equal("ctok", config.CustomToken);
+            Assert.Null(config.CloudToken);
+        }
+
+        [Fact]
+        public void Apply_FileToken_RoutesToCloudToken_InCloudMode()
+        {
+            using var _ = EnvFileScope.ClearAll();
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Cloud };
+            GodotMcpEnvFile.Apply(config, Map(GodotMcpConfig.EnvToken, "cltok"));
+            Assert.Equal("cltok", config.CloudToken);
+            Assert.Null(config.CustomToken);
+        }
+
+        [Fact]
+        public void Apply_FileToken_RoutesByFileMode_WhenFileSetsCustom()
+        {
+            // Config defaults Cloud, but the file flips mode to Custom and supplies a token in the same
+            // apply: the token must route to CustomToken (mode is settled before the token routes).
+            using var _ = EnvFileScope.ClearAll();
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Cloud };
+            GodotMcpEnvFile.Apply(config, new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [GodotMcpConfig.EnvConnectionMode] = "Custom",
+                [GodotMcpConfig.EnvToken] = "ctok"
+            });
+            Assert.Equal("ctok", config.CustomToken);
+            Assert.Null(config.CloudToken);
+        }
+
+        // --- Loopback auto-mode ---
+
+        [Theory]
+        [InlineData("http://localhost:5300")]
+        [InlineData("http://127.0.0.1:5300")]
+        [InlineData("http://[::1]:5300")]
+        public void Apply_LoopbackFileHost_AutoSelectsCustomMode(string host)
+        {
+            using var _ = EnvFileScope.ClearAll();
+            // Config defaults to Cloud; a loopback host in the file with no explicit mode infers Custom.
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Cloud };
+            GodotMcpEnvFile.Apply(config, Map(GodotMcpConfig.EnvHost, host));
+            Assert.Equal(GodotMcpConnectionMode.Custom, config.ActiveMode);
+            Assert.Equal(host, config.Host);
+        }
+
+        [Fact]
+        public void Apply_RemoteFileHost_DoesNotChangeMode()
+        {
+            using var _ = EnvFileScope.ClearAll();
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Cloud };
+            GodotMcpEnvFile.Apply(config, Map(GodotMcpConfig.EnvHost, "https://remote.example.com"));
+            Assert.Equal(GodotMcpConnectionMode.Cloud, config.ActiveMode);
+        }
+
+        [Fact]
+        public void Apply_ExplicitFileMode_OverridesLoopbackInference()
+        {
+            using var _ = EnvFileScope.ClearAll();
+            // Loopback host WOULD infer Custom, but an explicit file mode=Cloud wins.
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Cloud };
+            GodotMcpEnvFile.Apply(config, new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [GodotMcpConfig.EnvHost] = "http://localhost:5300",
+                [GodotMcpConfig.EnvConnectionMode] = "Cloud"
+            });
+            Assert.Equal(GodotMcpConnectionMode.Cloud, config.ActiveMode);
+        }
+
+        [Fact]
+        public void Apply_LoopbackEnvHost_AutoSelectsCustom_EvenWithoutFileHost()
+        {
+            // Env host is loopback (no file host). The loopback inference reads the EFFECTIVE host,
+            // which prefers env, so Custom is inferred.
+            using var _ = EnvFileScope.Set(GodotMcpConfig.EnvHost, "http://127.0.0.1:5300");
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Cloud };
+            GodotMcpEnvFile.Apply(config, Map(GodotMcpConfig.EnvToken, "tok"));
+            Assert.Equal(GodotMcpConnectionMode.Custom, config.ActiveMode);
+        }
+
+        [Fact]
+        public void Apply_FileMode_NumericString_DoesNotChangeMode()
+        {
+            // Numeric strings are rejected (parity with ResolveActiveMode); the loopback fallback also
+            // does not fire here (no loopback host), so the configured mode stands.
+            using var _ = EnvFileScope.ClearAll();
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Cloud };
+            GodotMcpEnvFile.Apply(config, Map(GodotMcpConfig.EnvConnectionMode, "1"));
+            Assert.Equal(GodotMcpConnectionMode.Cloud, config.ActiveMode);
+        }
+
+        // --- helpers ---
+
+        static Dictionary<string, string> Map(string key, string value) =>
+            new(StringComparer.Ordinal) { [key] = value };
+
+        /// <summary>
+        /// Sets/clears the four <c>GODOT_MCP_*</c> process env vars and restores prior values on dispose.
+        /// Mirrors <see cref="GodotMcpConfigTests"/>'s env isolation so the loopback/precedence tests
+        /// (which read env live) stay deterministic.
+        /// </summary>
+        sealed class EnvFileScope : IDisposable
+        {
+            static readonly string[] Names =
+            {
+                GodotMcpConfig.EnvCloudUrl,
+                GodotMcpConfig.EnvHost,
+                GodotMcpConfig.EnvToken,
+                GodotMcpConfig.EnvConnectionMode
+            };
+
+            readonly Dictionary<string, string?> _prior = new();
+
+            EnvFileScope()
+            {
+                foreach (var name in Names)
+                    _prior[name] = Environment.GetEnvironmentVariable(name);
+            }
+
+            public static EnvFileScope ClearAll()
+            {
+                var scope = new EnvFileScope();
+                foreach (var name in Names)
+                    Environment.SetEnvironmentVariable(name, null);
+                return scope;
+            }
+
+            public static EnvFileScope Set(string name, string? value)
+            {
+                var scope = ClearAll();
+                Environment.SetEnvironmentVariable(name, value);
+                return scope;
+            }
+
+            public void Dispose()
+            {
+                foreach (var kv in _prior)
+                    Environment.SetEnvironmentVariable(kv.Key, kv.Value);
+            }
+        }
+    }
+}

--- a/addons/godot_mcp/Connection/GodotMcpConfig.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConfig.cs
@@ -217,8 +217,14 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// Single normalization for env/config string values: trim surrounding whitespace and a single
         /// pair of wrapping double-quotes (so <c>GODOT_MCP_TOKEN="abc"</c> yields <c>abc</c>, not a
         /// bearer value with literal quotes). Returns <c>null</c> for null/blank input.
+        ///
+        /// <para>
+        /// Exposed <c>internal</c> so the <c>.env</c> file layer
+        /// (<see cref="GodotMcpEnvFile"/>) sanitizes file values identically to process-env values
+        /// — see the precedence note on <see cref="GodotMcpEnvFile.Apply"/>.
+        /// </para>
         /// </summary>
-        static string? NormalizeEnv(string? raw)
+        internal static string? NormalizeEnv(string? raw)
         {
             if (string.IsNullOrWhiteSpace(raw))
                 return null;
@@ -230,15 +236,37 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// URL-flavored normalization: <see cref="NormalizeEnv"/> plus a trailing-slash trim so URL
         /// resolvers compare/append cleanly. Returns <c>null</c> for null/blank input.
         /// </summary>
-        static string? NormalizeUrl(string? raw)
+        internal static string? NormalizeUrl(string? raw)
         {
             var normalized = NormalizeEnv(raw);
             return string.IsNullOrEmpty(normalized) ? null : normalized.TrimEnd('/');
         }
 
         /// <summary>True when <paramref name="value"/> is an absolute http or https URL.</summary>
-        static bool IsValidHttpUrl(string value) =>
+        internal static bool IsValidHttpUrl(string value) =>
             Uri.TryCreate(value, UriKind.Absolute, out var uri) &&
             (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+
+        /// <summary>
+        /// True when <paramref name="url"/> targets a loopback host (<c>localhost</c>, an IPv4
+        /// <c>127.0.0.0/8</c> address, or IPv6 <c>::1</c>). Mirrors Unity-MCP's
+        /// <c>EnvironmentUtils.IsLoopbackUrl</c> — used to auto-select <see cref="GodotMcpConnectionMode.Custom"/>
+        /// when a local-dev host is configured without an explicit mode. Pure-managed (no Godot types).
+        /// </summary>
+        internal static bool IsLoopbackUrl(string? url)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+                return false;
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+                return false;
+
+            var host = uri.Host;
+            if (string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase))
+                return true;
+            if (System.Net.IPAddress.TryParse(host, out var ip))
+                return System.Net.IPAddress.IsLoopback(ip);
+
+            return false;
+        }
     }
 }

--- a/addons/godot_mcp/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConnection.cs
@@ -74,6 +74,13 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 return;
             }
 
+            // Layer the project-root `.env` BENEATH the live process-env overrides the config already
+            // applies in its getters. Godot is launched from the GUI (no inherited shell exports), so a
+            // committed `res://.env` is how a project self-configures its MCP host/token. Process env
+            // still wins because GodotMcpConfig reads it live on every Host/Token/ActiveMode access —
+            // see GodotMcpEnvFile's precedence note.
+            ApplyProjectEnvFile();
+
             Reflector reflector = GodotReflectorFactory.CreateDefaultReflector();
 
             // Publish the connection's reflector as the ambient one so tool handlers (e.g. node-modify)
@@ -105,6 +112,34 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
             // Fire-and-forget connect; KeepConnected drives reconnection in the client.
             _ = ConnectAsync();
+        }
+
+        /// <summary>
+        /// Resolve the project-root <c>.env</c> (<c>res://.env</c> → absolute via
+        /// <see cref="ProjectSettings.GlobalizePath(string)"/>) and apply its recognized
+        /// <c>GODOT_MCP_*</c> values to <see cref="_config"/> beneath the process-env layer. The native
+        /// <c>ProjectSettings</c> call is the only Godot dependency; the parse/apply core is pure-managed
+        /// (<see cref="GodotMcpEnvFile"/>). A missing file is a silent no-op.
+        /// </summary>
+        void ApplyProjectEnvFile()
+        {
+            string envPath;
+            try
+            {
+                envPath = ProjectSettings.GlobalizePath("res://.env");
+            }
+            catch (Exception ex)
+            {
+                GD.PushWarning($"[Godot-MCP] could not resolve res://.env path: {ex.Message}");
+                return;
+            }
+
+            var values = GodotMcpEnvFile.LoadFile(envPath);
+            if (values.Count == 0)
+                return;
+
+            GodotMcpEnvFile.Apply(_config, values);
+            GD.Print($"[Godot-MCP] applied {values.Count} setting(s) from project .env ({envPath}).");
         }
 
         async Task ConnectAsync()

--- a/addons/godot_mcp/Connection/GodotMcpEnvFile.cs
+++ b/addons/godot_mcp/Connection/GodotMcpEnvFile.cs
@@ -1,0 +1,251 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// Pure-managed loader for a project-root <c>.env</c> file that self-configures the Godot-MCP
+    /// connection. Lets a Godot project ship its server URL + token (e.g. a worktree pointing at a
+    /// local dev server) WITHOUT the developer having to export process environment variables — Godot
+    /// is normally launched from the GUI, which inherits no shell exports. The Godot superset of
+    /// Unity-MCP's <c>EnvironmentUtils</c> env-override path (Unity reads only process env; here we add
+    /// a file layer beneath it).
+    ///
+    /// <para>
+    /// Precedence (highest wins), realised by <see cref="Apply"/>:
+    /// <list type="number">
+    ///   <item>process environment variable (<c>GODOT_MCP_*</c>) — still wins, applied live by the
+    ///   <see cref="GodotMcpConfig"/> getters AFTER this layer writes its fields;</item>
+    ///   <item><c>.env</c> file value — written here into the config's serialized backing fields;</item>
+    ///   <item>serialized config field (whatever the config already carried);</item>
+    ///   <item>built-in default.</item>
+    /// </list>
+    /// Because <see cref="GodotMcpConfig"/>'s <c>Host</c>/<c>Token</c>/<c>ActiveMode</c> read the
+    /// process env live on every access, writing the <c>.env</c> value into the backing field below the
+    /// env layer is exactly what makes env outrank file: an env value shadows the field we set here.
+    /// </para>
+    ///
+    /// <para>
+    /// Entirely pure-managed — no Godot native types — so it is unit-testable in the plain-xUnit
+    /// <c>Godot-MCP.Tests</c> host. The editor boot path (<see cref="GodotMcpConnection"/>, behind
+    /// <c>#if TOOLS</c>) resolves the file path via <c>ProjectSettings.GlobalizePath("res://.env")</c>
+    /// and feeds it through <see cref="LoadFile"/> + <see cref="Apply"/>.
+    /// </para>
+    /// </summary>
+    public static class GodotMcpEnvFile
+    {
+        /// <summary>The four recognized keys. Any other key in the file is ignored.</summary>
+        static readonly string[] RecognizedKeys =
+        {
+            GodotMcpConfig.EnvConnectionMode,
+            GodotMcpConfig.EnvHost,
+            GodotMcpConfig.EnvCloudUrl,
+            GodotMcpConfig.EnvToken
+        };
+
+        /// <summary>
+        /// Load and parse the <c>.env</c> file at <paramref name="path"/>, returning the recognized
+        /// <c>GODOT_MCP_*</c> values. A missing or unreadable file returns an empty dictionary (never
+        /// throws) — the absence of a <c>.env</c> file is the common case, not an error.
+        /// </summary>
+        public static IReadOnlyDictionary<string, string> LoadFile(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                return Empty;
+
+            string[] lines;
+            try
+            {
+                if (!File.Exists(path))
+                    return Empty;
+                lines = File.ReadAllLines(path);
+            }
+            catch (Exception)
+            {
+                // IO/permission/encoding failure — treat as "no .env" rather than breaking plugin boot.
+                return Empty;
+            }
+
+            return Parse(lines);
+        }
+
+        /// <summary>
+        /// Parse <c>.env</c>-style lines into the recognized <c>GODOT_MCP_*</c> values. Rules:
+        /// <list type="bullet">
+        ///   <item>blank lines and lines whose first non-whitespace char is <c>#</c> are skipped;</item>
+        ///   <item>each line is split on the first <c>=</c>; lines without one are skipped;</item>
+        ///   <item>the key is trimmed; only the four <c>GODOT_MCP_*</c> keys are kept (case-sensitive,
+        ///   matching how process env vars are read);</item>
+        ///   <item>the value is sanitized via the SAME normalizer the config applies to process-env
+        ///   values (<see cref="GodotMcpConfig.NormalizeEnv"/>: trim whitespace + a single pair of
+        ///   wrapping quotes), so <c>GODOT_MCP_TOKEN="abc"</c> yields <c>abc</c>;</item>
+        ///   <item>a blank value (after sanitize) is skipped — it carries no override;</item>
+        ///   <item>on duplicate keys the LAST occurrence wins.</item>
+        /// </list>
+        /// Single-quote wrapping is also stripped (a convenience superset over process env, which is
+        /// already shell-unquoted by the time it reaches the process).
+        /// </summary>
+        public static IReadOnlyDictionary<string, string> Parse(IEnumerable<string>? lines)
+        {
+            if (lines == null)
+                return Empty;
+
+            var result = new Dictionary<string, string>(StringComparer.Ordinal);
+
+            foreach (var rawLine in lines)
+            {
+                if (rawLine == null)
+                    continue;
+
+                var line = rawLine.Trim();
+                if (line.Length == 0 || line[0] == '#')
+                    continue;
+
+                var eq = line.IndexOf('=');
+                if (eq <= 0)
+                    continue;
+
+                var key = line.Substring(0, eq).Trim();
+                if (Array.IndexOf(RecognizedKeys, key) < 0)
+                    continue;
+
+                var rawValue = line.Substring(eq + 1);
+                var value = Sanitize(rawValue);
+                if (string.IsNullOrEmpty(value))
+                    continue;
+
+                result[key] = value!;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Apply the parsed <c>.env</c> <paramref name="values"/> to <paramref name="config"/>, writing
+        /// each recognized key into the matching serialized backing field — BENEATH the process-env
+        /// layer (see the class precedence note). Token routes to the active mode's token field
+        /// (Cloud → <see cref="GodotMcpConfig.CloudToken"/>, Custom → <see cref="GodotMcpConfig.CustomToken"/>),
+        /// mirroring the process-env token path.
+        ///
+        /// <para>
+        /// Mode selection (highest wins): an explicit <c>GODOT_MCP_CONNECTION_MODE</c> from the env layer
+        /// already wins via <see cref="GodotMcpConfig.ActiveMode"/> (it is not set here — env is live).
+        /// Otherwise an explicit mode in the <c>.env</c> file wins; otherwise, if the effective host
+        /// (env host &gt; file host &gt; configured host) is a loopback address, auto-select
+        /// <see cref="GodotMcpConnectionMode.Custom"/> (parity with Unity-MCP's loopback inference).
+        /// </para>
+        ///
+        /// <para>
+        /// Idempotent / no-op when <paramref name="values"/> is empty. Pure-managed; safe to call from
+        /// the unit-test host. Returns <paramref name="config"/> for fluent use.
+        /// </para>
+        /// </summary>
+        public static GodotMcpConfig Apply(GodotMcpConfig config, IReadOnlyDictionary<string, string>? values)
+        {
+            if (config == null)
+                throw new ArgumentNullException(nameof(config));
+            if (values == null || values.Count == 0)
+                return config;
+
+            // 1) Host fields. The file CLOUD_URL writes through to the cloud-base used by Cloud mode;
+            //    HOST writes the custom-mode host. (The config's live getters still let env override.)
+            if (values.TryGetValue(GodotMcpConfig.EnvHost, out var fileHost))
+                config.CustomHost = fileHost;
+
+            // GODOT_MCP_CLOUD_URL has no serialized backing field on the config (the cloud base is
+            // resolved purely from env/default by ResolveCloudBaseUrl). There is nothing to write for it
+            // at the file layer beyond informing the loopback decision below; a file CLOUD_URL only takes
+            // effect when also exported to the process env, matching the env-only cloud-base contract.
+
+            // 2) Mode: explicit file mode wins next; else loopback host → Custom. (Env mode already wins
+            //    live via ActiveMode, so we never need to special-case it here.)
+            if (values.TryGetValue(GodotMcpConfig.EnvConnectionMode, out var fileMode) &&
+                TryParseMode(fileMode, out var parsedMode))
+            {
+                config.ConnectionMode = parsedMode;
+            }
+            else if (GodotMcpConfig.IsLoopbackUrl(EffectiveHostForLoopback(values)))
+            {
+                config.ConnectionMode = GodotMcpConnectionMode.Custom;
+            }
+
+            // 3) Token: route to the active mode's token field (after mode is settled above so the route
+            //    matches what the connection will actually use). Env token still wins live.
+            if (values.TryGetValue(GodotMcpConfig.EnvToken, out var fileToken))
+            {
+                if (config.ActiveMode == GodotMcpConnectionMode.Cloud)
+                    config.CloudToken = fileToken;
+                else
+                    config.CustomToken = fileToken;
+            }
+
+            return config;
+        }
+
+        /// <summary>
+        /// The host string used for the loopback auto-mode decision: process-env host (highest), then
+        /// the <c>.env</c> file host. CLOUD_URL is excluded because a cloud base never implies Custom
+        /// mode, and the already-configured <c>CustomHost</c> is excluded too: loopback inference fires
+        /// only for an EXPLICITLY-supplied host (env or file), never the disk-baseline default — mirroring
+        /// Unity-MCP, where only an env/flag-supplied URL (not the persisted <c>LocalHost</c>) flips the
+        /// mode. Without this, the default <c>CustomHost</c> (<c>http://localhost:8080</c>, itself a
+        /// loopback) would silently flip every Cloud config to Custom.
+        /// </summary>
+        static string? EffectiveHostForLoopback(IReadOnlyDictionary<string, string> values)
+        {
+            var envHost = GodotMcpConfig.NormalizeUrl(Environment.GetEnvironmentVariable(GodotMcpConfig.EnvHost));
+            if (!string.IsNullOrEmpty(envHost))
+                return envHost;
+
+            if (values.TryGetValue(GodotMcpConfig.EnvHost, out var fileHost) && !string.IsNullOrWhiteSpace(fileHost))
+                return GodotMcpConfig.NormalizeUrl(fileHost);
+
+            return null;
+        }
+
+        /// <summary>
+        /// Parse a connection-mode string to <see cref="GodotMcpConnectionMode"/>, accepting only the
+        /// named values (<c>Cloud</c>/<c>Custom</c>, case-insensitive) and rejecting numeric strings —
+        /// identical discipline to <see cref="GodotMcpConfig.ResolveActiveMode"/>.
+        /// </summary>
+        static bool TryParseMode(string? raw, out GodotMcpConnectionMode mode)
+        {
+            mode = default;
+            var normalized = Sanitize(raw);
+            if (string.IsNullOrEmpty(normalized))
+                return false;
+            if (int.TryParse(normalized, out _))
+                return false;
+            return Enum.TryParse(normalized, ignoreCase: true, out mode);
+        }
+
+        /// <summary>Sanitize a file value identically to a process-env value (see <see cref="Parse"/>).</summary>
+        static string? Sanitize(string? raw)
+        {
+            // Strip a single pair of wrapping single quotes first (env normalizer only handles double
+            // quotes), then defer to the shared env normalizer for whitespace + double-quote trimming.
+            if (raw != null)
+            {
+                var trimmed = raw.Trim();
+                if (trimmed.Length >= 2 && trimmed[0] == '\'' && trimmed[^1] == '\'')
+                    raw = trimmed.Substring(1, trimmed.Length - 2);
+            }
+
+            return GodotMcpConfig.NormalizeEnv(raw);
+        }
+
+        static readonly IReadOnlyDictionary<string, string> Empty =
+            new Dictionary<string, string>(StringComparer.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- Add a project-root `.env` layer to the Godot-MCP connection config so a project self-configures the MCP server host/token without exporting process env vars (Godot launches from the GUI — no inherited shell exports). Parity with Unity-MCP's `EnvironmentUtils`, plus a `.env` file superset.
- Precedence (highest wins): **process env > `.env` file > serialized config field > built-in default**. The file value is written into the config's backing field beneath the live process-env getters, so env outranks file naturally.
- New `GodotMcpEnvFile` (pure-managed parser + applier: comment/blank/quoted/whitespace/unknown-key handling, token mode-routing, loopback host → Custom auto-mode for an explicitly-supplied host); editor wiring resolves `res://.env` via `ProjectSettings.GlobalizePath` (`#if TOOLS`).

## Test plan
- [x] Suite 1 build — `dotnet build Godot-MCP.sln` — 0 errors, 0 warnings.
- [x] Suite 2 unit tests — `dotnet test Godot-MCP.Tests` — 227 passed / 0 failed (23 new `.env` cases).
- [ ] Suite 3 live-editor `.env`-load smoke — pending operator (parse/apply core is unit-verified; the single `ProjectSettings.GlobalizePath` boot call compiles into the editor assembly).

Reused NuGet pins (McpPlugin 6.7.0 / ReflectorNet 5.3.1) left untouched.

Closes #24