### PR TITLE
feat(editor): AI Game Developer dock scaffold + config persistence

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -48,6 +48,10 @@
          no #if TOOLS). The editor wiring (ProjectSettings.GlobalizePath) lives in GodotMcpConnection.cs
          (#if TOOLS), verified via the headless smoke; the parse/apply core is unit-tested here. -->
     <Compile Include="..\addons\godot_mcp\Connection\GodotMcpEnvFile.cs" Link="Source\GodotMcpEnvFile.cs" />
+    <!-- Config persistence store: pure-managed System.Text.Json load/save of the serialized-config
+         precedence layer (no Godot native types, no #if TOOLS). The editor wiring that resolves the
+         user:// path lives in GodotMcpConnection.cs (#if TOOLS); the path-injectable core is unit-tested. -->
+    <Compile Include="..\addons\godot_mcp\Connection\GodotMcpConfigStore.cs" Link="Source\GodotMcpConfigStore.cs" />
     <!-- Editor-runtime NuGet-dependency resolver. Pure-BCL (System.Runtime.Loader), no #if TOOLS,
          no Godot native types — so it is unit-testable in this plain-xUnit host. -->
     <Compile Include="..\addons\godot_mcp\Connection\GodotMcpAssemblyResolver.cs" Link="Source\GodotMcpAssemblyResolver.cs" />

--- a/Godot-MCP.Tests/GodotMcpConfigStoreTests.cs
+++ b/Godot-MCP.Tests/GodotMcpConfigStoreTests.cs
@@ -1,0 +1,280 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using com.IvanMurzak.Godot.MCP.Connection;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the pure-managed config persistence layer (<see cref="GodotMcpConfigStore"/>): the
+    /// Save→Load round-trip of the serialized fields (mode/host/token/cloudToken), the missing/corrupt
+    /// file → <c>null</c> (no-throw) contract, and the documented precedence — a persisted value is used
+    /// when no env/.env override is present, but an env or <c>.env</c> override still WINS over the
+    /// persisted value (process env &gt; .env &gt; persisted config &gt; default).
+    ///
+    /// <para>
+    /// The precedence tests mutate process env vars + apply the <c>.env</c> layer, so this class joins the
+    /// shared <c>env</c> collection (no cross-class parallel env races) and restores prior env via
+    /// <see cref="EnvScope"/>. Filesystem fixtures use a unique temp dir per test, cleaned on dispose.
+    /// </para>
+    /// </summary>
+    [Collection("env")]
+    public class GodotMcpConfigStoreTests : IDisposable
+    {
+        readonly string _dir;
+
+        public GodotMcpConfigStoreTests()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "godot-mcp-store-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(_dir))
+                    Directory.Delete(_dir, recursive: true);
+            }
+            catch
+            {
+                // Best-effort cleanup; a leaked temp dir is harmless.
+            }
+        }
+
+        string PathFor(string name) => Path.Combine(_dir, name);
+
+        // --- Round-trip ---
+
+        [Fact]
+        public void SaveLoad_RoundTripsAllSerializedFields()
+        {
+            using var _ = EnvScope.ClearAll();
+
+            var path = PathFor("config.json");
+            var original = new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Custom,
+                CustomHost = "http://localhost:5300",
+                CustomToken = "custom-tok",
+                CloudToken = "cloud-tok"
+            };
+
+            GodotMcpConfigStore.Save(path, original);
+            var loaded = GodotMcpConfigStore.Load(path);
+
+            Assert.NotNull(loaded);
+            Assert.Equal(GodotMcpConnectionMode.Custom, loaded!.ConnectionMode);
+            Assert.Equal("http://localhost:5300", loaded.CustomHost);
+            Assert.Equal("custom-tok", loaded.CustomToken);
+            Assert.Equal("cloud-tok", loaded.CloudToken);
+        }
+
+        [Fact]
+        public void Save_WritesEnumByName_NotNumber()
+        {
+            using var _ = EnvScope.ClearAll();
+
+            var path = PathFor("by-name.json");
+            GodotMcpConfigStore.Save(path, new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Cloud });
+
+            var json = File.ReadAllText(path);
+            // Enum serialized by name so it matches how GODOT_MCP_CONNECTION_MODE is parsed by the env/.env layers.
+            Assert.Contains("\"connectionMode\": \"Cloud\"", json);
+        }
+
+        [Fact]
+        public void Save_CreatesMissingParentDirectory()
+        {
+            using var _ = EnvScope.ClearAll();
+
+            var path = Path.Combine(_dir, "nested", "deep", "config.json");
+            GodotMcpConfigStore.Save(path, new GodotMcpConfig { CustomHost = "http://localhost:9" });
+
+            Assert.True(File.Exists(path));
+            Assert.NotNull(GodotMcpConfigStore.Load(path));
+        }
+
+        // --- Missing / corrupt → null (no throw) ---
+
+        [Fact]
+        public void Load_MissingFile_ReturnsNull()
+        {
+            Assert.Null(GodotMcpConfigStore.Load(PathFor("does-not-exist.json")));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Load_BlankPath_ReturnsNull(string? path)
+        {
+            Assert.Null(GodotMcpConfigStore.Load(path));
+        }
+
+        [Fact]
+        public void Load_EmptyFile_ReturnsNull()
+        {
+            var path = PathFor("empty.json");
+            File.WriteAllText(path, "");
+            Assert.Null(GodotMcpConfigStore.Load(path));
+        }
+
+        [Fact]
+        public void Load_CorruptJson_ReturnsNull_NoThrow()
+        {
+            var path = PathFor("corrupt.json");
+            File.WriteAllText(path, "{ this is not valid json ::: ");
+            // Must not throw — a corrupt config is the same as "no persisted config".
+            var loaded = GodotMcpConfigStore.Load(path);
+            Assert.Null(loaded);
+        }
+
+        // --- Precedence: persisted used when no override ---
+
+        [Fact]
+        public void Precedence_PersistedValueUsed_WhenNoEnvOrFileOverride()
+        {
+            using var _ = EnvScope.ClearAll();
+
+            var path = PathFor("persisted.json");
+            GodotMcpConfigStore.Save(path, new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Custom,
+                CustomHost = "http://persisted-host:1234",
+                CustomToken = "persisted-tok"
+            });
+
+            // Boot order: seed from persisted, then apply an EMPTY .env layer (no override).
+            var target = new GodotMcpConfig();
+            GodotMcpConfigStore.ApplyPersisted(target, GodotMcpConfigStore.Load(path));
+            GodotMcpEnvFile.Apply(target, new Dictionary<string, string>());
+
+            Assert.Equal(GodotMcpConnectionMode.Custom, target.ActiveMode);
+            Assert.Equal("http://persisted-host:1234", target.Host);
+            Assert.Equal("persisted-tok", target.Token);
+        }
+
+        // --- Precedence: process env WINS over persisted ---
+
+        [Fact]
+        public void Precedence_ProcessEnv_WinsOverPersisted()
+        {
+            using var _ = EnvScope.Set(GodotMcpConfig.EnvHost, "http://env-host:9999");
+
+            var path = PathFor("persisted.json");
+            GodotMcpConfigStore.Save(path, new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Custom,
+                CustomHost = "http://persisted-host:1234"
+            });
+
+            var target = new GodotMcpConfig();
+            GodotMcpConfigStore.ApplyPersisted(target, GodotMcpConfigStore.Load(path));
+
+            // Live process-env getter shadows the persisted CustomHost field.
+            Assert.Equal(GodotMcpConnectionMode.Custom, target.ActiveMode);
+            Assert.Equal("http://env-host:9999", target.Host);
+        }
+
+        [Fact]
+        public void Precedence_ProcessEnvToken_WinsOverPersisted()
+        {
+            using var _ = EnvScope.Set(GodotMcpConfig.EnvToken, "env-tok");
+
+            var path = PathFor("persisted.json");
+            GodotMcpConfigStore.Save(path, new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Cloud,
+                CloudToken = "persisted-cloud-tok"
+            });
+
+            var target = new GodotMcpConfig();
+            GodotMcpConfigStore.ApplyPersisted(target, GodotMcpConfigStore.Load(path));
+
+            Assert.Equal("env-tok", target.Token);
+        }
+
+        // --- Precedence: .env file WINS over persisted ---
+
+        [Fact]
+        public void Precedence_EnvFile_WinsOverPersisted()
+        {
+            using var _ = EnvScope.ClearAll();
+
+            var path = PathFor("persisted.json");
+            GodotMcpConfigStore.Save(path, new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Custom,
+                CustomHost = "http://persisted-host:1234"
+            });
+
+            var target = new GodotMcpConfig();
+            GodotMcpConfigStore.ApplyPersisted(target, GodotMcpConfigStore.Load(path));
+            // .env layer overrides the persisted host.
+            GodotMcpEnvFile.Apply(target, new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [GodotMcpConfig.EnvHost] = "http://envfile-host:5555"
+            });
+
+            Assert.Equal(GodotMcpConnectionMode.Custom, target.ActiveMode);
+            Assert.Equal("http://envfile-host:5555", target.Host);
+        }
+
+        /// <summary>
+        /// Sets/clears the four <c>GODOT_MCP_*</c> process env vars and restores prior values on dispose.
+        /// Mirrors the env isolation used by the config / env-file test classes so the precedence tests
+        /// (which read env live) stay deterministic under the shared <c>env</c> collection.
+        /// </summary>
+        sealed class EnvScope : IDisposable
+        {
+            static readonly string[] Names =
+            {
+                GodotMcpConfig.EnvCloudUrl,
+                GodotMcpConfig.EnvHost,
+                GodotMcpConfig.EnvToken,
+                GodotMcpConfig.EnvConnectionMode
+            };
+
+            readonly Dictionary<string, string?> _prior = new();
+
+            EnvScope()
+            {
+                foreach (var name in Names)
+                    _prior[name] = Environment.GetEnvironmentVariable(name);
+            }
+
+            public static EnvScope ClearAll()
+            {
+                var scope = new EnvScope();
+                foreach (var name in Names)
+                    Environment.SetEnvironmentVariable(name, null);
+                return scope;
+            }
+
+            public static EnvScope Set(string name, string? value)
+            {
+                var scope = ClearAll();
+                Environment.SetEnvironmentVariable(name, value);
+                return scope;
+            }
+
+            public void Dispose()
+            {
+                foreach (var kv in _prior)
+                    Environment.SetEnvironmentVariable(kv.Key, kv.Value);
+            }
+        }
+    }
+}

