### PR TITLE
feat(connection): Custom-mode auth + mode-toggle UX + Disconnect clarity (#33)

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -52,6 +52,9 @@
          precedence layer (no Godot native types, no #if TOOLS). The editor wiring that resolves the
          user:// path lives in GodotMcpConnection.cs (#if TOOLS); the path-injectable core is unit-tested. -->
     <Compile Include="..\addons\godot_mcp\Connection\GodotMcpConfigStore.cs" Link="Source\GodotMcpConfigStore.cs" />
+    <!-- URL-safe bearer-token generator: pure-managed (RandomNumberGenerator + Convert), no Godot native
+         types / no #if TOOLS. Output is random, so the tests pin FORMAT invariants (length/charset). -->
+    <Compile Include="..\addons\godot_mcp\Connection\GodotMcpTokenGenerator.cs" Link="Source\GodotMcpTokenGenerator.cs" />
     <!-- Editor-runtime NuGet-dependency resolver. Pure-BCL (System.Runtime.Loader), no #if TOOLS,
          no Godot native types — so it is unit-testable in this plain-xUnit host. -->
     <Compile Include="..\addons\godot_mcp\Connection\GodotMcpAssemblyResolver.cs" Link="Source\GodotMcpAssemblyResolver.cs" />

--- a/Godot-MCP.Tests/GodotMcpAuthOptionTests.cs
+++ b/Godot-MCP.Tests/GodotMcpAuthOptionTests.cs
@@ -1,0 +1,225 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak)             │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.IO;
+using System.Text.Json;
+using com.IvanMurzak.Godot.MCP.Connection;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the Custom-mode authorization option (none/required): serialize / round-trip through
+    /// <see cref="GodotMcpConfigStore"/>, the env override precedence (env &gt; persisted &gt; default),
+    /// and the <see cref="GodotMcpConfig.ResolveCustomToken"/> gating (no bearer when auth is None).
+    ///
+    /// <para>
+    /// Tests that mutate process env are marked <c>[Collection("env")]</c> to serialize against the
+    /// shared env, and restore prior values via <see cref="AuthEnvScope"/>.
+    /// </para>
+    /// </summary>
+    [Collection("env")]
+    public class GodotMcpAuthOptionTests
+    {
+        // --- Default ---
+
+        [Fact]
+        public void DefaultAuthOption_IsNone()
+        {
+            using var _ = AuthEnvScope.ClearAll();
+            var config = new GodotMcpConfig();
+            Assert.Equal(GodotMcpAuthOption.None, config.ActiveAuthOption);
+        }
+
+        // --- Env override precedence ---
+
+        [Theory]
+        [InlineData("Required", GodotMcpAuthOption.Required)]
+        [InlineData("required", GodotMcpAuthOption.Required)]
+        [InlineData("NONE", GodotMcpAuthOption.None)]
+        public void EnvAuthOption_Overrides_ConfiguredValue(string envValue, GodotMcpAuthOption expected)
+        {
+            using var _ = AuthEnvScope.Set(GodotMcpConfig.EnvAuthOption, envValue);
+            // Configured = None; env should win (including the round-trip None case).
+            var config = new GodotMcpConfig { AuthOption = GodotMcpAuthOption.None };
+            Assert.Equal(expected, config.ActiveAuthOption);
+        }
+
+        [Theory]
+        [InlineData("not-an-option")]
+        [InlineData("1")]
+        [InlineData("")]
+        public void EnvAuthOption_Unrecognized_FallsBackToConfigured(string envValue)
+        {
+            using var _ = AuthEnvScope.Set(GodotMcpConfig.EnvAuthOption, envValue);
+            var config = new GodotMcpConfig { AuthOption = GodotMcpAuthOption.Required };
+            Assert.Equal(GodotMcpAuthOption.Required, config.ActiveAuthOption);
+        }
+
+        // --- ResolveCustomToken gating ---
+
+        [Fact]
+        public void ResolveCustomToken_None_ReturnsNull_EvenWithStoredToken()
+        {
+            using var _ = AuthEnvScope.ClearAll();
+            var config = new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Custom,
+                AuthOption = GodotMcpAuthOption.None,
+                CustomToken = "stored-token-keeps-its-value"
+            };
+            // Anonymous connection: no bearer on the wire, but the stored value is NOT discarded.
+            Assert.Null(config.ResolveCustomToken());
+            Assert.Equal("stored-token-keeps-its-value", config.CustomToken);
+        }
+
+        [Fact]
+        public void ResolveCustomToken_Required_ReturnsStoredToken()
+        {
+            using var _ = AuthEnvScope.ClearAll();
+            var config = new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Custom,
+                AuthOption = GodotMcpAuthOption.Required,
+                CustomToken = "abc123"
+            };
+            Assert.Equal("abc123", config.ResolveCustomToken());
+        }
+
+        [Fact]
+        public void ResolveCustomToken_Required_EnvTokenWinsOverStored()
+        {
+            using var _ = AuthEnvScope.Set(GodotMcpConfig.EnvToken, "env-token");
+            var config = new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Custom,
+                AuthOption = GodotMcpAuthOption.Required,
+                CustomToken = "stored"
+            };
+            Assert.Equal("env-token", config.ResolveCustomToken());
+        }
+
+        [Fact]
+        public void ResolveCustomToken_EnvAuthRequired_OverridesPersistedNone()
+        {
+            // Persisted None, but env forces Required => the stored token now flows to the bearer.
+            using var _ = AuthEnvScope.Set(GodotMcpConfig.EnvAuthOption, "Required");
+            var config = new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Custom,
+                AuthOption = GodotMcpAuthOption.None,
+                CustomToken = "stored"
+            };
+            Assert.Equal(GodotMcpAuthOption.Required, config.ActiveAuthOption);
+            Assert.Equal("stored", config.ResolveCustomToken());
+        }
+
+        // --- Serialization round-trip via the store ---
+
+        [Fact]
+        public void AuthOption_Serializes_AsNamedValue()
+        {
+            var config = new GodotMcpConfig { AuthOption = GodotMcpAuthOption.Required };
+            var json = JsonSerializer.Serialize(config, new JsonSerializerOptions
+            {
+                Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+            });
+            Assert.Contains("\"authOption\"", json);
+            Assert.Contains("Required", json);
+        }
+
+        [Fact]
+        public void AuthOption_RoundTrips_ThroughStore()
+        {
+            using var _ = AuthEnvScope.ClearAll();
+            var path = Path.Combine(Path.GetTempPath(), $"godot-mcp-auth-{Guid.NewGuid():N}.json");
+            try
+            {
+                var saved = new GodotMcpConfig
+                {
+                    ConnectionMode = GodotMcpConnectionMode.Custom,
+                    AuthOption = GodotMcpAuthOption.Required,
+                    CustomToken = "round-trip-token"
+                };
+                GodotMcpConfigStore.Save(path, saved);
+
+                var loaded = GodotMcpConfigStore.Load(path);
+                Assert.NotNull(loaded);
+                Assert.Equal(GodotMcpAuthOption.Required, loaded!.AuthOption);
+
+                // ApplyPersisted seeds the auth option onto a fresh target (the boot precedence path).
+                var target = new GodotMcpConfig();
+                GodotMcpConfigStore.ApplyPersisted(target, loaded);
+                Assert.Equal(GodotMcpAuthOption.Required, target.AuthOption);
+                Assert.Equal("round-trip-token", target.CustomToken);
+            }
+            finally
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void ApplyPersisted_Default_RoundTripsNone()
+        {
+            using var _ = AuthEnvScope.ClearAll();
+            var persisted = new GodotMcpConfig { AuthOption = GodotMcpAuthOption.None };
+            var target = new GodotMcpConfig { AuthOption = GodotMcpAuthOption.Required };
+            GodotMcpConfigStore.ApplyPersisted(target, persisted);
+            Assert.Equal(GodotMcpAuthOption.None, target.AuthOption);
+        }
+
+        /// <summary>
+        /// Local env scope covering the keys these auth tests touch (auth option + token). Restores prior
+        /// values on dispose so cross-test env leakage cannot occur.
+        /// </summary>
+        sealed class AuthEnvScope : IDisposable
+        {
+            static readonly string[] Names =
+            {
+                GodotMcpConfig.EnvAuthOption,
+                GodotMcpConfig.EnvToken,
+                GodotMcpConfig.EnvConnectionMode,
+                GodotMcpConfig.EnvHost
+            };
+
+            readonly System.Collections.Generic.Dictionary<string, string?> _prior = new();
+
+            AuthEnvScope()
+            {
+                foreach (var name in Names)
+                    _prior[name] = Environment.GetEnvironmentVariable(name);
+            }
+
+            public static AuthEnvScope ClearAll()
+            {
+                var scope = new AuthEnvScope();
+                foreach (var name in Names)
+                    Environment.SetEnvironmentVariable(name, null);
+                return scope;
+            }
+
+            public static AuthEnvScope Set(string name, string? value)
+            {
+                var scope = ClearAll();
+                Environment.SetEnvironmentVariable(name, value);
+                return scope;
+            }
+
+            public void Dispose()
+            {
+                foreach (var kv in _prior)
+                    Environment.SetEnvironmentVariable(kv.Key, kv.Value);
+            }
+        }
+    }
+}

