### PR TITLE
feat(editor): MCP features panel + nested enable/disable windows

### DIFF
--- a/Godot-MCP.Tests/FeaturesPanelViewTests.cs
+++ b/Godot-MCP.Tests/FeaturesPanelViewTests.cs
@@ -1,0 +1,62 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using com.IvanMurzak.Godot.MCP.Connection;
+using com.IvanMurzak.Godot.MCP.UI;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the pure-managed features-panel label formatting (<see cref="FeaturesPanelView"/>) — the
+    /// "&lt;Title&gt;: X / Y" count row, the "~N tokens" sub-label, and the "—" placeholders. The editor Control
+    /// wiring (FeaturesPanel.cs / FeatureRow.cs / FeatureListWindow.cs, all <c>#if TOOLS</c>) instantiates live
+    /// Godot nodes and is verified via the headless Godot smoke (test.md Suite 3) — NOT here.
+    /// </summary>
+    public class FeaturesPanelViewTests
+    {
+        [Theory]
+        [InlineData(GodotMcpFeatureKind.Tools, "Tools")]
+        [InlineData(GodotMcpFeatureKind.Prompts, "Prompts")]
+        [InlineData(GodotMcpFeatureKind.Resources, "Resources")]
+        public void Title_maps_each_kind(GodotMcpFeatureKind kind, string expected)
+        {
+            Assert.Equal(expected, FeaturesPanelView.Title(kind));
+        }
+
+        [Fact]
+        public void CountLabel_formats_enabled_over_total_with_title()
+        {
+            Assert.Equal("Tools: 3 / 7", FeaturesPanelView.CountLabel(GodotMcpFeatureKind.Tools, 3, 7));
+            Assert.Equal("Prompts: 0 / 0", FeaturesPanelView.CountLabel(GodotMcpFeatureKind.Prompts, 0, 0));
+            Assert.Equal("Resources: 5 / 5", FeaturesPanelView.CountLabel(GodotMcpFeatureKind.Resources, 5, 5));
+        }
+
+        [Fact]
+        public void UnavailableLabel_uses_the_dash_placeholder_for_both_counts()
+        {
+            Assert.Equal("Tools: — / —", FeaturesPanelView.UnavailableLabel(GodotMcpFeatureKind.Tools));
+            Assert.Equal("—", FeaturesPanelView.Unavailable);
+        }
+
+        [Fact]
+        public void TokenLabel_formats_with_tilde_and_suffix()
+        {
+            Assert.Equal("~1234 tokens", FeaturesPanelView.TokenLabel(1234));
+            Assert.Equal("~0 tokens", FeaturesPanelView.TokenLabel(0));
+        }
+
+        [Fact]
+        public void UnavailableTokenLabel_uses_the_dash_placeholder()
+        {
+            Assert.Equal("~— tokens", FeaturesPanelView.UnavailableTokenLabel());
+        }
+    }
+}

--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -52,6 +52,14 @@
          precedence layer (no Godot native types, no #if TOOLS). The editor wiring that resolves the
          user:// path lives in GodotMcpConnection.cs (#if TOOLS); the path-injectable core is unit-tested. -->
     <Compile Include="..\addons\godot_mcp\Connection\GodotMcpConfigStore.cs" Link="Source\GodotMcpConfigStore.cs" />
+    <!-- MCP-features enable-map — pure-managed (no Godot native types, no #if TOOLS, no McpPlugin dependency):
+         the per-kind feature-state list (GodotMcpFeatureMap/GodotMcpFeatureState) that GodotMcpConfig serializes,
+         and the merge/capture logic (GodotMcpFeatureStateMerge) the boot-reapply + window-toggle drive. The live
+         IToolManager/IPromptManager/IResourceManager wiring (FeatureManagerAdapters.cs) is #if TOOLS and verified
+         via the headless Godot smoke (test.md Suite 3); the merge rules are unit-tested here. -->
+    <Compile Include="..\addons\godot_mcp\Connection\GodotMcpFeatureState.cs" Link="Source\GodotMcpFeatureState.cs" />
+    <Compile Include="..\addons\godot_mcp\Connection\GodotMcpFeatureMap.cs" Link="Source\GodotMcpFeatureMap.cs" />
+    <Compile Include="..\addons\godot_mcp\Connection\GodotMcpFeatureStateMerge.cs" Link="Source\GodotMcpFeatureStateMerge.cs" />
     <!-- URL-safe bearer-token generator: pure-managed (RandomNumberGenerator + Convert), no Godot native
          types / no #if TOOLS. Output is random, so the tests pin FORMAT invariants (length/charset). -->
     <Compile Include="..\addons\godot_mcp\Connection\GodotMcpTokenGenerator.cs" Link="Source\GodotMcpTokenGenerator.cs" />
@@ -115,6 +123,11 @@
          URLs/copy opened by the dock footer. The editor Control wiring (SupportFooter.cs) is #if TOOLS and
          verified via the headless Godot smoke (test.md Suite 3); the constants are unit-tested here. -->
     <Compile Include="..\addons\godot_mcp\UI\SupportFooterLinks.cs" Link="Source\SupportFooterLinks.cs" />
+    <!-- Features-panel presentation logic — pure-managed (no Godot native types, no #if TOOLS): the
+         "<Title>: X / Y" count label, the "~N tokens" sub-label, per-kind titles, and the "—" placeholder.
+         The editor Control wiring (FeaturesPanel.cs / FeatureRow.cs / FeatureListWindow.cs) is #if TOOLS and
+         verified via the headless Godot smoke (test.md Suite 3); the label formatting is unit-tested here. -->
+    <Compile Include="..\addons\godot_mcp\UI\FeaturesPanelView.cs" Link="Source\FeaturesPanelView.cs" />
   </ItemGroup>
 
 </Project>

--- a/Godot-MCP.Tests/GodotMcpFeatureMapPersistenceTests.cs
+++ b/Godot-MCP.Tests/GodotMcpFeatureMapPersistenceTests.cs
@@ -1,0 +1,134 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using com.IvanMurzak.Godot.MCP.Connection;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the persistence of the MCP-feature enable-map (<see cref="GodotMcpFeatureMap"/>) through the
+    /// pure-managed <see cref="GodotMcpConfigStore"/>: the <c>features</c> key Save→Load round-trip, the
+    /// default-empty (fresh install disables nothing) baseline, the <see cref="GodotMcpConfigStore.ApplyPersisted"/>
+    /// seeding of the boot path, and backwards-compatibility with an older config file that has NO <c>features</c>
+    /// key. Filesystem fixtures use a unique temp dir per test, cleaned on dispose.
+    /// </summary>
+    public class GodotMcpFeatureMapPersistenceTests : IDisposable
+    {
+        readonly string _dir;
+
+        public GodotMcpFeatureMapPersistenceTests()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "godot-mcp-features-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(_dir))
+                    Directory.Delete(_dir, recursive: true);
+            }
+            catch
+            {
+                // Best-effort cleanup; a leaked temp dir is harmless.
+            }
+        }
+
+        string PathFor(string name) => Path.Combine(_dir, name);
+
+        [Fact]
+        public void Fresh_config_has_an_empty_feature_map_disabling_nothing()
+        {
+            var config = new GodotMcpConfig();
+
+            Assert.NotNull(config.Features);
+            Assert.Empty(config.Features.Tools);
+            Assert.Empty(config.Features.Prompts);
+            Assert.Empty(config.Features.Resources);
+        }
+
+        [Fact]
+        public void Save_then_Load_round_trips_the_feature_map()
+        {
+            var path = PathFor("config.json");
+            var config = new GodotMcpConfig();
+            config.Features.Tools.Add(new GodotMcpFeatureState("ping", false));
+            config.Features.Tools.Add(new GodotMcpFeatureState("node-find", true));
+            config.Features.Prompts.Add(new GodotMcpFeatureState("greet", false));
+            config.Features.Resources.Add(new GodotMcpFeatureState("res-a", false));
+
+            GodotMcpConfigStore.Save(path, config);
+            var loaded = GodotMcpConfigStore.Load(path);
+
+            Assert.NotNull(loaded);
+            Assert.Equal(2, loaded!.Features.Tools.Count);
+            Assert.False(loaded.Features.Tools.Single(t => t.Name == "ping").Enabled);
+            Assert.True(loaded.Features.Tools.Single(t => t.Name == "node-find").Enabled);
+            Assert.False(loaded.Features.Prompts.Single(p => p.Name == "greet").Enabled);
+            Assert.False(loaded.Features.Resources.Single(r => r.Name == "res-a").Enabled);
+        }
+
+        [Fact]
+        public void Saved_json_uses_the_features_key_and_per_kind_lists()
+        {
+            var path = PathFor("config.json");
+            var config = new GodotMcpConfig();
+            config.Features.Tools.Add(new GodotMcpFeatureState("ping", false));
+
+            GodotMcpConfigStore.Save(path, config);
+            var json = File.ReadAllText(path);
+
+            Assert.Contains("\"features\"", json);
+            Assert.Contains("\"tools\"", json);
+            Assert.Contains("\"ping\"", json);
+        }
+
+        [Fact]
+        public void ApplyPersisted_seeds_the_feature_map_onto_the_boot_config()
+        {
+            var persisted = new GodotMcpConfig();
+            persisted.Features.Tools.Add(new GodotMcpFeatureState("ping", false));
+
+            var target = new GodotMcpConfig();
+            GodotMcpConfigStore.ApplyPersisted(target, persisted);
+
+            Assert.Single(target.Features.Tools);
+            Assert.False(target.Features.Tools[0].Enabled);
+        }
+
+        [Fact]
+        public void Loading_an_older_config_without_a_features_key_yields_an_empty_map()
+        {
+            // Backwards-compat: a config file written before the features section existed has no `features`
+            // key — it must deserialize to a non-null, empty map (the property initializer), not null.
+            var path = PathFor("legacy.json");
+            File.WriteAllText(path, "{ \"host\": \"http://localhost:9000\", \"connectionMode\": \"Custom\" }");
+
+            var loaded = GodotMcpConfigStore.Load(path);
+
+            Assert.NotNull(loaded);
+            Assert.NotNull(loaded!.Features);
+            Assert.Empty(loaded.Features.Tools);
+            Assert.Empty(loaded.Features.Prompts);
+            Assert.Empty(loaded.Features.Resources);
+
+            // ApplyPersisted onto a fresh config likewise leaves an empty (non-null) map.
+            var target = new GodotMcpConfig();
+            GodotMcpConfigStore.ApplyPersisted(target, loaded);
+            Assert.NotNull(target.Features);
+            Assert.Empty(target.Features.Tools);
+        }
+    }
+}

