### PR TITLE
feat(connection): route McpPlugin logging to Godot Output + Log Level dropdown

### DIFF
--- a/Godot-MCP.Tests/ConnectionPanelViewTests.cs
+++ b/Godot-MCP.Tests/ConnectionPanelViewTests.cs
@@ -70,6 +70,24 @@ namespace com.IvanMurzak.Godot.MCP.Tests
                 ConnectionPanelView.Reduce(state, keepConnected: false));
         }
 
+        // --- Reduce: exhaustive matrix (every HubConnectionState × keepConnected → expected status) ---
+
+        [Theory]
+        // keepConnected = true
+        [InlineData(HubConnectionState.Connected, true, ConnectionStatus.Connected)]
+        [InlineData(HubConnectionState.Connecting, true, ConnectionStatus.Connecting)]
+        [InlineData(HubConnectionState.Reconnecting, true, ConnectionStatus.Connecting)]
+        [InlineData(HubConnectionState.Disconnected, true, ConnectionStatus.Connecting)]
+        // keepConnected = false (the client is not trying to be connected → always Disconnected)
+        [InlineData(HubConnectionState.Connected, false, ConnectionStatus.Disconnected)]
+        [InlineData(HubConnectionState.Connecting, false, ConnectionStatus.Disconnected)]
+        [InlineData(HubConnectionState.Reconnecting, false, ConnectionStatus.Disconnected)]
+        [InlineData(HubConnectionState.Disconnected, false, ConnectionStatus.Disconnected)]
+        public void Reduce_FullMatrix(HubConnectionState state, bool keepConnected, ConnectionStatus expected)
+        {
+            Assert.Equal(expected, ConnectionPanelView.Reduce(state, keepConnected));
+        }
+
         // --- StatusLabel ---
 
         [Theory]

