### PR TITLE
feat(connection): Cloud device-code auth (login from the dock)

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -55,6 +55,12 @@
     <!-- URL-safe bearer-token generator: pure-managed (RandomNumberGenerator + Convert), no Godot native
          types / no #if TOOLS. Output is random, so the tests pin FORMAT invariants (length/charset). -->
     <Compile Include="..\addons\godot_mcp\Connection\GodotMcpTokenGenerator.cs" Link="Source\GodotMcpTokenGenerator.cs" />
+    <!-- Cloud device-code auth core: the HTTP transport (mockable HttpMessageHandler) + the flow state
+         machine. Both pure-managed (no Godot native types, no #if TOOLS), so the device flow is unit-tested
+         here with a fake handler + injected delay/clock; the editor wiring lives in the #if TOOLS
+         ConnectionPanel (browser-open + token persistence), verified via the headless smoke (test.md Suite 3). -->
+    <Compile Include="..\addons\godot_mcp\Connection\GodotDeviceAuthService.cs" Link="Source\GodotDeviceAuthService.cs" />
+    <Compile Include="..\addons\godot_mcp\Connection\GodotDeviceAuthFlow.cs" Link="Source\GodotDeviceAuthFlow.cs" />
     <!-- Editor-runtime NuGet-dependency resolver. Pure-BCL (System.Runtime.Loader), no #if TOOLS,
          no Godot native types — so it is unit-testable in this plain-xUnit host. -->
     <Compile Include="..\addons\godot_mcp\Connection\GodotMcpAssemblyResolver.cs" Link="Source\GodotMcpAssemblyResolver.cs" />

--- a/Godot-MCP.Tests/GodotDeviceAuthFlowTests.cs
+++ b/Godot-MCP.Tests/GodotDeviceAuthFlowTests.cs
@@ -1,0 +1,364 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.Godot.MCP.Connection;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Covers the pure-managed cloud device-code auth core (<see cref="GodotDeviceAuthFlow"/> +
+    /// <see cref="GodotDeviceAuthService"/>) with a scripted <see cref="HttpMessageHandler"/> and an
+    /// injected no-op delay + clock so the polling loop runs instantly (never the real 5s interval).
+    ///
+    /// <para>
+    /// SECURITY assertion threaded through the suite: the issued access token must NEVER appear in any
+    /// flow <see cref="GodotDeviceAuthFlow.ErrorMessage"/>, <see cref="GodotDeviceAuthFlow.UserCode"/>, or
+    /// the verification URL. The token is observable ONLY as the <c>StartAsync</c> return value.
+    /// </para>
+    /// </summary>
+    public class GodotDeviceAuthFlowTests
+    {
+        const string CloudBaseUrl = "https://ai-game.dev";
+        const string AccessToken = "super-secret-access-token-value";
+
+        // --- Happy path: issuance + immediate token ---
+
+        [Fact]
+        public async Task StartAsync_ImmediateToken_ReachesAuthorized_AndReturnsToken()
+        {
+            var handler = new ScriptedHandler(
+                AuthorizeOk(userCode: "WXYZ-1234"),
+                TokenOk(AccessToken));
+
+            var (flow, states) = MakeFlow(handler);
+
+            var token = await flow.StartAsync(CloudBaseUrl, "Godot Editor");
+
+            Assert.Equal(AccessToken, token);
+            Assert.Equal(GodotDeviceAuthFlowState.Authorized, flow.State);
+            Assert.Equal("WXYZ-1234", flow.UserCode);
+            Assert.Equal($"{CloudBaseUrl}/verify?code=WXYZ-1234", flow.VerificationUriComplete);
+
+            // State events fire in order: Initiating -> WaitingForUser -> Polling -> Authorized.
+            Assert.Equal(new[]
+            {
+                GodotDeviceAuthFlowState.Initiating,
+                GodotDeviceAuthFlowState.WaitingForUser,
+                GodotDeviceAuthFlowState.Polling,
+                GodotDeviceAuthFlowState.Authorized
+            }, states);
+
+            AssertTokenNotLeaked(flow);
+        }
+
+        [Fact]
+        public async Task InitiateDeviceAuth_ParsesAllFields()
+        {
+            var handler = new ScriptedHandler(
+                AuthorizeOk(userCode: "AAAA-BBBB", deviceCode: "dev-code-123", interval: 5, expiresIn: 600),
+                TokenOk(AccessToken));
+
+            var service = new GodotDeviceAuthService(new HttpClient(handler));
+            var response = await service.InitiateDeviceAuthAsync(CloudBaseUrl, "Godot Editor");
+
+            Assert.Equal("dev-code-123", response.DeviceCode);
+            Assert.Equal("AAAA-BBBB", response.UserCode);
+            Assert.Equal(5, response.Interval);
+            Assert.Equal(600, response.ExpiresIn);
+            Assert.Equal($"{CloudBaseUrl}/verify?code=AAAA-BBBB", response.VerificationUriComplete);
+        }
+
+        // --- authorization_pending keeps polling, then succeeds ---
+
+        [Fact]
+        public async Task StartAsync_PendingThenToken_KeepsPolling_ThenAuthorized()
+        {
+            var handler = new ScriptedHandler(
+                AuthorizeOk(),
+                TokenError("authorization_pending"),
+                TokenError("authorization_pending"),
+                TokenOk(AccessToken));
+
+            var (flow, _) = MakeFlow(handler);
+
+            var token = await flow.StartAsync(CloudBaseUrl);
+
+            Assert.Equal(AccessToken, token);
+            Assert.Equal(GodotDeviceAuthFlowState.Authorized, flow.State);
+            // 1 authorize + 3 token polls.
+            Assert.Equal(4, handler.RequestCount);
+            AssertTokenNotLeaked(flow);
+        }
+
+        // --- slow_down backs the interval off ---
+
+        [Fact]
+        public async Task StartAsync_SlowDown_BacksOffInterval()
+        {
+            var delays = new List<TimeSpan>();
+            var handler = new ScriptedHandler(
+                AuthorizeOk(interval: 5),
+                TokenError("slow_down"),
+                TokenError("slow_down"),
+                TokenOk(AccessToken));
+
+            var flow = new GodotDeviceAuthFlow(
+                new GodotDeviceAuthService(new HttpClient(handler)),
+                delay: (ts, _) => { delays.Add(ts); return Task.CompletedTask; },
+                utcNow: FixedClock());
+
+            var token = await flow.StartAsync(CloudBaseUrl);
+
+            Assert.Equal(AccessToken, token);
+            // Interval starts at 5s, +5 per slow_down (capped at 30): poll1=5, poll2=10, poll3=15.
+            Assert.Equal(3, delays.Count);
+            Assert.Equal(TimeSpan.FromSeconds(5), delays[0]);
+            Assert.Equal(TimeSpan.FromSeconds(10), delays[1]);
+            Assert.Equal(TimeSpan.FromSeconds(15), delays[2]);
+        }
+
+        [Fact]
+        public async Task StartAsync_SlowDown_IntervalCapsAtMax()
+        {
+            var delays = new List<TimeSpan>();
+            // 6 slow_downs would push 5 -> 35 uncapped; the cap holds it at 30.
+            var responses = new List<Func<HttpResponseMessage>> { AuthorizeOk(interval: 5) };
+            for (var i = 0; i < 6; i++)
+                responses.Add(TokenError("slow_down"));
+            responses.Add(TokenOk(AccessToken));
+
+            var flow = new GodotDeviceAuthFlow(
+                new GodotDeviceAuthService(new HttpClient(new ScriptedHandler(responses.ToArray()))),
+                delay: (ts, _) => { delays.Add(ts); return Task.CompletedTask; },
+                utcNow: FixedClock());
+
+            await flow.StartAsync(CloudBaseUrl);
+
+            Assert.Equal(TimeSpan.FromSeconds(GodotDeviceAuthFlow.MaxIntervalSeconds), delays[^1]);
+            Assert.All(delays, d => Assert.True(d <= TimeSpan.FromSeconds(GodotDeviceAuthFlow.MaxIntervalSeconds)));
+        }
+
+        // --- access_denied -> Failed ---
+
+        [Fact]
+        public async Task StartAsync_AccessDenied_ReachesFailed()
+        {
+            var handler = new ScriptedHandler(AuthorizeOk(), TokenError("access_denied"));
+            var (flow, _) = MakeFlow(handler);
+
+            var token = await flow.StartAsync(CloudBaseUrl);
+
+            Assert.Null(token);
+            Assert.Equal(GodotDeviceAuthFlowState.Failed, flow.State);
+            Assert.False(string.IsNullOrEmpty(flow.ErrorMessage));
+            AssertTokenNotLeaked(flow);
+        }
+
+        // --- expired_token -> Expired ---
+
+        [Fact]
+        public async Task StartAsync_ExpiredToken_ReachesExpired()
+        {
+            var handler = new ScriptedHandler(AuthorizeOk(), TokenError("expired_token"));
+            var (flow, _) = MakeFlow(handler);
+
+            var token = await flow.StartAsync(CloudBaseUrl);
+
+            Assert.Null(token);
+            Assert.Equal(GodotDeviceAuthFlowState.Expired, flow.State);
+        }
+
+        // --- deadline reached (expires_in elapses) -> Expired ---
+
+        [Fact]
+        public async Task StartAsync_DeadlineElapses_ReachesExpired()
+        {
+            // expires_in = 10s; the fake clock jumps 20s on the first now() AFTER the deadline is computed,
+            // so the while-loop condition is false before any poll. Pending response is present but unused.
+            var handler = new ScriptedHandler(AuthorizeOk(expiresIn: 10), TokenError("authorization_pending"));
+
+            // Clock: first call (deadline base) = t0; subsequent calls = t0 + 20s (past the 10s deadline).
+            var t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var calls = 0;
+            Func<DateTime> clock = () => calls++ == 0 ? t0 : t0.AddSeconds(20);
+
+            var flow = new GodotDeviceAuthFlow(
+                new GodotDeviceAuthService(new HttpClient(handler)),
+                delay: (_, _) => Task.CompletedTask,
+                utcNow: clock);
+
+            var token = await flow.StartAsync(CloudBaseUrl);
+
+            Assert.Null(token);
+            Assert.Equal(GodotDeviceAuthFlowState.Expired, flow.State);
+        }
+
+        // --- Cancel() -> Cancelled ---
+
+        [Fact]
+        public async Task Cancel_DuringPoll_ReachesCancelled()
+        {
+            GodotDeviceAuthFlow? flowRef = null;
+
+            // Cancel the flow the moment the token endpoint is first hit (mid-poll), via the handler hook.
+            var handler = new ScriptedHandler(AuthorizeOk(), TokenError("authorization_pending"))
+            {
+                OnTokenRequest = () => flowRef!.Cancel()
+            };
+
+            var flow = new GodotDeviceAuthFlow(
+                new GodotDeviceAuthService(new HttpClient(handler)),
+                delay: Task.Delay,
+                utcNow: FixedClock());
+            flowRef = flow;
+
+            var token = await flow.StartAsync(CloudBaseUrl);
+
+            Assert.Null(token);
+            Assert.Equal(GodotDeviceAuthFlowState.Cancelled, flow.State);
+            AssertTokenNotLeaked(flow);
+        }
+
+        // --- HTTP failure on authorize -> Failed, no token in message ---
+
+        [Fact]
+        public async Task StartAsync_AuthorizeHttp500_ReachesFailed_NoTokenLeak()
+        {
+            var handler = new ScriptedHandler(() => new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            {
+                Content = new StringContent("boom")
+            });
+            var (flow, _) = MakeFlow(handler);
+
+            var token = await flow.StartAsync(CloudBaseUrl);
+
+            Assert.Null(token);
+            Assert.Equal(GodotDeviceAuthFlowState.Failed, flow.State);
+            AssertTokenNotLeaked(flow);
+        }
+
+        // --- Token is never exposed anywhere except the return value ---
+
+        [Fact]
+        public async Task StartAsync_Authorized_TokenNotInAnyStringSurface()
+        {
+            var handler = new ScriptedHandler(AuthorizeOk(userCode: "CODE-9999"), TokenOk(AccessToken));
+            var (flow, states) = MakeFlow(handler);
+
+            var token = await flow.StartAsync(CloudBaseUrl);
+            Assert.Equal(AccessToken, token);
+
+            // Token must not appear in UserCode / VerificationUriComplete / ErrorMessage, nor in any
+            // pure-managed status message the UI would render for the observed states.
+            AssertTokenNotLeaked(flow);
+            foreach (var s in states)
+            {
+                var msg = UI.ConnectionPanelView.CloudAuthStatusMessage(s, flow.UserCode, flow.ErrorMessage);
+                Assert.DoesNotContain(AccessToken, msg, StringComparison.Ordinal);
+            }
+        }
+
+        // --- helpers ---
+
+        static (GodotDeviceAuthFlow flow, List<GodotDeviceAuthFlowState> states) MakeFlow(ScriptedHandler handler)
+        {
+            var flow = new GodotDeviceAuthFlow(
+                new GodotDeviceAuthService(new HttpClient(handler)),
+                delay: (_, _) => Task.CompletedTask,
+                utcNow: FixedClock());
+
+            var states = new List<GodotDeviceAuthFlowState>();
+            flow.OnStateChanged += s => states.Add(s);
+            return (flow, states);
+        }
+
+        /// <summary>A clock that always returns the same early instant, so the expires_in deadline never elapses.</summary>
+        static Func<DateTime> FixedClock()
+        {
+            var t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            return () => t0;
+        }
+
+        static void AssertTokenNotLeaked(GodotDeviceAuthFlow flow)
+        {
+            Assert.True(string.IsNullOrEmpty(flow.UserCode) || !flow.UserCode!.Contains(AccessToken, StringComparison.Ordinal));
+            Assert.True(string.IsNullOrEmpty(flow.ErrorMessage) || !flow.ErrorMessage!.Contains(AccessToken, StringComparison.Ordinal));
+            Assert.True(string.IsNullOrEmpty(flow.VerificationUriComplete) || !flow.VerificationUriComplete!.Contains(AccessToken, StringComparison.Ordinal));
+        }
+
+        static Func<HttpResponseMessage> AuthorizeOk(
+            string userCode = "USER-CODE", string deviceCode = "device-code", int interval = 5, int expiresIn = 600)
+            => () => JsonResponse(HttpStatusCode.OK, $$"""
+                {
+                  "device_code": "{{deviceCode}}",
+                  "user_code": "{{userCode}}",
+                  "verification_uri": "https://ai-game.dev/verify",
+                  "verification_uri_complete": "https://ai-game.dev/verify?code={{userCode}}",
+                  "expires_in": {{expiresIn}},
+                  "interval": {{interval}}
+                }
+                """);
+
+        static Func<HttpResponseMessage> TokenOk(string accessToken)
+            => () => JsonResponse(HttpStatusCode.OK, $$"""
+                { "access_token": "{{accessToken}}", "token_type": "Bearer" }
+                """);
+
+        static Func<HttpResponseMessage> TokenError(string error)
+            => () => JsonResponse(HttpStatusCode.BadRequest, $$"""
+                { "error": "{{error}}", "error_description": "{{error}} description" }
+                """);
+
+        static HttpResponseMessage JsonResponse(HttpStatusCode code, string json)
+            => new(code) { Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json") };
+
+        /// <summary>
+        /// A test <see cref="HttpMessageHandler"/> that replays a scripted sequence of responses. The first
+        /// scripted response answers the authorize POST; each subsequent one answers a token POST. An
+        /// optional <see cref="OnTokenRequest"/> hook fires before each token response (used to cancel mid-poll).
+        /// </summary>
+        sealed class ScriptedHandler : HttpMessageHandler
+        {
+            readonly Queue<Func<HttpResponseMessage>> _responses;
+
+            public ScriptedHandler(params Func<HttpResponseMessage>[] responses)
+            {
+                _responses = new Queue<Func<HttpResponseMessage>>(responses);
+            }
+
+            public int RequestCount { get; private set; }
+
+            /// <summary>Invoked just before each token-endpoint response is produced (authorize is skipped).</summary>
+            public Action? OnTokenRequest { get; set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                RequestCount++;
+
+                var isToken = request.RequestUri!.AbsolutePath.EndsWith("/token", StringComparison.Ordinal);
+                if (isToken)
+                    OnTokenRequest?.Invoke();
+
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var next = _responses.Count > 0 ? _responses.Dequeue() : (() => JsonResponse(HttpStatusCode.BadRequest, "{ \"error\": \"authorization_pending\" }"));
+                return Task.FromResult(next());
+            }
+        }
+    }
+}

--- a/addons/godot_mcp/Connection/GodotDeviceAuthFlow.cs
+++ b/addons/godot_mcp/Connection/GodotDeviceAuthFlow.cs
@@ -1,0 +1,216 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>The state machine states of a single device-authorization run.</summary>
+    public enum GodotDeviceAuthFlowState
+    {
+        /// <summary>No flow has started yet (fresh instance).</summary>
+        Idle,
+
+        /// <summary>The authorize request is in flight.</summary>
+        Initiating,
+
+        /// <summary>The server returned a user code; the user must visit the verification URL and approve.</summary>
+        WaitingForUser,
+
+        /// <summary>Polling the token endpoint, waiting for the user's approval to land.</summary>
+        Polling,
+
+        /// <summary>An access token was issued — the flow succeeded.</summary>
+        Authorized,
+
+        /// <summary>The authorization was denied, or an unexpected error occurred.</summary>
+        Failed,
+
+        /// <summary>The device code or the overall flow deadline expired before approval.</summary>
+        Expired,
+
+        /// <summary>The flow was cancelled (by <see cref="GodotDeviceAuthFlow.Cancel"/> or a cancellation token).</summary>
+        Cancelled
+    }
+
+    /// <summary>
+    /// Drives a single OAuth 2.0 device-authorization-grant run end-to-end: initiate → wait-for-user →
+    /// poll → terminal state. The Godot analog of Unity-MCP's <c>DeviceAuthFlow</c>, but engine-free:
+    /// it contains NO Godot types (no <c>Application.OpenURL</c>, no token persistence) so it is
+    /// unit-testable in the plain-xUnit host with a mockable <see cref="GodotDeviceAuthService"/>. The UI
+    /// layer (the <c>#if TOOLS</c> <c>ConnectionPanel</c>) opens the browser on
+    /// <see cref="GodotDeviceAuthFlowState.WaitingForUser"/> and persists the token on
+    /// <see cref="GodotDeviceAuthFlowState.Authorized"/>.
+    ///
+    /// <para>
+    /// SECURITY: the issued access token is returned from <see cref="StartAsync"/> for the caller to
+    /// persist — it is NEVER stored in <see cref="ErrorMessage"/>, logged, or otherwise surfaced as a
+    /// human-readable string. <see cref="ErrorMessage"/> only ever holds non-secret diagnostic text.
+    /// </para>
+    /// </summary>
+    public sealed class GodotDeviceAuthFlow
+    {
+        /// <summary>Minimum poll interval (seconds) the server's <c>interval</c> is clamped up to — the device-flow floor.</summary>
+        public const int MinIntervalSeconds = 5;
+
+        /// <summary>Increment (seconds) added to the interval on a <c>slow_down</c> server hint.</summary>
+        public const int SlowDownIncrementSeconds = 5;
+
+        /// <summary>Ceiling (seconds) the interval backs off to under repeated <c>slow_down</c> hints.</summary>
+        public const int MaxIntervalSeconds = 30;
+
+        readonly GodotDeviceAuthService _service;
+        readonly Func<TimeSpan, CancellationToken, Task> _delay;
+        readonly Func<DateTime> _utcNow;
+
+        CancellationTokenSource? _cts;
+
+        /// <summary>The current state. Starts at <see cref="GodotDeviceAuthFlowState.Idle"/>.</summary>
+        public GodotDeviceAuthFlowState State { get; private set; } = GodotDeviceAuthFlowState.Idle;
+
+        /// <summary>The short user code to display once <see cref="GodotDeviceAuthFlowState.WaitingForUser"/> is reached.</summary>
+        public string? UserCode { get; private set; }
+
+        /// <summary>The full verification URL (with the code embedded) for the UI to open in a browser. NOT a secret.</summary>
+        public string? VerificationUriComplete { get; private set; }
+
+        /// <summary>Non-secret diagnostic message for a Failed / Expired terminal state. NEVER contains a token.</summary>
+        public string? ErrorMessage { get; private set; }
+
+        /// <summary>Raised on every <see cref="State"/> transition. Subscribers must marshal to the UI thread themselves.</summary>
+        public event Action<GodotDeviceAuthFlowState>? OnStateChanged;
+
+        /// <summary>
+        /// Construct a flow. <paramref name="service"/> defaults to a fresh
+        /// <see cref="GodotDeviceAuthService"/> over the shared HttpClient. <paramref name="delay"/> and
+        /// <paramref name="utcNow"/> are injectable for fast, deterministic tests (the editor path uses the
+        /// real <see cref="Task.Delay(TimeSpan, CancellationToken)"/> + <see cref="DateTime.UtcNow"/>).
+        /// </summary>
+        public GodotDeviceAuthFlow(
+            GodotDeviceAuthService? service = null,
+            Func<TimeSpan, CancellationToken, Task>? delay = null,
+            Func<DateTime>? utcNow = null)
+        {
+            _service = service ?? new GodotDeviceAuthService();
+            _delay = delay ?? Task.Delay;
+            _utcNow = utcNow ?? (() => DateTime.UtcNow);
+        }
+
+        /// <summary>
+        /// Run the device flow against <paramref name="cloudBaseUrl"/>. Returns the issued access token on
+        /// success, or <c>null</c> on any non-Authorized terminal state. The token is the ONLY channel the
+        /// secret leaves through — it is never logged or placed in <see cref="ErrorMessage"/>. A second
+        /// call cancels any in-flight run first.
+        /// </summary>
+        public async Task<string?> StartAsync(string cloudBaseUrl, string? clientLabel = null)
+        {
+            Cancel();
+            _cts = new CancellationTokenSource();
+            var ct = _cts.Token;
+
+            try
+            {
+                SetState(GodotDeviceAuthFlowState.Initiating);
+
+                var authResponse = await _service
+                    .InitiateDeviceAuthAsync(cloudBaseUrl, clientLabel, ct)
+                    .ConfigureAwait(false);
+
+                UserCode = authResponse.UserCode;
+                VerificationUriComplete = authResponse.VerificationUriComplete;
+
+                SetState(GodotDeviceAuthFlowState.WaitingForUser);
+                SetState(GodotDeviceAuthFlowState.Polling);
+
+                var intervalSeconds = Math.Max(authResponse.Interval, MinIntervalSeconds);
+                var deadline = _utcNow().AddSeconds(authResponse.ExpiresIn);
+
+                while (_utcNow() < deadline)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    await _delay(TimeSpan.FromSeconds(intervalSeconds), ct).ConfigureAwait(false);
+
+                    var tokenResponse = await _service
+                        .PollDeviceTokenAsync(cloudBaseUrl, authResponse.DeviceCode, ct)
+                        .ConfigureAwait(false);
+
+                    if (!string.IsNullOrEmpty(tokenResponse.AccessToken))
+                    {
+                        // Reach the terminal state BEFORE returning the token, but never store the token
+                        // on this instance — it flows out only as the return value.
+                        SetState(GodotDeviceAuthFlowState.Authorized);
+                        return tokenResponse.AccessToken;
+                    }
+
+                    switch (tokenResponse.Error)
+                    {
+                        case "access_denied":
+                            ErrorMessage = "Authorization was denied.";
+                            SetState(GodotDeviceAuthFlowState.Failed);
+                            return null;
+
+                        case "expired_token":
+                            SetState(GodotDeviceAuthFlowState.Expired);
+                            return null;
+
+                        case "slow_down":
+                            intervalSeconds = Math.Min(intervalSeconds + SlowDownIncrementSeconds, MaxIntervalSeconds);
+                            break;
+
+                        // "authorization_pending" (and any other transient/unknown error) — keep polling.
+                        default:
+                            break;
+                    }
+                }
+
+                SetState(GodotDeviceAuthFlowState.Expired);
+                return null;
+            }
+            catch (OperationCanceledException)
+            {
+                SetState(GodotDeviceAuthFlowState.Cancelled);
+                return null;
+            }
+            catch (Exception ex)
+            {
+                // ex.Message comes from HTTP/JSON failures — never from a token, so it is safe to surface.
+                ErrorMessage = ex.Message;
+                SetState(GodotDeviceAuthFlowState.Failed);
+                return null;
+            }
+        }
+
+        /// <summary>Cancel any in-flight run; the active <see cref="StartAsync"/> settles on <see cref="GodotDeviceAuthFlowState.Cancelled"/>.</summary>
+        public void Cancel()
+        {
+            var cts = _cts;
+            _cts = null;
+            if (cts != null)
+            {
+                try { cts.Cancel(); } catch (ObjectDisposedException) { }
+                cts.Dispose();
+            }
+        }
+
+        /// <summary>True while the flow is mid-run (the Authorize button shows "Cancel" in these states).</summary>
+        public static bool IsRunning(GodotDeviceAuthFlowState state) =>
+            state == GodotDeviceAuthFlowState.Initiating
+            || state == GodotDeviceAuthFlowState.WaitingForUser
+            || state == GodotDeviceAuthFlowState.Polling;
+
+        void SetState(GodotDeviceAuthFlowState state)
+        {
+            State = state;
+            OnStateChanged?.Invoke(state);
+        }
+    }
+}