--- a/Godot-MCP.Tests/GodotMcpConfigStoreTests.cs
+++ b/Godot-MCP.Tests/GodotMcpConfigStoreTests.cs
@@ -152,6 +152,8 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             GodotMcpConfigStore.Save(path, new GodotMcpConfig
             {
                 ConnectionMode = GodotMcpConnectionMode.Custom,
+                // Persisting Required so the Custom-mode bearer flows (auth-option gate); it round-trips too.
+                AuthOption = GodotMcpAuthOption.Required,
                 CustomHost = "http://persisted-host:1234",
                 CustomToken = "persisted-tok"
             });
@@ -162,6 +164,7 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             GodotMcpEnvFile.Apply(target, new Dictionary<string, string>());
 
             Assert.Equal(GodotMcpConnectionMode.Custom, target.ActiveMode);
+            Assert.Equal(GodotMcpAuthOption.Required, target.ActiveAuthOption);
             Assert.Equal("http://persisted-host:1234", target.Host);
             Assert.Equal("persisted-tok", target.Token);
         }
@@ -244,7 +247,8 @@ namespace com.IvanMurzak.Godot.MCP.Tests
                 GodotMcpConfig.EnvCloudUrl,
                 GodotMcpConfig.EnvHost,
                 GodotMcpConfig.EnvToken,
-                GodotMcpConfig.EnvConnectionMode
+                GodotMcpConfig.EnvConnectionMode,
+                GodotMcpConfig.EnvAuthOption
             };
 
             readonly Dictionary<string, string?> _prior = new();

--- a/Godot-MCP.Tests/GodotMcpConfigTests.cs
+++ b/Godot-MCP.Tests/GodotMcpConfigTests.cs
@@ -223,6 +223,8 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             var config = new GodotMcpConfig
             {
                 ConnectionMode = GodotMcpConnectionMode.Custom,
+                // Custom-mode token only flows to the bearer when auth is Required (the auth-option gate).
+                AuthOption = GodotMcpAuthOption.Required,
                 CloudToken = "cloud-tok",
                 CustomToken = "custom-tok"
             };