--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -52,6 +52,14 @@
          precedence layer (no Godot native types, no #if TOOLS). The editor wiring that resolves the
          user:// path lives in GodotMcpConnection.cs (#if TOOLS); the path-injectable core is unit-tested. -->
     <Compile Include="..\addons\godot_mcp\Connection\GodotMcpConfigStore.cs" Link="Source\GodotMcpConfigStore.cs" />
+    <!-- Log-level config + gate + logger/provider — all pure-managed (no Godot native types, no #if TOOLS):
+         the GodotMcpLogLevel enum + GodotMcpLogGate (Microsoft LogLevel → GodotMcpLogLevel mapping/gating),
+         and the GodotMcpLogger/GodotMcpLoggerProvider that route the reused framework's logging to an
+         injected sink (the GD.* sink itself is wired in GodotMcpConnection.cs, #if TOOLS, verified via the
+         Suite-3 smoke). The gate + logger routing are unit-tested here with a capturing sink. -->
+    <Compile Include="..\addons\godot_mcp\Connection\GodotMcpLogLevel.cs" Link="Source\GodotMcpLogLevel.cs" />
+    <Compile Include="..\addons\godot_mcp\Connection\GodotMcpLogger.cs" Link="Source\GodotMcpLogger.cs" />
+    <Compile Include="..\addons\godot_mcp\Connection\GodotMcpLoggerProvider.cs" Link="Source\GodotMcpLoggerProvider.cs" />
     <!-- MCP-features enable-map — pure-managed (no Godot native types, no #if TOOLS, no McpPlugin dependency):
          the per-kind feature-state list (GodotMcpFeatureMap/GodotMcpFeatureState) that GodotMcpConfig serializes,
          and the merge/capture logic (GodotMcpFeatureStateMerge) the boot-reapply + window-toggle drive. The live

--- a/Godot-MCP.Tests/GodotMcpLogGateTests.cs
+++ b/Godot-MCP.Tests/GodotMcpLogGateTests.cs
@@ -1,0 +1,180 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Collections.Generic;
+using com.IvanMurzak.Godot.MCP.Connection;
+using com.IvanMurzak.Godot.MCP.Data;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using MicrosoftLogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the pure-managed log gate (<see cref="GodotMcpLogGate"/>) and the
+    /// <see cref="GodotMcpLogger"/> routing: for each configured <see cref="GodotMcpLogLevel"/>, which
+    /// framework <see cref="MicrosoftLogLevel"/> values are enabled vs suppressed, the Microsoft→Godot
+    /// severity mapping, and that the logger only routes enabled lines (with the <c>[McpPlugin]</c> prefix)
+    /// to its injected sink. All pure-managed — the real <c>GD.*</c> sink is wired in
+    /// <c>GodotMcpConnection.cs</c> (<c>#if TOOLS</c>) and verified via the Suite-3 smoke.
+    /// </summary>
+    public class GodotMcpLogGateTests
+    {
+        // --- Severity mapping (Microsoft LogLevel -> GodotMcpLogLevel bucket) ---
+
+        [Theory]
+        [InlineData(MicrosoftLogLevel.Trace, GodotMcpLogLevel.Trace)]
+        [InlineData(MicrosoftLogLevel.Debug, GodotMcpLogLevel.Debug)]
+        [InlineData(MicrosoftLogLevel.Information, GodotMcpLogLevel.Info)]
+        [InlineData(MicrosoftLogLevel.Warning, GodotMcpLogLevel.Warning)]
+        [InlineData(MicrosoftLogLevel.Error, GodotMcpLogLevel.Error)]
+        [InlineData(MicrosoftLogLevel.Critical, GodotMcpLogLevel.Error)] // Godot has no separate critical channel
+        [InlineData(MicrosoftLogLevel.None, GodotMcpLogLevel.None)]
+        public void Map_FoldsMicrosoftLevelToGodotBucket(MicrosoftLogLevel ms, GodotMcpLogLevel expected)
+        {
+            Assert.Equal(expected, GodotMcpLogGate.Map(ms));
+        }
+
+        // --- Threshold gating per configured level ---
+
+        [Fact]
+        public void Trace_EnablesEverything()
+        {
+            foreach (var ms in EmittableLevels)
+                Assert.True(GodotMcpLogGate.IsEnabled(ms, GodotMcpLogLevel.Trace), $"{ms} should be enabled at Trace");
+        }
+
+        [Fact]
+        public void Info_SuppressesTraceAndDebug_EnablesInfoAndAbove()
+        {
+            Assert.False(GodotMcpLogGate.IsEnabled(MicrosoftLogLevel.Trace, GodotMcpLogLevel.Info));
+            Assert.False(GodotMcpLogGate.IsEnabled(MicrosoftLogLevel.Debug, GodotMcpLogLevel.Info));
+            Assert.True(GodotMcpLogGate.IsEnabled(MicrosoftLogLevel.Information, GodotMcpLogLevel.Info));
+            Assert.True(GodotMcpLogGate.IsEnabled(MicrosoftLogLevel.Warning, GodotMcpLogLevel.Info));
+            Assert.True(GodotMcpLogGate.IsEnabled(MicrosoftLogLevel.Error, GodotMcpLogLevel.Info));
+            Assert.True(GodotMcpLogGate.IsEnabled(MicrosoftLogLevel.Critical, GodotMcpLogLevel.Info));
+        }
+
+        [Fact]
+        public void Warning_EnablesWarningErrorCritical_SuppressesInfoDebugTrace()
+        {
+            Assert.False(GodotMcpLogGate.IsEnabled(MicrosoftLogLevel.Trace, GodotMcpLogLevel.Warning));
+            Assert.False(GodotMcpLogGate.IsEnabled(MicrosoftLogLevel.Debug, GodotMcpLogLevel.Warning));
+            Assert.False(GodotMcpLogGate.IsEnabled(MicrosoftLogLevel.Information, GodotMcpLogLevel.Warning));
+            Assert.True(GodotMcpLogGate.IsEnabled(MicrosoftLogLevel.Warning, GodotMcpLogLevel.Warning));
+            Assert.True(GodotMcpLogGate.IsEnabled(MicrosoftLogLevel.Error, GodotMcpLogLevel.Warning));
+            Assert.True(GodotMcpLogGate.IsEnabled(MicrosoftLogLevel.Critical, GodotMcpLogLevel.Warning));
+        }
+
+        [Fact]
+        public void Error_EnablesErrorAndCriticalOnly()
+        {
+            Assert.False(GodotMcpLogGate.IsEnabled(MicrosoftLogLevel.Trace, GodotMcpLogLevel.Error));
+            Assert.False(GodotMcpLogGate.IsEnabled(MicrosoftLogLevel.Debug, GodotMcpLogLevel.Error));
+            Assert.False(GodotMcpLogGate.IsEnabled(MicrosoftLogLevel.Information, GodotMcpLogLevel.Error));
+            Assert.False(GodotMcpLogGate.IsEnabled(MicrosoftLogLevel.Warning, GodotMcpLogLevel.Error));
+            Assert.True(GodotMcpLogGate.IsEnabled(MicrosoftLogLevel.Error, GodotMcpLogLevel.Error));
+            Assert.True(GodotMcpLogGate.IsEnabled(MicrosoftLogLevel.Critical, GodotMcpLogLevel.Error));
+        }
+
+        [Fact]
+        public void None_SuppressesEverything()
+        {
+            foreach (var ms in EmittableLevels)
+                Assert.False(GodotMcpLogGate.IsEnabled(ms, GodotMcpLogLevel.None), $"{ms} should be suppressed at None");
+        }
+
+        [Fact]
+        public void MicrosoftNone_NeverEnabled_EvenAtTrace()
+        {
+            // A message mapped to None (LogLevel.None) is never actually logged, even at the most verbose threshold.
+            Assert.False(GodotMcpLogGate.IsEnabled(MicrosoftLogLevel.None, GodotMcpLogLevel.Trace));
+        }
+
+        // --- Logger routing (via injected capturing sink) ---
+
+        [Fact]
+        public void Logger_SuppressedLine_DoesNotRouteToSink()
+        {
+            var captured = new List<(GodotLogType Type, string Message)>();
+            var logger = new GodotMcpLogger("com.example.ConnectionManager",
+                () => GodotMcpLogLevel.Warning,
+                (type, msg) => captured.Add((type, msg)));
+
+            logger.LogInformation("connecting to hub");
+
+            Assert.Empty(captured); // Info is below the Warning threshold → not routed.
+        }
+
+        [Fact]
+        public void Logger_EnabledLine_RoutesPrefixedShortCategoryAtMappedSeverity()
+        {
+            var captured = new List<(GodotLogType Type, string Message)>();
+            var logger = new GodotMcpLogger("com.example.ConnectionManager",
+                () => GodotMcpLogLevel.Trace,
+                (type, msg) => captured.Add((type, msg)));
+
+            logger.LogWarning("handshake slow");
+
+            var line = Assert.Single(captured);
+            Assert.Equal(GodotLogType.Warning, line.Type);
+            Assert.StartsWith(GodotMcpLogger.Prefix, line.Message);
+            Assert.Contains("ConnectionManager", line.Message); // short category (namespace dropped)
+            Assert.Contains("handshake slow", line.Message);
+            Assert.DoesNotContain("com.example", line.Message); // namespace not shown
+        }
+
+        [Theory]
+        [InlineData(MicrosoftLogLevel.Information, GodotLogType.Log)]
+        [InlineData(MicrosoftLogLevel.Debug, GodotLogType.Log)]
+        [InlineData(MicrosoftLogLevel.Trace, GodotLogType.Log)]
+        [InlineData(MicrosoftLogLevel.Warning, GodotLogType.Warning)]
+        [InlineData(MicrosoftLogLevel.Error, GodotLogType.Error)]
+        [InlineData(MicrosoftLogLevel.Critical, GodotLogType.Error)]
+        public void Logger_RoutesEachSeverityToTheRightGodotLogType(MicrosoftLogLevel ms, GodotLogType expected)
+        {
+            var captured = new List<(GodotLogType Type, string Message)>();
+            var logger = new GodotMcpLogger("Cat",
+                () => GodotMcpLogLevel.Trace,
+                (type, msg) => captured.Add((type, msg)));
+
+            logger.Log(ms, default, "msg", null, (s, _) => s);
+
+            var line = Assert.Single(captured);
+            Assert.Equal(expected, line.Type);
+        }
+
+        [Fact]
+        public void Logger_ReadsLevelLive_DropdownChangeAppliesWithoutRebuild()
+        {
+            var captured = new List<(GodotLogType Type, string Message)>();
+            var level = GodotMcpLogLevel.Error; // start strict
+            var logger = new GodotMcpLogger("Cat", () => level, (type, msg) => captured.Add((type, msg)));
+
+            logger.LogInformation("first"); // suppressed at Error
+            Assert.Empty(captured);
+
+            level = GodotMcpLogLevel.Trace;   // simulate the dock dropdown moving to Trace
+            logger.LogInformation("second");  // now enabled — proves the level is read live, not cached
+            Assert.Single(captured);
+            Assert.Contains("second", captured[0].Message);
+        }
+
+        static readonly MicrosoftLogLevel[] EmittableLevels =
+        {
+            MicrosoftLogLevel.Trace,
+            MicrosoftLogLevel.Debug,
+            MicrosoftLogLevel.Information,
+            MicrosoftLogLevel.Warning,
+            MicrosoftLogLevel.Error,
+            MicrosoftLogLevel.Critical
+        };
+    }
+}

--- a/Godot-MCP.Tests/GodotMcpLogLevelConfigTests.cs
+++ b/Godot-MCP.Tests/GodotMcpLogLevelConfigTests.cs
@@ -1,0 +1,204 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using com.IvanMurzak.Godot.MCP.Connection;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the <c>logLevel</c> config field: default, serialize / round-trip through
+    /// <see cref="GodotMcpConfigStore"/>, the <see cref="GodotMcpConfig.EnvLogLevel"/> override precedence
+    /// (env &gt; persisted &gt; default), and the <c>.env</c>-file layer applied by
+    /// <see cref="GodotMcpEnvFile.Apply"/> (file &gt; persisted, with env still winning live). Mirrors the
+    /// shape of <see cref="GodotMcpAuthOptionTests"/>.
+    ///
+    /// <para>Env-mutating tests use <c>[Collection("env")]</c> + a restoring scope to avoid leakage.</para>
+    /// </summary>
+    [Collection("env")]
+    public class GodotMcpLogLevelConfigTests
+    {
+        // --- Default ---
+
+        [Fact]
+        public void DefaultLogLevel_IsInfo()
+        {
+            using var _ = LogEnvScope.ClearAll();
+            var config = new GodotMcpConfig();
+            Assert.Equal(GodotMcpLogLevel.Info, config.LogLevel);
+            Assert.Equal(GodotMcpLogLevel.Info, config.ActiveLogLevel);
+        }
+
+        // --- Env override precedence ---
+
+        [Theory]
+        [InlineData("Trace", GodotMcpLogLevel.Trace)]
+        [InlineData("trace", GodotMcpLogLevel.Trace)]
+        [InlineData("WARNING", GodotMcpLogLevel.Warning)]
+        [InlineData("None", GodotMcpLogLevel.None)]
+        public void EnvLogLevel_Overrides_ConfiguredValue(string envValue, GodotMcpLogLevel expected)
+        {
+            using var _ = LogEnvScope.Set(GodotMcpConfig.EnvLogLevel, envValue);
+            // Configured = Info; env should win.
+            var config = new GodotMcpConfig { LogLevel = GodotMcpLogLevel.Info };
+            Assert.Equal(expected, config.ActiveLogLevel);
+            // The persisted field is NOT mutated by the live override.
+            Assert.Equal(GodotMcpLogLevel.Info, config.LogLevel);
+        }
+
+        [Theory]
+        [InlineData("not-a-level")]
+        [InlineData("2")]   // numeric strings are rejected (parity with mode/auth resolvers)
+        [InlineData("")]
+        public void EnvLogLevel_Unrecognized_FallsBackToConfigured(string envValue)
+        {
+            using var _ = LogEnvScope.Set(GodotMcpConfig.EnvLogLevel, envValue);
+            var config = new GodotMcpConfig { LogLevel = GodotMcpLogLevel.Error };
+            Assert.Equal(GodotMcpLogLevel.Error, config.ActiveLogLevel);
+        }
+
+        // --- Serialization round-trip via the store ---
+
+        [Fact]
+        public void LogLevel_Serializes_AsNamedValue()
+        {
+            var config = new GodotMcpConfig { LogLevel = GodotMcpLogLevel.Warning };
+            var json = JsonSerializer.Serialize(config, new JsonSerializerOptions
+            {
+                Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+            });
+            Assert.Contains("\"logLevel\"", json);
+            Assert.Contains("Warning", json);
+        }
+
+        [Fact]
+        public void LogLevel_RoundTrips_ThroughStore_AndApplyPersisted()
+        {
+            using var _ = LogEnvScope.ClearAll();
+            var path = Path.Combine(Path.GetTempPath(), $"godot-mcp-loglevel-{Guid.NewGuid():N}.json");
+            try
+            {
+                var saved = new GodotMcpConfig { LogLevel = GodotMcpLogLevel.Debug };
+                GodotMcpConfigStore.Save(path, saved);
+
+                var loaded = GodotMcpConfigStore.Load(path);
+                Assert.NotNull(loaded);
+                Assert.Equal(GodotMcpLogLevel.Debug, loaded!.LogLevel);
+
+                // ApplyPersisted seeds the level onto a fresh target (the boot precedence path).
+                var target = new GodotMcpConfig();
+                GodotMcpConfigStore.ApplyPersisted(target, loaded);
+                Assert.Equal(GodotMcpLogLevel.Debug, target.LogLevel);
+            }
+            finally
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void OlderConfig_WithoutLogLevelKey_DefaultsToInfo()
+        {
+            using var _ = LogEnvScope.ClearAll();
+            var path = Path.Combine(Path.GetTempPath(), $"godot-mcp-loglevel-old-{Guid.NewGuid():N}.json");
+            try
+            {
+                // A config file written before logLevel existed (no key present).
+                File.WriteAllText(path, "{ \"connectionMode\": \"Custom\" }");
+                var loaded = GodotMcpConfigStore.Load(path);
+                Assert.NotNull(loaded);
+                Assert.Equal(GodotMcpLogLevel.Info, loaded!.LogLevel); // property initializer default
+            }
+            finally
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
+        }
+
+        // --- .env file layer (file > persisted; env still wins live) ---
+
+        [Fact]
+        public void EnvFile_LogLevel_WritesPersistedField()
+        {
+            using var _ = LogEnvScope.ClearAll();
+            var config = new GodotMcpConfig { LogLevel = GodotMcpLogLevel.Info };
+            var values = GodotMcpEnvFile.Parse(new[] { "GODOT_MCP_LOG_LEVEL=Trace" });
+            GodotMcpEnvFile.Apply(config, values);
+
+            Assert.Equal(GodotMcpLogLevel.Trace, config.LogLevel);
+            Assert.Equal(GodotMcpLogLevel.Trace, config.ActiveLogLevel); // no env override, so file value is live
+        }
+
+        [Fact]
+        public void EnvFile_LogLevel_Numeric_Ignored()
+        {
+            using var _ = LogEnvScope.ClearAll();
+            var config = new GodotMcpConfig { LogLevel = GodotMcpLogLevel.Warning };
+            var values = GodotMcpEnvFile.Parse(new[] { "GODOT_MCP_LOG_LEVEL=0" });
+            GodotMcpEnvFile.Apply(config, values);
+
+            // Numeric string rejected → persisted value unchanged.
+            Assert.Equal(GodotMcpLogLevel.Warning, config.LogLevel);
+        }
+
+        [Fact]
+        public void ProcessEnv_Wins_Over_EnvFileLogLevel()
+        {
+            using var _ = LogEnvScope.Set(GodotMcpConfig.EnvLogLevel, "Error");
+            var config = new GodotMcpConfig { LogLevel = GodotMcpLogLevel.Info };
+            // .env says Trace, but the process env says Error and is read live by ActiveLogLevel.
+            var values = GodotMcpEnvFile.Parse(new[] { "GODOT_MCP_LOG_LEVEL=Trace" });
+            GodotMcpEnvFile.Apply(config, values);
+
+            Assert.Equal(GodotMcpLogLevel.Trace, config.LogLevel);          // .env wrote the field…
+            Assert.Equal(GodotMcpLogLevel.Error, config.ActiveLogLevel);    // …but the env override wins live.
+        }
+
+        /// <summary>Restoring env scope covering the log-level key.</summary>
+        sealed class LogEnvScope : IDisposable
+        {
+            static readonly string[] Names = { GodotMcpConfig.EnvLogLevel };
+            readonly Dictionary<string, string?> _prior = new();
+
+            LogEnvScope()
+            {
+                foreach (var name in Names)
+                    _prior[name] = Environment.GetEnvironmentVariable(name);
+            }
+
+            public static LogEnvScope ClearAll()
+            {
+                var scope = new LogEnvScope();
+                foreach (var name in Names)
+                    Environment.SetEnvironmentVariable(name, null);
+                return scope;
+            }
+
+            public static LogEnvScope Set(string name, string? value)
+            {
+                var scope = ClearAll();
+                Environment.SetEnvironmentVariable(name, value);
+                return scope;
+            }
+
+            public void Dispose()
+            {
+                foreach (var kv in _prior)
+                    Environment.SetEnvironmentVariable(kv.Key, kv.Value);
+            }
+        }
+    }
+}

--- a/addons/godot_mcp/Connection/GodotMcpConfig.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConfig.cs
@@ -79,6 +79,14 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// </summary>
         public const string EnvAuthOption = "GODOT_MCP_AUTH_OPTION";
 
+        /// <summary>
+        /// Forces the plugin's log-verbosity threshold (<c>Trace</c> / <c>Debug</c> / <c>Info</c> /
+        /// <c>Warning</c> / <c>Error</c> / <c>None</c>, case-insensitive) — the Godot analog of a
+        /// <c>UNITY_MCP_LOG_LEVEL</c>. Honored live by <see cref="ActiveLogLevel"/> so a smoke run can be
+        /// driven at <c>Trace</c> without touching the persisted config.
+        /// </summary>
+        public const string EnvLogLevel = "GODOT_MCP_LOG_LEVEL";
+
         // --- Defaults. ---
 
         /// <summary>Base URL of the hosted cloud server. The <c>/mcp</c> hub path is appended by <see cref="ResolveCloudUrl"/>.</summary>
@@ -120,6 +128,16 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         public GodotMcpAuthOption AuthOption { get; set; } = GodotMcpAuthOption.None;
 
         /// <summary>
+        /// The configured log-verbosity threshold for the plugin's routing of the reused framework's
+        /// <c>Microsoft.Extensions.Logging</c> output to the Godot Output (overridable by
+        /// <see cref="EnvLogLevel"/> via <see cref="ResolveActiveLogLevel"/>). Defaults to
+        /// <see cref="GodotMcpLogLevel.Info"/> — the framework's connection/handshake info lines are shown,
+        /// but trace/debug noise is suppressed until the user opts in via the dock's Log Level dropdown.
+        /// </summary>
+        [JsonPropertyName("logLevel")]
+        public GodotMcpLogLevel LogLevel { get; set; } = GodotMcpLogLevel.Info;
+
+        /// <summary>
         /// Persisted per-feature enable/disable map for the dock's MCP-features section (tools / prompts /
         /// resources). Only user-touched items are stored; an empty map means "everything at its live default"
         /// (the McpPlugin managers default to enabled), so a fresh install disables nothing. Reapplied on plugin
@@ -143,6 +161,15 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// </summary>
         [JsonIgnore]
         public GodotMcpAuthOption ActiveAuthOption => ResolveActiveAuthOption(AuthOption);
+
+        /// <summary>
+        /// The effective log-verbosity threshold after applying the <see cref="EnvLogLevel"/> override.
+        /// Never serialized — recomputed from the env each access so a process-level override always wins
+        /// (parity with <see cref="ActiveMode"/> / <see cref="ActiveAuthOption"/>). The logger reads this
+        /// LIVE on every log call, so the dock's Log Level dropdown takes effect without a rebuild.
+        /// </summary>
+        [JsonIgnore]
+        public GodotMcpLogLevel ActiveLogLevel => ResolveActiveLogLevel(LogLevel);
 
         /// <summary>
         /// Active connection URL based on <see cref="ActiveMode"/>:
@@ -281,6 +308,25 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 return configured;
 
             if (Enum.TryParse<GodotMcpAuthOption>(normalized, ignoreCase: true, out var parsed) &&
+                !int.TryParse(normalized, out _))
+                return parsed;
+
+            return configured;
+        }
+
+        /// <summary>
+        /// Resolve the active log-verbosity threshold, letting <see cref="EnvLogLevel"/> override the
+        /// configured value. An unrecognized/empty/numeric env value falls through to
+        /// <paramref name="configured"/> — identical discipline to <see cref="ResolveActiveMode"/> /
+        /// <see cref="ResolveActiveAuthOption"/>.
+        /// </summary>
+        public static GodotMcpLogLevel ResolveActiveLogLevel(GodotMcpLogLevel configured)
+        {
+            var normalized = NormalizeEnv(ReadEnv(EnvLogLevel));
+            if (string.IsNullOrEmpty(normalized))
+                return configured;
+
+            if (Enum.TryParse<GodotMcpLogLevel>(normalized, ignoreCase: true, out var parsed) &&
                 !int.TryParse(normalized, out _))
                 return parsed;
 

--- a/addons/godot_mcp/Connection/GodotMcpConfigStore.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConfigStore.cs
@@ -115,7 +115,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// <summary>
         /// Apply the SERIALIZED-LAYER values from <paramref name="persisted"/> onto <paramref name="target"/>,
         /// writing only the serialized backing fields (<c>CustomHost</c>/<c>CustomToken</c>/
-        /// <c>CloudToken</c>/<c>ConnectionMode</c>/<c>AuthOption</c>/<c>Features</c>). This is how the boot path
+        /// <c>CloudToken</c>/<c>ConnectionMode</c>/<c>AuthOption</c>/<c>LogLevel</c>/<c>Features</c>). This is how the boot path
         /// seeds the config with the persisted baseline BEFORE the <c>.env</c>/process-env layers are applied on
         /// top — keeping the documented precedence intact. No-op when <paramref name="persisted"/> is
         /// <c>null</c>. Returns <paramref name="target"/> for fluent use.
@@ -132,6 +132,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             target.CloudToken = persisted.CloudToken;
             target.ConnectionMode = persisted.ConnectionMode;
             target.AuthOption = persisted.AuthOption;
+            target.LogLevel = persisted.LogLevel;
             // The persisted feature enable-map (tools/prompts/resources). A missing `features` key in an older
             // config file deserializes to a non-null empty map (the property initializer), so this is always safe.
             target.Features = persisted.Features ?? new GodotMcpFeatureMap();

--- a/addons/godot_mcp/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConnection.cs
@@ -14,8 +14,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using com.IvanMurzak.Godot.MCP.Data;
 using com.IvanMurzak.Godot.MCP.MainThreadDispatch;
 using com.IvanMurzak.Godot.MCP.Reflection;
+using com.IvanMurzak.Godot.MCP.Tools;
 using com.IvanMurzak.Godot.MCP.UI;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet;
@@ -194,7 +196,15 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             // Scan THIS addon assembly for [AiToolType]/[AiTool] (the ping tool, and future families).
             Assembly addonAssembly = typeof(GodotMcpConnection).Assembly;
 
-            var builder = new McpPluginBuilder(version)
+            // Route the reused framework's Microsoft.Extensions.Logging output (ConnectionManager /
+            // hub-connector connect, hub-state, version handshake, errors) to the Godot Output, gated by the
+            // LIVE configured Log Level (read off _config each call so the dock dropdown applies without a
+            // rebuild). Without a provider these framework logs are invisible — they are the diagnostic for
+            // the "Connecting…" hang. The provider/logger are pure-managed; the only Godot dependency is the
+            // injected GD.* + log-collector sink below.
+            var loggerProvider = new GodotMcpLoggerProvider(() => _config.ActiveLogLevel, RouteFrameworkLog);
+
+            var builder = new McpPluginBuilder(version, loggerProvider)
                 .SetConfig(_config)
                 .WithToolsFromAssembly(addonAssembly)
                 .WithPromptsFromAssembly(addonAssembly)
@@ -314,6 +324,32 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 return;
             _status = status;
             ConnectionStatusChanged?.Invoke(status);
+        }
+
+        /// <summary>
+        /// The Godot sink the <see cref="GodotMcpLoggerProvider"/> routes the reused framework's log lines
+        /// to: write to the Godot Output by severity (info/debug/trace → <see cref="GD.Print"/>, warning →
+        /// <see cref="GD.PushWarning"/>, error/critical → <see cref="GD.PushError"/>) AND append to
+        /// <see cref="GodotLogCollector.Current"/> so <c>console-get-logs</c> captures the framework lines
+        /// too. The level decision already happened in the logger (this only runs for enabled lines). The
+        /// framework never logs secrets, and this pass-through adds none.
+        /// </summary>
+        static void RouteFrameworkLog(GodotLogType logType, string message)
+        {
+            switch (logType)
+            {
+                case GodotLogType.Error:
+                    GD.PushError(message);
+                    break;
+                case GodotLogType.Warning:
+                    GD.PushWarning(message);
+                    break;
+                default:
+                    GD.Print(message);
+                    break;
+            }
+
+            GodotLogCollector.Current?.Append(logType, message);
         }
 
         // --- MCP feature enable-map (tools / prompts / resources) -----------------------------------------

--- a/addons/godot_mcp/Connection/GodotMcpEnvFile.cs
+++ b/addons/godot_mcp/Connection/GodotMcpEnvFile.cs
@@ -52,7 +52,8 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             GodotMcpConfig.EnvHost,
             GodotMcpConfig.EnvCloudUrl,
             GodotMcpConfig.EnvToken,
-            GodotMcpConfig.EnvAuthOption
+            GodotMcpConfig.EnvAuthOption,
+            GodotMcpConfig.EnvLogLevel
         };
 
         /// <summary>