--- a/Godot-MCP.Tests/GodotMcpFeatureStateMergeTests.cs
+++ b/Godot-MCP.Tests/GodotMcpFeatureStateMergeTests.cs
@@ -1,0 +1,166 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using com.IvanMurzak.Godot.MCP.Connection;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the pure-managed MCP-feature enable-map merge/capture logic (<see cref="GodotMcpFeatureStateMerge"/>):
+    /// the boot REAPPLY (saved-map ⊕ live-names → explicit SetEnabled calls), the CAPTURE (live → persistable
+    /// list), and the single-item UPSERT used on a user toggle. These rules are the unit-testable core behind the
+    /// <c>#if TOOLS</c> editor wiring that talks to the live managers; the wiring itself is verified via the
+    /// headless Godot smoke (test.md Suite 3), not here.
+    /// </summary>
+    public class GodotMcpFeatureStateMergeTests
+    {
+        static GodotMcpFeatureState S(string name, bool enabled) => new(name, enabled);
+
+        [Fact]
+        public void ComputeReapply_default_empty_map_disables_nothing()
+        {
+            // DEFAULT-EMPTY = ALL-ENABLED: with no saved entries, no explicit SetEnabled calls are emitted, so
+            // every live item stays at the manager default (enabled).
+            var live = new[] { "a", "b", "c" };
+            var result = GodotMcpFeatureStateMerge.ComputeReapply(live, new List<GodotMcpFeatureState>());
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void ComputeReapply_applies_only_saved_entries_matching_live_items()
+        {
+            var live = new[] { "a", "b", "c" };
+            var saved = new List<GodotMcpFeatureState> { S("a", false), S("c", true) };
+
+            var result = GodotMcpFeatureStateMerge.ComputeReapply(live, saved);
+
+            // Only the two saved names are emitted; "b" (no saved entry) is omitted (stays at default).
+            Assert.Equal(2, result.Count);
+            Assert.False(result["a"]);
+            Assert.True(result["c"]);
+            Assert.False(result.ContainsKey("b"));
+        }
+
+        [Fact]
+        public void ComputeReapply_prunes_unknown_saved_names()
+        {
+            // A saved entry for a removed/renamed item ("ghost") is dropped — UNKNOWN-NAME PRUNING.
+            var live = new[] { "a" };
+            var saved = new List<GodotMcpFeatureState> { S("a", false), S("ghost", false) };
+
+            var result = GodotMcpFeatureStateMerge.ComputeReapply(live, saved);
+
+            Assert.Single(result);
+            Assert.False(result["a"]);
+            Assert.False(result.ContainsKey("ghost"));
+        }
+
+        [Fact]
+        public void ComputeReapply_last_wins_on_duplicate_saved_names()
+        {
+            var live = new[] { "a" };
+            var saved = new List<GodotMcpFeatureState> { S("a", true), S("a", false) };
+
+            var result = GodotMcpFeatureStateMerge.ComputeReapply(live, saved);
+
+            Assert.False(result["a"]); // last entry wins
+        }
+
+        [Fact]
+        public void ComputeReapply_ignores_null_and_empty_named_saved_entries()
+        {
+            var live = new[] { "a" };
+            var saved = new List<GodotMcpFeatureState> { null!, S("", false), S("a", false) };
+
+            var result = GodotMcpFeatureStateMerge.ComputeReapply(live, saved);
+
+            Assert.Single(result);
+            Assert.False(result["a"]);
+        }
+
+        [Fact]
+        public void Capture_snapshots_every_live_item()
+        {
+            var live = new (string, bool)[] { ("a", true), ("b", false), ("c", true) };
+
+            var captured = GodotMcpFeatureStateMerge.Capture(live);
+
+            Assert.Equal(3, captured.Count);
+            Assert.Equal("a", captured[0].Name);
+            Assert.True(captured[0].Enabled);
+            Assert.Equal("b", captured[1].Name);
+            Assert.False(captured[1].Enabled);
+        }
+
+        [Fact]
+        public void Capture_skips_empty_names_and_dedupes()
+        {
+            var live = new (string, bool)[] { ("a", true), ("", false), ("a", false) };
+
+            var captured = GodotMcpFeatureStateMerge.Capture(live);
+
+            Assert.Single(captured);
+            Assert.Equal("a", captured[0].Name);
+            Assert.True(captured[0].Enabled); // first "a" wins (dedupe keeps first)
+        }
+
+        [Fact]
+        public void Capture_then_ComputeReapply_round_trips_disabled_state()
+        {
+            // A user disables "b"; capturing then reapplying restores exactly that disable.
+            var live = new (string Name, bool Enabled)[] { ("a", true), ("b", false), ("c", true) };
+            var saved = GodotMcpFeatureStateMerge.Capture(live);
+
+            var reapply = GodotMcpFeatureStateMerge.ComputeReapply(live.Select(x => x.Name), saved);
+
+            Assert.True(reapply["a"]);
+            Assert.False(reapply["b"]);
+            Assert.True(reapply["c"]);
+        }
+
+        [Fact]
+        public void Upsert_inserts_a_new_entry()
+        {
+            var saved = new List<GodotMcpFeatureState>();
+
+            GodotMcpFeatureStateMerge.Upsert(saved, "a", false);
+
+            Assert.Single(saved);
+            Assert.Equal("a", saved[0].Name);
+            Assert.False(saved[0].Enabled);
+        }
+
+        [Fact]
+        public void Upsert_updates_an_existing_entry_in_place()
+        {
+            var saved = new List<GodotMcpFeatureState> { S("a", true), S("b", true) };
+
+            GodotMcpFeatureStateMerge.Upsert(saved, "a", false);
+
+            Assert.Equal(2, saved.Count); // no new entry added
+            Assert.False(saved.Single(s => s.Name == "a").Enabled);
+            Assert.True(saved.Single(s => s.Name == "b").Enabled);
+        }
+
+        [Fact]
+        public void Upsert_ignores_empty_name()
+        {
+            var saved = new List<GodotMcpFeatureState>();
+
+            GodotMcpFeatureStateMerge.Upsert(saved, "", true);
+
+            Assert.Empty(saved);
+        }
+    }
+}