--- a/addons/godot_mcp/Connection/GodotDeviceAuthService.cs
+++ b/addons/godot_mcp/Connection/GodotDeviceAuthService.cs
@@ -1,0 +1,143 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// Stateless HTTP transport for the OAuth 2.0 device-authorization-grant ("device code") flow against
+    /// the cloud server's <c>/api/auth/device/*</c> endpoints. The Godot analog of Unity-MCP's
+    /// <c>DeviceAuthService</c> — pure-managed (no Godot native types, no <c>#if TOOLS</c>), so it is
+    /// unit-testable in the plain-xUnit <c>Godot-MCP.Tests</c> host with a mockable
+    /// <see cref="HttpMessageHandler"/>.
+    ///
+    /// <para>
+    /// The <see cref="HttpClient"/> is injected (default: a process-shared instance) so tests can
+    /// substitute a fake handler. JSON uses <see cref="JsonNamingPolicy.SnakeCaseLower"/> +
+    /// case-insensitive matching, mirroring the server contract.
+    /// </para>
+    /// </summary>
+    public sealed class GodotDeviceAuthService
+    {
+        static readonly HttpClient SharedHttpClient = new();
+
+        static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            PropertyNameCaseInsensitive = true
+        };
+
+        readonly HttpClient _httpClient;
+
+        /// <summary>
+        /// Create a service over a specific <see cref="HttpClient"/> (tests inject one wrapping a fake
+        /// <see cref="HttpMessageHandler"/>). When <paramref name="httpClient"/> is <c>null</c>, the
+        /// process-shared client is used (the editor path).
+        /// </summary>
+        public GodotDeviceAuthService(HttpClient? httpClient = null)
+        {
+            _httpClient = httpClient ?? SharedHttpClient;
+        }
+
+        /// <summary>
+        /// POST <c>&lt;cloudBaseUrl&gt;/api/auth/device/authorize</c> with <c>{ "client_label": ... }</c>
+        /// to begin a device-authorization flow. Throws on a non-success HTTP status (the caller's flow
+        /// turns the exception into a Failed state).
+        /// </summary>
+        public async Task<DeviceAuthorizeResponse> InitiateDeviceAuthAsync(
+            string cloudBaseUrl, string? clientLabel, CancellationToken ct = default)
+        {
+            var body = clientLabel != null
+                ? JsonSerializer.Serialize(new { client_label = clientLabel }, JsonOptions)
+                : "{}";
+
+            using var content = new StringContent(body, Encoding.UTF8, "application/json");
+            using var response = await _httpClient
+                .PostAsync($"{cloudBaseUrl.TrimEnd('/')}/api/auth/device/authorize", content, ct)
+                .ConfigureAwait(false);
+
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            return JsonSerializer.Deserialize<DeviceAuthorizeResponse>(json, JsonOptions)
+                ?? throw new InvalidOperationException("Failed to deserialize device authorize response.");
+        }
+
+        /// <summary>
+        /// POST <c>&lt;cloudBaseUrl&gt;/api/auth/device/token</c> with the device code + grant type to poll
+        /// for the access token. Unlike <see cref="InitiateDeviceAuthAsync"/>, this does NOT throw on a
+        /// non-2xx status: the device-flow spec carries pending/slow-down/denied as a structured
+        /// <c>error</c> body (often with a 400), so the caller inspects <see cref="DeviceTokenResponse.Error"/>.
+        /// </summary>
+        public async Task<DeviceTokenResponse> PollDeviceTokenAsync(
+            string cloudBaseUrl, string deviceCode, CancellationToken ct = default)
+        {
+            var body = JsonSerializer.Serialize(new
+            {
+                device_code = deviceCode,
+                grant_type = "urn:ietf:params:oauth:grant-type:device_code"
+            }, JsonOptions);
+
+            using var content = new StringContent(body, Encoding.UTF8, "application/json");
+            using var response = await _httpClient
+                .PostAsync($"{cloudBaseUrl.TrimEnd('/')}/api/auth/device/token", content, ct)
+                .ConfigureAwait(false);
+
+            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            return JsonSerializer.Deserialize<DeviceTokenResponse>(json, JsonOptions)
+                ?? throw new InvalidOperationException("Failed to deserialize device token response.");
+        }
+
+        /// <summary>Response of <c>POST /api/auth/device/authorize</c>.</summary>
+        public sealed class DeviceAuthorizeResponse
+        {
+            [JsonPropertyName("device_code")]
+            public string DeviceCode { get; set; } = "";
+
+            [JsonPropertyName("user_code")]
+            public string UserCode { get; set; } = "";
+
+            [JsonPropertyName("verification_uri")]
+            public string VerificationUri { get; set; } = "";
+
+            [JsonPropertyName("verification_uri_complete")]
+            public string VerificationUriComplete { get; set; } = "";
+
+            [JsonPropertyName("expires_in")]
+            public int ExpiresIn { get; set; }
+
+            [JsonPropertyName("interval")]
+            public int Interval { get; set; }
+        }
+
+        /// <summary>Response of <c>POST /api/auth/device/token</c> (success carries the token; otherwise an error).</summary>
+        public sealed class DeviceTokenResponse
+        {
+            [JsonPropertyName("access_token")]
+            public string? AccessToken { get; set; }
+
+            [JsonPropertyName("token_type")]
+            public string? TokenType { get; set; }
+
+            [JsonPropertyName("error")]
+            public string? Error { get; set; }
+
+            [JsonPropertyName("error_description")]
+            public string? ErrorDescription { get; set; }
+        }
+    }
+}

