### PR TITLE
feat(addon): editor dock support footer (Discord / issues / star + thanks)

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -102,6 +102,10 @@
          via the headless Godot smoke (test.md Suite 3); the view logic is unit-tested here. The SignalR
          HubConnectionState enum it switches on is provided transitively by com.IvanMurzak.McpPlugin. -->
     <Compile Include="..\addons\godot_mcp\UI\ConnectionPanelView.cs" Link="Source\ConnectionPanelView.cs" />
+    <!-- Support-footer link constants — pure-managed (no Godot native types, no #if TOOLS): the static
+         URLs/copy opened by the dock footer. The editor Control wiring (SupportFooter.cs) is #if TOOLS and
+         verified via the headless Godot smoke (test.md Suite 3); the constants are unit-tested here. -->
+    <Compile Include="..\addons\godot_mcp\UI\SupportFooterLinks.cs" Link="Source\SupportFooterLinks.cs" />
   </ItemGroup>
 
 </Project>

--- a/Godot-MCP.Tests/SupportFooterLinksTests.cs
+++ b/Godot-MCP.Tests/SupportFooterLinksTests.cs
@@ -1,0 +1,68 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using com.IvanMurzak.Godot.MCP.UI;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the pure-managed support-footer link constants (<see cref="SupportFooterLinks"/>) — the static
+    /// URLs the dock footer opens via <c>OS.ShellOpen</c>. The editor Control wiring (<c>SupportFooter.cs</c>,
+    /// <c>#if TOOLS</c>) instantiates live Godot nodes and is verified via the headless Godot smoke
+    /// (test.md Suite 3) — NOT here. Guards against a stale/typo'd URL (e.g. pointing at the wrong repo)
+    /// silently shipping.
+    /// </summary>
+    public class SupportFooterLinksTests
+    {
+        [Fact]
+        public void IssuesUrl_targets_the_godot_mcp_repo_issues_page()
+        {
+            Assert.Equal("https://github.com/IvanMurzak/Godot-MCP/issues", SupportFooterLinks.IssuesUrl);
+        }
+
+        [Fact]
+        public void RepositoryUrl_targets_the_godot_mcp_repo()
+        {
+            Assert.Equal("https://github.com/IvanMurzak/Godot-MCP", SupportFooterLinks.RepositoryUrl);
+        }
+
+        [Fact]
+        public void DiscordUrl_is_the_shared_invite()
+        {
+            Assert.Equal("https://discord.gg/cfbdMZX99G", SupportFooterLinks.DiscordUrl);
+        }
+
+        [Theory]
+        [InlineData("Discord")]
+        [InlineData("Issues")]
+        [InlineData("Repository")]
+        public void All_urls_are_absolute_https(string which)
+        {
+            var url = which switch
+            {
+                "Discord" => SupportFooterLinks.DiscordUrl,
+                "Issues" => SupportFooterLinks.IssuesUrl,
+                _ => SupportFooterLinks.RepositoryUrl
+            };
+
+            Assert.True(Uri.TryCreate(url, UriKind.Absolute, out var parsed), $"{which} URL must be absolute: {url}");
+            Assert.Equal(Uri.UriSchemeHttps, parsed!.Scheme);
+        }
+
+        [Fact]
+        public void Copy_strings_are_non_empty()
+        {
+            Assert.False(string.IsNullOrWhiteSpace(SupportFooterLinks.PromptText));
+            Assert.False(string.IsNullOrWhiteSpace(SupportFooterLinks.ThanksText));
+        }
+    }
+}

--- a/addons/godot_mcp/UI/GodotMcpDock.cs
+++ b/addons/godot_mcp/UI/GodotMcpDock.cs
@@ -50,6 +50,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
         readonly GodotMcpConnection? _connection;
         ConnectionPanel? _connectionPanel;
+        SupportFooter? _supportFooter;
 
         /// <summary>
         /// Construct the dock wired to the live <paramref name="connection"/> so its connection panel can
@@ -110,6 +111,11 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 _connectionPanel = new ConnectionPanel(_connection);
                 Body.AddChild(_connectionPanel);
             }
+
+            // Support/footer section — static links + thanks, appended BELOW the connection panel. It holds
+            // no live state / subscriptions, so it builds unconditionally (independent of the connection).
+            _supportFooter = new SupportFooter();
+            Body.AddChild(_supportFooter);
         }
 
         /// <summary>