--- a/addons/godot_mcp/Connection/FeatureManagerAdapters.cs
+++ b/addons/godot_mcp/Connection/FeatureManagerAdapters.cs
@@ -1,0 +1,100 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using com.IvanMurzak.McpPlugin;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// A uniform view over one of the reused McpPlugin feature managers (<see cref="IToolManager"/> /
+    /// <see cref="IPromptManager"/> / <see cref="IResourceManager"/>). The three managers expose the same
+    /// shape (enumerate / count / is-enabled / set-enabled) under different method names; this collapses them
+    /// to one surface so <see cref="GodotMcpConnection"/> and the dock's features UI can address any kind
+    /// generically via <see cref="GodotMcpFeatureKind"/>. Editor-only (<c>#if TOOLS</c>): it depends on the
+    /// reused client types, which are only present once the connection assembly is loaded. The map merge/
+    /// capture decisions stay pure-managed in <see cref="GodotMcpFeatureStateMerge"/>; this adapter is just the
+    /// thin live-manager binding (verified via the headless Godot smoke, not the plain-xUnit host).
+    /// </summary>
+    public interface IFeatureManagerAdapter
+    {
+        /// <summary>Live item names of this kind.</summary>
+        IEnumerable<string> GetNames();
+
+        /// <summary>Live items as (name, description, enabled) tuples.</summary>
+        IEnumerable<(string Name, string? Description, bool Enabled)> GetItems();
+
+        /// <summary>(enabled, total, enabledTokenCount) — token count is non-zero only for tools.</summary>
+        (int Enabled, int Total, int EnabledTokenCount) GetCounts();
+
+        /// <summary>Set one item's enabled-state on the live manager.</summary>
+        void SetEnabled(string name, bool enabled);
+    }
+
+    /// <summary>Adapter over <see cref="IToolManager"/> (the only kind with a token count).</summary>
+    public sealed class ToolManagerAdapter : IFeatureManagerAdapter
+    {
+        readonly IToolManager _manager;
+        public ToolManagerAdapter(IToolManager manager) => _manager = manager;
+
+        public IEnumerable<string> GetNames() =>
+            _manager.GetAllTools().Where(t => t != null).Select(t => t.Name);
+
+        public IEnumerable<(string Name, string? Description, bool Enabled)> GetItems() =>
+            _manager.GetAllTools().Where(t => t != null)
+                .Select(t => (t.Name, t.Description, _manager.IsToolEnabled(t.Name)));
+
+        public (int Enabled, int Total, int EnabledTokenCount) GetCounts() =>
+            (_manager.EnabledToolsCount, _manager.TotalToolsCount, _manager.EnabledToolsTokenCount);
+
+        public void SetEnabled(string name, bool enabled) => _manager.SetToolEnabled(name, enabled);
+    }
+
+    /// <summary>Adapter over <see cref="IPromptManager"/> (no token count → reports 0).</summary>
+    public sealed class PromptManagerAdapter : IFeatureManagerAdapter
+    {
+        readonly IPromptManager _manager;
+        public PromptManagerAdapter(IPromptManager manager) => _manager = manager;
+
+        public IEnumerable<string> GetNames() =>
+            _manager.GetAllPrompts().Where(p => p != null).Select(p => p.Name);
+
+        public IEnumerable<(string Name, string? Description, bool Enabled)> GetItems() =>
+            _manager.GetAllPrompts().Where(p => p != null)
+                .Select(p => (p.Name, p.Description, _manager.IsPromptEnabled(p.Name)));
+
+        public (int Enabled, int Total, int EnabledTokenCount) GetCounts() =>
+            (_manager.EnabledPromptsCount, _manager.TotalPromptsCount, 0);
+
+        public void SetEnabled(string name, bool enabled) => _manager.SetPromptEnabled(name, enabled);
+    }
+
+    /// <summary>Adapter over <see cref="IResourceManager"/> (no token count → reports 0).</summary>
+    public sealed class ResourceManagerAdapter : IFeatureManagerAdapter
+    {
+        readonly IResourceManager _manager;
+        public ResourceManagerAdapter(IResourceManager manager) => _manager = manager;
+
+        public IEnumerable<string> GetNames() =>
+            _manager.GetAllResources().Where(r => r != null).Select(r => r.Name);
+
+        public IEnumerable<(string Name, string? Description, bool Enabled)> GetItems() =>
+            _manager.GetAllResources().Where(r => r != null)
+                .Select(r => (r.Name, r.Description, _manager.IsResourceEnabled(r.Name)));
+
+        public (int Enabled, int Total, int EnabledTokenCount) GetCounts() =>
+            (_manager.EnabledResourcesCount, _manager.TotalResourcesCount, 0);
+
+        public void SetEnabled(string name, bool enabled) => _manager.SetResourceEnabled(name, enabled);
+    }
+}
+#endif

--- a/addons/godot_mcp/Connection/GodotMcpConfig.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConfig.cs
@@ -120,6 +120,16 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         public GodotMcpAuthOption AuthOption { get; set; } = GodotMcpAuthOption.None;
 
         /// <summary>
+        /// Persisted per-feature enable/disable map for the dock's MCP-features section (tools / prompts /
+        /// resources). Only user-touched items are stored; an empty map means "everything at its live default"
+        /// (the McpPlugin managers default to enabled), so a fresh install disables nothing. Reapplied on plugin
+        /// boot (see <c>GodotMcpConnection.ReapplyFeatureStates</c>) and updated when the user toggles an item in
+        /// a feature list window. The merge/capture logic is pure-managed (<see cref="GodotMcpFeatureStateMerge"/>).
+        /// </summary>
+        [JsonPropertyName("features")]
+        public GodotMcpFeatureMap Features { get; set; } = new();
+
+        /// <summary>
         /// The effective connection mode after applying the <see cref="EnvConnectionMode"/> override.
         /// Never serialized — recomputed from the env each access so a process-level override always wins.
         /// </summary>

--- a/addons/godot_mcp/Connection/GodotMcpConfigStore.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConfigStore.cs
@@ -115,8 +115,8 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// <summary>
         /// Apply the SERIALIZED-LAYER values from <paramref name="persisted"/> onto <paramref name="target"/>,
         /// writing only the serialized backing fields (<c>CustomHost</c>/<c>CustomToken</c>/
-        /// <c>CloudToken</c>/<c>ConnectionMode</c>/<c>AuthOption</c>). This is how the boot path seeds the
-        /// config with the persisted baseline BEFORE the <c>.env</c>/process-env layers are applied on
+        /// <c>CloudToken</c>/<c>ConnectionMode</c>/<c>AuthOption</c>/<c>Features</c>). This is how the boot path
+        /// seeds the config with the persisted baseline BEFORE the <c>.env</c>/process-env layers are applied on
         /// top — keeping the documented precedence intact. No-op when <paramref name="persisted"/> is
         /// <c>null</c>. Returns <paramref name="target"/> for fluent use.
         /// </summary>
@@ -132,6 +132,9 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             target.CloudToken = persisted.CloudToken;
             target.ConnectionMode = persisted.ConnectionMode;
             target.AuthOption = persisted.AuthOption;
+            // The persisted feature enable-map (tools/prompts/resources). A missing `features` key in an older
+            // config file deserializes to a non-null empty map (the property initializer), so this is always safe.
+            target.Features = persisted.Features ?? new GodotMcpFeatureMap();
 
             return target;
         }