--- a/addons/godot_mcp/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConnection.cs
@@ -70,6 +70,14 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// </summary>
         readonly SerialDisposable _stateSubscription = new();
 
+        /// <summary>
+        /// Live subscription to the reused client's <see cref="IConnection.OnAuthorizationRejected"/> stream.
+        /// Re-created on every <see cref="Start"/> and disposed on <see cref="Dispose"/> (same lifecycle as
+        /// <see cref="_stateSubscription"/>). Marshals the rejection onto the editor main thread before
+        /// raising <see cref="AuthorizationRejected"/>.
+        /// </summary>
+        readonly SerialDisposable _authRejectedSubscription = new();
+
         /// <summary>Last reduced status, cached so <see cref="ConnectionStatus"/> is readable without a live plugin.</summary>
         ConnectionStatus _status = ConnectionStatus.Disconnected;
 
@@ -78,6 +86,22 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
         /// <summary>The built plugin instance, or null before <see cref="Start"/> / after <see cref="Dispose"/>.</summary>
         public IMcpPlugin? Plugin => _plugin;
+
+        /// <summary>
+        /// The resolved cloud BASE url (no <c>/mcp</c> hub suffix) — the host the device-auth endpoints
+        /// (<c>/api/auth/device/*</c>) live on. The dock's Cloud-auth section passes this to
+        /// <see cref="GodotDeviceAuthFlow.StartAsync"/>. Read live off the config so an env override applies.
+        /// </summary>
+        public string CloudBaseUrl => GodotMcpConfig.ResolveCloudBaseUrl();
+
+        /// <summary>
+        /// Raised when the server rejects the connection's authorization token (the reused client's
+        /// <see cref="IConnection.OnAuthorizationRejected"/> fired). ALWAYS marshalled onto the Godot editor
+        /// main thread, so a UI handler may clear the stored token and touch <see cref="Godot.Control"/>s
+        /// directly. The Cloud-auth section subscribes to drop the rejected <c>CloudToken</c> and revert to
+        /// the Authorize state. The token itself is never passed through this event (it carries no payload).
+        /// </summary>
+        public event Action? AuthorizationRejected;
 
         /// <summary>
         /// The current simplified connection status (Disconnected / Connecting / Connected), reduced from