@@ -189,6 +190,14 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 config.AuthOption = parsedAuth;
             }
 
+            // 2c) Log level (cross-cutting): an explicit file value writes the serialized field beneath the
+            //     env layer (env GODOT_MCP_LOG_LEVEL still wins live via ActiveLogLevel).
+            if (values.TryGetValue(GodotMcpConfig.EnvLogLevel, out var fileLogLevel) &&
+                TryParseLogLevel(fileLogLevel, out var parsedLogLevel))
+            {
+                config.LogLevel = parsedLogLevel;
+            }
+
             // 3) Token: route to the active mode's token field (after mode is settled above so the route
             //    matches what the connection will actually use). Env token still wins live.
             if (values.TryGetValue(GodotMcpConfig.EnvToken, out var fileToken))
@@ -253,6 +262,22 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             if (int.TryParse(normalized, out _))
                 return false;
             return Enum.TryParse(normalized, ignoreCase: true, out authOption);
+        }
+
+        /// <summary>
+        /// Parse a log-level string to <see cref="GodotMcpLogLevel"/>, accepting only the named values
+        /// (case-insensitive) and rejecting numeric strings — identical discipline to
+        /// <see cref="TryParseMode"/> / <see cref="GodotMcpConfig.ResolveActiveLogLevel"/>.
+        /// </summary>
+        static bool TryParseLogLevel(string? raw, out GodotMcpLogLevel logLevel)
+        {
+            logLevel = default;
+            var normalized = Sanitize(raw);
+            if (string.IsNullOrEmpty(normalized))
+                return false;
+            if (int.TryParse(normalized, out _))
+                return false;
+            return Enum.TryParse(normalized, ignoreCase: true, out logLevel);
         }
 
         /// <summary>Sanitize a file value identically to a process-env value (see <see cref="Parse"/>).</summary>