--- a/addons/godot_mcp/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConnection.cs
@@ -10,6 +10,8 @@
 #if TOOLS
 #nullable enable
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using com.IvanMurzak.Godot.MCP.MainThreadDispatch;
@@ -78,6 +80,15 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// </summary>
         readonly SerialDisposable _authRejectedSubscription = new();
 
+        /// <summary>
+        /// Live subscription to the three feature managers' <c>On*Updated</c> streams (tools / prompts /
+        /// resources), merged into a single editor-main-thread <see cref="FeaturesUpdated"/> event the dock's
+        /// features panel refreshes from. Re-created on every <see cref="Start"/> (a new plugin exposes new
+        /// managers/streams) and released on plugin teardown — same <see cref="SerialDisposable"/> discipline as
+        /// <see cref="_stateSubscription"/>, so a reconnect never leaks a stale subscription.
+        /// </summary>
+        readonly SerialDisposable _featuresSubscription = new();
+
         /// <summary>Last reduced status, cached so <see cref="ConnectionStatus"/> is readable without a live plugin.</summary>
         ConnectionStatus _status = ConnectionStatus.Disconnected;
 
@@ -86,6 +97,14 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
         /// <summary>The built plugin instance, or null before <see cref="Start"/> / after <see cref="Dispose"/>.</summary>
         public IMcpPlugin? Plugin => _plugin;
+
+        /// <summary>
+        /// The plugin's <see cref="IMcpManager"/> (owns the tool/prompt/resource managers), or null before
+        /// <see cref="Start"/> / after <see cref="Dispose"/>. The dock's features section reaches the
+        /// per-kind managers (<see cref="IMcpManager.ToolManager"/> etc.) through this rather than poking the
+        /// plugin internals, so the editor UI has a single, null-safe accessor for the feature stats.
+        /// </summary>
+        public IMcpManager? McpManager => _plugin?.McpManager;
 
         /// <summary>
         /// The resolved cloud BASE url (no <c>/mcp</c> hub suffix) — the host the device-auth endpoints
@@ -118,6 +137,15 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// an actual change (de-duplicated) to avoid redundant UI churn.
         /// </summary>
         public event Action<ConnectionStatus>? ConnectionStatusChanged;
+
+        /// <summary>
+        /// Raised when any feature manager's registry changes (a tool/prompt/resource was enabled, disabled,
+        /// added, or removed — the reused client's <c>On*Updated</c> fired). ALWAYS marshalled onto the Godot
+        /// editor main thread, so the dock's features panel may refresh its count labels by touching
+        /// <see cref="Godot.Control"/>s directly. Carries no payload — the panel re-reads counts from the
+        /// managers. Re-wired to the new managers on every <see cref="Start"/>/<see cref="Reconnect"/>.
+        /// </summary>
+        public event Action? FeaturesUpdated;
 
         public GodotMcpConnection(GodotMcpConfig? config = null)
         {
@@ -174,7 +202,14 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
             _plugin = builder.Build(reflector);
 
+            // Reapply the persisted per-feature enable-map now that the managers exist (the tool/prompt/
+            // resource registries are populated during Build via the assembly scan). A saved disable for a
+            // still-registered item is restored; stale entries (renamed/removed) are pruned; items with no
+            // saved entry stay at the manager default (enabled). See ReapplyFeatureStates.
+            ReapplyFeatureStates(_plugin);
+
             SubscribeToConnectionState(_plugin);
+            SubscribeToFeatureUpdates(_plugin);
 
             var mode = _config.ActiveMode;
             var host = _config.Host;
@@ -228,6 +263,47 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         }
 
         /// <summary>
+        /// Subscribe to the freshly-built plugin's three feature-manager <c>On*Updated</c> streams (tools /
+        /// prompts / resources) and raise the merged <see cref="FeaturesUpdated"/> event on the editor main
+        /// thread. The streams fire off the SignalR thread, so each is hopped to the main thread before
+        /// raising — mirroring <see cref="SubscribeToConnectionState"/>. Stored in a
+        /// <see cref="SerialDisposable"/> so a later <see cref="Start"/> (new managers) replaces it cleanly.
+        /// Any kind whose manager is null is simply skipped.
+        /// </summary>
+        void SubscribeToFeatureUpdates(IMcpPlugin plugin)
+        {
+            var mgr = plugin.McpManager;
+            if (mgr == null)
+            {
+                _featuresSubscription.Disposable = null;
+                return;
+            }
+
+            var streams = new List<Observable<Unit>>();
+            if (mgr.ToolManager?.OnToolsUpdated is { } toolsUpdated)
+                streams.Add(toolsUpdated);
+            if (mgr.PromptManager?.OnPromptsUpdated is { } promptsUpdated)
+                streams.Add(promptsUpdated);
+            if (mgr.ResourceManager?.OnResourcesUpdated is { } resourcesUpdated)
+                streams.Add(resourcesUpdated);
+
+            if (streams.Count == 0)
+            {
+                _featuresSubscription.Disposable = null;
+                return;
+            }
+
+            _featuresSubscription.Disposable = Observable.Merge(streams)
+                .Subscribe(_ =>
+                {
+                    if (MainThreadDispatcher.Instance != null && !MainThreadDispatcher.IsMainThread)
+                        MainThreadDispatcher.Enqueue(() => FeaturesUpdated?.Invoke());
+                    else
+                        FeaturesUpdated?.Invoke();
+                });
+        }
+
+        /// <summary>
         /// Update the cached <see cref="ConnectionStatus"/> and raise <see cref="ConnectionStatusChanged"/>
         /// when it actually changed. De-duplicated so identical consecutive states (e.g. the seed plus an
         /// immediate first push) do not double-fire the UI. MUST be called on the editor main thread.
@@ -238,6 +314,94 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 return;
             _status = status;
             ConnectionStatusChanged?.Invoke(status);
+        }
+
+        // --- MCP feature enable-map (tools / prompts / resources) -----------------------------------------
+
+        /// <summary>
+        /// The per-kind feature manager off the freshly-built plugin, or null when that kind's manager is not
+        /// available. The three managers share the same shape (enumerate / count / is-enabled / set-enabled),
+        /// so the dock addresses them generically through <see cref="GodotMcpFeatureKind"/>.
+        /// </summary>
+        IFeatureManagerAdapter? FeatureManager(GodotMcpFeatureKind kind, IMcpPlugin? plugin)
+        {
+            var mgr = plugin?.McpManager;
+            if (mgr == null)
+                return null;
+
+            return kind switch
+            {
+                GodotMcpFeatureKind.Tools => mgr.ToolManager is { } t ? new ToolManagerAdapter(t) : null,
+                GodotMcpFeatureKind.Prompts => mgr.PromptManager is { } p ? new PromptManagerAdapter(p) : null,
+                GodotMcpFeatureKind.Resources => mgr.ResourceManager is { } r ? new ResourceManagerAdapter(r) : null,
+                _ => null
+            };
+        }
+
+        /// <summary>
+        /// Reapply the persisted enable-map to a freshly-built plugin's managers. For each kind, the pure
+        /// <see cref="GodotMcpFeatureStateMerge.ComputeReapply"/> decides which live items get an explicit
+        /// <c>SetEnabled</c> (saved entries matching a live item) — stale saved names are pruned and items with
+        /// no saved entry stay at the manager default (enabled). A null/empty map disables nothing. Runs once
+        /// per <see cref="Start"/>, right after the plugin is built.
+        /// </summary>
+        void ReapplyFeatureStates(IMcpPlugin plugin)
+        {
+            foreach (GodotMcpFeatureKind kind in Enum.GetValues(typeof(GodotMcpFeatureKind)))
+            {
+                var manager = FeatureManager(kind, plugin);
+                if (manager == null)
+                    continue;
+
+                var liveNames = manager.GetNames().ToList();
+                var saved = _config.Features.For(kind);
+                var toApply = GodotMcpFeatureStateMerge.ComputeReapply(liveNames, saved);
+
+                foreach (var pair in toApply)
+                    manager.SetEnabled(pair.Key, pair.Value);
+            }
+        }
+
+        /// <summary>
+        /// Enumerate the live items of a feature kind as (name, description, enabled) tuples for the list
+        /// window. Empty when the plugin/managers are not yet available. Reads the LIVE enabled-state off the
+        /// manager (which reflects any reapplied persisted disable).
+        /// </summary>
+        public IReadOnlyList<(string Name, string? Description, bool Enabled)> GetFeatureItems(GodotMcpFeatureKind kind)
+        {
+            var manager = FeatureManager(kind, _plugin);
+            return manager == null
+                ? Array.Empty<(string, string?, bool)>()
+                : manager.GetItems().ToList();
+        }
+
+        /// <summary>
+        /// Count summary (enabled, total, enabledTokenCount) for a feature kind, or null when the
+        /// plugin/managers are not yet available (the panel shows the "—" placeholder then). Only the
+        /// <see cref="GodotMcpFeatureKind.Tools"/> kind reports a non-zero token count
+        /// (<c>EnabledToolsTokenCount</c>); prompts/resources have no token analog.
+        /// </summary>
+        public (int Enabled, int Total, int EnabledTokenCount)? GetFeatureCounts(GodotMcpFeatureKind kind)
+        {
+            var manager = FeatureManager(kind, _plugin);
+            return manager?.GetCounts();
+        }
+
+        /// <summary>
+        /// Toggle one item's enabled-state: push it to the live manager AND patch + persist the enable-map so
+        /// the choice survives a restart. No-op (returns false) when the manager is unavailable. The map is
+        /// patched via the pure <see cref="GodotMcpFeatureStateMerge.Upsert"/> then <see cref="Save"/>d.
+        /// </summary>
+        public bool SetFeatureEnabled(GodotMcpFeatureKind kind, string name, bool enabled)
+        {
+            var manager = FeatureManager(kind, _plugin);
+            if (manager == null)
+                return false;
+
+            manager.SetEnabled(name, enabled);
+            GodotMcpFeatureStateMerge.Upsert(_config.Features.For(kind), name, enabled);
+            Save();
+            return true;
         }
 
         /// <summary>