@@ -188,6 +212,18 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                         MainThreadDispatcher.Enqueue(() => PublishStatus(status));
                     else
                         PublishStatus(status);
+                });
+
+            // Surface the reused client's authorization-rejected stream as a main-thread event the dock can
+            // act on (clear the rejected token, revert to Authorize). R3 fires off the SignalR thread, so we
+            // hop to the editor main thread before raising, mirroring the status subscription above.
+            _authRejectedSubscription.Disposable = plugin.OnAuthorizationRejected
+                .Subscribe(_ =>
+                {
+                    if (MainThreadDispatcher.Instance != null && !MainThreadDispatcher.IsMainThread)
+                        MainThreadDispatcher.Enqueue(() => AuthorizationRejected?.Invoke());
+                    else
+                        AuthorizationRejected?.Invoke();
                 });
         }
 
@@ -395,6 +431,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         public void Dispose()
         {
             _stateSubscription.Dispose();
+            _authRejectedSubscription.Dispose();
             DisposePlugin();
         }
 
@@ -407,8 +444,10 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// </summary>
         void DisposePlugin()
         {
-            // Release the live state subscription's inner disposable (keeps the SerialDisposable reusable).
+            // Release the live state + auth-rejected subscriptions' inner disposables (keeps the
+            // SerialDisposables reusable for the next Start()).
             _stateSubscription.Disposable = null;
+            _authRejectedSubscription.Disposable = null;
 
             // Clear the ambient reflector if it is the one we published, so a stale instance does not
             // outlive the connection that owned it.

--- a/addons/godot_mcp/UI/ConnectionPanel.cs
+++ b/addons/godot_mcp/UI/ConnectionPanel.cs
@@ -9,7 +9,9 @@
 */
 #if TOOLS
 #nullable enable
+using System.Threading.Tasks;
 using com.IvanMurzak.Godot.MCP.Connection;
+using com.IvanMurzak.Godot.MCP.MainThreadDispatch;
 using Godot;
 
 namespace com.IvanMurzak.Godot.MCP.UI
@@ -49,8 +51,17 @@ namespace com.IvanMurzak.Godot.MCP.UI
         OptionButton _modeSelector = null!;
         VBoxContainer _customHostRow = null!;
         LineEdit _hostField = null!;
-        Label _cloudNote = null!;
         Label _overrideNote = null!;
+
+        // Cloud-mode auth section (device-code flow): masked token + Authorize/Revoke + status.
+        VBoxContainer _cloudAuthRow = null!;
+        LineEdit _cloudTokenField = null!;
+        Button _authorizeButton = null!;
+        Button _revokeButton = null!;
+        Label _cloudAuthStatus = null!;
+
+        // The in-flight device-auth flow (null when none has run). Recreated per Authorize click.
+        GodotDeviceAuthFlow? _deviceAuthFlow;
 
         // Custom-mode authorization row (auth option + masked token + Generate).
         OptionButton _authSelector = null!;
@@ -78,8 +89,9 @@ namespace com.IvanMurzak.Godot.MCP.UI
             BuildUi();
 
             // Subscribe AFTER the UI exists so the first push has controls to write to. The connection
-            // marshals this event onto the editor main thread, so the handler may touch Controls directly.
+            // marshals these events onto the editor main thread, so the handlers may touch Controls directly.
             _connection.ConnectionStatusChanged += OnConnectionStatusChanged;
+            _connection.AuthorizationRejected += OnAuthorizationRejected;
 
             // Render the current state immediately (the event only fires on CHANGE).
             ApplyStatus(_connection.ConnectionStatus);
@@ -171,14 +183,41 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _generateTokenButton.Pressed += OnGenerateTokenPressed;
             tokenLine.AddChild(_generateTokenButton);
 
-            // --- Cloud-mode note (shown only in Cloud mode; cloud auth is a later task) ---
-            _cloudNote = new Label
+            // --- Cloud-mode auth section (shown only in Cloud mode): device-code login ---
+            _cloudAuthRow = new VBoxContainer { Name = "CloudAuthRow" };
+            AddChild(_cloudAuthRow);
+
+            _cloudAuthRow.AddChild(new Label { Name = "CloudTokenLabel", Text = "Cloud Token" });
+
+            var cloudTokenLine = new HBoxContainer { Name = "CloudTokenLine" };
+            _cloudAuthRow.AddChild(cloudTokenLine);
+
+            _cloudTokenField = new LineEdit
             {
-                Name = "CloudNote",
-                Text = "Cloud auth is configured separately.",
+                Name = "CloudTokenField",
+                // Masked + read-only: the access token is never shown in clear text and is only ever set by
+                // the device-auth flow (never typed/logged). Mirrors the Custom-mode token field.
+                Secret = true,
+                Editable = false,
+                PlaceholderText = ConnectionPanelView.CloudTokenPlaceholder,
+                SizeFlagsHorizontal = SizeFlags.ExpandFill
+            };
+            cloudTokenLine.AddChild(_cloudTokenField);
+
+            _authorizeButton = new Button { Name = "AuthorizeButton", Text = ConnectionPanelView.AuthorizeButtonText };
+            _authorizeButton.Pressed += OnAuthorizeButtonPressed;
+            cloudTokenLine.AddChild(_authorizeButton);
+
+            _revokeButton = new Button { Name = "RevokeButton", Text = "Revoke" };
+            _revokeButton.Pressed += OnRevokeButtonPressed;
+            cloudTokenLine.AddChild(_revokeButton);
+
+            _cloudAuthStatus = new Label
+            {
+                Name = "CloudAuthStatus",
                 AutowrapMode = TextServer.AutowrapMode.WordSmart
             };
-            AddChild(_cloudNote);
+            _cloudAuthRow.AddChild(_cloudAuthStatus);
 
             // --- Env/.env override note (shown when a process env / .env value forces mode or host) ---
             _overrideNote = new Label
@@ -386,13 +425,17 @@ namespace com.IvanMurzak.Godot.MCP.UI
             var persistedCustom = persistedMode == GodotMcpConnectionMode.Custom;
 
             _customHostRow.Visible = persistedCustom;
-            _cloudNote.Visible = !persistedCustom;
+            _cloudAuthRow.Visible = !persistedCustom;
 
             if (persistedCustom)
             {
                 // Show the EFFECTIVE custom host (env GODOT_MCP_HOST wins over the persisted value).
                 _hostField.Text = _connection.Config.ResolveCustomHost();
                 ApplyAuthVisibility();
+            }
+            else
+            {
+                ApplyCloudAuthState();
             }
 
             // The active mode differs from the persisted mode only when an env/.env override forced it.
@@ -423,6 +466,148 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _tokenField.Text = required ? (_connection.Config.CustomToken ?? string.Empty) : string.Empty;
         }
 