--- a/addons/godot_mcp/Connection/GodotMcpConfigStore.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConfigStore.cs
@@ -1,0 +1,138 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// Pure-managed (no Godot native types) persistence helper for <see cref="GodotMcpConfig"/>. Loads
+    /// and saves the serialized config layer to a path supplied by the caller, so it is unit-testable in
+    /// the plain-xUnit <c>Godot-MCP.Tests</c> host. The editor wiring that resolves the concrete on-disk
+    /// path (<c>ProjectSettings.GlobalizePath("user://godot-mcp-config.json")</c>) lives behind
+    /// <c>#if TOOLS</c> in <see cref="GodotMcpConnection"/>; the load/save core stays here, path-injectable.
+    ///
+    /// <para>
+    /// <b>Precedence (critical).</b> The persisted file is the <em>serialized config</em> layer. The full
+    /// precedence — highest wins — remains:
+    /// <list type="number">
+    ///   <item>process environment variable (<c>GODOT_MCP_*</c>);</item>
+    ///   <item><c>.env</c> file value (<see cref="GodotMcpEnvFile"/>);</item>
+    ///   <item>persisted config (this store);</item>
+    ///   <item>built-in default.</item>
+    /// </list>
+    /// To honour that, the boot path (<see cref="GodotMcpConnection"/>) applies the PERSISTED values
+    /// FIRST — into the config's serialized backing fields — and only THEN layers the <c>.env</c> file
+    /// and (live) process-env on top. Because <see cref="GodotMcpConfig"/>'s <c>Host</c>/<c>Token</c>/
+    /// <c>ActiveMode</c> read the process env live on every access, and <see cref="GodotMcpEnvFile.Apply"/>
+    /// overwrites the same backing fields this store wrote, an explicit env/.env value always shadows the
+    /// persisted one. This store therefore NEVER reads env — it only round-trips the serialized fields.
+    /// </para>
+    /// </summary>
+    public static class GodotMcpConfigStore
+    {
+        /// <summary>
+        /// Shared serialization options. Indented for human-readability of the on-disk file; the config's
+        /// own <c>[JsonPropertyName]</c> attributes drive the property names (<c>host</c>/<c>token</c>/
+        /// <c>cloudToken</c>/<c>connectionMode</c>), and the enum is written by name (matching how the
+        /// <c>.env</c>/process-env layers parse <c>GODOT_MCP_CONNECTION_MODE</c>).
+        /// </summary>
+        static readonly JsonSerializerOptions SerializerOptions = new()
+        {
+            WriteIndented = true,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+        };
+
+        /// <summary>
+        /// Load the persisted <see cref="GodotMcpConfig"/> from <paramref name="path"/>. Returns the
+        /// deserialized config on success, or <c>null</c> when the file is missing, empty, unreadable, or
+        /// corrupt — a missing/corrupt config file is the common first-run case, NOT an error, so this
+        /// never throws. The caller treats <c>null</c> as "no persisted layer; use the default config".
+        /// </summary>
+        public static GodotMcpConfig? Load(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                return null;
+
+            string json;
+            try
+            {
+                if (!File.Exists(path))
+                    return null;
+                json = File.ReadAllText(path);
+            }
+            catch (Exception)
+            {
+                // IO / permission / encoding failure — treat as "no persisted config".
+                return null;
+            }
+
+            if (string.IsNullOrWhiteSpace(json))
+                return null;
+
+            try
+            {
+                return JsonSerializer.Deserialize<GodotMcpConfig>(json, SerializerOptions);
+            }
+            catch (JsonException)
+            {
+                // Corrupt / partially-written file — treat as "no persisted config" rather than breaking boot.
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Serialize <paramref name="config"/> to <paramref name="path"/> using the config's
+        /// <c>[JsonPropertyName]</c> serialization (host/token/cloudToken/connectionMode). Creates any
+        /// missing parent directory first (the <c>user://</c> dir normally exists, but a caller may pass an
+        /// arbitrary path). Throws nothing for the missing-parent case; genuine IO errors propagate so a
+        /// save the user explicitly triggered surfaces a failure rather than silently dropping it.
+        /// </summary>
+        public static void Save(string path, GodotMcpConfig config)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                throw new ArgumentException("Config path must be non-empty.", nameof(path));
+            if (config == null)
+                throw new ArgumentNullException(nameof(config));
+
+            var dir = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+
+            var json = JsonSerializer.Serialize(config, SerializerOptions);
+            File.WriteAllText(path, json);
+        }
+
+        /// <summary>
+        /// Apply the SERIALIZED-LAYER values from <paramref name="persisted"/> onto <paramref name="target"/>,
+        /// writing only the four serialized backing fields (<c>CustomHost</c>/<c>CustomToken</c>/
+        /// <c>CloudToken</c>/<c>ConnectionMode</c>). This is how the boot path seeds the config with the
+        /// persisted baseline BEFORE the <c>.env</c>/process-env layers are applied on top — keeping the
+        /// documented precedence intact. No-op when <paramref name="persisted"/> is <c>null</c>. Returns
+        /// <paramref name="target"/> for fluent use.
+        /// </summary>
+        public static GodotMcpConfig ApplyPersisted(GodotMcpConfig target, GodotMcpConfig? persisted)
+        {
+            if (target == null)
+                throw new ArgumentNullException(nameof(target));
+            if (persisted == null)
+                return target;
+
+            target.CustomHost = persisted.CustomHost;
+            target.CustomToken = persisted.CustomToken;
+            target.CloudToken = persisted.CloudToken;
+            target.ConnectionMode = persisted.ConnectionMode;
+
+            return target;
+        }
+    }
+}