--- a/addons/godot_mcp/Connection/GodotMcpLogLevel.cs
+++ b/addons/godot_mcp/Connection/GodotMcpLogLevel.cs
@@ -1,0 +1,97 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using MicrosoftLogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// The user-facing verbosity threshold for the Godot-MCP plugin's logging — the Godot analog of
+    /// Unity-MCP's <c>com.IvanMurzak.Unity.MCP.Runtime.Utils.LogLevel</c>. Lower ordinals are more verbose;
+    /// a configured level shows that level and everything more severe. Pure-managed (no Godot native types,
+    /// no <c>#if TOOLS</c>) so it serializes into <see cref="GodotMcpConfig"/> and is unit-testable in the
+    /// plain-xUnit host.
+    ///
+    /// <para>
+    /// Unity carries a distinct <c>Exception</c> level between <c>Error</c> and <c>None</c>; Godot's
+    /// logging surface (<c>GD.Print</c>/<c>GD.PushWarning</c>/<c>GD.PushError</c>) has no separate
+    /// exception channel, so this enum collapses critical/error into the single <see cref="Error"/> bucket
+    /// — matching how <see cref="Data.GodotLogType"/> already mirrors Godot's three output levels.
+    /// </para>
+    /// </summary>
+    public enum GodotMcpLogLevel
+    {
+        /// <summary>Show everything — Trace, Debug, Info, Warning, Error.</summary>
+        Trace = 0,
+
+        /// <summary>Show Debug and above (Debug, Info, Warning, Error).</summary>
+        Debug = 1,
+
+        /// <summary>Show Info and above (Info, Warning, Error). The default.</summary>
+        Info = 2,
+
+        /// <summary>Show Warning and above (Warning, Error).</summary>
+        Warning = 3,
+
+        /// <summary>Show Error (and Critical) only.</summary>
+        Error = 4,
+
+        /// <summary>Show nothing.</summary>
+        None = 5
+    }
+
+    /// <summary>
+    /// Pure-managed level-gate for the Godot-MCP logger: maps a framework
+    /// <see cref="MicrosoftLogLevel"/> to the matching <see cref="GodotMcpLogLevel"/> bucket and decides
+    /// whether it is enabled under a configured threshold. The Godot analog of Unity-MCP's
+    /// <c>UnityLogger.IsEnabled</c> + <c>LogLevelEx.IsEnabled</c>. No Godot dependency, no
+    /// <c>#if TOOLS</c> — unit-tested directly in the plain-xUnit host.
+    /// </summary>
+    public static class GodotMcpLogGate
+    {
+        /// <summary>
+        /// Map a framework <see cref="MicrosoftLogLevel"/> to the matching <see cref="GodotMcpLogLevel"/>
+        /// bucket. <see cref="MicrosoftLogLevel.Critical"/> folds into <see cref="GodotMcpLogLevel.Error"/>
+        /// (Godot has no separate critical channel); <see cref="MicrosoftLogLevel.None"/> folds into
+        /// <see cref="GodotMcpLogLevel.None"/> (it is never actually logged). Mirrors the switch in
+        /// Unity-MCP's <c>UnityLogger.IsEnabled</c>.
+        /// </summary>
+        public static GodotMcpLogLevel Map(MicrosoftLogLevel msLevel) => msLevel switch
+        {
+            MicrosoftLogLevel.Trace => GodotMcpLogLevel.Trace,
+            MicrosoftLogLevel.Debug => GodotMcpLogLevel.Debug,
+            MicrosoftLogLevel.Information => GodotMcpLogLevel.Info,
+            MicrosoftLogLevel.Warning => GodotMcpLogLevel.Warning,
+            MicrosoftLogLevel.Error => GodotMcpLogLevel.Error,
+            MicrosoftLogLevel.Critical => GodotMcpLogLevel.Error,
+            _ => GodotMcpLogLevel.None
+        };
+
+        /// <summary>
+        /// True when a message at <paramref name="msLevel"/> should be shown under the
+        /// <paramref name="configured"/> threshold. A message is enabled when its mapped bucket is at least
+        /// as severe as the configured level (i.e. <c>configured &lt;= mapped</c>, mirroring Unity's
+        /// <c>LogLevelEx.IsEnabled</c>). <see cref="GodotMcpLogLevel.None"/> as the configured threshold
+        /// suppresses everything; a message that maps to <see cref="GodotMcpLogLevel.None"/> (i.e.
+        /// <see cref="MicrosoftLogLevel.None"/>) is never enabled.
+        /// </summary>
+        public static bool IsEnabled(MicrosoftLogLevel msLevel, GodotMcpLogLevel configured)
+        {
+            if (configured == GodotMcpLogLevel.None)
+                return false;
+
+            var mapped = Map(msLevel);
+            if (mapped == GodotMcpLogLevel.None)
+                return false;
+
+            return configured <= mapped;
+        }
+    }
+}