@@ -432,6 +596,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         {
             _stateSubscription.Dispose();
             _authRejectedSubscription.Dispose();
+            _featuresSubscription.Dispose();
             DisposePlugin();
         }
 
@@ -444,10 +609,11 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// </summary>
         void DisposePlugin()
         {
-            // Release the live state + auth-rejected subscriptions' inner disposables (keeps the
+            // Release the live state + auth-rejected + features subscriptions' inner disposables (keeps the
             // SerialDisposables reusable for the next Start()).
             _stateSubscription.Disposable = null;
             _authRejectedSubscription.Disposable = null;
+            _featuresSubscription.Disposable = null;
 
             // Clear the ambient reflector if it is the one we published, so a stale instance does not
             // outlive the connection that owned it.

--- a/addons/godot_mcp/Connection/GodotMcpFeatureMap.cs
+++ b/addons/godot_mcp/Connection/GodotMcpFeatureMap.cs
@@ -1,0 +1,79 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// The persisted enable-map for the three MCP feature kinds (tools / prompts / resources). Each list
+    /// holds the user-touched <see cref="GodotMcpFeatureState"/> entries for that kind; an empty list means
+    /// "everything at its live default" (which for the McpPlugin managers is enabled). Serialized as part of
+    /// <see cref="GodotMcpConfig"/> under the <c>features</c> key so a user's per-item disable survives a
+    /// restart. Pure-managed (no Godot native types, no <c>#if TOOLS</c>) — the merge/apply/capture logic in
+    /// <see cref="GodotMcpFeatureStateMerge"/> is unit-testable in the plain-xUnit host.
+    /// </summary>
+    public sealed class GodotMcpFeatureMap
+    {
+        /// <summary>Persisted tool enable/disable entries (user-touched only).</summary>
+        [JsonPropertyName("tools")]
+        public List<GodotMcpFeatureState> Tools { get; set; } = new();
+
+        /// <summary>Persisted prompt enable/disable entries (user-touched only).</summary>
+        [JsonPropertyName("prompts")]
+        public List<GodotMcpFeatureState> Prompts { get; set; } = new();
+
+        /// <summary>Persisted resource enable/disable entries (user-touched only).</summary>
+        [JsonPropertyName("resources")]
+        public List<GodotMcpFeatureState> Resources { get; set; } = new();
+
+        /// <summary>
+        /// The list for a given <see cref="GodotMcpFeatureKind"/>, so callers can address one kind generically
+        /// (the panel/window are parameterized by kind). Returns the live backing list (mutations persist).
+        /// </summary>
+        public List<GodotMcpFeatureState> For(GodotMcpFeatureKind kind) => kind switch
+        {
+            GodotMcpFeatureKind.Tools => Tools,
+            GodotMcpFeatureKind.Prompts => Prompts,
+            _ => Resources
+        };
+
+        /// <summary>Replace the entries for one kind in-place (used when capturing live state back into the map).</summary>
+        public void Set(GodotMcpFeatureKind kind, List<GodotMcpFeatureState> entries)
+        {
+            switch (kind)
+            {
+                case GodotMcpFeatureKind.Tools:
+                    Tools = entries;
+                    break;
+                case GodotMcpFeatureKind.Prompts:
+                    Prompts = entries;
+                    break;
+                default:
+                    Resources = entries;
+                    break;
+            }
+        }
+    }
+
+    /// <summary>Which MCP feature kind a panel row / list window addresses.</summary>
+    public enum GodotMcpFeatureKind
+    {
+        /// <summary>MCP tools (<c>IToolManager</c>).</summary>
+        Tools,
+
+        /// <summary>MCP prompts (<c>IPromptManager</c>).</summary>
+        Prompts,
+
+        /// <summary>MCP resources (<c>IResourceManager</c>).</summary>
+        Resources
+    }
+}

--- a/addons/godot_mcp/Connection/GodotMcpFeatureState.cs
+++ b/addons/godot_mcp/Connection/GodotMcpFeatureState.cs
@@ -1,0 +1,45 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// One persisted MCP-feature enable/disable entry — a feature item's name plus whether the user has it
+    /// enabled. The Godot analog of Unity-MCP's per-feature enabled flags persisted by the tool/prompt/
+    /// resource managers. Pure-managed (no Godot native types, no <c>#if TOOLS</c>) so the persistence /
+    /// merge logic is unit-testable in the plain-xUnit host.
+    ///
+    /// <para>
+    /// Persistence policy: only entries the user has actually TOUCHED are stored (an absent name means
+    /// "use the live default", which for the McpPlugin managers is enabled). Storing a name with
+    /// <see cref="Enabled"/> <c>false</c> is therefore how a user disable survives a restart.
+    /// </para>
+    /// </summary>
+    public sealed class GodotMcpFeatureState
+    {
+        /// <summary>The feature item's unique name (tool/prompt/resource name as the manager reports it).</summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>Whether this feature item is enabled. Serialized so a user disable persists.</summary>
+        [JsonPropertyName("enabled")]
+        public bool Enabled { get; set; } = true;
+
+        public GodotMcpFeatureState() { }
+
+        public GodotMcpFeatureState(string name, bool enabled)
+        {
+            Name = name;
+            Enabled = enabled;
+        }
+    }
+}

