### PR TITLE
feat(connection): editor dock connection panel (status, mode, URL, timeline)

### DIFF
--- a/Godot-MCP.Tests/ConnectionPanelViewTests.cs
+++ b/Godot-MCP.Tests/ConnectionPanelViewTests.cs
@@ -1,0 +1,204 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.IO;
+using com.IvanMurzak.Godot.MCP.Connection;
+using com.IvanMurzak.Godot.MCP.UI;
+using Microsoft.AspNetCore.SignalR.Client;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the pure-managed presentation logic of the connection panel (<see cref="ConnectionPanelView"/>):
+    /// the <see cref="HubConnectionState"/> + <c>keepConnected</c> → <see cref="ConnectionStatus"/> reduction,
+    /// the label/button-text/disabled/colour mappings, and the server-URL validation rule. The editor
+    /// Control wiring (<c>ConnectionPanel.cs</c>, <c>#if TOOLS</c>) instantiates live Godot nodes and is
+    /// verified via the headless Godot smoke (test.md Suite 3) — NOT here.
+    ///
+    /// <para>
+    /// Also covers the mode-toggle persistence round-trip via <see cref="GodotMcpConfigStore"/>, which is
+    /// exactly what the panel's mode selector triggers (write <c>ConnectionMode</c> → <c>Save()</c>).
+    /// </para>
+    /// </summary>
+    public class ConnectionPanelViewTests
+    {
+        // --- Reduce: HubConnectionState + keepConnected -> ConnectionStatus ---
+
+        [Fact]
+        public void Reduce_Connected_AndKeepConnected_IsConnected()
+        {
+            Assert.Equal(ConnectionStatus.Connected,
+                ConnectionPanelView.Reduce(HubConnectionState.Connected, keepConnected: true));
+        }
+
+        [Fact]
+        public void Reduce_Connected_ButNotKeepConnected_IsDisconnected()
+        {
+            // KeepConnected off means the user asked to disconnect; even a momentarily-Connected hub
+            // should read as Disconnected (matches the Unity reference's GetConnectionStatusClass).
+            Assert.Equal(ConnectionStatus.Disconnected,
+                ConnectionPanelView.Reduce(HubConnectionState.Connected, keepConnected: false));
+        }
+
+        [Theory]
+        [InlineData(HubConnectionState.Connecting)]
+        [InlineData(HubConnectionState.Reconnecting)]
+        [InlineData(HubConnectionState.Disconnected)]
+        public void Reduce_NotConnected_WhileKeepConnected_IsConnecting(HubConnectionState state)
+        {
+            // KeepConnected on + not yet Connected = the client is trying/retrying => Connecting.
+            Assert.Equal(ConnectionStatus.Connecting,
+                ConnectionPanelView.Reduce(state, keepConnected: true));
+        }
+
+        [Theory]
+        [InlineData(HubConnectionState.Connecting)]
+        [InlineData(HubConnectionState.Reconnecting)]
+        [InlineData(HubConnectionState.Disconnected)]
+        public void Reduce_NotConnected_NotKeepConnected_IsDisconnected(HubConnectionState state)
+        {
+            Assert.Equal(ConnectionStatus.Disconnected,
+                ConnectionPanelView.Reduce(state, keepConnected: false));
+        }
+
+        // --- StatusLabel ---
+
+        [Theory]
+        [InlineData(ConnectionStatus.Connected, "Godot: Connected")]
+        [InlineData(ConnectionStatus.Connecting, "Godot: Connecting…")]
+        [InlineData(ConnectionStatus.Disconnected, "Godot: Disconnected")]
+        public void StatusLabel_MapsEachStatus(ConnectionStatus status, string expected)
+        {
+            Assert.Equal(expected, ConnectionPanelView.StatusLabel(status));
+        }
+
+        // --- ButtonText + ButtonDisabled ---
+
+        [Theory]
+        [InlineData(ConnectionStatus.Connected, ConnectionPanelView.ButtonTextDisconnect)]
+        [InlineData(ConnectionStatus.Connecting, ConnectionPanelView.ButtonTextConnecting)]
+        [InlineData(ConnectionStatus.Disconnected, ConnectionPanelView.ButtonTextConnect)]
+        public void ButtonText_MapsEachStatus(ConnectionStatus status, string expected)
+        {
+            Assert.Equal(expected, ConnectionPanelView.ButtonText(status));
+        }
+
+        [Theory]
+        [InlineData(ConnectionStatus.Connecting, true)]
+        [InlineData(ConnectionStatus.Connected, false)]
+        [InlineData(ConnectionStatus.Disconnected, false)]
+        public void ButtonDisabled_OnlyWhileConnecting(ConnectionStatus status, bool expectedDisabled)
+        {
+            Assert.Equal(expectedDisabled, ConnectionPanelView.ButtonDisabled(status));
+        }
+
+        // --- StatusColor ---
+
+        [Fact]
+        public void StatusColor_DistinctPerStatus()
+        {
+            var connected = ConnectionPanelView.StatusColor(ConnectionStatus.Connected);
+            var connecting = ConnectionPanelView.StatusColor(ConnectionStatus.Connecting);
+            var disconnected = ConnectionPanelView.StatusColor(ConnectionStatus.Disconnected);
+
+            Assert.Equal(ConnectionPanelView.ColorConnected, connected);
+            Assert.Equal(ConnectionPanelView.ColorConnecting, connecting);
+            Assert.Equal(ConnectionPanelView.ColorDisconnected, disconnected);
+
+            // The three are visually distinct (green / amber / gray), not accidentally equal.
+            Assert.NotEqual(connected, connecting);
+            Assert.NotEqual(connecting, disconnected);
+            Assert.NotEqual(connected, disconnected);
+        }
+
+        // --- IsValidServerUrl ---
+
+        [Theory]
+        [InlineData("http://localhost:8080")]
+        [InlineData("https://ai-game.dev")]
+        [InlineData("http://127.0.0.1:5300")]
+        [InlineData("  http://localhost:9000  ")]   // surrounding whitespace trimmed
+        [InlineData("\"https://example.com\"")]      // wrapping quotes trimmed
+        [InlineData("https://example.com/")]          // trailing slash tolerated
+        public void IsValidServerUrl_AcceptsAbsoluteHttpUrls(string url)
+        {
+            Assert.True(ConnectionPanelView.IsValidServerUrl(url));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("localhost:8080")]   // no scheme
+        [InlineData("ftp://example.com")] // wrong scheme
+        [InlineData("not a url")]
+        [InlineData("/relative/path")]
+        public void IsValidServerUrl_RejectsNonHttpOrRelative(string? url)
+        {
+            Assert.False(ConnectionPanelView.IsValidServerUrl(url));
+        }
+
+        // --- Mode-toggle persistence round-trip (what the panel's mode selector triggers) ---
+
+        [Fact]
+        public void ModeToggle_PersistsAndReloads()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "godot-mcp-panel-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, "godot-mcp-config.json");
+            try
+            {
+                // Default config is Cloud; the panel flips it to Custom + saves.
+                var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Cloud };
+                config.ConnectionMode = GodotMcpConnectionMode.Custom;
+                GodotMcpConfigStore.Save(path, config);
+
+                var reloaded = GodotMcpConfigStore.Load(path);
+                Assert.NotNull(reloaded);
+                Assert.Equal(GodotMcpConnectionMode.Custom, reloaded!.ConnectionMode);
+
+                // And back to Cloud.
+                reloaded.ConnectionMode = GodotMcpConnectionMode.Cloud;
+                GodotMcpConfigStore.Save(path, reloaded);
+                var reloaded2 = GodotMcpConfigStore.Load(path);
+                Assert.NotNull(reloaded2);
+                Assert.Equal(GodotMcpConnectionMode.Cloud, reloaded2!.ConnectionMode);
+            }
+            finally
+            {
+                try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ }
+            }
+        }
+
+        [Fact]
+        public void CustomHost_PersistsAndReloads()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "godot-mcp-panel-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, "godot-mcp-config.json");
+            try
+            {
+                // The panel writes CustomHost on a valid URL submit, then Save()s.
+                var config = new GodotMcpConfig { CustomHost = "http://localhost:5300" };
+                GodotMcpConfigStore.Save(path, config);
+
+                var reloaded = GodotMcpConfigStore.Load(path);
+                Assert.NotNull(reloaded);
+                Assert.Equal("http://localhost:5300", reloaded!.CustomHost);
+            }
+            finally
+            {
+                try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ }
+            }
+        }
+    }
+}