--- a/addons/godot_mcp/Connection/GodotMcpLogger.cs
+++ b/addons/godot_mcp/Connection/GodotMcpLogger.cs
@@ -1,0 +1,115 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using com.IvanMurzak.Godot.MCP.Data;
+using Microsoft.Extensions.Logging;
+using MicrosoftLogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// An <see cref="ILogger"/> that routes the reused <c>com.IvanMurzak.McpPlugin</c> framework's
+    /// <c>Microsoft.Extensions.Logging</c> output to the Godot editor Output — the Godot analog of
+    /// Unity-MCP's <c>UnityLogger</c>. The framework's connection / version-handshake / hub-state logs
+    /// (currently invisible because the plugin passes no logger provider to <c>McpPluginBuilder</c>) become
+    /// visible here, gated by a configurable <see cref="GodotMcpLogLevel"/>.
+    ///
+    /// <para>
+    /// <b>Pure-managed by design.</b> The only Godot dependency — writing to <c>GD.Print</c>/
+    /// <c>GD.PushWarning</c>/<c>GD.PushError</c> — is injected as a <see cref="GodotLogSink"/> delegate, and
+    /// the LIVE configured level is read through a <see cref="Func{TResult}"/> on every call (so the dock's
+    /// Log Level dropdown takes effect without a rebuild). This keeps the logger (and its
+    /// <see cref="GodotMcpLoggerProvider"/>) outside <c>#if TOOLS</c> and unit-testable in the plain-xUnit
+    /// host with a fake sink; the editor boot wires a real <c>GD.*</c> + <see cref="Tools.GodotLogCollector"/>
+    /// sink. The level decision itself lives in the pure <see cref="GodotMcpLogGate"/>.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Security.</b> This logger only passes through messages the framework already emits; it never
+    /// constructs or logs a token. The framework avoids logging secrets, and nothing here re-introduces one.
+    /// </para>
+    /// </summary>
+    public sealed class GodotMcpLogger : ILogger
+    {
+        /// <summary>Prefix prepended to every routed line so framework logs are attributable in the Output.</summary>
+        public const string Prefix = "[McpPlugin] ";
+
+        readonly string _categoryName;
+        readonly Func<GodotMcpLogLevel> _levelProvider;
+        readonly GodotLogSink _sink;
+
+        /// <summary>
+        /// Construct a logger for <paramref name="categoryName"/>.
+        /// </summary>
+        /// <param name="categoryName">The DI category (typically a framework type name); the short name is shown.</param>
+        /// <param name="levelProvider">Reads the LIVE configured threshold on every call (dropdown takes effect without rebuild).</param>
+        /// <param name="sink">Routes a formatted line to the Godot Output + log collector. Injected so the core stays pure-managed.</param>
+        public GodotMcpLogger(string categoryName, Func<GodotMcpLogLevel> levelProvider, GodotLogSink sink)
+        {
+            // Short category (drop the namespace) for a compact Output line, mirroring UnityLogger.
+            _categoryName = categoryName != null && categoryName.Contains('.')
+                ? categoryName.Substring(categoryName.LastIndexOf('.') + 1)
+                : categoryName ?? string.Empty;
+            _levelProvider = levelProvider ?? throw new ArgumentNullException(nameof(levelProvider));
+            _sink = sink ?? throw new ArgumentNullException(nameof(sink));
+        }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        /// <summary>
+        /// True when a message at <paramref name="logLevel"/> passes the LIVE configured threshold. Read
+        /// live (not cached) so toggling the dock's Log Level dropdown changes verbosity without rebuilding
+        /// the connection.
+        /// </summary>
+        public bool IsEnabled(MicrosoftLogLevel logLevel) =>
+            GodotMcpLogGate.IsEnabled(logLevel, _levelProvider());
+
+        public void Log<TState>(
+            MicrosoftLogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+                return;
+            if (formatter == null)
+                throw new ArgumentNullException(nameof(formatter));
+
+            var text = formatter(state, exception);
+            var message = string.IsNullOrEmpty(_categoryName)
+                ? $"{Prefix}{text}"
+                : $"{Prefix}{_categoryName}: {text}";
+
+            // Append the exception detail (message + stack) so a failing handshake/connect is diagnosable.
+            if (exception != null)
+                message = $"{message}\n{exception}";
+
+            var godotType = logLevel switch
+            {
+                MicrosoftLogLevel.Critical => GodotLogType.Error,
+                MicrosoftLogLevel.Error => GodotLogType.Error,
+                MicrosoftLogLevel.Warning => GodotLogType.Warning,
+                _ => GodotLogType.Log
+            };
+
+            _sink(godotType, message);
+        }
+    }
+
+    /// <summary>
+    /// Routes a single formatted log line at a given <see cref="GodotLogType"/> severity to its
+    /// destination(s). The editor boot injects a sink that writes to <c>GD.Print</c>/<c>GD.PushWarning</c>/
+    /// <c>GD.PushError</c> AND appends to <see cref="Tools.GodotLogCollector"/>; the unit-test host injects a
+    /// capturing sink. Keeping this a delegate is what lets <see cref="GodotMcpLogger"/> stay pure-managed.
+    /// </summary>
+    public delegate void GodotLogSink(GodotLogType logType, string message);
+}