--- a/addons/godot_mcp/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConnection.cs
@@ -46,6 +46,13 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// <summary>Plugin version reported to the server in the MCP handshake.</summary>
         public const string PluginVersion = "0.1.0";
 
+        /// <summary>
+        /// <c>user://</c> path of the persisted config file (the serialized-config precedence layer).
+        /// Resolved to an absolute path lazily in <see cref="ConfigFilePath"/> via
+        /// <see cref="ProjectSettings.GlobalizePath(string)"/>.
+        /// </summary>
+        const string ConfigUserPath = "user://godot-mcp-config.json";
+
         readonly GodotMcpConfig _config;
         IMcpPlugin? _plugin;
         Reflector? _publishedReflector;
@@ -74,11 +81,16 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 return;
             }
 
-            // Layer the project-root `.env` BENEATH the live process-env overrides the config already
-            // applies in its getters. Godot is launched from the GUI (no inherited shell exports), so a
-            // committed `res://.env` is how a project self-configures its MCP host/token. Process env
-            // still wins because GodotMcpConfig reads it live on every Host/Token/ActiveMode access —
-            // see GodotMcpEnvFile's precedence note.
+            // PRECEDENCE: process env > .env file > persisted config > built-in default.
+            // 1) Seed the SERIALIZED-config layer first (lowest layer above the built-in defaults), so the
+            //    .env and live process-env layers below override it — never the other way around.
+            ApplyPersistedConfig();
+
+            // 2) Layer the project-root `.env` BENEATH the live process-env overrides the config already
+            //    applies in its getters. Godot is launched from the GUI (no inherited shell exports), so a
+            //    committed `res://.env` is how a project self-configures its MCP host/token. Process env
+            //    still wins because GodotMcpConfig reads it live on every Host/Token/ActiveMode access —
+            //    see GodotMcpEnvFile's precedence note.
             ApplyProjectEnvFile();
 
             Reflector reflector = GodotReflectorFactory.CreateDefaultReflector();