@@ -248,6 +250,8 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             var config = new GodotMcpConfig
             {
                 ConnectionMode = GodotMcpConnectionMode.Custom,
+                // Token routing in Custom mode is gated on auth being Required (see AuthOption tests).
+                AuthOption = GodotMcpAuthOption.Required,
                 CustomToken = "custom-tok"
             };
             Assert.Equal("env-tok", config.Token);
@@ -319,7 +323,8 @@ namespace com.IvanMurzak.Godot.MCP.Tests
                 GodotMcpConfig.EnvCloudUrl,
                 GodotMcpConfig.EnvHost,
                 GodotMcpConfig.EnvToken,
-                GodotMcpConfig.EnvConnectionMode
+                GodotMcpConfig.EnvConnectionMode,
+                GodotMcpConfig.EnvAuthOption
             };
 
             readonly Dictionary<string, string?> _prior = new();

--- a/Godot-MCP.Tests/GodotMcpEnvFileTests.cs
+++ b/Godot-MCP.Tests/GodotMcpEnvFileTests.cs
@@ -244,6 +244,37 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Equal(GodotMcpConnectionMode.Custom, config.ActiveMode);
         }
 
+        // --- Auth option: file layer + env precedence ---
+
+        [Fact]
+        public void Apply_FileAuthOption_WritesConfiguredField()
+        {
+            using var _ = EnvFileScope.ClearAll();
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Custom };
+            GodotMcpEnvFile.Apply(config, Map(GodotMcpConfig.EnvAuthOption, "Required"));
+            Assert.Equal(GodotMcpAuthOption.Required, config.ActiveAuthOption);
+        }
+
+        [Fact]
+        public void EnvAuthOption_Beats_FileAuthOption()
+        {
+            // File says None, env says Required → env wins (ActiveAuthOption reads env live).
+            using var _ = EnvFileScope.Set(GodotMcpConfig.EnvAuthOption, "Required");
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Custom };
+            GodotMcpEnvFile.Apply(config, Map(GodotMcpConfig.EnvAuthOption, "None"));
+            Assert.Equal(GodotMcpAuthOption.Required, config.ActiveAuthOption);
+        }
+
+        [Fact]
+        public void Apply_FileAuthOption_Numeric_IsIgnored()
+        {
+            using var _ = EnvFileScope.ClearAll();
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Custom };
+            GodotMcpEnvFile.Apply(config, Map(GodotMcpConfig.EnvAuthOption, "1"));
+            // Numeric rejected → configured default (None) stands.
+            Assert.Equal(GodotMcpAuthOption.None, config.ActiveAuthOption);
+        }
+
         // --- Default wins when neither env nor file present ---
 
         [Fact]
@@ -372,7 +403,8 @@ namespace com.IvanMurzak.Godot.MCP.Tests
                 GodotMcpConfig.EnvCloudUrl,
                 GodotMcpConfig.EnvHost,
                 GodotMcpConfig.EnvToken,
-                GodotMcpConfig.EnvConnectionMode
+                GodotMcpConfig.EnvConnectionMode,
+                GodotMcpConfig.EnvAuthOption
             };
 
             readonly Dictionary<string, string?> _prior = new();

--- a/Godot-MCP.Tests/GodotMcpTokenGeneratorTests.cs
+++ b/Godot-MCP.Tests/GodotMcpTokenGeneratorTests.cs
@@ -1,0 +1,71 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using com.IvanMurzak.Godot.MCP.Connection;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the URL-safe bearer-token generator. The output is cryptographically random, so the tests
+    /// assert FORMAT invariants (charset, url-safety, length, uniqueness) rather than a fixed value —
+    /// mirroring the Unity reference's <c>UnityMcpPlugin.GenerateToken()</c> contract.
+    /// </summary>
+    public class GodotMcpTokenGeneratorTests
+    {
+        [Fact]
+        public void Generate_IsNonEmpty()
+        {
+            Assert.False(string.IsNullOrEmpty(GodotMcpTokenGenerator.Generate()));
+        }
+
+        [Fact]
+        public void Generate_UsesOnlyUrlSafeChars()
+        {
+            // URL-safe Base64 alphabet: A-Z a-z 0-9 '-' '_'. No '+', '/', or '=' padding.
+            var token = GodotMcpTokenGenerator.Generate();
+            Assert.All(token, c =>
+                Assert.True(
+                    char.IsLetterOrDigit(c) || c == '-' || c == '_',
+                    $"unexpected char '{c}' in token"));
+        }
+
+        [Theory]
+        [InlineData('+')]
+        [InlineData('/')]
+        [InlineData('=')]
+        public void Generate_StripsNonUrlSafeChars(char forbidden)
+        {
+            // Run several times: the random input could otherwise hide an unstripped char by chance.
+            for (var i = 0; i < 50; i++)
+                Assert.DoesNotContain(forbidden, GodotMcpTokenGenerator.Generate());
+        }
+
+        [Fact]
+        public void Generate_HasExpectedLength()
+        {
+            // 32 bytes -> Base64 is ceil(32/3)*4 = 44 chars, minus the two trailing '=' padding chars
+            // that the generator strips => 43 chars. Charset substitutions don't change the length.
+            var token = GodotMcpTokenGenerator.Generate();
+            Assert.Equal(43, token.Length);
+        }
+
+        [Fact]
+        public void Generate_ProducesUniqueValues()
+        {
+            // Random => practically-zero collision probability across a small sample.
+            var tokens = new HashSet<string>(Enumerable.Range(0, 100).Select(_ => GodotMcpTokenGenerator.Generate()));
+            Assert.Equal(100, tokens.Count);
+        }
+    }
+}