+        /// <summary>
+        /// Render the Cloud-mode auth controls from the persisted <see cref="GodotMcpConfig.CloudToken"/>:
+        /// the masked field carries the stored token (or shows the placeholder via empty text), and the
+        /// Revoke button is visible only when a token is stored. Called on Cloud-mode entry and after every
+        /// token change. The token is never shown in clear text or logged.
+        /// </summary>
+        void ApplyCloudAuthState()
+        {
+            var token = _connection.Config.CloudToken;
+            var hasToken = !string.IsNullOrEmpty(token);
+
+            // Empty text → the masked LineEdit shows its PlaceholderText ("Token — press Authorize").
+            _cloudTokenField.Text = hasToken ? token! : string.Empty;
+            _revokeButton.Visible = hasToken;
+        }
+
+        /// <summary>
+        /// Start (or cancel) the device-code authorization flow. While running, the button shows "Cancel"
+        /// and a click cancels the in-flight flow. The flow runs on a background task; every state change is
+        /// marshalled onto the editor main thread before touching any <see cref="Control"/>. On
+        /// <see cref="GodotDeviceAuthFlowState.WaitingForUser"/> the verification URL is opened in the
+        /// browser; on <see cref="GodotDeviceAuthFlowState.Authorized"/> the returned token is persisted and
+        /// the connection reconnects. The token is never logged.
+        /// </summary>
+        void OnAuthorizeButtonPressed()
+        {
+            // A click while a flow is running means "Cancel".
+            if (_deviceAuthFlow != null && GodotDeviceAuthFlow.IsRunning(_deviceAuthFlow.State))
+            {
+                _deviceAuthFlow.Cancel();
+                return;
+            }
+
+            _deviceAuthFlow?.Cancel();
+            var flow = new GodotDeviceAuthFlow();
+            _deviceAuthFlow = flow;
+
+            flow.OnStateChanged += state =>
+            {
+                // OnStateChanged fires on the flow's background task thread; hop to the editor main thread
+                // before touching Controls. A missing dispatcher (between editor reloads) degrades to a
+                // direct call rather than throwing.
+                if (MainThreadDispatcher.Instance != null && !MainThreadDispatcher.IsMainThread)
+                    MainThreadDispatcher.Enqueue(() => OnAuthFlowStateChanged(flow, state));
+                else
+                    OnAuthFlowStateChanged(flow, state);
+            };
+
+            // Fire-and-forget; the state-change handler drives the status/button/browser UI, and the awaited
+            // result persists the token (the token NEVER lives on the flow instance — it only flows out as
+            // StartAsync's return value, so config writes stay on the main thread via the dispatcher).
+            _ = RunAuthFlowAsync(flow);
+        }
+
+        async Task RunAuthFlowAsync(GodotDeviceAuthFlow flow)
+        {
+            var token = await flow.StartAsync(_connection.CloudBaseUrl, "Godot Editor");
+            if (string.IsNullOrEmpty(token))
+                return; // Non-Authorized terminal state: nothing to persist (UI already reflects it).
+
+            // Persist + reconnect on the editor main thread (the awaited continuation may run off-thread).
+            if (MainThreadDispatcher.Instance != null && !MainThreadDispatcher.IsMainThread)
+                MainThreadDispatcher.Enqueue(() => PersistAuthorizedToken(flow, token!));
+            else
+                PersistAuthorizedToken(flow, token!);
+        }
+
+        /// <summary>
+        /// Apply one device-auth flow state transition to the UI (status line, button label, browser-open).
+        /// MUST run on the editor main thread. Ignores events from a stale flow (a newer Authorize click
+        /// replaced <see cref="_deviceAuthFlow"/>). Token persistence happens in
+        /// <see cref="PersistAuthorizedToken"/> off the awaited result, not here.
+        /// </summary>
+        void OnAuthFlowStateChanged(GodotDeviceAuthFlow flow, GodotDeviceAuthFlowState state)
+        {
+            // Drop late events from a flow that has been superseded by a newer one.
+            if (!ReferenceEquals(_deviceAuthFlow, flow))
+                return;
+
+            // Status line. UserCode is safe to show; the access token never reaches this string.
+            _cloudAuthStatus.Text = ConnectionPanelView.CloudAuthStatusMessage(state, flow.UserCode, flow.ErrorMessage);
+            _authorizeButton.Text = ConnectionPanelView.CloudAuthButtonText(state);
+
+            // Open the verification URL so the user can approve in the browser.
+            if (state == GodotDeviceAuthFlowState.WaitingForUser && !string.IsNullOrEmpty(flow.VerificationUriComplete))
+                OS.ShellOpen(flow.VerificationUriComplete);
+        }
+
+        /// <summary>
+        /// Persist the cloud token produced by an Authorized flow, refresh the masked field, and reconnect.
+        /// MUST run on the editor main thread. Ignores a stale flow. The token is written straight to config
+        /// and never logged.
+        /// </summary>
+        void PersistAuthorizedToken(GodotDeviceAuthFlow flow, string token)
+        {
+            if (!ReferenceEquals(_deviceAuthFlow, flow))
+                return;
+
+            _connection.Config.CloudToken = token;
+            _connection.Save();
+            ApplyCloudAuthState();
+
+            // Reconnect so the new bearer is used — only meaningful when the live mode is Cloud.
+            if (_connection.Config.ActiveMode == GodotMcpConnectionMode.Cloud)
+                _connection.Reconnect();
+        }
+
+        /// <summary>
+        /// Revoke the stored cloud token: clear it, persist, revert the UI to the Authorize state, and (if
+        /// the live mode is Cloud) disconnect so the now-unauthenticated session does not linger.
+        /// </summary>
+        void OnRevokeButtonPressed()
+        {
+            _connection.Config.CloudToken = null;
+            _connection.Save();
+            _cloudAuthStatus.Text = "Token revoked.";
+            ApplyCloudAuthState();
+
+            if (_connection.Config.ActiveMode == GodotMcpConnectionMode.Cloud)
+                _connection.Disconnect();
+        }
+
+        /// <summary>
+        /// Handle a server-side authorization rejection (the connection's
+        /// <see cref="GodotMcpConnection.AuthorizationRejected"/> fired, already on the main thread): drop
+        /// the rejected cloud token, persist, revert the UI to Authorize, and warn the user WITHOUT logging
+        /// the token (it carries no payload through this event anyway).
+        /// </summary>
+        void OnAuthorizationRejected()
+        {
+            // Only relevant to Cloud mode — a Custom-mode rejection is the Custom token's concern.
+            if (_connection.Config.ActiveMode != GodotMcpConnectionMode.Cloud)
+                return;
+
+            _connection.Config.CloudToken = null;
+            _connection.Save();
+            _cloudAuthStatus.Text = "Authorization rejected by server — press Authorize.";
+            ApplyCloudAuthState();
+
+            GD.PushWarning("[Godot-MCP] server rejected the authorization token; cleared — press Authorize.");
+        }
+
         void SyncModeSelector(GodotMcpConnectionMode activeMode)
         {
             // Reflect the PERSISTED mode the user edits (not the env-forced live mode); the override note
@@ -445,8 +630,13 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
         public override void _ExitTree()
         {
-            // Unsubscribe so a freed panel does not receive a late main-thread status push.
+            // Unsubscribe so a freed panel does not receive a late main-thread push.
             _connection.ConnectionStatusChanged -= OnConnectionStatusChanged;
+            _connection.AuthorizationRejected -= OnAuthorizationRejected;
+
+            // Cancel any in-flight device-auth flow so its background poll loop stops touching a freed panel.
+            _deviceAuthFlow?.Cancel();
+            _deviceAuthFlow = null;
         }
     }
 }