@@ -140,6 +152,59 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
             GodotMcpEnvFile.Apply(_config, values);
             GD.Print($"[Godot-MCP] applied {values.Count} setting(s) from project .env ({envPath}).");
+        }
+
+        /// <summary>
+        /// Absolute on-disk path of the persisted config file, resolved from <see cref="ConfigUserPath"/>.
+        /// The only Godot dependency of the persistence path; the load/save core
+        /// (<see cref="GodotMcpConfigStore"/>) is pure-managed.
+        /// </summary>
+        public string ConfigFilePath => ProjectSettings.GlobalizePath(ConfigUserPath);
+
+        /// <summary>
+        /// Load the persisted config (serialized layer) from <see cref="ConfigFilePath"/> and seed the
+        /// active <see cref="_config"/>'s serialized backing fields from it — BENEATH the <c>.env</c> and
+        /// process-env layers applied afterwards. A missing/corrupt file is a silent no-op (Load returns
+        /// null). This is the persisted half of the precedence chain documented on
+        /// <see cref="GodotMcpConfigStore"/>.
+        /// </summary>
+        void ApplyPersistedConfig()
+        {
+            string path;
+            try
+            {
+                path = ConfigFilePath;
+            }
+            catch (Exception ex)
+            {
+                GD.PushWarning($"[Godot-MCP] could not resolve persisted config path: {ex.Message}");
+                return;
+            }
+
+            var persisted = GodotMcpConfigStore.Load(path);
+            if (persisted == null)
+                return;
+
+            GodotMcpConfigStore.ApplyPersisted(_config, persisted);
+            GD.Print($"[Godot-MCP] loaded persisted config ({path}).");
+        }
+
+        /// <summary>
+        /// Persist the active config's serialized layer to <see cref="ConfigFilePath"/>. Invoked by the
+        /// dock / connection when the user edits a setting (later UI tasks wire the edit callbacks). IO
+        /// failures are caught and logged so a transient save error does not break the editor session.
+        /// </summary>
+        public void Save()
+        {
+            try
+            {
+                GodotMcpConfigStore.Save(ConfigFilePath, _config);
+                GD.Print($"[Godot-MCP] saved config ({ConfigFilePath}).");
+            }
+            catch (Exception ex)
+            {
+                GD.PushError($"[Godot-MCP] failed to save config: {ex.Message}");
+            }
         }
 
         async Task ConnectAsync()