--- a/addons/godot_mcp/Connection/GodotMcpConfig.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConfig.cs
@@ -27,6 +27,22 @@ namespace com.IvanMurzak.Godot.MCP.Connection
     }
 
     /// <summary>
+    /// Whether the Custom-mode connection sends a bearer token. The Godot analog of Unity-MCP's
+    /// <c>com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server.AuthOption</c> (<c>none</c>/<c>required</c>),
+    /// condensed to the two states the Godot Custom-mode UI exposes. Only meaningful in
+    /// <see cref="GodotMcpConnectionMode.Custom"/> — Cloud-mode auth is handled separately (device flow,
+    /// a later task).
+    /// </summary>
+    public enum GodotMcpAuthOption
+    {
+        /// <summary>No bearer token is sent (the Custom server accepts anonymous connections).</summary>
+        None,
+
+        /// <summary>A bearer token is sent (the Custom server requires authorization).</summary>
+        Required
+    }
+
+    /// <summary>
     /// Connection configuration for the Godot-MCP plugin. The Godot analog of Unity-MCP's
     /// <c>UnityMcpPlugin.UnityConnectionConfig</c> — it extends the reused
     /// <see cref="ConnectionConfig"/> from <c>com.IvanMurzak.McpPlugin</c> (so the SignalR client
@@ -56,6 +72,12 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
         /// <summary>Forces the connection mode (<c>Cloud</c> / <c>Custom</c>, case-insensitive).</summary>
         public const string EnvConnectionMode = "GODOT_MCP_CONNECTION_MODE";
+
+        /// <summary>
+        /// Forces the Custom-mode authorization option (<c>None</c> / <c>Required</c>, case-insensitive).
+        /// The Godot analog of Unity-MCP's <c>UNITY_MCP_AUTH_OPTION</c>.
+        /// </summary>
+        public const string EnvAuthOption = "GODOT_MCP_AUTH_OPTION";
 
         // --- Defaults. ---
 
@@ -90,11 +112,27 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         public GodotMcpConnectionMode ConnectionMode { get; set; } = GodotMcpConnectionMode.Cloud;
 
         /// <summary>
+        /// The configured Custom-mode authorization option (overridable by <see cref="EnvAuthOption"/> via
+        /// <see cref="ResolveActiveAuthOption"/>). Defaults to <see cref="GodotMcpAuthOption.None"/> — a
+        /// fresh Custom connection is anonymous until the user opts into auth. Only consulted in Custom mode.
+        /// </summary>
+        [JsonPropertyName("authOption")]
+        public GodotMcpAuthOption AuthOption { get; set; } = GodotMcpAuthOption.None;
+
+        /// <summary>
         /// The effective connection mode after applying the <see cref="EnvConnectionMode"/> override.
         /// Never serialized — recomputed from the env each access so a process-level override always wins.
         /// </summary>
         [JsonIgnore]
         public GodotMcpConnectionMode ActiveMode => ResolveActiveMode(ConnectionMode);
+
+        /// <summary>
+        /// The effective Custom-mode authorization option after applying the <see cref="EnvAuthOption"/>
+        /// override. Never serialized — recomputed from the env each access so a process-level override
+        /// always wins (parity with <see cref="ActiveMode"/>).
+        /// </summary>
+        [JsonIgnore]
+        public GodotMcpAuthOption ActiveAuthOption => ResolveActiveAuthOption(AuthOption);
 
         /// <summary>
         /// Active connection URL based on <see cref="ActiveMode"/>:
@@ -204,11 +242,39 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             return string.IsNullOrEmpty(envToken) ? CloudToken : envToken;
         }
 
-        /// <summary>Resolve the active custom token, applying the <see cref="EnvToken"/> override.</summary>
+        /// <summary>
+        /// Resolve the active custom token, applying the <see cref="EnvToken"/> override. Returns
+        /// <c>null</c> when the active auth option is <see cref="GodotMcpAuthOption.None"/> — an anonymous
+        /// Custom connection sends no bearer, regardless of any token the user previously generated (so
+        /// flipping auth back to <c>None</c> drops the token from the wire without discarding the stored
+        /// value). When auth is <see cref="GodotMcpAuthOption.Required"/>, the env token wins over the
+        /// persisted <see cref="CustomToken"/>, mirroring the other resolvers.
+        /// </summary>
         public string? ResolveCustomToken()
         {
+            if (ActiveAuthOption == GodotMcpAuthOption.None)
+                return null;
+
             var envToken = NormalizeEnv(ReadEnv(EnvToken));
             return string.IsNullOrEmpty(envToken) ? CustomToken : envToken;
+        }
+
+        /// <summary>
+        /// Resolve the active Custom-mode auth option, letting <see cref="EnvAuthOption"/> override the
+        /// configured value. An unrecognized/empty/numeric env value falls through to
+        /// <paramref name="configured"/> — identical discipline to <see cref="ResolveActiveMode"/>.
+        /// </summary>
+        public static GodotMcpAuthOption ResolveActiveAuthOption(GodotMcpAuthOption configured)
+        {
+            var normalized = NormalizeEnv(ReadEnv(EnvAuthOption));
+            if (string.IsNullOrEmpty(normalized))
+                return configured;
+
+            if (Enum.TryParse<GodotMcpAuthOption>(normalized, ignoreCase: true, out var parsed) &&
+                !int.TryParse(normalized, out _))
+                return parsed;
+
+            return configured;
         }
 
         static string? ReadEnv(string name) => Environment.GetEnvironmentVariable(name);

