### PR TITLE
fix(connection): converge dock status label to live connection state (#42)

### DIFF
--- a/Godot-MCP.Tests/ConnectionStatusTrackerTests.cs
+++ b/Godot-MCP.Tests/ConnectionStatusTrackerTests.cs
@@ -1,0 +1,182 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Collections.Generic;
+using com.IvanMurzak.Godot.MCP.UI;
+using Microsoft.AspNetCore.SignalR.Client;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the pure-managed connection status path behind issue #42 ("status stuck at Connecting…"):
+    /// the <see cref="ConnectionStatusTracker"/> de-dup rule, the late-subscriber / re-sync convergence
+    /// (a subscriber that attaches AFTER the status already advanced still converges by reading
+    /// <see cref="ConnectionStatusTracker.Current"/> directly), and the Reconnect reset. The editor
+    /// <c>ConnectionPanel</c> Timer wiring that drives the periodic re-sync is <c>#if TOOLS</c> and verified
+    /// via the headless Godot smoke (test.md Suite 3) — NOT here.
+    /// </summary>
+    public class ConnectionStatusTrackerTests
+    {
+        // --- De-dup: TryAdvance only reports a change on an actual transition ---
+
+        [Fact]
+        public void TryAdvance_FromSeedToNewStatus_AdvancesAndReportsChange()
+        {
+            var tracker = new ConnectionStatusTracker(); // seeds Disconnected
+
+            Assert.True(tracker.TryAdvance(ConnectionStatus.Connecting));
+            Assert.Equal(ConnectionStatus.Connecting, tracker.Current);
+        }
+
+        [Fact]
+        public void TryAdvance_SameStatusTwice_SecondIsDeDuped()
+        {
+            var tracker = new ConnectionStatusTracker();
+
+            Assert.True(tracker.TryAdvance(ConnectionStatus.Connected));
+            // Identical consecutive state (e.g. the seed plus an immediate first push) must not re-fire.
+            Assert.False(tracker.TryAdvance(ConnectionStatus.Connected));
+            Assert.Equal(ConnectionStatus.Connected, tracker.Current);
+        }
+
+        [Fact]
+        public void TryAdvance_SeededAtSameValue_FirstOfferIsDeDuped()
+        {
+            // A tracker seeded Disconnected, then offered Disconnected again, is a no-op (matches the
+            // ConnectionPanel ctor seed followed by an immediate seed-from-current push of the same value).
+            var tracker = new ConnectionStatusTracker(ConnectionStatus.Disconnected);
+
+            Assert.False(tracker.TryAdvance(ConnectionStatus.Disconnected));
+            Assert.Equal(ConnectionStatus.Disconnected, tracker.Current);
+        }
+
+        [Fact]
+        public void TryAdvance_UpdatesCurrentBeforeReturning()
+        {
+            // The de-dup mutates Current BEFORE returning, so a getter read inside a change-notification
+            // already reflects the new value (the connection raises ConnectionStatusChanged right after this).
+            var tracker = new ConnectionStatusTracker();
+            tracker.TryAdvance(ConnectionStatus.Connecting);
+            Assert.Equal(ConnectionStatus.Connecting, tracker.Current);
+        }
+
+        // --- Late-subscriber convergence: the #42 fix in microcosm ---
+
+        [Fact]
+        public void LateSubscriber_ReadsLatestStatus_EvenIfItMissedTheTransitionEvent()
+        {
+            // Model the race: the status advances Disconnected -> Connecting -> Connected via the event path
+            // BEFORE a subscriber (the dock panel) attaches. Events fired before attach are lost.
+            var tracker = new ConnectionStatusTracker();
+            var observedEvents = new List<ConnectionStatus>();
+
+            // Simulate the connection's PublishStatus loop firing to NO subscriber yet.
+            AdvanceAndMaybeRaise(tracker, ConnectionStatus.Connecting, subscriber: null, observedEvents);
+            AdvanceAndMaybeRaise(tracker, ConnectionStatus.Connected, subscriber: null, observedEvents);
+
+            // Subscriber attaches now — it missed every event.
+            Assert.Empty(observedEvents);
+
+            // The periodic re-sync reads Current DIRECTLY (bypassing the event) and converges on Connected.
+            var rendered = tracker.Current;
+            Assert.Equal(ConnectionStatus.Connected, rendered);
+        }
+
+        [Fact]
+        public void Resync_AfterMissedPush_ConvergesOnLiveStatus()
+        {
+            // The panel rendered Connecting (its last seen event). A subsequent Connected push was "lost"
+            // (never delivered to the panel), but the tracker advanced. The re-sync reads Current and the
+            // panel re-applies the drift.
+            var tracker = new ConnectionStatusTracker();
+            tracker.TryAdvance(ConnectionStatus.Connecting);
+            ConnectionStatus rendered = tracker.Current; // panel rendered Connecting
+
+            // Lost push: tracker advances to Connected but the panel never saw the event.
+            tracker.TryAdvance(ConnectionStatus.Connected);
+
+            // Re-sync detects drift (rendered != live) and re-applies.
+            if (rendered != tracker.Current)
+                rendered = tracker.Current;
+
+            Assert.Equal(ConnectionStatus.Connected, rendered);
+        }
+
+        // --- Reconnect reset: a rebuilt plugin's status seeds from a clean baseline ---
+
+        [Fact]
+        public void Reset_FromConnected_ReturnsToDisconnected_AndReportsChange()
+        {
+            var tracker = new ConnectionStatusTracker();
+            tracker.TryAdvance(ConnectionStatus.Connected);
+
+            Assert.True(tracker.Reset());
+            Assert.Equal(ConnectionStatus.Disconnected, tracker.Current);
+        }
+
+        [Fact]
+        public void Reset_WhenAlreadyAtTarget_IsNoOp()
+        {
+            var tracker = new ConnectionStatusTracker(); // already Disconnected
+            Assert.False(tracker.Reset());
+            Assert.Equal(ConnectionStatus.Disconnected, tracker.Current);
+        }
+
+        [Fact]
+        public void Reconnect_ResetThenReseed_RendersNewConnectionsStatus()
+        {
+            // Old connection was Connected; a Reconnect resets to Disconnected, then the NEW plugin's seed
+            // (Reduce over the fresh client) advances to Connecting and eventually Connected — none of which
+            // is de-duped against the stale Connected from the old plugin because of the reset.
+            var tracker = new ConnectionStatusTracker();
+            tracker.TryAdvance(ConnectionStatus.Connected);
+
+            // Reconnect resets.
+            Assert.True(tracker.Reset());
+
+            // New plugin seeds Connecting, then reaches Connected — both are real transitions now.
+            Assert.True(tracker.TryAdvance(ConnectionStatus.Connecting));
+            Assert.True(tracker.TryAdvance(ConnectionStatus.Connected));
+            Assert.Equal(ConnectionStatus.Connected, tracker.Current);
+        }
+
+        // --- The reduction that feeds the tracker reaches Connected on a connected hub (end-to-end of #42) ---
+
+        [Fact]
+        public void HealthyHandshake_ReducesToConnected_AndTrackerAdvances()
+        {
+            // The diagnosis: the hub DID reach Connected (handshake completed) — so the reduced status the
+            // tracker is offered IS Connected. Prove the path the panel depends on end-to-end.
+            var tracker = new ConnectionStatusTracker();
+
+            // boot seed: client starts Disconnected, KeepConnected on -> Connecting.
+            tracker.TryAdvance(ConnectionPanelView.Reduce(HubConnectionState.Disconnected, keepConnected: true));
+            Assert.Equal(ConnectionStatus.Connecting, tracker.Current);
+
+            // hub connects + handshake completes -> Connected.
+            Assert.True(tracker.TryAdvance(ConnectionPanelView.Reduce(HubConnectionState.Connected, keepConnected: true)));
+            Assert.Equal(ConnectionStatus.Connected, tracker.Current);
+        }
+
+        // --- Helper modelling the connection's PublishStatus(event) path against an optional subscriber ---
+
+        static void AdvanceAndMaybeRaise(
+            ConnectionStatusTracker tracker,
+            ConnectionStatus status,
+            List<ConnectionStatus>? subscriber,
+            List<ConnectionStatus> sink)
+        {
+            if (tracker.TryAdvance(status))
+                subscriber?.Add(status); // only delivered if a subscriber is attached at fire time
+            _ = sink;
+        }
+    }
+}