--- a/addons/godot_mcp/GodotMcpPlugin.cs
+++ b/addons/godot_mcp/GodotMcpPlugin.cs
@@ -15,6 +15,7 @@ using com.IvanMurzak.Godot.MCP.Connection;
 using com.IvanMurzak.Godot.MCP.Data;
 using com.IvanMurzak.Godot.MCP.MainThreadDispatch;
 using com.IvanMurzak.Godot.MCP.Tools;
+using com.IvanMurzak.Godot.MCP.UI;
 
 namespace com.IvanMurzak.Godot.MCP
 {
@@ -36,6 +37,7 @@ namespace com.IvanMurzak.Godot.MCP
 
         MainThreadDispatcher? _dispatcher;
         GodotMcpConnection? _connection;
+        GodotMcpDock? _dock;
 
         public override void _EnterTree()
         {
@@ -65,7 +67,30 @@ namespace com.IvanMurzak.Godot.MCP
 
             Log("[Godot-MCP] plugin loaded");
 
+            // Register the "AI Game Developer" editor dock. Defensive: a dock failure must never break
+            // plugin load or the MCP connection boot below, so it is wrapped and logged rather than thrown.
+            RegisterDock();
+
             BootMcp();
+        }
+
+        /// <summary>
+        /// Instantiate the <see cref="GodotMcpDock"/> and add it to an editor dock slot. Isolated and
+        /// defensively wrapped so a UI failure cannot take down plugin load or the connection boot — the
+        /// dock is additive scaffolding, not load-bearing for the MCP path.
+        /// </summary>
+        void RegisterDock()
+        {
+            try
+            {
+                _dock = new GodotMcpDock();
+                AddControlToDock(DockSlot.RightUl, _dock);
+            }
+            catch (System.Exception ex)
+            {
+                LogError($"[Godot-MCP] failed to register editor dock: {ex.Message}");
+                _dock = null;
+            }
         }
 
         /// <summary>
@@ -119,6 +144,14 @@ namespace com.IvanMurzak.Godot.MCP
             {
                 _connection.Dispose();
                 _connection = null;
+            }
+
+            if (_dock != null)
+            {
+                // Remove from the dock slot before freeing so Godot does not hold a dangling control ref.
+                RemoveControlFromDocks(_dock);
+                _dock.QueueFree();
+                _dock = null;
             }
 
             if (_dispatcher != null)

--- a/addons/godot_mcp/UI/GodotMcpDock.cs
+++ b/addons/godot_mcp/UI/GodotMcpDock.cs
@@ -1,0 +1,109 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.UI
+{
+    /// <summary>
+    /// Root editor-dock <see cref="Control"/> for the Godot-MCP addon — the "AI Game Developer" panel
+    /// the user docks in the Godot editor. This FOUNDATION scaffold builds only the header section (title
+    /// + addon version) and exposes a <see cref="Body"/> container plus a <see cref="Refresh"/> hook that
+    /// later tasks fill in (connection status / mode toggle, features list, footer, cloud auth). It is
+    /// registered/unregistered by <see cref="GodotMcpPlugin"/> via
+    /// <c>AddControlToDock</c>/<c>RemoveControlFromDocks</c>.
+    ///
+    /// <para>
+    /// Editor-only (<c>#if TOOLS</c>): it constructs live Godot UI <see cref="Node"/>s, so it is verified
+    /// via the headless Godot smoke (see <c>test.md</c> Suite 3), not the plain-xUnit host.
+    /// </para>
+    /// </summary>
+    [Tool]
+    public partial class GodotMcpDock : VBoxContainer
+    {
+        /// <summary>
+        /// Addon version shown in the dock header. Kept in sync MANUALLY with <c>plugin.cfg</c>'s
+        /// <c>version=</c> field (the dock does not parse <c>plugin.cfg</c> at runtime — it is not on the
+        /// project's resource path in a published install, and a const avoids the IO). This mirrors the
+        /// <c>PluginVersion</c> const on <c>GodotMcpConnection</c>; bump both when the addon version moves.
+        /// </summary>
+        public const string AddonVersion = "0.1.0";
+
+        /// <summary>The dock's display title (also its tab name in the editor dock).</summary>
+        public const string DockTitle = "AI Game Developer";
+
+        /// <summary>
+        /// Container into which later tasks insert the connection / features / footer / cloud-auth
+        /// sections. Populated empty by this foundation scaffold; exposed so those tasks add children here
+        /// rather than re-parenting the whole dock.
+        /// </summary>
+        public VBoxContainer? Body { get; private set; }
+
+        public GodotMcpDock()
+        {
+            Name = DockTitle;
+            BuildUi();
+        }
+
+        /// <summary>
+        /// Build the static dock chrome: a header (title + version) and the (currently empty)
+        /// <see cref="Body"/> placeholder. Logo is intentionally omitted in this foundation (no committed
+        /// logo asset yet) — a later task can add it to the header without changing this layout.
+        /// </summary>
+        void BuildUi()
+        {
+            SizeFlagsHorizontal = SizeFlags.ExpandFill;
+            SizeFlagsVertical = SizeFlags.ExpandFill;
+
+            // --- Header section ---
+            var header = new VBoxContainer { Name = "Header" };
+            AddChild(header);
+
+            var title = new Label
+            {
+                Name = "Title",
+                Text = DockTitle
+            };
+            header.AddChild(title);
+
+            var version = new Label
+            {
+                Name = "Version",
+                Text = $"v{AddonVersion}"
+            };
+            header.AddChild(version);
+
+            header.AddChild(new HSeparator { Name = "HeaderSeparator" });
+
+            // --- Body placeholder ---
+            // Later tasks (connection status + mode toggle, features list, footer, cloud auth) add their
+            // sections as children of Body. Left empty by this foundation scaffold on purpose.
+            Body = new VBoxContainer
+            {
+                Name = "Body",
+                SizeFlagsVertical = SizeFlags.ExpandFill
+            };
+            AddChild(Body);
+        }
+
+        /// <summary>
+        /// Re-render the dock from current state. No-op in this foundation scaffold — there is no dynamic
+        /// state to show yet. The later connection task fills this in (status line, mode indicator) and
+        /// the connection layer calls it on the editor main thread (e.g. via the main-thread dispatcher)
+        /// when the connection state changes. Safe to call any number of times.
+        /// </summary>
+        public void Refresh()
+        {
+            // Intentionally empty until a later task adds dynamic sections to Body.
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Add the `AI Game Developer` editor dock (`GodotMcpDock`, `#if TOOLS`): header (title + addon-version const) + empty `Body` container + `Refresh()` hook. Registered in `RightUl` slot in `_EnterTree` (defensively wrapped), removed+freed in `_ExitTree`. Additive — the existing `BootMcp()` connection path is unchanged.
- Add `GodotMcpConfigStore`: pure-managed, path-injectable `Load`/`Save` of the serialized-config layer (`System.Text.Json`; host/token/cloudToken/connectionMode). Missing/corrupt file on `Load` returns `null` (no throw).
- Wire persistence into `GodotMcpConnection` boot: load `user://godot-mcp-config.json` FIRST (serialized baseline), THEN the `.env` layer, with live process-env winning. Precedence stays: **process env > .env > persisted config > built-in default**. Adds a `Save()` for later UI edit callbacks.
- This is the FOUNDATION — connection controls, mode toggle, features, footer, and cloud-auth are deferred to separate tasks.

## Test plan
- [x] Suite 1 — `dotnet build Godot-MCP.sln` (CI parity): 0 errors, 0 warnings.
- [x] Suite 2 — `dotnet test`: 240/240 pass (13 new store tests: round-trip, missing/corrupt→null, env/.env-wins-over-persisted precedence).
- [x] Suite 3 — headless Godot 4.5.1 smoke: `[Godot-MCP] plugin loaded`, dock registers/unregisters cleanly with no errors, connection boot intact, no `FileNotFoundException`.

Closes #26