--- a/addons/godot_mcp/Connection/GodotMcpConfigStore.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConfigStore.cs
@@ -114,11 +114,11 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
         /// <summary>
         /// Apply the SERIALIZED-LAYER values from <paramref name="persisted"/> onto <paramref name="target"/>,
-        /// writing only the four serialized backing fields (<c>CustomHost</c>/<c>CustomToken</c>/
-        /// <c>CloudToken</c>/<c>ConnectionMode</c>). This is how the boot path seeds the config with the
-        /// persisted baseline BEFORE the <c>.env</c>/process-env layers are applied on top — keeping the
-        /// documented precedence intact. No-op when <paramref name="persisted"/> is <c>null</c>. Returns
-        /// <paramref name="target"/> for fluent use.
+        /// writing only the serialized backing fields (<c>CustomHost</c>/<c>CustomToken</c>/
+        /// <c>CloudToken</c>/<c>ConnectionMode</c>/<c>AuthOption</c>). This is how the boot path seeds the
+        /// config with the persisted baseline BEFORE the <c>.env</c>/process-env layers are applied on
+        /// top — keeping the documented precedence intact. No-op when <paramref name="persisted"/> is
+        /// <c>null</c>. Returns <paramref name="target"/> for fluent use.
         /// </summary>
         public static GodotMcpConfig ApplyPersisted(GodotMcpConfig target, GodotMcpConfig? persisted)
         {
@@ -131,6 +131,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             target.CustomToken = persisted.CustomToken;
             target.CloudToken = persisted.CloudToken;
             target.ConnectionMode = persisted.ConnectionMode;
+            target.AuthOption = persisted.AuthOption;
 
             return target;
         }

--- a/addons/godot_mcp/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConnection.cs
@@ -206,13 +206,28 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
         /// <summary>
         /// (Re)connect with the CURRENT <see cref="GodotMcpConfig"/> (mode/host/token). If a plugin
-        /// already exists it is reused — the reused client reconnects via <c>KeepConnected</c>; otherwise
-        /// this builds a fresh plugin via <see cref="Start"/>. The boot path calls <see cref="Start"/>
-        /// directly; the dock's Connect button calls this. Idempotent and safe to call repeatedly.
+        /// already exists it is reused — the reused client re-arms its own <c>KeepConnected</c> intent
+        /// inside <see cref="IConnection.Connect"/>; otherwise this builds a fresh plugin via
+        /// <see cref="Start"/>. The boot path calls <see cref="Start"/> directly; the dock's Connect
+        /// button calls this. Idempotent and safe to call repeatedly.
+        ///
+        /// <para>
+        /// Auto-reconnect intent lives in the reused client's <see cref="IConnection.KeepConnected"/>
+        /// reactive property, NOT in <see cref="GodotMcpConfig.KeepConnected"/>: the McpPlugin
+        /// <c>ConnectionManager</c> sets its internal reconnect flag to <c>true</c> inside
+        /// <see cref="IConnection.Connect"/> and to <c>false</c> inside <see cref="IConnection.Disconnect"/>;
+        /// it never reads the <see cref="ConnectionConfig.KeepConnected"/> field at runtime. Calling
+        /// <c>plugin.Connect()</c> is therefore what re-arms reconnection after a manual Disconnect — this
+        /// is the exact mechanism the Unity reference uses (its <c>UnityMcpPluginEditor.KeepConnected</c>
+        /// gates only the BOOT path's <c>ConnectIfNeeded</c>, while the live client is driven by
+        /// <c>mcpPlugin.Connect()</c> / <c>mcpPlugin.Disconnect()</c>).
+        /// </para>
         /// </summary>
         public void Connect()
         {
-            // Re-arm the intent to stay connected (the Disconnect button clears it) BEFORE (re)connecting.
+            // Keep the persisted/boot intent aligned with the user's explicit Connect (boot honours this
+            // via Start()'s ConnectIfNeeded analogue); the LIVE reconnect re-arm happens inside
+            // plugin.Connect() below, which flips the client's own KeepConnected to true.
             _config.KeepConnected = true;
 
             if (_plugin == null)
@@ -225,13 +240,21 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         }
 
         /// <summary>