--- a/addons/godot_mcp/Connection/GodotMcpLoggerProvider.cs
+++ b/addons/godot_mcp/Connection/GodotMcpLoggerProvider.cs
@@ -1,0 +1,50 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// The <see cref="ILoggerProvider"/> handed to <c>McpPluginBuilder</c> so the reused framework's
+    /// <c>ILogger&lt;T&gt;</c> calls (ConnectionManager / hub connector connect, hub-state, version
+    /// handshake, errors) reach the Godot editor Output. The Godot analog of Unity-MCP's
+    /// <c>UnityLoggerProvider</c>.
+    ///
+    /// <para>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>): the level threshold is read live via the
+    /// injected <see cref="Func{TResult}"/> (so the dock dropdown applies without a rebuild) and the Godot
+    /// Output sink is the injected <see cref="GodotLogSink"/>. <see cref="GodotMcpConnection"/> constructs
+    /// this with a <c>() =&gt; _config.ActiveLogLevel</c> level provider and a <c>GD.*</c>+collector sink.
+    /// </para>
+    /// </summary>
+    public sealed class GodotMcpLoggerProvider : ILoggerProvider
+    {
+        readonly Func<GodotMcpLogLevel> _levelProvider;
+        readonly GodotLogSink _sink;
+
+        /// <summary>
+        /// Construct the provider.
+        /// </summary>
+        /// <param name="levelProvider">Reads the LIVE configured threshold on every log call.</param>
+        /// <param name="sink">Routes a formatted line to the Godot Output + log collector.</param>
+        public GodotMcpLoggerProvider(Func<GodotMcpLogLevel> levelProvider, GodotLogSink sink)
+        {
+            _levelProvider = levelProvider ?? throw new ArgumentNullException(nameof(levelProvider));
+            _sink = sink ?? throw new ArgumentNullException(nameof(sink));
+        }
+
+        public ILogger CreateLogger(string categoryName) =>
+            new GodotMcpLogger(categoryName, _levelProvider, _sink);
+
+        public void Dispose() { /* No resources to dispose. */ }
+    }
+}