--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -96,6 +96,12 @@
     <Compile Include="..\addons\godot_mcp\Data\LogEntry.cs" Link="Source\LogEntry.cs" />
     <Compile Include="..\addons\godot_mcp\Data\SelectionData.cs" Link="Source\SelectionData.cs" />
     <Compile Include="..\addons\godot_mcp\Tools\GodotLogCollector.cs" Link="Source\GodotLogCollector.cs" />
+    <!-- Connection-panel presentation logic — pure-managed (no Godot native types, no #if TOOLS): the
+         HubConnectionState+keepConnected → ConnectionStatus reduction, label/button/colour mappings, and
+         server-URL validation. The editor Control wiring (ConnectionPanel.cs) is #if TOOLS and verified
+         via the headless Godot smoke (test.md Suite 3); the view logic is unit-tested here. The SignalR
+         HubConnectionState enum it switches on is provided transitively by com.IvanMurzak.McpPlugin. -->
+    <Compile Include="..\addons\godot_mcp\UI\ConnectionPanelView.cs" Link="Source\ConnectionPanelView.cs" />
   </ItemGroup>
 
 </Project>

--- a/addons/godot_mcp/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConnection.cs
@@ -12,10 +12,14 @@
 using System;
 using System.Reflection;
 using System.Threading.Tasks;
+using com.IvanMurzak.Godot.MCP.MainThreadDispatch;
 using com.IvanMurzak.Godot.MCP.Reflection;
+using com.IvanMurzak.Godot.MCP.UI;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet;
 using Godot;
+using Microsoft.AspNetCore.SignalR.Client;
+using R3;
 using McpVersion = com.IvanMurzak.McpPlugin.Common.Version;
 
 namespace com.IvanMurzak.Godot.MCP.Connection
@@ -57,11 +61,39 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         IMcpPlugin? _plugin;
         Reflector? _publishedReflector;
 
+        /// <summary>
+        /// Live subscription to the reused client's <see cref="IConnection.ConnectionState"/> +
+        /// <see cref="IConnection.KeepConnected"/> reactive properties. Re-created on every
+        /// <see cref="Start"/> (a new plugin instance exposes new properties) and disposed on
+        /// <see cref="Dispose"/>. <see cref="SerialDisposable"/> auto-disposes the prior subscription when
+        /// reassigned, so a reconnect never leaks a stale subscription.
+        /// </summary>
+        readonly SerialDisposable _stateSubscription = new();
+
+        /// <summary>Last reduced status, cached so <see cref="ConnectionStatus"/> is readable without a live plugin.</summary>
+        ConnectionStatus _status = ConnectionStatus.Disconnected;
+
         /// <summary>The active config (resolved Host/Token/mode are read live off this).</summary>
         public GodotMcpConfig Config => _config;
 
         /// <summary>The built plugin instance, or null before <see cref="Start"/> / after <see cref="Dispose"/>.</summary>
         public IMcpPlugin? Plugin => _plugin;
+
+        /// <summary>
+        /// The current simplified connection status (Disconnected / Connecting / Connected), reduced from
+        /// the reused client's <see cref="HubConnectionState"/> + <c>KeepConnected</c> via
+        /// <see cref="ConnectionPanelView.Reduce"/>. The dock reads this for its initial render and is
+        /// pushed subsequent changes via <see cref="ConnectionStatusChanged"/>.
+        /// </summary>
+        public ConnectionStatus ConnectionStatus => _status;
+
+        /// <summary>
+        /// Raised whenever <see cref="ConnectionStatus"/> changes. ALWAYS marshalled onto the Godot editor
+        /// main thread (the McpPlugin client fires its R3 properties from background SignalR threads), so a
+        /// UI handler can touch <see cref="Godot.Control"/>s directly without re-dispatching. Only fired on
+        /// an actual change (de-duplicated) to avoid redundant UI churn.
+        /// </summary>
+        public event Action<ConnectionStatus>? ConnectionStatusChanged;
 
         public GodotMcpConnection(GodotMcpConfig? config = null)
         {
@@ -118,12 +150,122 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
             _plugin = builder.Build(reflector);
 
+            SubscribeToConnectionState(_plugin);
+
             var mode = _config.ActiveMode;
             var host = _config.Host;
             GD.Print($"[Godot-MCP] connecting (mode={mode}, host={host}) ...");
 
             // Fire-and-forget connect; KeepConnected drives reconnection in the client.
             _ = ConnectAsync();
+        }
+
+        /// <summary>
+        /// Subscribe to the reused client's <see cref="IConnection.ConnectionState"/> +
+        /// <see cref="IConnection.KeepConnected"/> reactive properties and push the reduced
+        /// <see cref="ConnectionStatus"/> to <see cref="ConnectionStatusChanged"/> on the editor main
+        /// thread. Mirrors the Unity reference's <c>SubscribeToConnectionState</c> (CombineLatest of the
+        /// two properties), but marshals via the Godot main-thread dispatcher instead of a Unity
+        /// synchronization context. The subscription is stored in a <see cref="SerialDisposable"/> so a
+        /// later <see cref="Start"/> (new plugin) replaces it cleanly.
+        /// </summary>
+        void SubscribeToConnectionState(IMcpPlugin plugin)
+        {
+            // Seed from current values so the dock's first render is correct even before any change fires.
+            PublishStatus(ConnectionPanelView.Reduce(plugin.ConnectionState.CurrentValue, plugin.KeepConnected.CurrentValue));
+
+            _stateSubscription.Disposable = Observable
+                .CombineLatest(
+                    plugin.ConnectionState,
+                    plugin.KeepConnected,
+                    (state, keepConnected) => ConnectionPanelView.Reduce(state, keepConnected))
+                .Subscribe(status =>
+                {
+                    // R3 fires off the SignalR thread; hop to the editor main thread before raising the
+                    // event so subscribers (the dock) can touch Control nodes directly. A missing
+                    // dispatcher (between editor reloads) degrades to a direct call rather than throwing.
+                    if (MainThreadDispatcher.Instance != null && !MainThreadDispatcher.IsMainThread)
+                        MainThreadDispatcher.Enqueue(() => PublishStatus(status));
+                    else
+                        PublishStatus(status);
+                });
+        }
+
+        /// <summary>
+        /// Update the cached <see cref="ConnectionStatus"/> and raise <see cref="ConnectionStatusChanged"/>
+        /// when it actually changed. De-duplicated so identical consecutive states (e.g. the seed plus an
+        /// immediate first push) do not double-fire the UI. MUST be called on the editor main thread.
+        /// </summary>
+        void PublishStatus(ConnectionStatus status)
+        {
+            if (_status == status)
+                return;
+            _status = status;
+            ConnectionStatusChanged?.Invoke(status);
+        }
+
+        /// <summary>
+        /// (Re)connect with the CURRENT <see cref="GodotMcpConfig"/> (mode/host/token). If a plugin
+        /// already exists it is reused — the reused client reconnects via <c>KeepConnected</c>; otherwise
+        /// this builds a fresh plugin via <see cref="Start"/>. The boot path calls <see cref="Start"/>
+        /// directly; the dock's Connect button calls this. Idempotent and safe to call repeatedly.
+        /// </summary>
+        public void Connect()
+        {
+            // Re-arm the intent to stay connected (the Disconnect button clears it) BEFORE (re)connecting.
+            _config.KeepConnected = true;
+
+            if (_plugin == null)
+            {
+                Start();
+                return;
+            }
+
+            _ = ConnectAsync();
+        }
+
+        /// <summary>
+        /// Disconnect from the MCP server and stop auto-reconnect. Clears <c>KeepConnected</c> so the
+        /// reused client does not immediately reconnect, then asks it to disconnect. The plugin instance
+        /// is kept (not disposed) so a subsequent <see cref="Connect"/> can reuse it; full teardown happens
+        /// in <see cref="Dispose"/> at plugin unload.
+        /// </summary>
+        public void Disconnect()
+        {
+            _config.KeepConnected = false;
+
+            var plugin = _plugin;
+            if (plugin == null)
+                return;
+
+            _ = DisconnectAsync(plugin);
+        }
+
+        /// <summary>
+        /// Apply the current config (mode / host / token) by rebuilding the connection from scratch:
+        /// dispose the existing plugin and <see cref="Start"/> a fresh one. Used by the dock when the user
+        /// changes connection mode or the server URL — those alter the resolved <see cref="GodotMcpConfig.Host"/>,
+        /// and the cleanest way to re-point the SignalR client at a new host is a fresh build (mirrors the
+        /// Unity reference's dispose-then-rebuild on host/mode change). Re-arms <c>KeepConnected</c>.
+        /// </summary>
+        public void Reconnect()
+        {
+            _config.KeepConnected = true;
+            DisposePlugin();
+            Start();
+        }
+
+        async Task DisconnectAsync(IMcpPlugin plugin)
+        {
+            try
+            {
+                await plugin.Disconnect();
+                GD.Print("[Godot-MCP] disconnected.");
+            }
+            catch (Exception ex)
+            {
+                GD.PushError($"[Godot-MCP] disconnect failed: {ex.Message}");
+            }
         }
 
         /// <summary>
@@ -229,6 +371,22 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
         public void Dispose()
         {
+            _stateSubscription.Dispose();
+            DisposePlugin();
+        }
+
+        /// <summary>
+        /// Tear down the current plugin instance (and the ambient reflector it published) without
+        /// disposing the long-lived <see cref="_stateSubscription"/> holder — so <see cref="Reconnect"/>
+        /// can rebuild a fresh plugin. The <see cref="SerialDisposable"/>'s CURRENT inner subscription is
+        /// released here (the next <see cref="Start"/> reassigns it); the holder itself is only disposed in
+        /// <see cref="Dispose"/>.
+        /// </summary>
+        void DisposePlugin()
+        {
+            // Release the live state subscription's inner disposable (keeps the SerialDisposable reusable).
+            _stateSubscription.Disposable = null;
+
             // Clear the ambient reflector if it is the one we published, so a stale instance does not
             // outlive the connection that owned it.
             if (ReferenceEquals(GodotMcpReflector.Current, _publishedReflector))

--- a/addons/godot_mcp/GodotMcpPlugin.cs
+++ b/addons/godot_mcp/GodotMcpPlugin.cs
@@ -67,23 +67,22 @@ namespace com.IvanMurzak.Godot.MCP
 
             Log("[Godot-MCP] plugin loaded");
 
-            // Register the "AI Game Developer" editor dock. Defensive: a dock failure must never break
-            // plugin load or the MCP connection boot below, so it is wrapped and logged rather than thrown.
-            RegisterDock();
-
+            // Build the connection, register the dock (wired to it), and boot the MCP connection. All three
+            // touch NuGet-dependency types (McpPlugin / ReflectorNet), so they live in a single non-inlined
+            // method invoked AFTER the assembly resolver is installed above — see BootMcp's remarks.
             BootMcp();
         }
 
         /// <summary>
-        /// Instantiate the <see cref="GodotMcpDock"/> and add it to an editor dock slot. Isolated and
-        /// defensively wrapped so a UI failure cannot take down plugin load or the connection boot — the
-        /// dock is additive scaffolding, not load-bearing for the MCP path.
+        /// Instantiate the <see cref="GodotMcpDock"/> (wired to <paramref name="connection"/>) and add it to
+        /// an editor dock slot. Isolated and defensively wrapped so a UI failure cannot take down plugin
+        /// load or the connection boot — the dock is additive scaffolding, not load-bearing for the MCP path.
         /// </summary>
-        void RegisterDock()
+        void RegisterDock(GodotMcpConnection? connection)
         {
             try
             {
-                _dock = new GodotMcpDock();
+                _dock = new GodotMcpDock(connection);
                 AddControlToDock(DockSlot.RightUl, _dock);
             }
             catch (System.Exception ex)
@@ -118,11 +117,13 @@ namespace com.IvanMurzak.Godot.MCP
         }
 
         /// <summary>
-        /// Boot the MCP connection. Isolated in its own non-inlined method so the JIT does not resolve
-        /// the NuGet-dependency types it references until AFTER <see cref="GodotMcpAssemblyResolver"/>
-        /// has been installed by <see cref="_EnterTree"/>. (Type references are resolved when a method
-        /// is JIT-compiled; keeping this out of <c>_EnterTree</c> guarantees the resolver wins the race.)
-        /// Failures here must not break plugin load — the catch keeps the editor usable.
+        /// Build the connection, register the dock wired to it, and boot the MCP connection. Isolated in
+        /// its own non-inlined method so the JIT does not resolve the NuGet-dependency types it (and the
+        /// dock's <c>ConnectionPanel</c>) reference until AFTER <see cref="GodotMcpAssemblyResolver"/> has
+        /// been installed by <see cref="_EnterTree"/>. (Type references are resolved when a method is
+        /// JIT-compiled; keeping this out of <c>_EnterTree</c> guarantees the resolver wins the race.)
+        /// Dock registration runs even if the connection construction throws, so a UI failure and a
+        /// connection failure are independent — each is caught and logged, keeping the editor usable.
         /// </summary>
         [MethodImpl(MethodImplOptions.NoInlining)]
         void BootMcp()
@@ -130,6 +131,21 @@ namespace com.IvanMurzak.Godot.MCP
             try
             {
                 _connection = new GodotMcpConnection();
+            }
+            catch (System.Exception ex)
+            {
+                LogError($"[Godot-MCP] failed to create MCP connection: {ex.Message}");
+                _connection = null;
+            }
+
+            // Register the dock (wired to the connection if one was built; header-only otherwise).
+            RegisterDock(_connection);
+
+            if (_connection == null)
+                return;
+
+            try
+            {
                 _connection.Start();
             }
             catch (System.Exception ex)

--- a/addons/godot_mcp/UI/ConnectionPanel.cs
+++ b/addons/godot_mcp/UI/ConnectionPanel.cs
@@ -1,0 +1,314 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using com.IvanMurzak.Godot.MCP.Connection;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.UI
+{
+    /// <summary>
+    /// The connection section of the Godot-MCP editor dock — the Godot <see cref="Control"/> analog of
+    /// Unity-MCP's <c>MainWindowEditor.Connection</c>. A <see cref="VBoxContainer"/> the
+    /// <see cref="GodotMcpDock"/> drops into its Body, wired to a <see cref="GodotMcpConnection"/>. It
+    /// renders, top to bottom:
+    /// <list type="bullet">
+    ///   <item>A status row — a coloured dot + a "Godot: …" label, live from
+    ///   <see cref="GodotMcpConnection.ConnectionStatus"/>.</item>
+    ///   <item>A Connect/Disconnect button whose text + enabled-state reflect the status.</item>
+    ///   <item>A Custom|Cloud mode selector that persists the choice and reconnects.</item>
+    ///   <item>A Server URL field (Custom mode only) bound to the custom host, with validation.</item>
+    ///   <item>A simplified Godot → MCP server → AI agent timeline of status dots.</item>
+    /// </list>
+    ///
+    /// <para>
+    /// Editor-only (<c>#if TOOLS</c>): it builds live Godot UI <see cref="Node"/>s, so it is verified via
+    /// the headless Godot smoke (<c>test.md</c> Suite 3), not the plain-xUnit host. ALL presentation
+    /// decisions (status reduction, label/button text, dot colour, URL validation) live in the
+    /// pure-managed <see cref="ConnectionPanelView"/> so they ARE unit-tested.
+    /// </para>
+    /// </summary>
+    [Tool]
+    public partial class ConnectionPanel : VBoxContainer
+    {
+        readonly GodotMcpConnection _connection;
+
+        // Status row.
+        ColorRect _statusDot = null!;
+        Label _statusLabel = null!;
+        Button _connectButton = null!;
+
+        // Mode selector + custom-host row.
+        OptionButton _modeSelector = null!;
+        VBoxContainer _customHostRow = null!;
+        LineEdit _hostField = null!;
+        Label _cloudNote = null!;
+        Label _overrideNote = null!;
+
+        // Timeline dots.
+        ColorRect _timelineGodotDot = null!;
+        ColorRect _timelineServerDot = null!;
+        ColorRect _timelineAgentDot = null!;
+
+        // Index of the two OptionButton entries — kept stable so a selection maps back to a mode.
+        const int ModeIdCustom = 0;
+        const int ModeIdCloud = 1;
+
+        public ConnectionPanel(GodotMcpConnection connection)
+        {
+            _connection = connection;
+            Name = "ConnectionPanel";
+            BuildUi();
+
+            // Subscribe AFTER the UI exists so the first push has controls to write to. The connection
+            // marshals this event onto the editor main thread, so the handler may touch Controls directly.
+            _connection.ConnectionStatusChanged += OnConnectionStatusChanged;
+
+            // Render the current state immediately (the event only fires on CHANGE).
+            ApplyStatus(_connection.ConnectionStatus);
+            ApplyModeVisibility(_connection.Config.ActiveMode);
+        }
+
+        void BuildUi()
+        {
+            SizeFlagsHorizontal = SizeFlags.ExpandFill;
+            AddThemeConstantOverride("separation", 6);
+
+            // --- Status row: dot + label ---
+            var statusRow = new HBoxContainer { Name = "StatusRow" };
+            AddChild(statusRow);
+
+            _statusDot = MakeDot("StatusDot");
+            statusRow.AddChild(_statusDot);
+
+            _statusLabel = new Label { Name = "StatusLabel" };
+            statusRow.AddChild(_statusLabel);
+
+            // --- Connect/Disconnect button ---
+            _connectButton = new Button { Name = "ConnectButton" };
+            _connectButton.Pressed += OnConnectButtonPressed;
+            AddChild(_connectButton);
+
+            // --- Mode selector ---
+            var modeRow = new HBoxContainer { Name = "ModeRow" };
+            AddChild(modeRow);
+
+            modeRow.AddChild(new Label { Name = "ModeLabel", Text = "Mode" });
+
+            _modeSelector = new OptionButton { Name = "ModeSelector" };
+            _modeSelector.AddItem("Custom", ModeIdCustom);
+            _modeSelector.AddItem("Cloud", ModeIdCloud);
+            _modeSelector.ItemSelected += OnModeSelected;
+            modeRow.AddChild(_modeSelector);
+
+            // --- Custom-mode server-URL row (shown only in Custom mode) ---
+            _customHostRow = new VBoxContainer { Name = "CustomHostRow" };
+            AddChild(_customHostRow);
+
+            _customHostRow.AddChild(new Label { Name = "HostLabel", Text = "Server URL" });
+
+            _hostField = new LineEdit
+            {
+                Name = "HostField",
+                PlaceholderText = GodotMcpConfig.DefaultCustomHost,
+                SizeFlagsHorizontal = SizeFlags.ExpandFill
+            };
+            // Commit on Enter and on focus-out (mirrors the Unity reference's FocusOut commit).
+            _hostField.TextSubmitted += OnHostSubmitted;
+            _hostField.FocusExited += OnHostFocusExited;
+            _customHostRow.AddChild(_hostField);
+
+            // --- Cloud-mode note (shown only in Cloud mode; cloud auth is a later task) ---
+            _cloudNote = new Label
+            {
+                Name = "CloudNote",
+                Text = "Cloud auth is configured separately.",
+                AutowrapMode = TextServer.AutowrapMode.WordSmart
+            };
+            AddChild(_cloudNote);
+
+            // --- Env/.env override note (shown when a process env / .env value forces mode or host) ---
+            _overrideNote = new Label
+            {
+                Name = "OverrideNote",
+                Text = "Overridden by environment (GODOT_MCP_*) — UI changes won't take effect.",
+                AutowrapMode = TextServer.AutowrapMode.WordSmart
+            };
+            _overrideNote.AddThemeColorOverride("font_color", new Color(0.92f, 0.74f, 0.20f));
+            AddChild(_overrideNote);
+
+            AddChild(new HSeparator { Name = "TimelineSeparator" });
+
+            // --- Simplified timeline: Godot -> MCP server -> AI agent ---
+            var timeline = new VBoxContainer { Name = "Timeline" };
+            AddChild(timeline);
+
+            _timelineGodotDot = MakeDot("TimelineGodotDot");
+            timeline.AddChild(MakeTimelineRow(_timelineGodotDot, "Godot"));
+
+            _timelineServerDot = MakeDot("TimelineServerDot");
+            timeline.AddChild(MakeTimelineRow(_timelineServerDot, "MCP server"));
+
+            _timelineAgentDot = MakeDot("TimelineAgentDot");
+            timeline.AddChild(MakeTimelineRow(_timelineAgentDot, "AI agent (connects on demand)"));
+
+            // Sync the mode selector to the current config.
+            SyncModeSelector(_connection.Config.ActiveMode);
+        }
+
+        static ColorRect MakeDot(string name) => new ColorRect
+        {
+            Name = name,
+            CustomMinimumSize = new Vector2(10, 10),
+            SizeFlagsVertical = SizeFlags.ShrinkCenter,
+            Color = ToColor(ConnectionPanelView.ColorDisconnected)
+        };
+
+        static HBoxContainer MakeTimelineRow(ColorRect dot, string label)
+        {
+            var row = new HBoxContainer();
+            row.AddChild(dot);
+            row.AddChild(new Label { Text = label });
+            return row;
+        }
+
+        static Color ToColor((float R, float G, float B) rgb) => new Color(rgb.R, rgb.G, rgb.B);
+
+        void OnConnectionStatusChanged(ConnectionStatus status) => ApplyStatus(status);
+
+        /// <summary>
+        /// Push a <see cref="ConnectionStatus"/> into the status row, button, and the Godot + MCP-server
+        /// timeline dots. All derived presentation comes from <see cref="ConnectionPanelView"/>. The
+        /// "Godot" and "MCP server" timeline dots track the same hub state (a single connection); the
+        /// "AI agent" dot is informational and stays neutral (the cloud-auth / agent-info task fills it in).
+        /// </summary>
+        void ApplyStatus(ConnectionStatus status)
+        {
+            var color = ToColor(ConnectionPanelView.StatusColor(status));
+
+            _statusDot.Color = color;
+            _statusLabel.Text = ConnectionPanelView.StatusLabel(status);
+
+            _connectButton.Text = ConnectionPanelView.ButtonText(status);
+            _connectButton.Disabled = ConnectionPanelView.ButtonDisabled(status);
+
+            _timelineGodotDot.Color = color;
+            _timelineServerDot.Color = color;
+        }
+
+        void OnConnectButtonPressed()
+        {
+            if (_connection.ConnectionStatus == ConnectionStatus.Connected)
+                _connection.Disconnect();
+            else
+                _connection.Connect();
+        }
+
+        void OnModeSelected(long index)
+        {
+            var mode = index == ModeIdCloud
+                ? GodotMcpConnectionMode.Cloud
+                : GodotMcpConnectionMode.Custom;
+
+            if (_connection.Config.ConnectionMode == mode)
+            {
+                // No persisted change (e.g. an env override is forcing the active mode); just re-render.
+                ApplyModeVisibility(_connection.Config.ActiveMode);
+                return;
+            }
+
+            _connection.Config.ConnectionMode = mode;
+            _connection.Save();
+            ApplyModeVisibility(_connection.Config.ActiveMode);
+            _connection.Reconnect();
+        }
+
+        void OnHostSubmitted(string text) => CommitHost(text);
+
+        void OnHostFocusExited() => CommitHost(_hostField.Text);
+
+        /// <summary>
+        /// Validate + persist a Custom-mode server URL, then reconnect. Invalid input (not an absolute
+        /// http/https URL) is rejected: the field is reverted to the configured host and no write/reconnect
+        /// happens. A no-op edit (unchanged value) is ignored so a focus-out without a change does not
+        /// needlessly tear down a live connection.
+        /// </summary>
+        void CommitHost(string text)
+        {
+            if (!ConnectionPanelView.IsValidServerUrl(text))
+            {
+                // Reject: restore the displayed value to the current configured host.
+                _hostField.Text = _connection.Config.CustomHost;
+                GD.PushWarning($"[Godot-MCP] ignored invalid server URL: '{text}' (must be an absolute http/https URL).");
+                return;
+            }
+
+            var normalized = text.Trim().Trim('"').TrimEnd('/');
+            if (_connection.Config.CustomHost == normalized)
+                return;
+
+            _connection.Config.CustomHost = normalized;
+            _connection.Save();
+
+            // Only a Custom-mode host change warrants a reconnect; in Cloud mode the field is hidden.
+            if (_connection.Config.ActiveMode == GodotMcpConnectionMode.Custom)
+                _connection.Reconnect();
+        }
+
+        /// <summary>
+        /// Show the Server-URL row only in Custom mode and the cloud note only in Cloud mode. Also surfaces
+        /// the env/.env override note when a process env / <c>.env</c> value is forcing the active mode away
+        /// from the persisted <see cref="GodotMcpConfig.ConnectionMode"/> (so the user understands why a UI
+        /// change may not take effect). Reflects the EFFECTIVE host in the field (env override shown).
+        /// </summary>
+        void ApplyModeVisibility(GodotMcpConnectionMode activeMode)
+        {
+            var isCustom = activeMode == GodotMcpConnectionMode.Custom;
+            _customHostRow.Visible = isCustom;
+            _cloudNote.Visible = !isCustom;
+
+            if (isCustom)
+            {
+                // Show the EFFECTIVE custom host (env GODOT_MCP_HOST wins over the persisted value).
+                _hostField.Text = _connection.Config.ResolveCustomHost();
+            }
+
+            // The active mode differs from the persisted mode only when an env/.env override forced it.
+            var overridden = activeMode != _connection.Config.ConnectionMode;
+            _overrideNote.Visible = overridden;
+            // When overridden, the persisted-mode UI cannot change the effective mode: disable the field.
+            _hostField.Editable = !overridden;
+            _modeSelector.Disabled = overridden;
+        }
+
+        void SyncModeSelector(GodotMcpConnectionMode activeMode)
+        {
+            _modeSelector.Selected = activeMode == GodotMcpConnectionMode.Cloud ? ModeIdCloud : ModeIdCustom;
+        }
+
+        /// <summary>
+        /// Re-render the panel from current connection state. Forwarded from <see cref="GodotMcpDock.Refresh"/>.
+        /// Safe to call repeatedly.
+        /// </summary>
+        public void Refresh()
+        {
+            SyncModeSelector(_connection.Config.ActiveMode);
+            ApplyModeVisibility(_connection.Config.ActiveMode);
+            ApplyStatus(_connection.ConnectionStatus);
+        }
+
+        public override void _ExitTree()
+        {
+            // Unsubscribe so a freed panel does not receive a late main-thread status push.
+            _connection.ConnectionStatusChanged -= OnConnectionStatusChanged;
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/UI/ConnectionPanelView.cs
+++ b/addons/godot_mcp/UI/ConnectionPanelView.cs
@@ -1,0 +1,130 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace com.IvanMurzak.Godot.MCP.UI
+{
+    /// <summary>
+    /// The simplified, editor-facing connection status the dock renders, derived from the reused
+    /// McpPlugin client's <see cref="HubConnectionState"/> plus its <c>KeepConnected</c> flag. Three
+    /// buckets (instead of SignalR's four) because the dock only needs to show the user one of: not
+    /// trying to connect, trying/handshaking, or fully connected.
+    /// </summary>
+    public enum ConnectionStatus
+    {
+        /// <summary>Not connected and not attempting to (KeepConnected is off, or the hub is down).</summary>
+        Disconnected,
+
+        /// <summary>Attempting to connect / reconnect / handshake (KeepConnected on, not yet Connected).</summary>
+        Connecting,
+
+        /// <summary>Connected to the MCP server and the application-level handshake succeeded.</summary>
+        Connected
+    }
+
+    /// <summary>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) presentation logic for the connection
+    /// panel: the <see cref="HubConnectionState"/> + <c>keepConnected</c> → <see cref="ConnectionStatus"/>
+    /// reduction, the status/label/button text mappings, the status-dot colour mapping, and server-URL
+    /// validation. Keeping this here (rather than inline in the <c>#if TOOLS</c> <c>ConnectionPanel</c>)
+    /// makes every decision unit-testable in the plain-xUnit <c>Godot-MCP.Tests</c> host without
+    /// constructing a single Godot <see cref="Godot.Control"/>.
+    ///
+    /// <para>
+    /// The Godot analog of Unity-MCP's <c>MainWindowEditor.CreateGUI</c> status helpers
+    /// (<c>GetConnectionStatusText</c>/<c>GetButtonText</c>/<c>GetConnectionStatusClass</c>), condensed to
+    /// the single <see cref="ConnectionStatus"/> enum the dock binds to.
+    /// </para>
+    /// </summary>
+    public static class ConnectionPanelView
+    {
+        // --- Status dot colours (RGB tuples; the #if TOOLS panel maps these to a Godot Color). ---
+
+        /// <summary>Green — fully connected.</summary>
+        public static readonly (float R, float G, float B) ColorConnected = (0.30f, 0.78f, 0.35f);
+
+        /// <summary>Amber/yellow — connecting / reconnecting.</summary>
+        public static readonly (float R, float G, float B) ColorConnecting = (0.92f, 0.74f, 0.20f);
+
+        /// <summary>Gray — disconnected / idle.</summary>
+        public static readonly (float R, float G, float B) ColorDisconnected = (0.50f, 0.50f, 0.50f);
+
+        /// <summary>Button label shown when the plugin is disconnected (clicking connects).</summary>
+        public const string ButtonTextConnect = "Connect";
+
+        /// <summary>Button label shown when the plugin is connected (clicking disconnects).</summary>
+        public const string ButtonTextDisconnect = "Disconnect";
+
+        /// <summary>Button label shown mid-connect (the button is disabled while this shows).</summary>
+        public const string ButtonTextConnecting = "Connecting…";
+
+        /// <summary>
+        /// Reduce SignalR's four-state <see cref="HubConnectionState"/> plus the client's
+        /// <paramref name="keepConnected"/> intent into the three buckets the dock renders. Mirrors the
+        /// Unity reference's <c>GetConnectionStatusClass</c>: <see cref="ConnectionStatus.Connected"/> only
+        /// when the hub reports <see cref="HubConnectionState.Connected"/> AND the client still wants to be
+        /// connected; any other state while <paramref name="keepConnected"/> is on reads as
+        /// <see cref="ConnectionStatus.Connecting"/> (the client is retrying); otherwise
+        /// <see cref="ConnectionStatus.Disconnected"/>.
+        /// </summary>
+        public static ConnectionStatus Reduce(HubConnectionState state, bool keepConnected) => state switch
+        {
+            HubConnectionState.Connected when keepConnected => ConnectionStatus.Connected,
+            _ when keepConnected => ConnectionStatus.Connecting,
+            _ => ConnectionStatus.Disconnected
+        };
+
+        /// <summary>The "Godot: …" status line text for a given <see cref="ConnectionStatus"/>.</summary>
+        public static string StatusLabel(ConnectionStatus status) => status switch
+        {
+            ConnectionStatus.Connected => "Godot: Connected",
+            ConnectionStatus.Connecting => "Godot: Connecting…",
+            _ => "Godot: Disconnected"
+        };
+
+        /// <summary>The connect/disconnect button text for a given <see cref="ConnectionStatus"/>.</summary>
+        public static string ButtonText(ConnectionStatus status) => status switch
+        {
+            ConnectionStatus.Connected => ButtonTextDisconnect,
+            ConnectionStatus.Connecting => ButtonTextConnecting,
+            _ => ButtonTextConnect
+        };
+
+        /// <summary>
+        /// True when the connect/disconnect button should be disabled — only while
+        /// <see cref="ConnectionStatus.Connecting"/>, where neither "Connect" nor "Disconnect" is a clean
+        /// action (the client is mid-handshake / retrying).
+        /// </summary>
+        public static bool ButtonDisabled(ConnectionStatus status) => status == ConnectionStatus.Connecting;
+
+        /// <summary>The status-dot RGB for a given <see cref="ConnectionStatus"/>.</summary>
+        public static (float R, float G, float B) StatusColor(ConnectionStatus status) => status switch
+        {
+            ConnectionStatus.Connected => ColorConnected,
+            ConnectionStatus.Connecting => ColorConnecting,
+            _ => ColorDisconnected
+        };
+
+        /// <summary>
+        /// Validate a user-entered server URL for Custom mode: it must be a non-empty, absolute
+        /// <c>http</c>/<c>https</c> URL. Reuses <see cref="Connection.GodotMcpConfig.IsValidHttpUrl"/> so the
+        /// dock's accept/reject rule matches exactly what the connection layer would accept (no drift
+        /// between what the field allows and what the config resolver honours). Surrounding whitespace /
+        /// a single pair of wrapping quotes are normalized away first, matching the env/.env sanitization.
+        /// </summary>
+        public static bool IsValidServerUrl(string? url)
+        {
+            var normalized = Connection.GodotMcpConfig.NormalizeUrl(url);
+            return !string.IsNullOrEmpty(normalized) && Connection.GodotMcpConfig.IsValidHttpUrl(normalized!);
+        }
+    }
+}

--- a/addons/godot_mcp/UI/GodotMcpDock.cs
+++ b/addons/godot_mcp/UI/GodotMcpDock.cs
@@ -9,6 +9,7 @@
 */
 #if TOOLS
 #nullable enable
+using com.IvanMurzak.Godot.MCP.Connection;
 using Godot;
 
 namespace com.IvanMurzak.Godot.MCP.UI
@@ -42,13 +43,23 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
         /// <summary>
         /// Container into which later tasks insert the connection / features / footer / cloud-auth
-        /// sections. Populated empty by this foundation scaffold; exposed so those tasks add children here
-        /// rather than re-parenting the whole dock.
+        /// sections. Populated by <see cref="BuildUi"/> with the <see cref="ConnectionPanel"/>; later tasks
+        /// add their sections here rather than re-parenting the whole dock.
         /// </summary>
         public VBoxContainer? Body { get; private set; }
 
-        public GodotMcpDock()
+        readonly GodotMcpConnection? _connection;
+        ConnectionPanel? _connectionPanel;
+
+        /// <summary>
+        /// Construct the dock wired to the live <paramref name="connection"/> so its connection panel can
+        /// show status and drive Connect/Disconnect/mode/URL. <see cref="GodotMcpPlugin"/> owns the
+        /// connection and threads it through here. A null connection (defensive / design-preview) builds the
+        /// header-only chrome with no connection panel.
+        /// </summary>
+        public GodotMcpDock(GodotMcpConnection? connection)
         {
+            _connection = connection;
             Name = DockTitle;
             BuildUi();
         }
@@ -83,15 +94,22 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
             header.AddChild(new HSeparator { Name = "HeaderSeparator" });
 
-            // --- Body placeholder ---
-            // Later tasks (connection status + mode toggle, features list, footer, cloud auth) add their
-            // sections as children of Body. Left empty by this foundation scaffold on purpose.
+            // --- Body ---
+            // Hosts the connection section now; later tasks (features list, footer, cloud auth) add their
+            // sections as further children of Body.
             Body = new VBoxContainer
             {
                 Name = "Body",
                 SizeFlagsVertical = SizeFlags.ExpandFill
             };
             AddChild(Body);
+
+            // Connection section — only when a live connection was threaded in.
+            if (_connection != null)
+            {
+                _connectionPanel = new ConnectionPanel(_connection);
+                Body.AddChild(_connectionPanel);
+            }
         }
 
         /// <summary>
@@ -102,7 +120,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// </summary>
         public void Refresh()
         {
-            // Intentionally empty until a later task adds dynamic sections to Body.
+            _connectionPanel?.Refresh();
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add the core connection UX to the Godot-MCP editor dock Body (Godot analog of Unity-MCP's `MainWindowEditor.Connection`): live status dot+label, Connect/Disconnect button, Custom|Cloud mode selector (persists + reconnects), validated Custom-mode Server URL field, and a simplified Godot → MCP server → AI agent timeline.
- `GodotMcpConnection` now exposes a reduced `ConnectionStatus` (from the reused McpPlugin client's R3 `ConnectionState` + `KeepConnected`), a main-thread-marshalled `ConnectionStatusChanged` event, and `Connect()`/`Disconnect()`/`Reconnect()`. Boot still auto-connects.
- All presentation/validation logic lives in pure-managed `ConnectionPanelView` (unit-tested); the live Godot `Control` wiring (`ConnectionPanel`) stays behind `#if TOOLS`.
- Env/.env precedence preserved: the UI writes the persisted layer and surfaces an override note (disabling the field) when `GODOT_MCP_*` forces the effective mode/host.

## Test plan
- [x] Suite 1 — `dotnet build` 0 errors.
- [x] Suite 2 — `dotnet test` 273/273 pass (new `ConnectionPanelViewTests`: status reduction, label/button/colour mappings, URL accept/reject, mode + host persistence round-trip).
- [x] Suite 3 — headless Godot 4.5.1 mono smoke against the testbed: `[Godot-MCP] plugin loaded`, R3 resolved at editor runtime, docks loaded, connection boot (`connecting (mode=Custom, host=http://localhost:8090)`), clean unload — no `FileNotFoundException` / managed exception.

Reused NuGet pins unchanged (ReflectorNet 5.3.1 / McpPlugin 6.7.0).

Closes #28