-        /// Disconnect from the MCP server and stop auto-reconnect. Clears <c>KeepConnected</c> so the
-        /// reused client does not immediately reconnect, then asks it to disconnect. The plugin instance
-        /// is kept (not disposed) so a subsequent <see cref="Connect"/> can reuse it; full teardown happens
-        /// in <see cref="Dispose"/> at plugin unload.
+        /// Disconnect from the MCP server and stop auto-reconnect. The reconnect-stop is driven by
+        /// <see cref="IConnection.Disconnect"/> on the reused client — it cancels the in-flight connect
+        /// loop's token, flips the client's own <see cref="IConnection.KeepConnected"/> reactive property
+        /// to <c>false</c>, and stops + disposes the live <c>HubConnection</c> — so the client does NOT
+        /// auto-reconnect and the status subscription (which reduces over <c>plugin.KeepConnected</c>)
+        /// settles on <see cref="UI.ConnectionStatus.Disconnected"/> (gray). Setting
+        /// <see cref="GodotMcpConfig.KeepConnected"/> here is intent bookkeeping only (the client never
+        /// reads that field at runtime) and keeps the boot/persisted intent consistent. The plugin
+        /// instance is kept (not disposed) so a subsequent <see cref="Connect"/> can reuse it; full
+        /// teardown happens in <see cref="Dispose"/> at plugin unload.
         /// </summary>
         public void Disconnect()
         {
+            // Bookkeeping only — the client's live reconnect intent is cleared by plugin.Disconnect()
+            // below (ConnectionManager sets its internal KeepConnected=false there), not by this field.
             _config.KeepConnected = false;
 
             var plugin = _plugin;

--- a/addons/godot_mcp/Connection/GodotMcpEnvFile.cs
+++ b/addons/godot_mcp/Connection/GodotMcpEnvFile.cs
@@ -45,13 +45,14 @@ namespace com.IvanMurzak.Godot.MCP.Connection
     /// </summary>
     public static class GodotMcpEnvFile
     {
-        /// <summary>The four recognized keys. Any other key in the file is ignored.</summary>
+        /// <summary>The recognized keys. Any other key in the file is ignored.</summary>
         static readonly string[] RecognizedKeys =
         {
             GodotMcpConfig.EnvConnectionMode,
             GodotMcpConfig.EnvHost,
             GodotMcpConfig.EnvCloudUrl,
-            GodotMcpConfig.EnvToken
+            GodotMcpConfig.EnvToken,
+            GodotMcpConfig.EnvAuthOption
         };
 
         /// <summary>
@@ -180,6 +181,14 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 config.ConnectionMode = GodotMcpConnectionMode.Custom;
             }
 
+            // 2b) Auth option (Custom-mode only): an explicit file value writes the serialized field
+            //     beneath the env layer (env GODOT_MCP_AUTH_OPTION still wins live via ActiveAuthOption).
+            if (values.TryGetValue(GodotMcpConfig.EnvAuthOption, out var fileAuth) &&
+                TryParseAuthOption(fileAuth, out var parsedAuth))
+            {
+                config.AuthOption = parsedAuth;
+            }
+
             // 3) Token: route to the active mode's token field (after mode is settled above so the route
             //    matches what the connection will actually use). Env token still wins live.
             if (values.TryGetValue(GodotMcpConfig.EnvToken, out var fileToken))
@@ -228,6 +237,22 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             if (int.TryParse(normalized, out _))
                 return false;
             return Enum.TryParse(normalized, ignoreCase: true, out mode);
+        }
+
+        /// <summary>
+        /// Parse a Custom-mode auth-option string to <see cref="GodotMcpAuthOption"/>, accepting only the
+        /// named values (<c>None</c>/<c>Required</c>, case-insensitive) and rejecting numeric strings —
+        /// identical discipline to <see cref="TryParseMode"/> / <see cref="GodotMcpConfig.ResolveActiveAuthOption"/>.
+        /// </summary>
+        static bool TryParseAuthOption(string? raw, out GodotMcpAuthOption authOption)
+        {
+            authOption = default;
+            var normalized = Sanitize(raw);
+            if (string.IsNullOrEmpty(normalized))
+                return false;
+            if (int.TryParse(normalized, out _))
+                return false;
+            return Enum.TryParse(normalized, ignoreCase: true, out authOption);
         }
 
         /// <summary>Sanitize a file value identically to a process-env value (see <see cref="Parse"/>).</summary>

--- a/addons/godot_mcp/Connection/GodotMcpTokenGenerator.cs
+++ b/addons/godot_mcp/Connection/GodotMcpTokenGenerator.cs
@@ -1,0 +1,48 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Security.Cryptography;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// Generates a cryptographically-random, URL-safe bearer token for the Custom-mode connection.
+    /// The Godot analog of Unity-MCP's <c>UnityMcpPlugin.GenerateToken()</c>: 32 random bytes,
+    /// Base64-encoded, then made URL-safe (strip <c>=</c> padding, <c>+</c>→<c>-</c>, <c>/</c>→<c>_</c>).
+    ///
+    /// <para>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>): only <see cref="RandomNumberGenerator"/>
+    /// and <see cref="Convert"/>, so it is unit-testable in the plain-xUnit <c>Godot-MCP.Tests</c> host.
+    /// Because the output is random, the tests pin the FORMAT invariants (length / charset / url-safety),
+    /// not a fixed value.
+    /// </para>
+    /// </summary>
+    public static class GodotMcpTokenGenerator
+    {
+        /// <summary>Number of random bytes hashed into the token (matches the Unity reference).</summary>
+        public const int TokenByteLength = 32;
+
+        /// <summary>
+        /// Produce a fresh URL-safe token. 32 random bytes → Base64 → strip <c>=</c> padding, then
+        /// <c>+</c>→<c>-</c> and <c>/</c>→<c>_</c> so the result is safe in URLs / headers without escaping.
+        /// </summary>
+        public static string Generate()
+        {
+            var bytes = new byte[TokenByteLength];
+            using var rng = RandomNumberGenerator.Create();
+            rng.GetBytes(bytes);
+            return Convert.ToBase64String(bytes)
+                .TrimEnd('=')
+                .Replace('+', '-')
+                .Replace('/', '_');
+        }
+    }
+}

--- a/addons/godot_mcp/UI/ConnectionPanel.cs
+++ b/addons/godot_mcp/UI/ConnectionPanel.cs
@@ -52,6 +52,16 @@ namespace com.IvanMurzak.Godot.MCP.UI
         Label _cloudNote = null!;
         Label _overrideNote = null!;
 
+        // Custom-mode authorization row (auth option + masked token + Generate).
+        OptionButton _authSelector = null!;
+        VBoxContainer _tokenRow = null!;
+        LineEdit _tokenField = null!;
+        Button _generateTokenButton = null!;
+
+        // Index of the two Authorization OptionButton entries — kept stable so a selection maps to a value.
+        const int AuthIdNone = 0;
+        const int AuthIdRequired = 1;
+
         // Timeline dots.
         ColorRect _timelineGodotDot = null!;
         ColorRect _timelineServerDot = null!;