--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -127,6 +127,12 @@
          via the headless Godot smoke (test.md Suite 3); the view logic is unit-tested here. The SignalR
          HubConnectionState enum it switches on is provided transitively by com.IvanMurzak.McpPlugin. -->
     <Compile Include="..\addons\godot_mcp\UI\ConnectionPanelView.cs" Link="Source\ConnectionPanelView.cs" />
+    <!-- Connection status tracker — pure-managed (no Godot native types, no #if TOOLS): the current-status
+         holder + de-dup rule extracted out of GodotMcpConnection.PublishStatus (issue #42). The editor
+         Timer/_Process wiring that drives the periodic re-sync stays in ConnectionPanel.cs (#if TOOLS,
+         verified via the headless Godot smoke, test.md Suite 3); the de-dup / convergence / reset logic
+         is unit-tested here. -->
+    <Compile Include="..\addons\godot_mcp\UI\ConnectionStatusTracker.cs" Link="Source\ConnectionStatusTracker.cs" />
     <!-- Support-footer link constants — pure-managed (no Godot native types, no #if TOOLS): the static
          URLs/copy opened by the dock footer. The editor Control wiring (SupportFooter.cs) is #if TOOLS and
          verified via the headless Godot smoke (test.md Suite 3); the constants are unit-tested here. -->

--- a/addons/godot_mcp/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConnection.cs
@@ -91,8 +91,15 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// </summary>
         readonly SerialDisposable _featuresSubscription = new();
 
-        /// <summary>Last reduced status, cached so <see cref="ConnectionStatus"/> is readable without a live plugin.</summary>
-        ConnectionStatus _status = ConnectionStatus.Disconnected;
+        /// <summary>
+        /// Holds the last reduced status (so <see cref="ConnectionStatus"/> is readable without a live
+        /// plugin) and owns the de-dup rule. Pure-managed (<see cref="ConnectionStatusTracker"/>) so the
+        /// status path — de-dup, late-subscriber convergence, reconnect reset — is unit-tested in the
+        /// plain-xUnit host. The dock's periodic re-sync reads <see cref="ConnectionStatus"/> (i.e.
+        /// <c>_statusTracker.Current</c>) DIRECTLY, bypassing the event, so a render can never be
+        /// permanently lost to the de-dup (the root cause of issue #42).
+        /// </summary>
+        readonly ConnectionStatusTracker _statusTracker = new();
 
         /// <summary>The active config (resolved Host/Token/mode are read live off this).</summary>
         public GodotMcpConfig Config => _config;
@@ -130,7 +137,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// <see cref="ConnectionPanelView.Reduce"/>. The dock reads this for its initial render and is
         /// pushed subsequent changes via <see cref="ConnectionStatusChanged"/>.
         /// </summary>
-        public ConnectionStatus ConnectionStatus => _status;
+        public ConnectionStatus ConnectionStatus => _statusTracker.Current;
 
         /// <summary>
         /// Raised whenever <see cref="ConnectionStatus"/> changes. ALWAYS marshalled onto the Godot editor
@@ -241,7 +248,8 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         void SubscribeToConnectionState(IMcpPlugin plugin)
         {
             // Seed from current values so the dock's first render is correct even before any change fires.
-            PublishStatus(ConnectionPanelView.Reduce(plugin.ConnectionState.CurrentValue, plugin.KeepConnected.CurrentValue));
+            // Runs synchronously on the caller (Start, which is on the editor main thread), so it is "inline".
+            PublishStatus(ConnectionPanelView.Reduce(plugin.ConnectionState.CurrentValue, plugin.KeepConnected.CurrentValue), marshalled: false);
 
             _stateSubscription.Disposable = Observable
                 .CombineLatest(
@@ -254,9 +262,9 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                     // event so subscribers (the dock) can touch Control nodes directly. A missing
                     // dispatcher (between editor reloads) degrades to a direct call rather than throwing.
                     if (MainThreadDispatcher.Instance != null && !MainThreadDispatcher.IsMainThread)
-                        MainThreadDispatcher.Enqueue(() => PublishStatus(status));
+                        MainThreadDispatcher.Enqueue(() => PublishStatus(status, marshalled: true));
                     else
-                        PublishStatus(status);
+                        PublishStatus(status, marshalled: false);
                 });
 
             // Surface the reused client's authorization-rejected stream as a main-thread event the dock can
@@ -315,16 +323,52 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
         /// <summary>
         /// Update the cached <see cref="ConnectionStatus"/> and raise <see cref="ConnectionStatusChanged"/>
-        /// when it actually changed. De-duplicated so identical consecutive states (e.g. the seed plus an
-        /// immediate first push) do not double-fire the UI. MUST be called on the editor main thread.
+        /// when it actually changed. De-duplicated (via <see cref="_statusTracker"/>) so identical
+        /// consecutive states (e.g. the seed plus an immediate first push) do not double-fire the UI. MUST
+        /// be called on the editor main thread. <paramref name="marshalled"/> records whether this push was
+        /// hopped from the SignalR thread onto the main thread (<c>true</c>) or ran inline on the caller
+        /// (<c>false</c>) — surfaced at Trace so the full status path is visible in the Output when
+        /// diagnosing a stuck label (issue #42). The de-dup never permanently hides a render: the dock's
+        /// periodic re-sync reads <see cref="ConnectionStatus"/> directly.
         /// </summary>
-        void PublishStatus(ConnectionStatus status)
+        void PublishStatus(ConnectionStatus status, bool marshalled)
         {
-            if (_status == status)
+            var previous = _statusTracker.Current;
+            if (!_statusTracker.TryAdvance(status))
+            {
+                LogTrace($"[Godot-MCP] status push (de-duped, no change): {status} ({(marshalled ? "marshalled" : "inline")})");
                 return;
-            _status = status;
+            }
+
+            LogTrace($"[Godot-MCP] status: {previous} -> {status} ({(marshalled ? "marshalled to main thread" : "inline")})");
             ConnectionStatusChanged?.Invoke(status);
         }
+
+        /// <summary>
+        /// Emit a Trace-level diagnostic line through the same Godot Output + log-collector sink the
+        /// framework logs use, gated by the LIVE configured <see cref="GodotMcpConfig.ActiveLogLevel"/> (read
+        /// each call so the dock's Log Level dropdown applies without a rebuild). Used for the connection
+        /// status path (<see cref="PublishStatus"/>) so a smoke run at Trace shows whether/when
+        /// <see cref="ConnectionStatus.Connected"/> is reached and pushed. Never logs secrets — the status
+        /// enum carries none.
+        /// </summary>
+        void LogTrace(string message)
+        {
+            if (!GodotMcpLogGate.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Trace, _config.ActiveLogLevel))
+                return;
+
+            RouteFrameworkLog(GodotLogType.Log, message);
+        }
+
+        /// <summary>
+        /// Public Trace hook for the dock's <see cref="UI.ConnectionPanel"/> so it can record what status it
+        /// actually RENDERED (<c>ApplyStatus rendered status: …</c>) through the same Output + log-collector
+        /// sink and the same live <see cref="GodotMcpConfig.ActiveLogLevel"/> gate as the connection's own
+        /// status-push traces. Pairing the connection-side <c>status: X -> Y</c> line with the panel-side
+        /// <c>rendered status: Y</c> line is what lets a Trace smoke run SEE the terminal Connected render
+        /// arrive at the label (the diagnostic for issue #42). Never logs secrets.
+        /// </summary>
+        public void LogStatusTrace(string message) => LogTrace(message);
 
         /// <summary>
         /// The Godot sink the <see cref="GodotMcpLoggerProvider"/> routes the reused framework's log lines
@@ -511,6 +555,15 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         {
             _config.KeepConnected = true;
             DisposePlugin();
+
+            // Reset the status baseline so the NEW plugin's seed (pushed from Start → SubscribeToConnectionState)
+            // is free to advance from Disconnected rather than being de-duped against a stale value carried over
+            // from the disposed plugin. Without this, a Reconnect that lands back on the same reduced status as
+            // before would not re-fire ConnectionStatusChanged — the periodic re-sync still converges the label,
+            // but resetting keeps the event path correct too. Done on the main thread (callers are UI handlers).
+            if (_statusTracker.Reset())
+                ConnectionStatusChanged?.Invoke(_statusTracker.Current);
+
             Start();
         }
 

--- a/addons/godot_mcp/MainThread/MainThreadDispatcher.cs
+++ b/addons/godot_mcp/MainThread/MainThreadDispatcher.cs
@@ -47,6 +47,46 @@ namespace com.IvanMurzak.Godot.MCP.MainThreadDispatch
         static readonly ConcurrentQueue<Action> _actions = new ConcurrentQueue<Action>();
         static MainThreadDispatcher? _instance;
 
+        /// <summary>
+        /// Per-tick callbacks invoked on every main-thread <see cref="_Process"/> tick (after the queued
+        /// actions are drained), each receiving the frame <c>delta</c> in seconds. Unlike a dock Control's
+        /// own <see cref="Node._Process"/> — which Godot skips while the dock tab is hidden — the dispatcher
+        /// is a non-dock editor Node added under the <c>EditorPlugin</c>, so it ticks for the whole plugin
+        /// lifetime regardless of which dock tab is active. This is what makes the connection panel's periodic
+        /// status re-sync reliable even when its tab is not the foreground one (issue #42). Thread-affinity:
+        /// register/unregister + invocation all happen on the editor main thread.
+        /// </summary>
+        static event Action<double>? _onProcess;
+
+        /// <summary>
+        /// Register a per-frame <paramref name="callback"/> (receives the frame delta in seconds) invoked on
+        /// every main-thread tick. Returns an <see cref="IDisposable"/> that unregisters it — store it and
+        /// dispose on teardown so a freed subscriber stops being ticked. Safe to call before any dispatcher
+        /// is in the tree (the callback simply starts firing once one is).
+        /// </summary>
+        public static IDisposable RegisterProcess(Action<double> callback)
+        {
+            if (callback == null)
+                throw new ArgumentNullException(nameof(callback));
+
+            _onProcess += callback;
+            return new ProcessRegistration(callback);
+        }
+
+        sealed class ProcessRegistration : IDisposable
+        {
+            Action<double>? _callback;
+            public ProcessRegistration(Action<double> callback) => _callback = callback;
+
+            public void Dispose()
+            {
+                if (_callback == null)
+                    return;
+                _onProcess -= _callback;
+                _callback = null;
+            }
+        }
+
         /// <summary>The currently-installed dispatcher instance, or <c>null</c> when none is in the tree.</summary>
         public static MainThreadDispatcher? Instance => _instance;
 
@@ -89,6 +129,21 @@ namespace com.IvanMurzak.Godot.MCP.MainThreadDispatch
         public override void _Process(double delta)
         {
             DrainQueue();
+
+            // Fire per-tick subscribers (e.g. the connection panel's status re-sync). Snapshot the delegate
+            // so a callback that unregisters mid-invocation does not perturb the running invocation list.
+            var onProcess = _onProcess;
+            if (onProcess != null)
+            {
+                try
+                {
+                    onProcess(delta);
+                }
+                catch (Exception ex)
+                {
+                    GD.PushError($"[Godot-MCP] MainThreadDispatcher per-tick callback threw: {ex}");
+                }
+            }
         }
 
         static void DrainQueue()

--- a/addons/godot_mcp/UI/ConnectionPanel.cs
+++ b/addons/godot_mcp/UI/ConnectionPanel.cs
@@ -78,6 +78,22 @@ namespace com.IvanMurzak.Godot.MCP.UI
         ColorRect _timelineServerDot = null!;
         ColorRect _timelineAgentDot = null!;
 
+        // The last status the panel actually RENDERED, so the periodic re-sync only re-applies (and traces)
+        // when the live status has drifted from what is on screen — keeping the per-tick check cheap and quiet.
+        ConnectionStatus? _renderedStatus;
+
+        // Accumulated frame delta for the periodic re-sync. Reset each time it crosses the interval so the
+        // re-sync runs at a steady ~ResyncIntervalSeconds cadence regardless of frame rate.
+        double _resyncAccumulator;
+
+        // Registration of the re-sync into the main-thread dispatcher's per-tick hook (disposed in _ExitTree).
+        // The dispatcher — NOT this dock Control — is the pump, because Godot skips a dock Control's own
+        // _Process while its tab is hidden, whereas the dispatcher (a non-dock editor Node) always ticks.
+        System.IDisposable? _resyncRegistration;
+
+        /// <summary>Re-sync cadence: re-read + re-apply the live connection status this often (seconds).</summary>
+        const double ResyncIntervalSeconds = 0.5;
+
         // Index of the two OptionButton entries — kept stable so a selection maps back to a mode.
         const int ModeIdCustom = 0;
         const int ModeIdCloud = 1;
@@ -88,14 +104,48 @@ namespace com.IvanMurzak.Godot.MCP.UI
             Name = "ConnectionPanel";
             BuildUi();
 
-            // Subscribe AFTER the UI exists so the first push has controls to write to. The connection
-            // marshals these events onto the editor main thread, so the handlers may touch Controls directly.
+            // Initial mode visibility (the cheap, idempotent part). The connection wiring — event
+            // subscription, status seed, and re-sync registration — is done in _EnterTree so that a
+            // dock-layout reload (which DETACHES then RE-ATTACHES this Control, firing _ExitTree → _EnterTree)
+            // re-arms all of it. Doing it only in the ctor was the residual #42 bug: the editor reparents the
+            // dock during "Loading docks" right as the handshake completes, the original wiring was torn down
+            // by _ExitTree, and nothing re-seeded the re-attached panel — so it stayed on "Connecting…".
+            ApplyModeVisibility(_connection.Config.ActiveMode);
+        }
+
+        /// <summary>
+        /// (Re)arm the panel's connection wiring every time it enters the editor tree — including the
+        /// re-attach the editor performs during dock-layout restore. Subscribes to the connection events,
+        /// re-seeds the label from the LIVE status (the event only fires on CHANGE, so a status reached while
+        /// detached must be pulled in here), and registers the dispatcher-pumped periodic re-sync. Pairs with
+        /// <see cref="_ExitTree"/>, which tears all three down. Idempotent against duplicate subscription:
+        /// the handlers are removed first.
+        /// </summary>
+        public override void _EnterTree()
+        {
+            // Remove-then-add so a re-entry never double-subscribes. The connection marshals these events onto
+            // the editor main thread, so the handlers may touch Controls directly.
+            _connection.ConnectionStatusChanged -= OnConnectionStatusChanged;
             _connection.ConnectionStatusChanged += OnConnectionStatusChanged;
+            _connection.AuthorizationRejected -= OnAuthorizationRejected;
             _connection.AuthorizationRejected += OnAuthorizationRejected;
 
-            // Render the current state immediately (the event only fires on CHANGE).
+            // Re-seed from the LIVE status: a status reached while the panel was detached (e.g. Connected
+            // arriving during the dock reparent) is pulled onto the label here, since the change event was
+            // missed. This is the load-bearing #42 fix — the panel ALWAYS converges to the real status on
+            // (re)entry, independent of event-delivery timing.
             ApplyStatus(_connection.ConnectionStatus);
             ApplyModeVisibility(_connection.Config.ActiveMode);
+
+            // Belt-and-suspenders convergence: register a per-frame re-sync into the main-thread dispatcher's
+            // tick hook. Every ResyncIntervalSeconds it re-reads the LIVE connection status off the connection
+            // (NOT off the event) and re-applies it if the label has drifted. Reaches the real status within
+            // ~0.5s even if a push was lost to the off-thread marshalling / de-dup boundary, and covers a
+            // Reconnect settling on the new connection's status. The dispatcher pumps it (not this Control's
+            // own _Process), so it ticks even when the dock tab is hidden.
+            _resyncAccumulator = 0.0;
+            _resyncRegistration?.Dispose();
+            _resyncRegistration = MainThreadDispatcher.RegisterProcess(OnResyncTick);
         }
 
         void BuildUi()
@@ -286,6 +336,51 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
             _timelineGodotDot.Color = color;
             _timelineServerDot.Color = color;
+
+            _renderedStatus = status;
+
+            // Trace the actual render so a Trace smoke run shows the terminal Connected reaching the label
+            // (pairs with the connection's "status: X -> Y" push trace — see GodotMcpConnection.PublishStatus).
+            _connection.LogStatusTrace($"[Godot-MCP] ApplyStatus rendered status: {status}");
+        }
+
+        /// <summary>
+        /// Per-frame tick fired by the main-thread dispatcher. Accumulates <paramref name="delta"/> and runs
+        /// the cheap <see cref="SyncFromConnection"/> drift check once every <see cref="ResyncIntervalSeconds"/>s.
+        /// Driven by the dispatcher (a non-dock editor Node that always ticks) rather than this Control's own
+        /// <see cref="Node._Process"/>, which Godot skips while the dock tab is hidden — see the registration
+        /// in the constructor.
+        /// </summary>
+        void OnResyncTick(double delta)
+        {
+            _resyncAccumulator += delta;
+            if (_resyncAccumulator < ResyncIntervalSeconds)
+                return;
+
+            _resyncAccumulator = 0.0;
+            SyncFromConnection();
+        }
+
+        /// <summary>
+        /// Re-read the LIVE connection status DIRECTLY off <see cref="GodotMcpConnection.ConnectionStatus"/>
+        /// (bypassing the <see cref="GodotMcpConnection.ConnectionStatusChanged"/> event) and re-apply it
+        /// when it differs from what the panel last rendered. Driven by the periodic <see cref="_Process"/>
+        /// re-sync so the label converges to the real status within ~<see cref="ResyncIntervalSeconds"/>s even
+        /// if a status push was lost to the off-thread marshalling / de-dup boundary OR to a dock-layout
+        /// reload that re-instantiated/detached the panel mid-handshake (the root cause of issue #42), or a
+        /// Reconnect rebuilt the connection. Cheap and quiet: when the live status already matches the
+        /// rendered one this is a single enum comparison and returns without touching any Control. Runs on
+        /// the editor main thread (Godot fires <see cref="_Process"/> there).
+        /// </summary>
+        void SyncFromConnection()
+        {
+            var live = _connection.ConnectionStatus;
+            if (_renderedStatus == live)
+                return;
+
+            _connection.LogStatusTrace(
+                $"[Godot-MCP] re-sync: label '{_renderedStatus}' drifted from live '{live}' — re-applying.");
+            ApplyStatus(live);
         }
 
         void OnConnectButtonPressed()