--- a/addons/godot_mcp/UI/GodotMcpDock.cs
+++ b/addons/godot_mcp/UI/GodotMcpDock.cs
@@ -53,6 +53,11 @@ namespace com.IvanMurzak.Godot.MCP.UI
         FeaturesPanel? _featuresPanel;
         SupportFooter? _supportFooter;
 
+        // Log Level selector (header). Only built when a live connection was threaded in (it reads/writes
+        // the connection's config). The OptionButton item ids are the GodotMcpLogLevel enum ordinals.
+        OptionButton? _logLevelSelector;
+        Label? _logLevelOverrideNote;
+
         /// <summary>
         /// Construct the dock wired to the live <paramref name="connection"/> so its connection panel can
         /// show status and drive Connect/Disconnect/mode/URL. <see cref="GodotMcpPlugin"/> owns the
@@ -94,6 +99,12 @@ namespace com.IvanMurzak.Godot.MCP.UI
             };
             header.AddChild(version);
 
+            // Log Level selector — routes the reused framework's verbosity (connection / handshake logs) to
+            // the Godot Output. Compact, in the header so it is reachable for diagnostics regardless of which
+            // section is open. Only meaningful with a live connection (it binds the connection's config).
+            if (_connection != null)
+                BuildLogLevelRow(header, _connection);
+
             header.AddChild(new HSeparator { Name = "HeaderSeparator" });
 
             // --- Body ---