@@ -124,6 +134,42 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _hostField.TextSubmitted += OnHostSubmitted;
             _hostField.FocusExited += OnHostFocusExited;
             _customHostRow.AddChild(_hostField);
+
+            // --- Authorization (Custom mode only): none | required ---
+            var authRow = new HBoxContainer { Name = "AuthRow" };
+            _customHostRow.AddChild(authRow);
+
+            authRow.AddChild(new Label { Name = "AuthLabel", Text = "Authorization" });
+
+            _authSelector = new OptionButton { Name = "AuthSelector" };
+            _authSelector.AddItem("none", AuthIdNone);
+            _authSelector.AddItem("required", AuthIdRequired);
+            _authSelector.ItemSelected += OnAuthOptionSelected;
+            authRow.AddChild(_authSelector);
+
+            // --- Token row (shown only when Authorization == required): masked field + Generate ---
+            _tokenRow = new VBoxContainer { Name = "TokenRow" };
+            _customHostRow.AddChild(_tokenRow);
+
+            _tokenRow.AddChild(new Label { Name = "TokenLabel", Text = "Token" });
+
+            var tokenLine = new HBoxContainer { Name = "TokenLine" };
+            _tokenRow.AddChild(tokenLine);
+
+            _tokenField = new LineEdit
+            {
+                Name = "TokenField",
+                // Masked + read-only: the token is never shown in clear text and is only changed via
+                // Generate (never typed/logged). Mirrors the Unity reference's password token field.
+                Secret = true,
+                Editable = false,
+                SizeFlagsHorizontal = SizeFlags.ExpandFill
+            };
+            tokenLine.AddChild(_tokenField);
+
+            _generateTokenButton = new Button { Name = "GenerateTokenButton", Text = "New" };
+            _generateTokenButton.Pressed += OnGenerateTokenPressed;
+            tokenLine.AddChild(_generateTokenButton);
 
             // --- Cloud-mode note (shown only in Cloud mode; cloud auth is a later task) ---
             _cloudNote = new Label
@@ -219,15 +265,76 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
             if (_connection.Config.ConnectionMode == mode)
             {
-                // No persisted change (e.g. an env override is forcing the active mode); just re-render.
+                // No persisted change selected; just re-render.
                 ApplyModeVisibility(_connection.Config.ActiveMode);
                 return;
             }
 
+            // Persist the user's chosen PERSISTED mode regardless of any env/.env override. The selector
+            // is always enabled (the change "does something" — it updates the persisted layer that takes
+            // effect once the override is removed). Only RECONNECT when the change actually moves the LIVE
+            // active mode: under an env override ActiveMode is pinned, so a persisted-only edit must not
+            // tear down the current connection.
+            var liveModeBefore = _connection.Config.ActiveMode;
             _connection.Config.ConnectionMode = mode;
             _connection.Save();
             ApplyModeVisibility(_connection.Config.ActiveMode);
-            _connection.Reconnect();
+
+            if (_connection.Config.ActiveMode != liveModeBefore)
+                _connection.Reconnect();
+        }
+
+        /// <summary>
+        /// Persist the chosen Custom-mode authorization option (none/required) and reconnect so the
+        /// bearer-token routing takes effect. When set to <c>required</c> with no token yet, generate one
+        /// so the connection has a credential to send. Persists even under an env override (the override
+        /// note explains the env value wins live); only reconnects when the live mode is Custom.
+        /// </summary>
+        void OnAuthOptionSelected(long index)
+        {
+            var authOption = index == AuthIdRequired
+                ? GodotMcpAuthOption.Required
+                : GodotMcpAuthOption.None;
+
+            if (_connection.Config.AuthOption == authOption)
+            {
+                ApplyAuthVisibility();
+                return;
+            }
+
+            _connection.Config.AuthOption = authOption;
+
+            // When switching to required without a stored token, mint one so the connection is usable.
+            if (authOption == GodotMcpAuthOption.Required &&
+                string.IsNullOrEmpty(_connection.Config.CustomToken))
+            {
+                _connection.Config.CustomToken = GodotMcpTokenGenerator.Generate();
+            }
+
+            _connection.Save();
+            ApplyAuthVisibility();
+
+            // Only a live Custom connection is affected by the auth/token routing.
+            if (_connection.Config.ActiveMode == GodotMcpConnectionMode.Custom)
+                _connection.Reconnect();
+        }
+
+        /// <summary>
+        /// Generate a fresh Custom-mode token, persist it, and reconnect so the new bearer is used. The
+        /// token is never logged and is shown only as a masked field. Generating implies the user wants
+        /// auth, so this also flips <see cref="GodotMcpAuthOption"/> to <c>Required</c> if it was off.
+        /// </summary>
+        void OnGenerateTokenPressed()
+        {
+            _connection.Config.CustomToken = GodotMcpTokenGenerator.Generate();
+            if (_connection.Config.AuthOption == GodotMcpAuthOption.None)
+                _connection.Config.AuthOption = GodotMcpAuthOption.Required;
+
+            _connection.Save();
+            ApplyAuthVisibility();
+
+            if (_connection.Config.ActiveMode == GodotMcpConnectionMode.Custom)
+                _connection.Reconnect();
         }
 
         void OnHostSubmitted(string text) => CommitHost(text);
@@ -263,34 +370,66 @@ namespace com.IvanMurzak.Godot.MCP.UI
         }
 
         /// <summary>