@@ -633,6 +728,10 @@ namespace com.IvanMurzak.Godot.MCP.UI
             // Unsubscribe so a freed panel does not receive a late main-thread push.
             _connection.ConnectionStatusChanged -= OnConnectionStatusChanged;
             _connection.AuthorizationRejected -= OnAuthorizationRejected;
+
+            // Unregister the periodic re-sync so the dispatcher no longer ticks into a freed panel.
+            _resyncRegistration?.Dispose();
+            _resyncRegistration = null;
 
             // Cancel any in-flight device-auth flow so its background poll loop stops touching a freed panel.
             _deviceAuthFlow?.Cancel();

--- a/addons/godot_mcp/UI/ConnectionStatusTracker.cs
+++ b/addons/godot_mcp/UI/ConnectionStatusTracker.cs
@@ -1,0 +1,86 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+
+namespace com.IvanMurzak.Godot.MCP.UI
+{
+    /// <summary>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) holder for the connection panel's current
+    /// <see cref="ConnectionStatus"/> plus the de-duplication rule that decides whether a candidate status
+    /// is a real transition worth pushing to the UI. Extracted out of the editor-only
+    /// <c>GodotMcpConnection.PublishStatus</c> so the status-path behaviour — de-dup, late-subscriber
+    /// convergence, and reconnect reset — is unit-testable in the plain-xUnit <c>Godot-MCP.Tests</c> host
+    /// without constructing a single Godot <see cref="Godot.Control"/> or a live SignalR client.
+    ///
+    /// <para>
+    /// This was the missing piece behind issue #42 ("status stuck at Connecting…"): the connection
+    /// MECHANISM was healthy (the transport connected and the handshake completed), but a terminal
+    /// <c>Connected</c> render could be lost across the off-thread → main-thread marshalling / de-dup
+    /// boundary, and nothing re-seeded the panel afterwards. The fix is two-fold: (1) a periodic re-sync in
+    /// the panel that reads <see cref="Current"/> directly (bypassing the event), and (2) this explicit,
+    /// tested tracker so the de-dup can never permanently hide a needed render — a re-sync that reads the
+    /// live <see cref="Current"/> always renders the latest status regardless of event delivery.
+    /// </para>
+    /// </summary>
+    public sealed class ConnectionStatusTracker
+    {
+        ConnectionStatus _current;
+
+        /// <summary>
+        /// Construct a tracker seeded at <paramref name="initial"/> (defaults to
+        /// <see cref="ConnectionStatus.Disconnected"/>, matching a freshly-built connection before any
+        /// reactive value has arrived).
+        /// </summary>
+        public ConnectionStatusTracker(ConnectionStatus initial = ConnectionStatus.Disconnected)
+        {
+            _current = initial;
+        }
+
+        /// <summary>
+        /// The latest known status. A late subscriber / periodic re-sync reads this directly to converge on
+        /// the current state even if it never saw the transition event that produced it.
+        /// </summary>
+        public ConnectionStatus Current => _current;
+
+        /// <summary>
+        /// Offer a candidate <paramref name="status"/>. When it differs from <see cref="Current"/> the
+        /// tracker advances (updating <see cref="Current"/> BEFORE returning, so a getter read inside the
+        /// caller's change-notification already reflects the new value) and returns <c>true</c>. When it is
+        /// identical the tracker is unchanged and returns <c>false</c> — this is the de-dup that keeps
+        /// identical consecutive states (e.g. the seed plus an immediate first push) from double-firing the
+        /// UI. The de-dup is render-safe because the panel's periodic re-sync reads <see cref="Current"/>
+        /// directly rather than depending on a transition having fired.
+        /// </summary>
+        public bool TryAdvance(ConnectionStatus status)
+        {
+            if (_current == status)
+                return false;
+
+            _current = status;
+            return true;
+        }
+
+        /// <summary>
+        /// Reset the tracker to <paramref name="status"/> (defaults to
+        /// <see cref="ConnectionStatus.Disconnected"/>) unconditionally, returning whether the value
+        /// changed. Used when a reconnect rebuilds the underlying plugin/subscription: the next status seed
+        /// from the NEW connection should be free to advance from a clean baseline rather than being
+        /// de-duped against a stale value carried over from the previous plugin instance.
+        /// </summary>
+        public bool Reset(ConnectionStatus status = ConnectionStatus.Disconnected)
+        {
+            if (_current == status)
+                return false;
+
+            _current = status;
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fix the dock status label getting stuck at "Connecting…" even though the connection mechanism reaches Connected (transport connects, version handshake completes, `[Godot-MCP] connected.` fires).
- Root cause: the editor reparents the dock during "Loading docks" layout restore right as the handshake completes, firing the `ConnectionPanel`'s `_ExitTree` (tearing down its `ConnectionStatusChanged` subscription) then `_EnterTree` — but subscription + seed were wired only in the constructor, so the re-attached panel was no longer subscribed and never re-seeded, losing the terminal Connected push.
- Fix: move subscription + a live-status re-seed + the periodic re-sync registration into `_EnterTree` (torn down in `_ExitTree`) so a reattach re-arms everything; add a dispatcher-pumped ~0.5s re-sync that re-reads the live `ConnectionStatus` directly (bypassing the event + de-dup) and re-applies on drift; extract the status de-dup into a pure-managed, unit-tested `ConnectionStatusTracker` (reset on Reconnect); add Trace status-push + `ApplyStatus` render logging (no secrets).

## Test plan
- [x] Suite 1 — `dotnet build` 0 errors.
- [x] Suite 2 — `dotnet test` 401/401 (added 10 `ConnectionStatusTracker` tests covering de-dup, late-subscriber convergence, Reconnect reset).
- [x] Suite 3 — headless Godot smoke at Trace against the local DemoWebApp (:8090): Output shows `status: Connecting -> Connected` followed by `ApplyStatus rendered status: Connected` — the label converges.

Closes #42