@@ -127,6 +138,77 @@ namespace com.IvanMurzak.Godot.MCP.UI
         }
 
         /// <summary>
+        /// Build the compact "Log Level" row in the header: a label + an <see cref="OptionButton"/> listing
+        /// every <see cref="GodotMcpLogLevel"/> value (item id = enum ordinal), bound to the connection's
+        /// EFFECTIVE level. On change → write the PERSISTED <see cref="GodotMcpConfig.LogLevel"/> + Save; the
+        /// logger provider reads the level live, so no reconnect is needed. An <see cref="GodotMcpConfig.EnvLogLevel"/>
+        /// (env/.env) override is surfaced by a note and disables the selector (editing it would not take
+        /// effect live, unlike the connection-mode controls which write a layer the user can later re-enable).
+        /// </summary>
+        void BuildLogLevelRow(Container parent, GodotMcpConnection connection)
+        {
+            var row = new HBoxContainer { Name = "LogLevelRow" };
+            parent.AddChild(row);
+
+            row.AddChild(new Label { Name = "LogLevelLabel", Text = "Log Level" });
+
+            _logLevelSelector = new OptionButton { Name = "LogLevelSelector" };
+            foreach (GodotMcpLogLevel level in System.Enum.GetValues(typeof(GodotMcpLogLevel)))
+                _logLevelSelector.AddItem(level.ToString(), (int)level);
+            _logLevelSelector.ItemSelected += OnLogLevelSelected;
+            row.AddChild(_logLevelSelector);
+
+            _logLevelOverrideNote = new Label
+            {
+                Name = "LogLevelOverrideNote",
+                Text = "Overridden by environment (GODOT_MCP_LOG_LEVEL).",
+                AutowrapMode = TextServer.AutowrapMode.WordSmart
+            };
+            _logLevelOverrideNote.AddThemeColorOverride("font_color", new Color(0.92f, 0.74f, 0.20f));
+            parent.AddChild(_logLevelOverrideNote);
+
+            SyncLogLevelSelector();
+        }
+
+        /// <summary>
+        /// Persist the chosen log level and Save. The selector id IS the enum ordinal. No reconnect — the
+        /// logger provider reads the level live on every call. No-op when an env override pins the live level
+        /// (the selector is disabled in that case, so this should not fire, but it is guarded defensively).
+        /// </summary>
+        void OnLogLevelSelected(long id)
+        {
+            if (_connection == null)
+                return;
+
+            var level = (GodotMcpLogLevel)(int)id;
+            if (_connection.Config.LogLevel == level)
+                return;
+
+            _connection.Config.LogLevel = level;
+            _connection.Save();
+        }
+
+        /// <summary>
+        /// Reflect the EFFECTIVE log level in the selector and surface/disable on an env override. The
+        /// selector shows <see cref="GodotMcpConfig.ActiveLogLevel"/> (env wins); when an env/.env value
+        /// forces it away from the persisted <see cref="GodotMcpConfig.LogLevel"/>, the override note shows
+        /// and the selector is disabled (a UI edit would not take effect live).
+        /// </summary>
+        void SyncLogLevelSelector()
+        {
+            if (_connection == null || _logLevelSelector == null)
+                return;
+
+            var active = _connection.Config.ActiveLogLevel;
+            _logLevelSelector.Selected = _logLevelSelector.GetItemIndex((int)active);
+
+            var overridden = active != _connection.Config.LogLevel;
+            _logLevelSelector.Disabled = overridden;
+            if (_logLevelOverrideNote != null)
+                _logLevelOverrideNote.Visible = overridden;
+        }
+
+        /// <summary>
         /// Re-render the dock from current state. No-op in this foundation scaffold — there is no dynamic
         /// state to show yet. The later connection task fills this in (status line, mode indicator) and
         /// the connection layer calls it on the editor main thread (e.g. via the main-thread dispatcher)
@@ -136,6 +218,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         {
             _connectionPanel?.Refresh();
             _featuresPanel?.Refresh();
+            SyncLogLevelSelector();
         }
     }
 }


### PR DESCRIPTION
## Summary
- Route the reused McpPlugin framework's `Microsoft.Extensions.Logging` output (connection / version-handshake / hub-state / errors) to the Godot Output, gated by a configurable Log Level. Previously the plugin passed **no** logger provider to `McpPluginBuilder`, so these lines were invisible — leaving the "Connecting…" hang undiagnosable.
- `GodotMcpLogLevel` enum + pure-managed `GodotMcpLogGate` (Microsoft→Godot level mapping/threshold), mirroring Unity's `LogLevel` + `UnityLogger.IsEnabled`.
- `GodotMcpLogger`/`GodotMcpLoggerProvider`: pure-managed, level read **live** (dropdown applies without rebuild), Godot Output via an injected sink delegate (CI-testable); the `GD.*` + `GodotLogCollector` sink is wired in `GodotMcpConnection`.
- `logLevel` config field (default `Info`) with full precedence: `GODOT_MCP_LOG_LEVEL` env > `.env` > persisted > default. Provider passed to `new McpPluginBuilder(version, loggerProvider)` — same wiring as Unity.
- Compact Log Level `OptionButton` in the dock header (`#if TOOLS`), bound to the effective level, env-override aware.

Security: passes through only framework messages; never logs a token. Pins untouched (McpPlugin 6.7.0 / ReflectorNet 5.3.1).

## Test plan
- [x] Suite 1 (`dotnet build`) 0 errors / 0 warnings.
- [x] Suite 2 (`dotnet test`) — 391 pass (exhaustive `Reduce` matrix, log-gate enable/suppress matrix + logger routing, `logLevel` serialize/round-trip + env/.env/persisted precedence).
- [x] Suite 3 headless smoke at Trace against local DemoWebApp :8090 — the `[McpPlugin]` framework lifecycle now surfaces in the Godot Output (transport connect, version handshake `Compatible: True`, `[Godot-MCP] connected.`).

Closes #40