### PR TITLE
feat(editor): abbreviate token count with 'k' at 1000+ (#38)

### DIFF
--- a/Godot-MCP.Tests/FeaturesPanelViewTests.cs
+++ b/Godot-MCP.Tests/FeaturesPanelViewTests.cs
@@ -49,8 +49,25 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         [Fact]
         public void TokenLabel_formats_with_tilde_and_suffix()
         {
-            Assert.Equal("~1234 tokens", FeaturesPanelView.TokenLabel(1234));
+            Assert.Equal("~999 tokens", FeaturesPanelView.TokenLabel(999));
             Assert.Equal("~0 tokens", FeaturesPanelView.TokenLabel(0));
+            // 1000+ is abbreviated with a k suffix.
+            Assert.Equal("~1.2k tokens", FeaturesPanelView.TokenLabel(1234));
+        }
+
+        [Theory]
+        [InlineData(0, "0")]
+        [InlineData(1, "1")]
+        [InlineData(999, "999")]            // just under the threshold — rendered as-is
+        [InlineData(1000, "1k")]            // exact thousand — no decimal
+        [InlineData(1500, "1.5k")]          // half-thousand — one decimal
+        [InlineData(1234, "1.2k")]          // rounded to one decimal
+        [InlineData(2000, "2k")]            // trailing .0 trimmed
+        [InlineData(12345, "12.3k")]
+        [InlineData(1999, "2k")]            // rounds up at one decimal
+        public void FormatTokenCount_abbreviates_thousands_with_k(int count, string expected)
+        {
+            Assert.Equal(expected, FeaturesPanelView.FormatTokenCount(count));
         }
 
         [Fact]

--- a/addons/godot_mcp/UI/FeaturesPanelView.cs
+++ b/addons/godot_mcp/UI/FeaturesPanelView.cs
@@ -8,6 +8,7 @@
 └──────────────────────────────────────────────────────────────────┘
 */
 #nullable enable
+using System.Globalization;
 using com.IvanMurzak.Godot.MCP.Connection;
 
 namespace com.IvanMurzak.Godot.MCP.UI
@@ -48,9 +49,25 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// <summary>
         /// Format the tools-only "~N tokens" sub-label (from <c>EnabledToolsTokenCount</c>). Mirrors the Unity
         /// reference's "~{tokens} tokens" token label. Only the Tools row shows this; prompts/resources have no
-        /// token analog.
+        /// token analog. Counts of 1000+ are abbreviated with a <c>k</c> suffix (one decimal, trailing
+        /// <c>.0</c> trimmed): <c>999</c> → "~999 tokens", <c>1000</c> → "~1k tokens", <c>1500</c> →
+        /// "~1.5k tokens", <c>12345</c> → "~12.3k tokens".
         /// </summary>
-        public static string TokenLabel(int enabledTokenCount) => $"~{enabledTokenCount} tokens";
+        public static string TokenLabel(int enabledTokenCount) => $"~{FormatTokenCount(enabledTokenCount)} tokens";
+
+        /// <summary>
+        /// Abbreviate a token count: values under 1000 render as-is; 1000+ render as <c>{value/1000}k</c> with
+        /// one decimal place and a trimmed trailing <c>.0</c> (e.g. 1000 → "1k", 1500 → "1.5k", 2000 → "2k").
+        /// Uses the invariant culture so the decimal separator is always a dot regardless of editor locale.
+        /// </summary>
+        public static string FormatTokenCount(int enabledTokenCount)
+        {
+            if (enabledTokenCount < 1000)
+                return enabledTokenCount.ToString(CultureInfo.InvariantCulture);
+
+            var thousands = enabledTokenCount / 1000.0;
+            return thousands.ToString("0.#", CultureInfo.InvariantCulture) + "k";
+        }
 
         /// <summary>The token sub-label shown when the plugin/managers are not yet available — "~— tokens".</summary>
         public static string UnavailableTokenLabel() => $"~{Unavailable} tokens";


### PR DESCRIPTION
The features panel Tools '~N tokens' sub-label now abbreviates 1000+ with a 'k' suffix (one decimal, trailing .0 trimmed): 1000→~1k, 1500→~1.5k, 12345→~12.3k; <1000 unchanged. Invariant-culture decimal. Pure-managed FeaturesPanelView.FormatTokenCount, unit-tested (Theory). 347 xUnit green; NuGet pins untouched.

Closes #38