--- a/addons/godot_mcp/Connection/GodotMcpFeatureStateMerge.cs
+++ b/addons/godot_mcp/Connection/GodotMcpFeatureStateMerge.cs
@@ -1,0 +1,119 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Collections.Generic;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>, no McpPlugin dependency) merge/capture logic
+    /// for the MCP-feature enable-map. Splitting this from the live <c>IToolManager</c>/<c>IPromptManager</c>/
+    /// <c>IResourceManager</c> wiring keeps the effective-state and capture rules unit-testable in the
+    /// plain-xUnit <c>Godot-MCP.Tests</c> host: the editor-only code (in <c>GodotMcpConnection</c>, behind
+    /// <c>#if TOOLS</c>) just supplies the live item names + a setter delegate and lets this decide WHAT to do.
+    ///
+    /// <para>
+    /// Two operations, mirroring the two directions the dock needs:
+    /// <list type="bullet">
+    ///   <item><b>Reapply</b> (boot): saved-map ⊕ live-item-names → the set of explicit
+    ///   <c>SetEnabled(name, enabled)</c> calls to make. Only saved entries whose name still exists in the
+    ///   live set are applied (UNKNOWN-NAME PRUNING — a renamed/removed tool's stale entry is ignored); a
+    ///   live item with NO saved entry is left at its manager default (DEFAULT-EMPTY = ALL-ENABLED).</item>
+    ///   <item><b>Capture</b> (after a user toggle / for round-trip): live-item-names + their current enabled
+    ///   → the list of <see cref="GodotMcpFeatureState"/> entries to persist. Every live item is captured so
+    ///   the on-disk map is a faithful snapshot the next reapply can restore.</item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    public static class GodotMcpFeatureStateMerge
+    {
+        /// <summary>
+        /// Compute the explicit enabled-state to apply for each LIVE item given the SAVED entries. The result
+        /// maps each live item name to the enabled value the reapply step should push via the manager's
+        /// <c>SetEnabled</c>:
+        /// <list type="bullet">
+        ///   <item>name present in <paramref name="saved"/> → that saved <see cref="GodotMcpFeatureState.Enabled"/>;</item>
+        ///   <item>name NOT in <paramref name="saved"/> → omitted from the result (leave at live default —
+        ///   DEFAULT-EMPTY = ALL-ENABLED, so the reapply makes no call for it).</item>
+        /// </list>
+        /// Saved entries whose name is not in <paramref name="liveItemNames"/> are dropped (UNKNOWN-NAME
+        /// PRUNING). Last-wins on duplicate saved names (defensive against a hand-edited file). The returned
+        /// dictionary's key order is not significant.
+        /// </summary>
+        public static IReadOnlyDictionary<string, bool> ComputeReapply(
+            IEnumerable<string> liveItemNames,
+            IReadOnlyList<GodotMcpFeatureState> saved)
+        {
+            var live = new HashSet<string>(liveItemNames);
+
+            // Index saved by name (last-wins) so a duplicated / hand-edited entry resolves deterministically.
+            var savedByName = new Dictionary<string, bool>();
+            foreach (var entry in saved)
+            {
+                if (entry == null || string.IsNullOrEmpty(entry.Name))
+                    continue;
+                savedByName[entry.Name] = entry.Enabled;
+            }
+
+            var result = new Dictionary<string, bool>();
+            foreach (var name in live)
+            {
+                // Only emit an explicit call when the user has a saved preference for this live item;
+                // otherwise leave the manager default untouched (all-enabled by default).
+                if (savedByName.TryGetValue(name, out var enabled))
+                    result[name] = enabled;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Capture the current enabled-state of every LIVE item into a persistable list. <paramref name="liveItems"/>
+        /// pairs each live item name with its current enabled flag (as the manager reports it). Every live item
+        /// is captured (a faithful snapshot), so reapplying this exact map later restores the same state. Items
+        /// with an empty name are skipped (defensive). Order follows enumeration order of <paramref name="liveItems"/>.
+        /// </summary>
+        public static List<GodotMcpFeatureState> Capture(IEnumerable<(string Name, bool Enabled)> liveItems)
+        {
+            var captured = new List<GodotMcpFeatureState>();
+            var seen = new HashSet<string>();
+            foreach (var (name, enabled) in liveItems)
+            {
+                if (string.IsNullOrEmpty(name) || !seen.Add(name))
+                    continue;
+                captured.Add(new GodotMcpFeatureState(name, enabled));
+            }
+            return captured;
+        }
+
+        /// <summary>
+        /// Update (or insert) one item's saved entry in <paramref name="saved"/>, returning the same list for
+        /// fluent use. Used when the user toggles a single item in the list window: the in-memory map is patched
+        /// then persisted, without recapturing the whole live set. Last-wins if the name already exists.
+        /// </summary>
+        public static List<GodotMcpFeatureState> Upsert(List<GodotMcpFeatureState> saved, string name, bool enabled)
+        {
+            if (string.IsNullOrEmpty(name))
+                return saved;
+
+            for (int i = 0; i < saved.Count; i++)
+            {
+                if (saved[i] != null && saved[i].Name == name)
+                {
+                    saved[i].Enabled = enabled;
+                    return saved;
+                }
+            }
+
+            saved.Add(new GodotMcpFeatureState(name, enabled));
+            return saved;
+        }
+    }
+}

--- a/addons/godot_mcp/UI/FeatureListWindow.cs
+++ b/addons/godot_mcp/UI/FeatureListWindow.cs
@@ -1,0 +1,163 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using com.IvanMurzak.Godot.MCP.Connection;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.UI
+{
+    /// <summary>
+    /// A nested editor <see cref="Window"/> listing every item of one <see cref="GodotMcpFeatureKind"/> with a
+    /// per-item enable/disable <see cref="CheckBox"/> — the Godot analog of Unity-MCP's <c>McpToolsWindow</c>
+    /// (and its prompts/resources siblings), collapsed to ONE reusable class parameterized by kind. Each row
+    /// shows the item name + description and a checkbox reflecting the live enabled-state; toggling pushes the
+    /// change to the live manager AND persists it via <see cref="GodotMcpConnection.SetFeatureEnabled"/> (the
+    /// enable-map in <see cref="GodotMcpConfig"/>). A "Close" button (and the window-manager close request)
+    /// frees the window — no leaks.
+    ///
+    /// <para>
+    /// Editor-only (<c>#if TOOLS</c>): it builds live Godot UI <see cref="Node"/>s, so it is verified via the
+    /// headless Godot smoke (test.md Suite 3), not the plain-xUnit host. The enable-map merge/persist logic it
+    /// drives is pure-managed (<see cref="GodotMcpFeatureStateMerge"/>) and unit-tested separately.
+    /// </para>
+    /// </summary>
+    [Tool]
+    public partial class FeatureListWindow : Window
+    {
+        readonly GodotMcpConnection _connection;
+        readonly GodotMcpFeatureKind _kind;
+
+        VBoxContainer _list = null!;
+        Label _emptyLabel = null!;
+
+        public FeatureListWindow(GodotMcpConnection connection, GodotMcpFeatureKind kind)
+        {
+            _connection = connection;
+            _kind = kind;
+            Name = $"{FeaturesPanelView.Title(kind)}Window";
+            Title = $"MCP {FeaturesPanelView.Title(kind)}";
+            Size = new Vector2I(420, 480);
+            Unresizable = false;
+
+            // Free the window when the OS/editor close button (the X) is pressed.
+            CloseRequested += OnClosePressed;
+
+            BuildUi();
+            PopulateList();
+        }
+
+        void BuildUi()
+        {
+            var margin = new MarginContainer { Name = "Margin" };
+            margin.AddThemeConstantOverride("margin_left", 8);
+            margin.AddThemeConstantOverride("margin_right", 8);
+            margin.AddThemeConstantOverride("margin_top", 8);
+            margin.AddThemeConstantOverride("margin_bottom", 8);
+            margin.SetAnchorsPreset(Control.LayoutPreset.FullRect);
+            AddChild(margin);
+
+            var root = new VBoxContainer { Name = "Root" };
+            root.AddThemeConstantOverride("separation", 6);
+            margin.AddChild(root);
+
+            var scroll = new ScrollContainer
+            {
+                Name = "Scroll",
+                SizeFlagsVertical = Control.SizeFlags.ExpandFill,
+                SizeFlagsHorizontal = Control.SizeFlags.ExpandFill
+            };
+            root.AddChild(scroll);
+
+            _list = new VBoxContainer
+            {
+                Name = "List",
+                SizeFlagsHorizontal = Control.SizeFlags.ExpandFill
+            };
+            _list.AddThemeConstantOverride("separation", 4);
+            scroll.AddChild(_list);
+
+            _emptyLabel = new Label
+            {
+                Name = "EmptyLabel",
+                Text = "No items (connect to populate the registry).",
+                Visible = false
+            };
+            _list.AddChild(_emptyLabel);
+
+            var closeButton = new Button { Name = "CloseButton", Text = "Close" };
+            closeButton.Pressed += OnClosePressed;
+            root.AddChild(closeButton);
+        }
+
+        /// <summary>
+        /// Build one toggle row per live item of this kind. Reads items off the connection (name + description
+        /// + current enabled). When the registry is empty (no connection yet), shows the empty placeholder.
+        /// </summary>
+        void PopulateList()
+        {
+            var items = _connection.GetFeatureItems(_kind);
+            _emptyLabel.Visible = items.Count == 0;
+
+            foreach (var item in items)
+                _list.AddChild(BuildItemRow(item.Name, item.Description, item.Enabled));
+        }
+
+        Control BuildItemRow(string name, string? description, bool enabled)
+        {
+            var row = new VBoxContainer { Name = $"Item_{name}" };
+            row.AddThemeConstantOverride("separation", 1);
+
+            var checkBox = new CheckBox
+            {
+                Name = "Toggle",
+                Text = name,
+                ButtonPressed = enabled
+            };
+            // Capture the item name for the toggle callback; persist + push-live through the connection.
+            string itemName = name;
+            checkBox.Toggled += pressed => OnItemToggled(itemName, pressed);
+            row.AddChild(checkBox);
+
+            if (!string.IsNullOrEmpty(description))
+            {
+                var descLabel = new Label
+                {
+                    Name = "Description",
+                    Text = description,
+                    AutowrapMode = TextServer.AutowrapMode.WordSmart
+                };
+                descLabel.AddThemeColorOverride("font_color", new Color(0.65f, 0.65f, 0.65f));
+                row.AddChild(descLabel);
+            }
+
+            return row;
+        }
+
+        void OnItemToggled(string name, bool enabled)
+        {
+            // Push to the live manager AND persist into the enable-map (survives restart).
+            _connection.SetFeatureEnabled(_kind, name, enabled);
+        }
+
+        /// <summary>Pop the window up centred and visible. Called by the panel after parenting it into the tree.</summary>
+        public void PopupCenteredAndShow()
+        {
+            PopupCentered(Size);
+        }
+
+        void OnClosePressed()
+        {
+            // QueueFree frees the window and all rows next idle frame — no leaks.
+            QueueFree();
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/UI/FeatureRow.cs
+++ b/addons/godot_mcp/UI/FeatureRow.cs
@@ -1,0 +1,91 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using com.IvanMurzak.Godot.MCP.Connection;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.UI
+{
+    /// <summary>
+    /// One row of the dock's <see cref="FeaturesPanel"/> for a single <see cref="GodotMcpFeatureKind"/>: a
+    /// "&lt;Title&gt;: enabled / total" count label, an optional "~N tokens" sub-label (tools only), and an
+    /// "Open" button that raises the panel-supplied open callback. All text comes from the pure-managed
+    /// <see cref="FeaturesPanelView"/> so the formatting is unit-tested. Editor-only (<c>#if TOOLS</c>):
+    /// verified via the headless Godot smoke (test.md Suite 3).
+    /// </summary>
+    [Tool]
+    public partial class FeatureRow : HBoxContainer
+    {
+        /// <summary>The feature kind this row represents.</summary>
+        public GodotMcpFeatureKind Kind { get; }
+
+        readonly bool _showTokens;
+        readonly Action<GodotMcpFeatureKind> _onOpen;
+
+        Label _countLabel = null!;
+        Label? _tokenLabel;
+
+        public FeatureRow(GodotMcpFeatureKind kind, bool showTokens, Action<GodotMcpFeatureKind> onOpen)
+        {
+            Kind = kind;
+            _showTokens = showTokens;
+            _onOpen = onOpen;
+            Name = $"{FeaturesPanelView.Title(kind)}Row";
+            BuildUi();
+        }
+
+        void BuildUi()
+        {
+            AddThemeConstantOverride("separation", 8);
+
+            _countLabel = new Label
+            {
+                Name = "CountLabel",
+                Text = FeaturesPanelView.UnavailableLabel(Kind),
+                SizeFlagsHorizontal = SizeFlags.ExpandFill
+            };
+            AddChild(_countLabel);
+
+            if (_showTokens)
+            {
+                _tokenLabel = new Label
+                {
+                    Name = "TokenLabel",
+                    Text = FeaturesPanelView.UnavailableTokenLabel()
+                };
+                _tokenLabel.AddThemeColorOverride("font_color", new Color(0.60f, 0.60f, 0.60f));
+                AddChild(_tokenLabel);
+            }
+
+            var openButton = new Button { Name = "OpenButton", Text = "Open" };
+            openButton.Pressed += () => _onOpen(Kind);
+            AddChild(openButton);
+        }
+
+        /// <summary>Show the "&lt;Title&gt;: enabled / total" counts (+ "~N tokens" for tools).</summary>
+        public void ShowCounts(int enabled, int total, int enabledTokenCount)
+        {
+            _countLabel.Text = FeaturesPanelView.CountLabel(Kind, enabled, total);
+            if (_tokenLabel != null)
+                _tokenLabel.Text = FeaturesPanelView.TokenLabel(enabledTokenCount);
+        }
+
+        /// <summary>Show the "—" placeholder (no connection/managers yet).</summary>
+        public void ShowUnavailable()
+        {
+            _countLabel.Text = FeaturesPanelView.UnavailableLabel(Kind);
+            if (_tokenLabel != null)
+                _tokenLabel.Text = FeaturesPanelView.UnavailableTokenLabel();
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/UI/FeaturesPanel.cs
+++ b/addons/godot_mcp/UI/FeaturesPanel.cs
@@ -1,0 +1,129 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using com.IvanMurzak.Godot.MCP.Connection;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.UI
+{
+    /// <summary>
+    /// The MCP-features section of the Godot-MCP editor dock — the Godot <see cref="Control"/> analog of
+    /// Unity-MCP's <c>MainWindowEditor.McpFeatures</c> (its Tools/Prompts/Resources count rows + "Open"
+    /// buttons). A <see cref="VBoxContainer"/> the <see cref="GodotMcpDock"/> drops into its Body BETWEEN the
+    /// connection panel and the support footer, wired to a <see cref="GodotMcpConnection"/>. It renders three
+    /// rows (tools / prompts / resources); each row shows a "&lt;Title&gt;: enabled / total" count label (plus,
+    /// for tools, a "~N tokens" sub-label) and an "Open" button that opens a <see cref="FeatureListWindow"/>
+    /// for per-item enable/disable.
+    ///
+    /// <para>
+    /// Counts update live: the panel subscribes to the connection's <see cref="GodotMcpConnection.FeaturesUpdated"/>
+    /// (any tool/prompt/resource registry change) and <see cref="GodotMcpConnection.ConnectionStatusChanged"/>
+    /// (a (re)build swaps the managers), both marshalled onto the editor main thread by the connection, so the
+    /// handlers touch Controls directly. Before a connection/managers exist, the counts show the "—" placeholder
+    /// and refresh once the plugin is built.
+    /// </para>
+    ///
+    /// <para>
+    /// Editor-only (<c>#if TOOLS</c>): it builds live Godot UI <see cref="Node"/>s, so it is verified via the
+    /// headless Godot smoke (<c>test.md</c> Suite 3), not the plain-xUnit host. ALL label formatting lives in
+    /// the pure-managed <see cref="FeaturesPanelView"/> so it IS unit-tested.
+    /// </para>
+    /// </summary>
+    [Tool]
+    public partial class FeaturesPanel : VBoxContainer
+    {
+        readonly GodotMcpConnection _connection;
+
+        FeatureRow _toolsRow = null!;
+        FeatureRow _promptsRow = null!;
+        FeatureRow _resourcesRow = null!;
+
+        public FeaturesPanel(GodotMcpConnection connection)
+        {
+            _connection = connection;
+            Name = "FeaturesPanel";
+            BuildUi();
+
+            // Subscribe AFTER the UI exists so the first push has controls to write to. The connection
+            // marshals these onto the editor main thread, so the handlers may touch Controls directly.
+            _connection.FeaturesUpdated += OnFeaturesUpdated;
+            _connection.ConnectionStatusChanged += OnConnectionStatusChanged;
+
+            // Render current state immediately (the events only fire on change).
+            RefreshAll();
+        }
+
+        void BuildUi()
+        {
+            SizeFlagsHorizontal = SizeFlags.ExpandFill;
+            AddThemeConstantOverride("separation", 6);
+
+            AddChild(new Label { Name = "FeaturesHeader", Text = "MCP Features" });
+
+            _toolsRow = new FeatureRow(GodotMcpFeatureKind.Tools, showTokens: true, OnOpenPressed);
+            AddChild(_toolsRow);
+
+            _promptsRow = new FeatureRow(GodotMcpFeatureKind.Prompts, showTokens: false, OnOpenPressed);
+            AddChild(_promptsRow);
+
+            _resourcesRow = new FeatureRow(GodotMcpFeatureKind.Resources, showTokens: false, OnOpenPressed);
+            AddChild(_resourcesRow);
+
+            AddChild(new HSeparator { Name = "FeaturesSeparator" });
+        }
+
+        void OnFeaturesUpdated() => RefreshAll();
+
+        void OnConnectionStatusChanged(ConnectionStatus _) => RefreshAll();
+
+        void OnOpenPressed(GodotMcpFeatureKind kind)
+        {
+            // Open (or focus) a list window for this kind. The window reads the live items off the connection
+            // and persists toggles back through it. Parent it to this panel so it lives in the editor tree and
+            // is freed with the dock if still open.
+            var window = new FeatureListWindow(_connection, kind);
+            AddChild(window);
+            window.PopupCenteredAndShow();
+        }
+
+        /// <summary>Re-read counts for all three rows from the connection's managers and update the labels.</summary>
+        void RefreshAll()
+        {
+            RefreshRow(_toolsRow);
+            RefreshRow(_promptsRow);
+            RefreshRow(_resourcesRow);
+        }
+
+        void RefreshRow(FeatureRow row)
+        {
+            var counts = _connection.GetFeatureCounts(row.Kind);
+            if (counts == null)
+            {
+                row.ShowUnavailable();
+                return;
+            }
+
+            var (enabled, total, tokenCount) = counts.Value;
+            row.ShowCounts(enabled, total, tokenCount);
+        }
+
+        /// <summary>Forwarded from <see cref="GodotMcpDock.Refresh"/>. Re-reads counts. Safe to call repeatedly.</summary>
+        public void Refresh() => RefreshAll();
+
+        public override void _ExitTree()
+        {
+            // Unsubscribe so a freed panel does not receive a late main-thread push.
+            _connection.FeaturesUpdated -= OnFeaturesUpdated;
+            _connection.ConnectionStatusChanged -= OnConnectionStatusChanged;
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/UI/FeaturesPanelView.cs
+++ b/addons/godot_mcp/UI/FeaturesPanelView.cs
@@ -1,0 +1,58 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using com.IvanMurzak.Godot.MCP.Connection;
+
+namespace com.IvanMurzak.Godot.MCP.UI
+{
+    /// <summary>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>, no McpPlugin dependency) presentation logic
+    /// for the dock's MCP-features section: the "&lt;Title&gt;: X / Y" count label, the "~N tokens" sub-label,
+    /// the per-kind titles, and the placeholder shown before a connection exists. Keeping these here (rather
+    /// than inline in the <c>#if TOOLS</c> <see cref="FeaturesPanel"/>) makes every label decision
+    /// unit-testable in the plain-xUnit <c>Godot-MCP.Tests</c> host without constructing a Godot
+    /// <see cref="Godot.Control"/>. The Godot analog of Unity-MCP's <c>SubscribeToFeatureStats</c> count
+    /// formatting (its "{enabled} / {total}" label + "~{tokens} tokens" token label).
+    /// </summary>
+    public static class FeaturesPanelView
+    {
+        /// <summary>Shown for a count value when no connection/managers exist yet (plugin null before connect).</summary>
+        public const string Unavailable = "—";
+
+        /// <summary>The human title for each feature kind (used in the row label and the list window heading).</summary>
+        public static string Title(GodotMcpFeatureKind kind) => kind switch
+        {
+            GodotMcpFeatureKind.Tools => "Tools",
+            GodotMcpFeatureKind.Prompts => "Prompts",
+            _ => "Resources"
+        };
+
+        /// <summary>
+        /// Format the "&lt;Title&gt;: X / Y" count row where X = enabled, Y = total. Mirrors the Unity
+        /// reference's "{enabledCount} / {totalCount}" label, prefixed with the kind title for the dock row.
+        /// </summary>
+        public static string CountLabel(GodotMcpFeatureKind kind, int enabled, int total) =>
+            $"{Title(kind)}: {enabled} / {total}";
+
+        /// <summary>The count row shown when the plugin/managers are not yet available — "&lt;Title&gt;: — / —".</summary>
+        public static string UnavailableLabel(GodotMcpFeatureKind kind) =>
+            $"{Title(kind)}: {Unavailable} / {Unavailable}";
+
+        /// <summary>
+        /// Format the tools-only "~N tokens" sub-label (from <c>EnabledToolsTokenCount</c>). Mirrors the Unity
+        /// reference's "~{tokens} tokens" token label. Only the Tools row shows this; prompts/resources have no
+        /// token analog.
+        /// </summary>
+        public static string TokenLabel(int enabledTokenCount) => $"~{enabledTokenCount} tokens";
+
+        /// <summary>The token sub-label shown when the plugin/managers are not yet available — "~— tokens".</summary>
+        public static string UnavailableTokenLabel() => $"~{Unavailable} tokens";
+    }
+}

--- a/addons/godot_mcp/UI/GodotMcpDock.cs
+++ b/addons/godot_mcp/UI/GodotMcpDock.cs
@@ -50,6 +50,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
         readonly GodotMcpConnection? _connection;
         ConnectionPanel? _connectionPanel;
+        FeaturesPanel? _featuresPanel;
         SupportFooter? _supportFooter;
 
         /// <summary>
@@ -110,6 +111,13 @@ namespace com.IvanMurzak.Godot.MCP.UI
             {
                 _connectionPanel = new ConnectionPanel(_connection);
                 Body.AddChild(_connectionPanel);
+
+                // MCP-features section — tools/prompts/resources counts + per-item enable/disable windows.
+                // Inserted BETWEEN the connection panel and the support footer, wired to the live connection
+                // (it reads the plugin's managers and subscribes to their update streams). Only meaningful with
+                // a live connection, so it shares the connection-null guard with the connection panel.
+                _featuresPanel = new FeaturesPanel(_connection);
+                Body.AddChild(_featuresPanel);
             }
 
             // Support/footer section — static links + thanks, appended BELOW the connection panel. It holds
@@ -127,6 +135,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         public void Refresh()
         {
             _connectionPanel?.Refresh();
+            _featuresPanel?.Refresh();
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add the dock's MCP-features section (Tools/Prompts/Resources): live "X / Y" counts + a tools "~N tokens" sub-label, each with an "Open" button.
- Add a reusable nested `FeatureListWindow` (one class, parameterized by kind) that lists each item (name + description) with a per-item enable/disable checkbox; toggles push to the live manager and persist.
- Persist the enable-map in `GodotMcpConfig` (`features` key) and reapply it on plugin boot (saved ⊕ live → SetEnabled; unknown names pruned; default-empty = all-enabled).

Reuses the shared `com.IvanMurzak.McpPlugin` 6.7.0 managers directly (zero porting). NuGet pins untouched (McpPlugin 6.7.0 / ReflectorNet 5.3.1). UI strictly `#if TOOLS`; label-formatting + merge/capture cores are pure-managed and unit-tested.

## Test plan
- [x] Suite 1 — `dotnet build Godot-MCP.sln` (CI parity): 0 errors.
- [x] Suite 2 — `dotnet test Godot-MCP.Tests`: 338 passed (315 → 338, +23 new across FeaturesPanelView formatting, the enable-map merge/capture/upsert, and the `features`-key persistence round-trip incl. legacy-no-key compat).
- [x] Suite 3 — headless Godot 4.5.1 smoke (testbed junction → worktree addon): `[Godot-MCP] plugin loaded`, all deps resolved (McpPlugin/Common 6.7.0, R3, SignalR), dock + features panel built, no FileNotFound/exception, clean unload.

Closes #32