--- a/addons/godot_mcp/UI/ConnectionPanelView.cs
+++ b/addons/godot_mcp/UI/ConnectionPanelView.cs
@@ -9,6 +9,7 @@
 */
 #nullable enable
 using System;
+using com.IvanMurzak.Godot.MCP.Connection;
 using Microsoft.AspNetCore.SignalR.Client;
 
 namespace com.IvanMurzak.Godot.MCP.UI
@@ -126,5 +127,40 @@ namespace com.IvanMurzak.Godot.MCP.UI
             var normalized = Connection.GodotMcpConfig.NormalizeUrl(url);
             return !string.IsNullOrEmpty(normalized) && Connection.GodotMcpConfig.IsValidHttpUrl(normalized!);
         }
+
+        // --- Cloud device-auth presentation (pure-managed, unit-tested). ---
+
+        /// <summary>Cloud-token field placeholder shown when no token is stored (the field is masked + read-only).</summary>
+        public const string CloudTokenPlaceholder = "Token — press Authorize";
+
+        /// <summary>Authorize-button label while the flow is idle / finished (clicking starts a new flow).</summary>
+        public const string AuthorizeButtonText = "Authorize";
+
+        /// <summary>Authorize-button label while the flow is running (clicking cancels it).</summary>
+        public const string AuthorizeButtonCancelText = "Cancel";
+
+        /// <summary>
+        /// The status line for a given device-auth flow state. Mirrors Unity-MCP's
+        /// <c>GetAuthFlowStatusMessage</c>. The <paramref name="userCode"/> is fine to show (it is the
+        /// short device code the user types into the browser); the access TOKEN is NEVER passed here or
+        /// shown anywhere except masked in the token field. <paramref name="errorMessage"/> is the flow's
+        /// non-secret diagnostic text. Pure-managed → unit-tested.
+        /// </summary>
+        public static string CloudAuthStatusMessage(
+            GodotDeviceAuthFlowState state, string? userCode, string? errorMessage) => state switch
+        {
+            GodotDeviceAuthFlowState.Initiating => "Initiating…",
+            GodotDeviceAuthFlowState.WaitingForUser => $"Code: {userCode} — Authorize in browser",
+            GodotDeviceAuthFlowState.Polling => $"Code: {userCode} — Waiting…",
+            GodotDeviceAuthFlowState.Authorized => "Authorized!",
+            GodotDeviceAuthFlowState.Failed => $"Failed: {errorMessage}",
+            GodotDeviceAuthFlowState.Expired => "Expired — try again",
+            GodotDeviceAuthFlowState.Cancelled => "Cancelled",
+            _ => string.Empty
+        };
+
+        /// <summary>The Authorize/Cancel button text for a given flow state (Cancel while running).</summary>
+        public static string CloudAuthButtonText(GodotDeviceAuthFlowState state) =>
+            GodotDeviceAuthFlow.IsRunning(state) ? AuthorizeButtonCancelText : AuthorizeButtonText;
     }
 }