-        /// Show the Server-URL row only in Custom mode and the cloud note only in Cloud mode. Also surfaces
-        /// the env/.env override note when a process env / <c>.env</c> value is forcing the active mode away
-        /// from the persisted <see cref="GodotMcpConfig.ConnectionMode"/> (so the user understands why a UI
-        /// change may not take effect). Reflects the EFFECTIVE host in the field (env override shown).
+        /// Drive the editable Custom section off the PERSISTED <see cref="GodotMcpConfig.ConnectionMode"/>
+        /// (so editing the selector / URL / auth always targets the layer the user can change), while the
+        /// override note surfaces when an env/.env value is forcing the LIVE active mode away from that
+        /// persisted choice. The selector + host field stay ENABLED even when overridden — a persisted
+        /// edit "does something" (it takes effect once the override is gone) and does NOT corrupt
+        /// precedence, since env/.env is read live by the config resolvers. The host field shows the
+        /// EFFECTIVE custom host (env override visible) for transparency.
         /// </summary>
         void ApplyModeVisibility(GodotMcpConnectionMode activeMode)
         {
-            var isCustom = activeMode == GodotMcpConnectionMode.Custom;
-            _customHostRow.Visible = isCustom;
-            _cloudNote.Visible = !isCustom;
+            // Editable controls follow the PERSISTED mode (what the user is editing); the cloud-vs-custom
+            // SECTION the user can configure is the persisted one, not the env-forced live one.
+            var persistedMode = _connection.Config.ConnectionMode;
+            var persistedCustom = persistedMode == GodotMcpConnectionMode.Custom;
 
-            if (isCustom)
+            _customHostRow.Visible = persistedCustom;
+            _cloudNote.Visible = !persistedCustom;
+
+            if (persistedCustom)
             {
                 // Show the EFFECTIVE custom host (env GODOT_MCP_HOST wins over the persisted value).
                 _hostField.Text = _connection.Config.ResolveCustomHost();
+                ApplyAuthVisibility();
             }
 
             // The active mode differs from the persisted mode only when an env/.env override forced it.
-            var overridden = activeMode != _connection.Config.ConnectionMode;
+            var overridden = activeMode != persistedMode;
             _overrideNote.Visible = overridden;
-            // When overridden, the persisted-mode UI cannot change the effective mode: disable the field.
-            _hostField.Editable = !overridden;
-            _modeSelector.Disabled = overridden;
+
+            // Keep BOTH the mode selector and the host field ENABLED even when an env/.env value currently
+            // forces the live mode/host: editing them updates the PERSISTED layer (it "does something"),
+            // which takes effect once the override is removed. The override note explains that the env
+            // value still wins for the live connection.
+            _hostField.Editable = true;
+            _modeSelector.Disabled = false;
+        }
+
+        /// <summary>
+        /// Render the Custom-mode authorization controls from the persisted config: the auth selector
+        /// reflects <see cref="GodotMcpConfig.AuthOption"/>, the masked token row is shown only when
+        /// <c>Required</c>, and the field carries the stored Custom token (masked). The token is never
+        /// shown in clear text or logged. Always reads/writes the PERSISTED layer (env auth override is
+        /// surfaced by the override note, not by disabling these controls).
+        /// </summary>
+        void ApplyAuthVisibility()
+        {
+            var required = _connection.Config.AuthOption == GodotMcpAuthOption.Required;
+            _authSelector.Selected = required ? AuthIdRequired : AuthIdNone;
+            _tokenRow.Visible = required;
+            // Masked field carries the stored token; only meaningful when required.
+            _tokenField.Text = required ? (_connection.Config.CustomToken ?? string.Empty) : string.Empty;
         }
 
         void SyncModeSelector(GodotMcpConnectionMode activeMode)
         {
-            _modeSelector.Selected = activeMode == GodotMcpConnectionMode.Cloud ? ModeIdCloud : ModeIdCustom;
+            // Reflect the PERSISTED mode the user edits (not the env-forced live mode); the override note
+            // explains when the two diverge.
+            _modeSelector.Selected = _connection.Config.ConnectionMode == GodotMcpConnectionMode.Cloud
+                ? ModeIdCloud
+                : ModeIdCustom;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- **Disconnect**: clarified that the reused McpPlugin client's reconnect intent lives in its own `KeepConnected` reactive property (set by `plugin.Connect()` / `plugin.Disconnect()`), not in `GodotMcpConfig.KeepConnected` (which the ConnectionManager never reads). `plugin.Disconnect()` already stops reconnect and settles the status to Disconnected; the config field is intent bookkeeping only. Mirrors the Unity reference.
- **Mode-toggle UX**: the mode selector + host field stay enabled even under an env/.env override; editing now persists the choice (takes effect once the override is removed). Reconnect fires only when the LIVE active mode changes; precedence is intact (env/.env read live).
- **Custom-mode auth (Unity parity)**: new `GodotMcpAuthOption` (None/Required, serialized + env-overridable via `GODOT_MCP_AUTH_OPTION`), a URL-safe `GodotMcpTokenGenerator`, auth-gated `ResolveCustomToken()`, and a `#if TOOLS` Authorization OptionButton + masked read-only token field + Generate ("New") button. Token never logged.

## Test plan
- [x] Suite 1 (build) and Suite 2 (xUnit, 304 tests) pass — see profile test.md
- [x] Suite 3 headless Godot 4.5.1 smoke: plugin loaded, deps resolved, dock loaded, Custom-mode connect, no FileNotFoundException, clean unload
- Reused NuGet pins untouched (McpPlugin 6.7.0 / ReflectorNet 5.3.1)

Closes #33