--- a/addons/godot_mcp/UI/SupportFooter.cs
+++ b/addons/godot_mcp/UI/SupportFooter.cs
@@ -1,0 +1,94 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.UI
+{
+    /// <summary>
+    /// The support/footer section of the Godot-MCP editor dock — the Godot <see cref="Control"/> analog of
+    /// Unity-MCP's window footer. A <see cref="VBoxContainer"/> the <see cref="GodotMcpDock"/> appends to its
+    /// Body BELOW the connection panel. It renders, top to bottom:
+    /// <list type="bullet">
+    ///   <item>A "Found an issue?" prompt label.</item>
+    ///   <item>An HBox of buttons that open external URLs via <see cref="OS.ShellOpen"/>:
+    ///   Help/Talk → Discord, Bug Report → GitHub issues, Star → the repository.</item>
+    ///   <item>A short "Thanks for using AI Game Developer" line.</item>
+    /// </list>
+    ///
+    /// <para>
+    /// STATIC links only — no live state, no connection coupling, no subscriptions or timers. The footer is
+    /// a plain child <see cref="Control"/> freed with the dock, so it needs no special <c>_ExitTree</c>
+    /// teardown. All URLs/copy come from the pure-managed <see cref="SupportFooterLinks"/> so they are
+    /// CI-unit-tested; this Control wiring is editor-only (<c>#if TOOLS</c>) and verified via the headless
+    /// Godot smoke (<c>test.md</c> Suite 3).
+    /// </para>
+    /// </summary>
+    [Tool]
+    public partial class SupportFooter : VBoxContainer
+    {
+        public SupportFooter()
+        {
+            Name = "SupportFooter";
+            BuildUi();
+        }
+
+        void BuildUi()
+        {
+            SizeFlagsHorizontal = SizeFlags.ExpandFill;
+            AddThemeConstantOverride("separation", 4);
+
+            AddChild(new HSeparator { Name = "FooterSeparator" });
+
+            AddChild(new Label
+            {
+                Name = "Prompt",
+                Text = SupportFooterLinks.PromptText
+            });
+
+            // --- Support links: open externally; no live state. ---
+            var links = new HBoxContainer { Name = "Links" };
+            AddChild(links);
+
+            links.AddChild(MakeLinkButton("Discord", "Help / Talk", SupportFooterLinks.DiscordUrl));
+            links.AddChild(MakeLinkButton("Issues", "Bug Report", SupportFooterLinks.IssuesUrl));
+            links.AddChild(MakeLinkButton("Star", "Star", SupportFooterLinks.RepositoryUrl));
+
+            // --- Thanks line (RichTextLabel so the product name can be emphasised). ---
+            var thanks = new RichTextLabel
+            {
+                Name = "Thanks",
+                BbcodeEnabled = true,
+                FitContent = true,
+                AutowrapMode = TextServer.AutowrapMode.WordSmart,
+                Text = $"[i]{SupportFooterLinks.ThanksText}[/i]"
+            };
+            AddChild(thanks);
+        }
+
+        /// <summary>
+        /// Build a button that opens <paramref name="url"/> in the user's default handler. <see cref="OS.ShellOpen"/>
+        /// is the Godot way to hand a URL/path to the OS (browser for http/https).
+        /// </summary>
+        static Button MakeLinkButton(string name, string text, string url)
+        {
+            var button = new Button
+            {
+                Name = name,
+                Text = text,
+                TooltipText = url
+            };
+            button.Pressed += () => OS.ShellOpen(url);
+            return button;
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/UI/SupportFooterLinks.cs
+++ b/addons/godot_mcp/UI/SupportFooterLinks.cs
@@ -1,0 +1,44 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+
+namespace com.IvanMurzak.Godot.MCP.UI
+{
+    /// <summary>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) holder for the static URLs and copy used
+    /// by the dock's <c>SupportFooter</c>. Kept out of the editor guard so the constants are CI-unit-tested
+    /// (the editor Control wiring in <c>SupportFooter.cs</c> is <c>#if TOOLS</c> and verified via the
+    /// headless Godot smoke — see <c>test.md</c> Suite 3). The footer is a static link strip with no live
+    /// state, so this is the only "logic" worth asserting.
+    /// </summary>
+    public static class SupportFooterLinks
+    {
+        /// <summary>
+        /// The Discord invite opened by the footer's "Help / Talk" button.
+        /// NOTE: this is the SHARED ai-game.dev / Unity-MCP community Discord invite (the same one used by
+        /// the Unity-MCP docs badges) — Godot-MCP has no separate server. The repo's README/CLAUDE.md did
+        /// not declare a Godot-specific invite at the time this was written; if a dedicated Godot-MCP invite
+        /// is later created, swap it here.
+        /// </summary>
+        public const string DiscordUrl = "https://discord.gg/cfbdMZX99G";
+
+        /// <summary>GitHub issues page — the footer's "Bug Report" button.</summary>
+        public const string IssuesUrl = "https://github.com/IvanMurzak/Godot-MCP/issues";
+
+        /// <summary>Repository home — the footer's "Star" button.</summary>
+        public const string RepositoryUrl = "https://github.com/IvanMurzak/Godot-MCP";
+
+        /// <summary>Heading shown above the support buttons.</summary>
+        public const string PromptText = "Found an issue?";
+
+        /// <summary>Closing thank-you line.</summary>
+        public const string ThanksText = "Thanks for using AI Game Developer \U0001F49A";
+    }
+}


### PR DESCRIPTION
## Summary
- New `addons/godot_mcp/UI/SupportFooter.cs` (`#if TOOLS`, VBoxContainer) appended to the dock Body BELOW the connection panel: a "Found an issue?" prompt, Discord (Help/Talk) / GitHub Issues (Bug Report) / Star buttons that open URLs via `OS.ShellOpen`, and a thanks line.
- New pure-managed `addons/godot_mcp/UI/SupportFooterLinks.cs` holds the URL/copy constants so they are CI-unit-tested (`SupportFooterLinksTests`); the editor Control wiring stays behind `#if TOOLS`.
- Discord button reuses the shared ai-game.dev community invite `https://discord.gg/cfbdMZX99G` (no Godot-specific server; README/CLAUDE declared none) — noted in code.
- Static links only: no live state, no connection coupling, no subscriptions/timers (no special `_ExitTree` teardown). NuGet pins untouched (McpPlugin 6.7.0 / ReflectorNet 5.3.1).

## Test plan
- [x] Suite 1 (`dotnet build Godot-MCP.sln`): 0 errors, 0 warnings.
- [x] Suite 2 (`dotnet test`): 280/280 pass (incl. new `SupportFooterLinksTests`).
- [x] Suite 3 headless Godot 4.5.1 smoke: dock + footer boots, `[Godot-MCP] plugin loaded` / `Loading docks...` / `plugin unloaded`, all deps resolved (McpPlugin 6.7.0), no FileNotFound/Exception.

Closes #30