### PR DESCRIPTION
## Summary
- Port Unity-MCP's cloud device-authorization-grant ("device code") flow so a user can log in to ai-game.dev from the Godot dock's **Cloud** mode.
- Pure-managed device-flow core (`GodotDeviceAuthService` HTTP transport + `GodotDeviceAuthFlow` state machine) — no Godot types, mockable `HttpMessageHandler`, injectable delay/clock — and the `#if TOOLS` Cloud-auth UI in `ConnectionPanel` (masked token field, Authorize/Cancel + Revoke, status line, `OS.ShellOpen` of the verification URL, persist + reconnect on success).
- `GodotMcpConnection` now exposes `CloudBaseUrl` and an `AuthorizationRejected` event wired to the reused client's `OnAuthorizationRejected` (clears the rejected token, reverts the UI).
- The access token is masked in the UI and **never logged** or placed in any status / error / exception text; it is stored only in `user://godot-mcp-config.json`.

## Test plan
- [x] Suite 1 — `dotnet build Godot-MCP.sln` (0 errors).
- [x] Suite 2 — `dotnet test Godot-MCP.Tests` (315 passed; +11 new device-auth tests: issuance, pending→success, slow_down backoff + cap, access_denied, expired/deadline, cancel, HTTP failure, no-token-leak across every state surface).
- [x] Suite 3 — headless Godot 4.5.1 smoke: `[Godot-MCP] plugin loaded`, all deps resolved (McpPlugin 6.7.0 / R3 / SignalR), no `FileNotFoundException`, dock built in Cloud mode (instantiates the new Cloud-auth section).

Reused NuGet pins untouched (McpPlugin 6.7.0 / ReflectorNet 5.3.1).

Closes #35