### PR TITLE
feat(editor): modular AI-agent configurators + dock AI agent section

### DIFF
--- a/Godot-MCP.Tests/AgentConfiguratorTests.cs
+++ b/Godot-MCP.Tests/AgentConfiguratorTests.cs
@@ -1,0 +1,326 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json.Nodes;
+using com.IvanMurzak.Godot.MCP.UI.Agents;
+using com.IvanMurzak.Godot.MCP.UI.Agents.Impl;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the pure-managed AI-agent configurator core: the snippet/entry shape (http type + url +
+    /// headers-only-when-token + token masking), the READ-MERGE-WRITE file ops (Configure / IsConfigured /
+    /// Remove round-trip on a temp file, robust to missing/empty/invalid files, never clobbering siblings), the
+    /// per-OS path resolver, and the registry. The dock UI (<c>AgentConfiguratorsPanel.cs</c>, <c>#if TOOLS</c>)
+    /// is verified via the headless Godot smoke (test.md Suite 3) — NOT here.
+    /// </summary>
+    public class AgentConfiguratorTests
+    {
+        const string Url = "https://ai-game.dev/mcp";
+        const string Token = "secret-bearer-xyz";
+
+        static GodotAgentConfigurator ClaudeCode() => new ClaudeCodeConfigurator();
+
+        // --- BuildServerEntry / snippet shape ---
+
+        [Fact]
+        public void ServerEntry_IsHttp_WithUrl_AndNoHeadersWhenNoToken()
+        {
+            var entry = AgentConfigJson.BuildServerEntry(Url, token: null);
+            Assert.Equal("http", entry["type"]!.GetValue<string>());
+            Assert.Equal(Url, entry["url"]!.GetValue<string>());
+            Assert.False(entry.ContainsKey("headers"));
+        }
+
+        [Fact]
+        public void ServerEntry_AddsAuthorizationHeader_WhenTokenPresent()
+        {
+            var entry = AgentConfigJson.BuildServerEntry(Url, Token);
+            var auth = entry["headers"]!["Authorization"]!.GetValue<string>();
+            Assert.Equal($"Bearer {Token}", auth);
+        }
+
+        [Fact]
+        public void Snippet_MasksTheToken_WhenMaskRequested()
+        {
+            var snippet = ClaudeCode().BuildSnippet(Url, Token, maskToken: true);
+            // The real token must NOT appear in the masked snippet.
+            Assert.DoesNotContain(Token, snippet);
+            Assert.Contains("Bearer ****", snippet);
+        }
+
+        [Fact]
+        public void Snippet_ContainsRealToken_WhenNotMasked()
+        {
+            var snippet = ClaudeCode().BuildSnippet(Url, Token, maskToken: false);
+            Assert.Contains($"Bearer {Token}", snippet);
+        }
+
+        [Fact]
+        public void Snippet_NestsEntryUnderBodyPathAndServerKey()
+        {
+            var agent = ClaudeCode();
+            var snippet = agent.BuildSnippet(Url, token: null, maskToken: false);
+            var root = JsonNode.Parse(snippet)!.AsObject();
+            var entry = root[agent.BodyPath]![agent.ServerKey]!.AsObject();
+            Assert.Equal(Url, entry["url"]!.GetValue<string>());
+        }
+
+        [Fact]
+        public void Snippet_VsCode_UsesServersBodyPath()
+        {
+            var vscode = new VisualStudioCodeConfigurator();
+            Assert.Equal("servers", vscode.BodyPath);
+            var root = JsonNode.Parse(vscode.BuildSnippet(Url, null, false))!.AsObject();
+            Assert.NotNull(root["servers"]);
+            Assert.Null(root["mcpServers"]);
+        }
+
+        // --- Configure / IsConfigured / Remove round-trip ---
+
+        [Fact]
+        public void Configure_CreatesEntry_AndIsConfigured_ThenRemove_RemovesIt()
+        {
+            var agent = ClaudeCode();
+            var path = TempFile();
+            try
+            {
+                Assert.False(agent.IsConfigured(path, Url)); // missing file
+
+                agent.Configure(path, Url, Token);
+                Assert.True(File.Exists(path));
+                Assert.True(agent.IsConfigured(path, Url));
+
+                // The real token landed in the written file.
+                Assert.Contains($"Bearer {Token}", File.ReadAllText(path));
+
+                Assert.True(agent.Remove(path));
+                Assert.False(agent.IsConfigured(path, Url));
+            }
+            finally
+            {
+                Cleanup(path);
+            }
+        }
+
+        [Fact]
+        public void Configure_DoesNotClobberPreexistingUnrelatedServer()
+        {
+            var agent = ClaudeCode();
+            var path = TempFile();
+            try
+            {
+                // Seed a config with an unrelated sibling server + an unrelated top-level key.
+                File.WriteAllText(path,
+                    "{ \"mcpServers\": { \"some-other-server\": { \"type\": \"http\", \"url\": \"http://other\" } }, \"unrelated\": 42 }");
+
+                agent.Configure(path, Url, Token);
+
+                var root = JsonNode.Parse(File.ReadAllText(path))!.AsObject();
+                var servers = root["mcpServers"]!.AsObject();
+
+                // Both the sibling and the addon entry must be present; the unrelated key preserved.
+                Assert.True(servers.ContainsKey("some-other-server"));
+                Assert.True(servers.ContainsKey(agent.ServerKey));
+                Assert.Equal("http://other", servers["some-other-server"]!["url"]!.GetValue<string>());
+                Assert.Equal(42, root["unrelated"]!.GetValue<int>());
+
+                // Remove drops only the addon entry, keeping the sibling.
+                agent.Remove(path);
+                servers = JsonNode.Parse(File.ReadAllText(path))!.AsObject()["mcpServers"]!.AsObject();
+                Assert.True(servers.ContainsKey("some-other-server"));
+                Assert.False(servers.ContainsKey(agent.ServerKey));
+            }
+            finally
+            {
+                Cleanup(path);
+            }
+        }
+
+        [Fact]
+        public void IsConfigured_FalseWhenUrlDiffers()
+        {
+            var agent = ClaudeCode();
+            var path = TempFile();
+            try
+            {
+                agent.Configure(path, "https://ai-game.dev/mcp", Token);
+                Assert.False(agent.IsConfigured(path, "http://localhost:8080/mcp"));
+            }
+            finally
+            {
+                Cleanup(path);
+            }
+        }
+
+        [Theory]
+        [InlineData("")]                       // empty file
+        [InlineData("   ")]                     // whitespace
+        [InlineData("{ not valid json ")]       // malformed
+        [InlineData("[1,2,3]")]                 // valid json but not an object
+        public void FileOps_AreRobustToMissingEmptyOrInvalidFile(string content)
+        {
+            var agent = ClaudeCode();
+            var path = TempFile();
+            try
+            {
+                File.WriteAllText(path, content);
+
+                // IsConfigured on a bad file is false (no throw); Remove is a no-op (returns false).
+                Assert.False(agent.IsConfigured(path, Url));
+                Assert.False(agent.Remove(path));
+
+                // Configure recovers by starting fresh — entry lands, file becomes valid.
+                agent.Configure(path, Url, Token);
+                Assert.True(agent.IsConfigured(path, Url));
+            }
+            finally
+            {
+                Cleanup(path);
+            }
+        }
+
+        [Fact]
+        public void Configure_CreatesMissingParentDirectories()
+        {
+            var agent = ClaudeCode();
+            var dir = Path.Combine(Path.GetTempPath(), "godot-mcp-agent-" + Guid.NewGuid().ToString("N"), "nested");
+            var path = Path.Combine(dir, ".mcp.json");
+            try
+            {
+                Assert.False(Directory.Exists(dir));
+                agent.Configure(path, Url, Token);
+                Assert.True(File.Exists(path));
+            }
+            finally
+            {
+                if (Directory.Exists(Path.GetDirectoryName(Path.GetDirectoryName(path))!))
+                    Directory.Delete(Path.GetDirectoryName(Path.GetDirectoryName(path))!, recursive: true);
+            }
+        }
+
+        // --- Registry ---
+
+        [Fact]
+        public void Registry_CustomConfiguratorIsLast()
+        {
+            var all = GodotAgentConfiguratorRegistry.All;
+            Assert.IsType<CustomConfigurator>(all[^1]);
+        }
+
+        [Fact]
+        public void Registry_AgentIdsAreUnique()
+        {
+            var ids = GodotAgentConfiguratorRegistry.All.Select(c => c.AgentId).ToList();
+            Assert.Equal(ids.Count, ids.Distinct().Count());
+        }
+
+        [Fact]
+        public void Registry_AgentNamesAreUnique_AndMatchOrder()
+        {
+            var names = GodotAgentConfiguratorRegistry.AgentNames;
+            Assert.Equal(names.Count, names.Distinct().Count());
+            Assert.Equal(GodotAgentConfiguratorRegistry.All.Count, names.Count);
+            Assert.Equal(GodotAgentConfiguratorRegistry.All.Select(c => c.AgentName), names);
+        }
+
+        [Fact]
+        public void Registry_LookupsByIdAndIndexAgree()
+        {
+            var index = GodotAgentConfiguratorRegistry.GetIndexByAgentId("cursor");
+            Assert.True(index >= 0);
+            var byId = GodotAgentConfiguratorRegistry.GetByAgentId("cursor");
+            Assert.NotNull(byId);
+            Assert.Equal("cursor", byId!.AgentId);
+            Assert.Same(byId, GodotAgentConfiguratorRegistry.All[index]);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("does-not-exist")]
+        public void Registry_UnknownId_ReturnsNullAndMinusOne(string? id)
+        {
+            Assert.Null(GodotAgentConfiguratorRegistry.GetByAgentId(id));
+            Assert.Equal(-1, GodotAgentConfiguratorRegistry.GetIndexByAgentId(id));
+        }
+
+        [Fact]
+        public void CustomConfigurator_HasNoConfigPath_SnippetOnly()
+        {
+            var custom = new CustomConfigurator();
+            Assert.Null(custom.ConfigFilePath(AgentOs.Windows, @"C:\Users\u", @"C:\Users\u\AppData\Roaming", @"C:\proj"));
+        }
+
+        // --- Per-OS path resolution (injected OS / home / appData / projectRoot) ---
+
+        [Fact]
+        public void ClaudeCode_PathIsProjectLocalMcpJson()
+        {
+            var agent = new ClaudeCodeConfigurator();
+            var path = agent.ConfigFilePath(AgentOs.Linux, "/home/u", "", "/proj")!;
+            Assert.Equal(Path.Combine("/proj", ".mcp.json"), path);
+        }
+
+        [Fact]
+        public void Cursor_PathIsProjectLocalCursorMcpJson()
+        {
+            var path = new CursorConfigurator().ConfigFilePath(AgentOs.Linux, "/home/u", "", "/proj")!;
+            Assert.Equal(Path.Combine("/proj", ".cursor", "mcp.json"), path);
+        }
+
+        [Fact]
+        public void VsCode_PathIsProjectLocalVscodeMcpJson()
+        {
+            var path = new VisualStudioCodeConfigurator().ConfigFilePath(AgentOs.Linux, "/home/u", "", "/proj")!;
+            Assert.Equal(Path.Combine("/proj", ".vscode", "mcp.json"), path);
+        }
+
+        [Theory]
+        [InlineData(AgentOs.Windows)]
+        [InlineData(AgentOs.MacOS)]
+        [InlineData(AgentOs.Linux)]
+        public void ClaudeDesktop_PathIsPerOs(AgentOs os)
+        {
+            var agent = new ClaudeDesktopConfigurator();
+            var home = os == AgentOs.Windows ? @"C:\Users\u" : "/home/u";
+            var appData = @"C:\Users\u\AppData\Roaming";
+            var path = agent.ConfigFilePath(os, home, appData, "/proj")!;
+
+            Assert.EndsWith("claude_desktop_config.json", path);
+            switch (os)
+            {
+                case AgentOs.Windows:
+                    Assert.Equal(Path.Combine(appData, "Claude", "claude_desktop_config.json"), path);
+                    break;
+                case AgentOs.MacOS:
+                    Assert.Equal(Path.Combine(home, "Library", "Application Support", "Claude", "claude_desktop_config.json"), path);
+                    break;
+                default:
+                    Assert.Equal(Path.Combine(home, ".config", "Claude", "claude_desktop_config.json"), path);
+                    break;
+            }
+        }
+
+        // --- helpers ---
+
+        static string TempFile() =>
+            Path.Combine(Path.GetTempPath(), "godot-mcp-agent-" + Guid.NewGuid().ToString("N") + ".json");
+
+        static void Cleanup(string path)
+        {
+            try { if (File.Exists(path)) File.Delete(path); } catch { /* best-effort */ }
+        }
+    }
+}

--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -142,6 +142,19 @@
          The editor Control wiring (FeaturesPanel.cs / FeatureRow.cs / FeatureListWindow.cs) is #if TOOLS and
          verified via the headless Godot smoke (test.md Suite 3); the label formatting is unit-tested here. -->
     <Compile Include="..\addons\godot_mcp\UI\FeaturesPanelView.cs" Link="Source\FeaturesPanelView.cs" />
+    <!-- AI-agent configurators — pure-managed (no Godot native types, no #if TOOLS): the abstract base, the
+         JSON read-merge-write helper, the per-OS path resolver, the concrete configurators, and the registry.
+         The dock UI (AgentConfiguratorsPanel.cs) is #if TOOLS and verified via the headless Godot smoke
+         (test.md Suite 3); the snippet/configure/remove/path/registry logic is unit-tested here. -->
+    <Compile Include="..\addons\godot_mcp\UI\Agents\GodotAgentConfigurator.cs" Link="Source\GodotAgentConfigurator.cs" />
+    <Compile Include="..\addons\godot_mcp\UI\Agents\AgentConfigJson.cs" Link="Source\AgentConfigJson.cs" />
+    <Compile Include="..\addons\godot_mcp\UI\Agents\AgentConfigPaths.cs" Link="Source\AgentConfigPaths.cs" />
+    <Compile Include="..\addons\godot_mcp\UI\Agents\GodotAgentConfiguratorRegistry.cs" Link="Source\GodotAgentConfiguratorRegistry.cs" />
+    <Compile Include="..\addons\godot_mcp\UI\Agents\Impl\ClaudeCodeConfigurator.cs" Link="Source\ClaudeCodeConfigurator.cs" />
+    <Compile Include="..\addons\godot_mcp\UI\Agents\Impl\ClaudeDesktopConfigurator.cs" Link="Source\ClaudeDesktopConfigurator.cs" />
+    <Compile Include="..\addons\godot_mcp\UI\Agents\Impl\CursorConfigurator.cs" Link="Source\CursorConfigurator.cs" />
+    <Compile Include="..\addons\godot_mcp\UI\Agents\Impl\VisualStudioCodeConfigurator.cs" Link="Source\VisualStudioCodeConfigurator.cs" />
+    <Compile Include="..\addons\godot_mcp\UI\Agents\Impl\CustomConfigurator.cs" Link="Source\CustomConfigurator.cs" />
   </ItemGroup>
 
 </Project>

--- a/Godot-MCP.Tests/GodotMcpConfigStoreTests.cs
+++ b/Godot-MCP.Tests/GodotMcpConfigStoreTests.cs
@@ -82,6 +82,41 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         }
 
         [Fact]
+        public void SaveLoad_RoundTripsSelectedAgentId_AndApplyPersistedCarriesIt()
+        {
+            using var _ = EnvScope.ClearAll();
+
+            var path = PathFor("config-agent.json");
+            var original = new GodotMcpConfig { SelectedAgentId = "cursor" };
+
+            GodotMcpConfigStore.Save(path, original);
+
+            var json = System.IO.File.ReadAllText(path);
+            Assert.Contains("\"selectedAgentId\"", json);
+
+            var loaded = GodotMcpConfigStore.Load(path);
+            Assert.Equal("cursor", loaded!.SelectedAgentId);
+
+            // ApplyPersisted carries the selected agent onto a fresh target (default would have been claude-code).
+            var target = new GodotMcpConfig();
+            GodotMcpConfigStore.ApplyPersisted(target, loaded);
+            Assert.Equal("cursor", target.SelectedAgentId);
+        }
+
+        [Fact]
+        public void ApplyPersisted_MissingSelectedAgentId_KeepsTargetDefault()
+        {
+            using var _ = EnvScope.ClearAll();
+
+            // An older config (no selectedAgentId key) deserializes to the property default; if a persisted value
+            // were somehow blank, ApplyPersisted must keep the target's default rather than blanking it.
+            var persisted = new GodotMcpConfig { SelectedAgentId = "" };
+            var target = new GodotMcpConfig(); // default "claude-code"
+            GodotMcpConfigStore.ApplyPersisted(target, persisted);
+            Assert.Equal("claude-code", target.SelectedAgentId);
+        }
+
+        [Fact]
         public void Save_WritesEnumByName_NotNumber()
         {
             using var _ = EnvScope.ClearAll();

--- a/Godot-MCP.Tests/GodotMcpConfigTests.cs
+++ b/Godot-MCP.Tests/GodotMcpConfigTests.cs
@@ -312,6 +312,66 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Contains("\"connectionMode\"", json);
         }
 
+        // --- MCP-client URL resolution (the URL an external AI client POSTs to — distinct from Host) ---
+
+        [Fact]
+        public void McpClientUrl_Cloud_IsTheCloudMcpUrl()
+        {
+            using var _ = EnvScope.ClearAll();
+            // Cloud Host already ends in /mcp (via ResolveCloudUrl); the MCP-client URL equals it, no double-suffix.
+            var config = new GodotMcpConfig { ConnectionMode = GodotMcpConnectionMode.Cloud };
+            Assert.Equal("https://ai-game.dev/mcp", GodotMcpConfig.ResolveMcpClientUrl(config));
+        }
+
+        [Fact]
+        public void McpClientUrl_Custom_AppendsMcpToHost()
+        {
+            using var _ = EnvScope.ClearAll();
+            // The plugin connects to <host>/hub/mcp-server; the AI client connects to <host>/mcp.
+            var config = new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Custom,
+                CustomHost = "http://localhost:8080"
+            };
+            Assert.Equal("http://localhost:8080/mcp", GodotMcpConfig.ResolveMcpClientUrl(config));
+        }
+
+        [Fact]
+        public void McpClientUrl_Custom_TrailingSlashHost_IsNormalized()
+        {
+            using var _ = EnvScope.ClearAll();
+            var config = new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Custom,
+                CustomHost = "http://localhost:8080/"
+            };
+            Assert.Equal("http://localhost:8080/mcp", GodotMcpConfig.ResolveMcpClientUrl(config));
+        }
+
+        [Fact]
+        public void McpClientUrl_Custom_HostAlreadyEndingInMcp_IsNotDoubleSuffixed()
+        {
+            using var _ = EnvScope.ClearAll();
+            var config = new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Custom,
+                CustomHost = "http://localhost:8080/mcp"
+            };
+            Assert.Equal("http://localhost:8080/mcp", GodotMcpConfig.ResolveMcpClientUrl(config));
+        }
+
+        [Fact]
+        public void McpClientUrl_Custom_HonorsEnvHostOverride()
+        {
+            using var _ = EnvScope.Set(GodotMcpConfig.EnvHost, "http://10.0.0.5:9000");
+            var config = new GodotMcpConfig
+            {
+                ConnectionMode = GodotMcpConnectionMode.Custom,
+                CustomHost = "http://localhost:8080"
+            };
+            Assert.Equal("http://10.0.0.5:9000/mcp", GodotMcpConfig.ResolveMcpClientUrl(config));
+        }
+
         /// <summary>
         /// Sets/clears process env vars relevant to <see cref="GodotMcpConfig"/> and restores the prior
         /// values on dispose. Keeps env-driven tests isolated and re-entry-safe.

--- a/addons/godot_mcp/Connection/GodotMcpConfig.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConfig.cs
@@ -148,6 +148,15 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         public GodotMcpFeatureMap Features { get; set; } = new();
 
         /// <summary>
+        /// The AI agent the dock's "AI agent" section has selected (the <c>AgentId</c> of a
+        /// <c>GodotAgentConfigurator</c>, e.g. <c>claude-code</c>). Persisted so the user's choice survives an editor
+        /// restart. Defaults to <c>claude-code</c> — the first-listed configurator. This is pure presentation state
+        /// (it does not affect the plugin's own connection), so it is never env-overridden.
+        /// </summary>
+        [JsonPropertyName("selectedAgentId")]
+        public string SelectedAgentId { get; set; } = "claude-code";
+
+        /// <summary>
         /// The effective connection mode after applying the <see cref="EnvConnectionMode"/> override.
         /// Never serialized — recomputed from the env each access so a process-level override always wins.
         /// </summary>
@@ -253,6 +262,40 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
         /// <summary>Resolve the full cloud connection URL (base + <see cref="CloudHubPath"/>).</summary>
         public static string ResolveCloudUrl() => ResolveCloudBaseUrl() + CloudHubPath;
+
+        /// <summary>
+        /// Resolve the MCP-client endpoint URL an external AI client (Claude Code, Cursor, …) should POST to —
+        /// the value the AI-agent configurators write into the user's MCP-client config. This is DISTINCT from
+        /// <see cref="Host"/> (the URL the <em>plugin</em> connects to): the plugin connects to
+        /// <c>&lt;host&gt;/hub/mcp-server</c> over SignalR, while an MCP client connects to <c>&lt;host&gt;/mcp</c>
+        /// over streamable-HTTP.
+        ///
+        /// <list type="bullet">
+        ///   <item><b>Cloud mode</b>: <see cref="ResolveCloudUrl"/> — already ends in <see cref="CloudHubPath"/>
+        ///   (<c>/mcp</c>), so it is returned unchanged.</item>
+        ///   <item><b>Custom mode</b>: the resolved custom host (trailing slash stripped) with
+        ///   <see cref="CloudHubPath"/> appended — e.g. <c>http://localhost:8080</c> → <c>http://localhost:8080/mcp</c>.
+        ///   A host that already ends in <c>/mcp</c> is not double-suffixed.</item>
+        /// </list>
+        ///
+        /// Reads the active mode/host LIVE off <paramref name="config"/> (so an env override applies) but is a
+        /// pure static — no Godot / SignalR dependency — so it is unit-testable in the plain-xUnit host.
+        /// </summary>
+        public static string ResolveMcpClientUrl(GodotMcpConfig config)
+        {
+            if (config == null)
+                throw new ArgumentNullException(nameof(config));
+
+            if (config.ActiveMode == GodotMcpConnectionMode.Cloud)
+                return ResolveCloudUrl();
+
+            // Custom mode: the plugin connects to <host>/hub/mcp-server; the MCP client connects to <host>/mcp.
+            var host = config.ResolveCustomHost().TrimEnd('/');
+            if (host.EndsWith(CloudHubPath, StringComparison.OrdinalIgnoreCase))
+                return host;
+
+            return host + CloudHubPath;
+        }
 
         /// <summary>
         /// Resolve the active custom-mode host, applying the <see cref="EnvHost"/> override.

--- a/addons/godot_mcp/Connection/GodotMcpConfigStore.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConfigStore.cs
@@ -136,6 +136,11 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             // The persisted feature enable-map (tools/prompts/resources). A missing `features` key in an older
             // config file deserializes to a non-null empty map (the property initializer), so this is always safe.
             target.Features = persisted.Features ?? new GodotMcpFeatureMap();
+            // The dock's selected AI-agent id (pure presentation state). A missing key in an older config file
+            // deserializes to the property default ("claude-code"); guard the null case defensively all the same.
+            target.SelectedAgentId = string.IsNullOrEmpty(persisted.SelectedAgentId)
+                ? target.SelectedAgentId
+                : persisted.SelectedAgentId;
 
             return target;
         }

--- a/addons/godot_mcp/UI/Agents/AgentConfigJson.cs
+++ b/addons/godot_mcp/UI/Agents/AgentConfigJson.cs
@@ -1,0 +1,203 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace com.IvanMurzak.Godot.MCP.UI.Agents
+{
+    /// <summary>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) JSON read-merge-write helpers shared by the
+    /// AI-agent configurators. Godot-MCP is a CLIENT of the shared/cloud MCP server, so a configurator only
+    /// ever emits the HTTP form of an MCP-client entry — <c>{"type":"http","url":&lt;mcpUrl&gt;[,"headers":{...}]}</c>
+    /// — under a <c>&lt;bodyPath&gt;.&lt;serverKey&gt;</c> nav inside the target client's config file.
+    ///
+    /// <para>
+    /// All file operations are READ-MERGE-WRITE: an existing config is loaded (if present, parseable) and only
+    /// the addon's own entry is set / removed; sibling servers and unrelated top-level keys are preserved. The
+    /// methods are path-injectable and robust to a missing / empty / invalid file, so they are unit-tested on
+    /// temp files in the plain-xUnit host. The editor wiring (resolving the per-OS absolute path, the dock
+    /// buttons) lives behind <c>#if TOOLS</c> in <c>AgentConfiguratorsPanel.cs</c>.
+    /// </para>
+    /// </summary>
+    public static class AgentConfigJson
+    {
+        /// <summary>The masked stand-in shown on-screen in place of a real bearer token (never copied/written).</summary>
+        public const string MaskedToken = "****";
+
+        static readonly JsonSerializerOptions PrettyOptions = new() { WriteIndented = true };
+
+        /// <summary>
+        /// Build the JSON object for a single MCP-client server entry: always <c>type</c>=<c>http</c> and the
+        /// <c>url</c>; an <c>Authorization: Bearer &lt;token&gt;</c> header is added under <c>headers</c> ONLY when
+        /// <paramref name="token"/> is non-empty. When <paramref name="maskToken"/> is true the header value uses
+        /// <see cref="MaskedToken"/> instead of the real token (for the on-screen snippet) — the real token is
+        /// never placed into a masked entry.
+        /// </summary>
+        public static JsonObject BuildServerEntry(string mcpUrl, string? token, bool maskToken = false)
+        {
+            var entry = new JsonObject
+            {
+                ["type"] = "http",
+                ["url"] = mcpUrl
+            };
+
+            if (!string.IsNullOrEmpty(token))
+            {
+                var shown = maskToken ? MaskedToken : token;
+                entry["headers"] = new JsonObject
+                {
+                    ["Authorization"] = $"Bearer {shown}"
+                };
+            }
+
+            return entry;
+        }
+
+        /// <summary>
+        /// Build the pretty-printed JSON SNIPPET a user copies into their MCP client — the addon's entry nested
+        /// under <paramref name="bodyPath"/> → <paramref name="serverKey"/>. When <paramref name="maskToken"/> is
+        /// true the bearer is masked (for on-screen display); the copy/Configure path passes
+        /// <paramref name="maskToken"/>=false to emit the real token. The snippet shows ONLY the addon's own entry
+        /// (not the user's whole merged file), which is the convention every MCP client documents.
+        /// </summary>
+        public static string BuildSnippet(string bodyPath, string serverKey, string mcpUrl, string? token, bool maskToken)
+        {
+            var root = new JsonObject
+            {
+                [bodyPath] = new JsonObject
+                {
+                    [serverKey] = BuildServerEntry(mcpUrl, token, maskToken)
+                }
+            };
+
+            return root.ToJsonString(PrettyOptions);
+        }
+
+        /// <summary>
+        /// True when the file at <paramref name="configPath"/> already contains the addon's entry under
+        /// <paramref name="bodyPath"/> → <paramref name="serverKey"/> AND its <c>url</c> matches
+        /// <paramref name="mcpUrl"/> (ordinal-ignore-case, so a host casing difference is tolerated). Returns false
+        /// for a missing / empty / invalid file, or when the entry is absent or points at a different url.
+        /// </summary>
+        public static bool IsConfigured(string configPath, string bodyPath, string serverKey, string mcpUrl)
+        {
+            var root = TryReadObject(configPath);
+            if (root == null)
+                return false;
+
+            if (root[bodyPath] is not JsonObject body)
+                return false;
+
+            if (body[serverKey] is not JsonObject entry)
+                return false;
+
+            var url = entry["url"]?.GetValue<string>();
+            return !string.IsNullOrEmpty(url)
+                && string.Equals(url, mcpUrl, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// READ-MERGE-WRITE the addon's entry into the config file at <paramref name="configPath"/>: load the
+        /// existing JSON (or start a fresh object when the file is missing / empty / invalid), set
+        /// <paramref name="bodyPath"/> → <paramref name="serverKey"/> to the freshly-built entry (with the REAL
+        /// token — writing the user's own client config is the point), and write the file back pretty-printed,
+        /// creating any missing parent directories. Sibling servers and unrelated top-level keys are preserved.
+        /// </summary>
+        public static void Configure(string configPath, string bodyPath, string serverKey, string mcpUrl, string? token)
+        {
+            if (string.IsNullOrWhiteSpace(configPath))
+                throw new ArgumentException("Config path must be non-empty.", nameof(configPath));
+
+            var root = TryReadObject(configPath) ?? new JsonObject();
+
+            if (root[bodyPath] is not JsonObject body)
+            {
+                body = new JsonObject();
+                root[bodyPath] = body;
+            }
+
+            body[serverKey] = BuildServerEntry(mcpUrl, token, maskToken: false);
+
+            WriteObject(configPath, root);
+        }
+
+        /// <summary>
+        /// Remove the addon's entry (<paramref name="bodyPath"/> → <paramref name="serverKey"/>) from the config
+        /// file at <paramref name="configPath"/>, preserving every sibling server and unrelated key, then write the
+        /// file back. No-op (no write) when the file is missing / empty / invalid or the entry is already absent.
+        /// Returns true when an entry was actually removed.
+        /// </summary>
+        public static bool Remove(string configPath, string bodyPath, string serverKey)
+        {
+            var root = TryReadObject(configPath);
+            if (root == null)
+                return false;
+
+            if (root[bodyPath] is not JsonObject body)
+                return false;
+
+            if (!body.ContainsKey(serverKey))
+                return false;
+
+            body.Remove(serverKey);
+            WriteObject(configPath, root);
+            return true;
+        }
+
+        // --- internals ---------------------------------------------------------------------------------------
+
+        /// <summary>
+        /// Read + parse the file at <paramref name="path"/> as a JSON object. Returns null for a missing / empty /
+        /// unreadable / non-object / malformed file — every "no usable existing config" case the merge treats as
+        /// "start fresh", so this never throws on a bad file (only genuine programmer misuse throws elsewhere).
+        /// </summary>
+        static JsonObject? TryReadObject(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                return null;
+
+            string text;
+            try
+            {
+                if (!File.Exists(path))
+                    return null;
+                text = File.ReadAllText(path);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+
+            if (string.IsNullOrWhiteSpace(text))
+                return null;
+
+            try
+            {
+                return JsonNode.Parse(text) as JsonObject;
+            }
+            catch (JsonException)
+            {
+                return null;
+            }
+        }
+
+        static void WriteObject(string path, JsonObject root)
+        {
+            var dir = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+
+            File.WriteAllText(path, root.ToJsonString(PrettyOptions));
+        }
+    }
+}

--- a/addons/godot_mcp/UI/Agents/AgentConfigPaths.cs
+++ b/addons/godot_mcp/UI/Agents/AgentConfigPaths.cs
@@ -1,0 +1,69 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.IO;
+
+namespace com.IvanMurzak.Godot.MCP.UI.Agents
+{
+    /// <summary>
+    /// The operating-system families an AI-agent configurator resolves its config-file path against. Injected
+    /// (rather than read from <c>Godot.OS</c>) so the per-OS path resolution is pure-managed and unit-testable in
+    /// the plain-xUnit host. The editor wiring maps <c>Godot.OS.GetName()</c> onto this in
+    /// <c>AgentConfiguratorsPanel.cs</c> (<c>#if TOOLS</c>).
+    /// </summary>
+    public enum AgentOs
+    {
+        Windows,
+        MacOS,
+        Linux
+    }
+
+    /// <summary>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) per-OS config-path helpers for the AI-agent
+    /// configurators. All inputs (OS family, home dir, %APPDATA%, project root) are INJECTED so the resolution is
+    /// deterministic and unit-testable; the editor passes the real values (<c>Godot.OS.GetName()</c>,
+    /// <c>OS.GetEnvironment("USERPROFILE"/"HOME")</c>, <c>OS.GetEnvironment("APPDATA")</c>, and
+    /// <c>ProjectSettings.GlobalizePath("res://")</c>).
+    /// </summary>
+    public static class AgentConfigPaths
+    {
+        /// <summary>
+        /// Combine + normalize path segments to an absolute config path. Uses <see cref="Path.Combine(string[])"/>
+        /// so the host OS's separator is applied, then collapses any mixed separators to the platform separator via
+        /// <see cref="Path.GetFullPath(string)"/>-free normalization (we keep it simple: forward-slash inputs are
+        /// fine on every platform for the consumers, which open the file with <c>System.IO</c>).
+        /// </summary>
+        static string Combine(params string[] parts) => Path.Combine(parts);
+
+        /// <summary>
+        /// Resolve the Claude Desktop config path for <paramref name="os"/>:
+        /// <list type="bullet">
+        ///   <item>Windows: <c>&lt;appData&gt;/Claude/claude_desktop_config.json</c></item>
+        ///   <item>macOS: <c>&lt;home&gt;/Library/Application Support/Claude/claude_desktop_config.json</c></item>
+        ///   <item>Linux: <c>&lt;home&gt;/.config/Claude/claude_desktop_config.json</c></item>
+        /// </list>
+        /// </summary>
+        public static string ClaudeDesktop(AgentOs os, string home, string appData) => os switch
+        {
+            AgentOs.Windows => Combine(appData, "Claude", "claude_desktop_config.json"),
+            AgentOs.MacOS => Combine(home, "Library", "Application Support", "Claude", "claude_desktop_config.json"),
+            _ => Combine(home, ".config", "Claude", "claude_desktop_config.json"),
+        };
+
+        /// <summary>Claude Code project-local config: <c>&lt;projectRoot&gt;/.mcp.json</c>.</summary>
+        public static string ClaudeCode(string projectRoot) => Combine(projectRoot, ".mcp.json");
+
+        /// <summary>Cursor project-local config: <c>&lt;projectRoot&gt;/.cursor/mcp.json</c>.</summary>
+        public static string Cursor(string projectRoot) => Combine(projectRoot, ".cursor", "mcp.json");
+
+        /// <summary>VS Code project-local config: <c>&lt;projectRoot&gt;/.vscode/mcp.json</c>.</summary>
+        public static string VisualStudioCode(string projectRoot) => Combine(projectRoot, ".vscode", "mcp.json");
+    }
+}

--- a/addons/godot_mcp/UI/Agents/AgentConfiguratorsPanel.cs
+++ b/addons/godot_mcp/UI/Agents/AgentConfiguratorsPanel.cs
@@ -1,0 +1,322 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System.Collections.Generic;
+using com.IvanMurzak.Godot.MCP.Connection;
+using com.IvanMurzak.Godot.MCP.UI.Agents;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.UI
+{
+    /// <summary>
+    /// The dock's "AI agent" section — the Godot <see cref="Control"/> analog of Unity-MCP's
+    /// <c>MainWindowEditor.AiAgents</c>, condensed to the HTTP-only client shape. A <see cref="VBoxContainer"/> the
+    /// <see cref="GodotMcpDock"/> inserts into its Body between the features section and the support footer. It
+    /// renders a header + an agent <see cref="OptionButton"/> (populated from
+    /// <see cref="GodotAgentConfiguratorRegistry.AgentNames"/>), and below it a swappable panel for the selected
+    /// configurator: the agent's links, the generated HTTP-config snippet (token masked by default, with a Reveal
+    /// toggle + Copy), and — for configurators that have a config-file path — Configure / Remove buttons + a status
+    /// line + the config path.
+    ///
+    /// <para>
+    /// Editor-only (<c>#if TOOLS</c>): it constructs live Godot UI nodes and reads the live
+    /// <see cref="GodotMcpConfig"/> off the threaded-in connection for the URL/token/mode. All the snippet/file
+    /// LOGIC lives in the pure-managed <see cref="GodotAgentConfigurator"/> + <see cref="AgentConfigJson"/> +
+    /// <see cref="AgentConfigPaths"/> (CI-unit-tested); this class is verified via the headless Godot smoke
+    /// (<c>test.md</c> Suite 3).
+    /// </para>
+    /// </summary>
+    [Tool]
+    public partial class AgentConfiguratorsPanel : VBoxContainer
+    {
+        readonly GodotMcpConnection _connection;
+
+        OptionButton? _agentSelector;
+        VBoxContainer? _agentView;
+
+        // Live state for the currently-shown configurator's view.
+        GodotAgentConfigurator? _current;
+        bool _revealToken;
+        TextEdit? _snippetText;
+        Button? _revealButton;
+        Label? _statusLabel;
+
+        /// <summary>
+        /// Construct the section wired to the live <paramref name="connection"/> (it reads the resolved MCP-client
+        /// URL + token off the connection's <see cref="GodotMcpConfig"/> and persists the selected agent via the
+        /// connection's <c>Save</c>). Only built by the dock when a live connection exists.
+        /// </summary>
+        public AgentConfiguratorsPanel(GodotMcpConnection connection)
+        {
+            _connection = connection;
+            Name = "AgentConfigurators";
+            BuildUi();
+        }
+
+        void BuildUi()
+        {
+            SizeFlagsHorizontal = SizeFlags.ExpandFill;
+            AddThemeConstantOverride("separation", 4);
+
+            AddChild(new HSeparator { Name = "AgentSeparator" });
+            AddChild(new Label { Name = "AgentHeader", Text = "AI agent" });
+
+            // Agent dropdown — populated from the registry, item id = registry index.
+            var row = new HBoxContainer { Name = "AgentSelectorRow" };
+            AddChild(row);
+            row.AddChild(new Label { Name = "AgentSelectorLabel", Text = "Agent" });
+
+            _agentSelector = new OptionButton { Name = "AgentSelector" };
+            var names = GodotAgentConfiguratorRegistry.AgentNames;
+            for (int i = 0; i < names.Count; i++)
+                _agentSelector.AddItem(names[i], i);
+            _agentSelector.ItemSelected += OnAgentSelected;
+            row.AddChild(_agentSelector);
+
+            // Swappable per-agent view.
+            _agentView = new VBoxContainer { Name = "AgentView", SizeFlagsHorizontal = SizeFlags.ExpandFill };
+            _agentView.AddThemeConstantOverride("separation", 4);
+            AddChild(_agentView);
+
+            // Restore the persisted selection (default claude-code), falling back to the first agent.
+            var persistedId = _connection.Config.SelectedAgentId;
+            var index = GodotAgentConfiguratorRegistry.GetIndexByAgentId(persistedId);
+            if (index < 0)
+                index = 0;
+
+            _agentSelector.Selected = _agentSelector.GetItemIndex(index);
+            ShowAgent(index);
+        }
+
+        void OnAgentSelected(long index)
+        {
+            var i = (int)index;
+            var all = GodotAgentConfiguratorRegistry.All;
+            if (i < 0 || i >= all.Count)
+                return;
+
+            // Persist the selected agent id so the choice survives a restart.
+            var selected = all[i];
+            if (_connection.Config.SelectedAgentId != selected.AgentId)
+            {
+                _connection.Config.SelectedAgentId = selected.AgentId;
+                _connection.Save();
+            }
+
+            ShowAgent(i);
+        }
+
+        /// <summary>Rebuild the per-agent view for the configurator at registry index <paramref name="index"/>.</summary>
+        void ShowAgent(int index)
+        {
+            if (_agentView == null)
+                return;
+
+            var all = GodotAgentConfiguratorRegistry.All;
+            if (index < 0 || index >= all.Count)
+                return;
+
+            _current = all[index];
+            _revealToken = false; // reset masking when switching agents (never leak a revealed token across agents)
+
+            // Clear the previous agent's view synchronously: detach + free each child so the rebuild below starts
+            // from an empty container (QueueFree alone defers to the next idle frame, which would briefly double the
+            // controls). Reset the per-view node refs so a stale Refresh() cannot touch a freed node.
+            foreach (var child in _agentView.GetChildren())
+            {
+                _agentView.RemoveChild(child);
+                child.QueueFree();
+            }
+            _snippetText = null;
+            _revealButton = null;
+            _statusLabel = null;
+
+            BuildAgentView(_current);
+        }
+
+        void BuildAgentView(GodotAgentConfigurator agent)
+        {
+            if (_agentView == null)
+                return;
+
+            _agentView.AddChild(new Label { Name = "AgentName", Text = agent.AgentName });
+
+            // --- Links: Download (+ optional Tutorial). Open externally via OS.ShellOpen. ---
+            var links = new HBoxContainer { Name = "Links" };
+            _agentView.AddChild(links);
+            links.AddChild(MakeLinkButton("Download", "Download", agent.DownloadUrl));
+            if (!string.IsNullOrEmpty(agent.TutorialUrl))
+                links.AddChild(MakeLinkButton("Tutorial", "Tutorial", agent.TutorialUrl!));
+
+            // --- Generated HTTP-config snippet (read-only, token masked by default). ---
+            _agentView.AddChild(new Label
+            {
+                Name = "SnippetLabel",
+                Text = "Copy this into your MCP client config:"
+            });
+
+            _snippetText = new TextEdit
+            {
+                Name = "Snippet",
+                Editable = false,
+                CustomMinimumSize = new Vector2(0, 120),
+                SizeFlagsHorizontal = SizeFlags.ExpandFill
+            };
+            _agentView.AddChild(_snippetText);
+
+            // Snippet action buttons: Reveal token + Copy (copies the UNMASKED snippet).
+            var snippetActions = new HBoxContainer { Name = "SnippetActions" };
+            _agentView.AddChild(snippetActions);
+
+            _revealButton = new Button { Name = "Reveal", Text = "Reveal token" };
+            _revealButton.Pressed += OnRevealToggled;
+            snippetActions.AddChild(_revealButton);
+
+            var copyButton = new Button { Name = "Copy", Text = "Copy" };
+            copyButton.Pressed += OnCopyPressed;
+            snippetActions.AddChild(copyButton);
+
+            // --- Config-file controls (only for agents that have a writable config). ---
+            var configPath = ResolveConfigPath(agent);
+            if (configPath != null)
+            {
+                _statusLabel = new Label { Name = "Status" };
+                _agentView.AddChild(_statusLabel);
+
+                _agentView.AddChild(new Label
+                {
+                    Name = "ConfigPath",
+                    Text = configPath,
+                    AutowrapMode = TextServer.AutowrapMode.WordSmart
+                });
+
+                var configActions = new HBoxContainer { Name = "ConfigActions" };
+                _agentView.AddChild(configActions);
+
+                var configureButton = new Button { Name = "Configure", Text = "Configure" };
+                configureButton.Pressed += () => OnConfigurePressed(agent, configPath);
+                configActions.AddChild(configureButton);
+
+                var removeButton = new Button { Name = "Remove", Text = "Remove" };
+                removeButton.Pressed += () => OnRemovePressed(agent, configPath);
+                configActions.AddChild(removeButton);
+            }
+            else
+            {
+                _statusLabel = null;
+            }
+
+            RefreshSnippet();
+            RefreshStatus();
+        }
+
+        void OnRevealToggled()
+        {
+            _revealToken = !_revealToken;
+            if (_revealButton != null)
+                _revealButton.Text = _revealToken ? "Hide token" : "Reveal token";
+            RefreshSnippet();
+        }
+
+        void OnCopyPressed()
+        {
+            if (_current == null)
+                return;
+
+            // Copy ALWAYS uses the real token — writing the user's own client config is the point. Never logged.
+            var snippet = _current.BuildSnippet(McpUrl, Token, maskToken: false);
+            DisplayServer.ClipboardSet(snippet);
+        }
+
+        void OnConfigurePressed(GodotAgentConfigurator agent, string configPath)
+        {
+            // Configure writes the REAL token into the user's own config file. Never logged.
+            agent.Configure(configPath, McpUrl, Token);
+            RefreshStatus();
+        }
+
+        void OnRemovePressed(GodotAgentConfigurator agent, string configPath)
+        {
+            agent.Remove(configPath);
+            RefreshStatus();
+        }
+
+        /// <summary>Re-render the snippet TextEdit honoring the current mask/reveal state. Never logs the token.</summary>
+        void RefreshSnippet()
+        {
+            if (_current == null || _snippetText == null)
+                return;
+
+            _snippetText.Text = _current.BuildSnippet(McpUrl, Token, maskToken: !_revealToken);
+        }
+
+        /// <summary>Re-render the "Configured"/"Not configured" status label for the current agent.</summary>
+        void RefreshStatus()
+        {
+            if (_current == null || _statusLabel == null)
+                return;
+
+            var configPath = ResolveConfigPath(_current);
+            if (configPath == null)
+                return;
+
+            var configured = _current.IsConfigured(configPath, McpUrl);
+            _statusLabel.Text = configured ? "Configured" : "Not configured";
+        }
+
+        /// <summary>
+        /// Re-sync the section when the connection URL/token/mode changes (forwarded from
+        /// <see cref="GodotMcpDock.Refresh"/>). Re-renders the snippet (URL/token may have changed) and the status.
+        /// </summary>
+        public void Refresh()
+        {
+            RefreshSnippet();
+            RefreshStatus();
+        }
+
+        // --- live resolution off the connection config -------------------------------------------------------
+
+        /// <summary>The MCP-client endpoint URL (resolved off the live config — Cloud <c>/mcp</c> or Custom <c>&lt;host&gt;/mcp</c>).</summary>
+        string McpUrl => GodotMcpConfig.ResolveMcpClientUrl(_connection.Config);
+
+        /// <summary>The active bearer token (routed by mode), or null/empty when none — never logged.</summary>
+        string? Token => _connection.Config.Token;
+
+        /// <summary>Resolve the agent's per-OS absolute config path from live editor values, or null (snippet-only).</summary>
+        string? ResolveConfigPath(GodotAgentConfigurator agent)
+        {
+            var os = MapOs(OS.GetName());
+            var home = OS.GetEnvironment("USERPROFILE");
+            if (string.IsNullOrEmpty(home))
+                home = OS.GetEnvironment("HOME");
+            var appData = OS.GetEnvironment("APPDATA");
+            var projectRoot = ProjectSettings.GlobalizePath("res://").TrimEnd('/');
+
+            return agent.ConfigFilePath(os, home, appData, projectRoot);
+        }
+
+        /// <summary>Map Godot's <c>OS.GetName()</c> ("Windows"/"macOS"/"Linux"/…) onto the injectable <see cref="AgentOs"/>.</summary>
+        static AgentOs MapOs(string godotOsName) => godotOsName switch
+        {
+            "Windows" => AgentOs.Windows,
+            "macOS" => AgentOs.MacOS,
+            _ => AgentOs.Linux,
+        };
+
+        static Button MakeLinkButton(string name, string text, string url)
+        {
+            var button = new Button { Name = name, Text = text, TooltipText = url };
+            button.Pressed += () => OS.ShellOpen(url);
+            return button;
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/UI/Agents/GodotAgentConfigurator.cs
+++ b/addons/godot_mcp/UI/Agents/GodotAgentConfigurator.cs
@@ -1,0 +1,97 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+
+namespace com.IvanMurzak.Godot.MCP.UI.Agents
+{
+    /// <summary>
+    /// Abstract base for an AI-agent configurator — the Godot analog of Unity-MCP's
+    /// <c>AiAgentConfigurator</c>, condensed to the HTTP-only client shape Godot-MCP needs. Godot ships NO server
+    /// binary: the plugin is a CLIENT of the shared/cloud MCP server, so every configurator emits ONLY the HTTP
+    /// form of an MCP-client entry (pointing the AI client at the SAME server the plugin uses, plus the bearer
+    /// token). There is no stdio "launch the server" form here.
+    ///
+    /// <para>
+    /// This base is PURE-MANAGED (no Godot native types, no <c>#if TOOLS</c>): it carries the agent's metadata
+    /// (name / id / urls), the JSON-nav knobs (<see cref="BodyPath"/> / <see cref="ServerKey"/>), and delegates all
+    /// snippet/file work to the pure-managed <see cref="AgentConfigJson"/> helper. The dock UI that renders a
+    /// configurator (<c>AgentConfiguratorsPanel.cs</c>) is <c>#if TOOLS</c> and reads from these members; keeping
+    /// the base outside the guard makes the registry + concrete configurators CI-unit-testable.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>To add a new AI agent:</b> create a <see cref="GodotAgentConfigurator"/> subclass under <c>Impl/</c> and
+    /// add one line to <see cref="GodotAgentConfiguratorRegistry"/>. That is the entire scaling contract.
+    /// </para>
+    /// </summary>
+    public abstract class GodotAgentConfigurator
+    {
+        /// <summary>Display name of the AI agent (shown in the dock dropdown and the panel header).</summary>
+        public abstract string AgentName { get; }
+
+        /// <summary>Stable unique id (used for the persisted selected-agent value and registry lookups).</summary>
+        public abstract string AgentId { get; }
+
+        /// <summary>The agent's download / docs URL (opened by the panel's Download button).</summary>
+        public abstract string DownloadUrl { get; }
+
+        /// <summary>Optional tutorial URL (the panel hides its Tutorial button when null/empty).</summary>
+        public virtual string? TutorialUrl => null;
+
+        /// <summary>Optional icon file name for the panel (null = no icon). Display-only metadata.</summary>
+        public virtual string? IconFileName => null;
+
+        /// <summary>
+        /// The entry name the addon's server is written under inside the client config (the key of the
+        /// <see cref="BodyPath"/> object). Defaults to <c>ai-game-developer</c>; mirrors the product name so a user
+        /// scanning their config recognizes it. Subclasses rarely override this.
+        /// </summary>
+        public virtual string ServerKey => "ai-game-developer";
+
+        /// <summary>
+        /// The JSON top-level nav under which servers are listed in this agent's config format. Almost every MCP
+        /// client uses <c>mcpServers</c>; VS Code uses <c>servers</c>. Subclasses override this when they differ.
+        /// </summary>
+        public virtual string BodyPath => "mcpServers";
+
+        /// <summary>
+        /// The per-OS absolute config-file path for this agent, or <c>null</c> when the agent has no on-disk config
+        /// the addon can write (the Custom configurator) — a null path means the panel shows the copyable snippet
+        /// only, with no Configure/Remove buttons. Implementations resolve the path from the injected OS family /
+        /// home / appData / projectRoot via <see cref="AgentConfigPaths"/> so they stay pure-managed.
+        /// </summary>
+        /// <param name="os">The host OS family (injected; the editor maps <c>Godot.OS.GetName()</c> onto it).</param>
+        /// <param name="home">The user home directory (USERPROFILE / HOME).</param>
+        /// <param name="appData">The Windows %APPDATA% directory (ignored on macOS/Linux).</param>
+        /// <param name="projectRoot">The absolute Godot project root (<c>ProjectSettings.GlobalizePath("res://")</c>).</param>
+        public abstract string? ConfigFilePath(AgentOs os, string home, string appData, string projectRoot);
+
+        /// <summary>
+        /// Build the JSON snippet a user copies into this agent's MCP client — the addon's HTTP entry under
+        /// <see cref="BodyPath"/> → <see cref="ServerKey"/>. When <paramref name="maskToken"/> is true the bearer is
+        /// masked (on-screen display); pass false to emit the real token (copy / configure path). Delegates to the
+        /// pure-managed <see cref="AgentConfigJson.BuildSnippet"/>.
+        /// </summary>
+        public string BuildSnippet(string mcpUrl, string? token, bool maskToken) =>
+            AgentConfigJson.BuildSnippet(BodyPath, ServerKey, mcpUrl, token, maskToken);
+
+        /// <summary>True when this agent's config file already contains the addon's entry pointing at <paramref name="mcpUrl"/>.</summary>
+        public bool IsConfigured(string configPath, string mcpUrl) =>
+            AgentConfigJson.IsConfigured(configPath, BodyPath, ServerKey, mcpUrl);
+
+        /// <summary>READ-MERGE-WRITE the addon's HTTP entry into this agent's config file (real token), preserving siblings.</summary>
+        public void Configure(string configPath, string mcpUrl, string? token) =>
+            AgentConfigJson.Configure(configPath, BodyPath, ServerKey, mcpUrl, token);
+
+        /// <summary>Remove the addon's entry from this agent's config file, preserving siblings. Returns true when one was removed.</summary>
+        public bool Remove(string configPath) =>
+            AgentConfigJson.Remove(configPath, BodyPath, ServerKey);
+    }
+}

--- a/addons/godot_mcp/UI/Agents/GodotAgentConfiguratorRegistry.cs
+++ b/addons/godot_mcp/UI/Agents/GodotAgentConfiguratorRegistry.cs
@@ -1,0 +1,70 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using com.IvanMurzak.Godot.MCP.UI.Agents.Impl;
+
+namespace com.IvanMurzak.Godot.MCP.UI.Agents
+{
+    /// <summary>
+    /// Static registry of every <see cref="GodotAgentConfigurator"/> the dock's "AI agent" section offers. The
+    /// Godot analog of Unity-MCP's <c>AiAgentConfiguratorRegistry</c>. Pure-managed (no Godot native types, no
+    /// <c>#if TOOLS</c>) so the list + lookups are CI-unit-tested.
+    ///
+    /// <para>
+    /// <b>To add a new AI agent:</b> create a <see cref="GodotAgentConfigurator"/> subclass under <c>Impl/</c> and
+    /// add ONE line to <see cref="_configurators"/> below (keep <see cref="Impl.CustomConfigurator"/> last). No
+    /// other file needs to change — the dock panel binds to <see cref="AgentNames"/> / <see cref="All"/> generically.
+    /// </para>
+    /// </summary>
+    public static class GodotAgentConfiguratorRegistry
+    {
+        // The configurator list. Custom is intentionally LAST (it is the snippet-only fallback). To add an agent,
+        // add one line here.
+        static readonly IReadOnlyList<GodotAgentConfigurator> _configurators = new GodotAgentConfigurator[]
+        {
+            new ClaudeCodeConfigurator(),
+            new ClaudeDesktopConfigurator(),
+            new CursorConfigurator(),
+            new VisualStudioCodeConfigurator(),
+            new CustomConfigurator(), // keep last
+        };
+
+        /// <summary>Every registered configurator, in display order (Custom last).</summary>
+        public static IReadOnlyList<GodotAgentConfigurator> All => _configurators;
+
+        /// <summary>The display names, in registry order — populates the dock's agent dropdown.</summary>
+        public static IReadOnlyList<string> AgentNames => _configurators.Select(c => c.AgentName).ToList();
+
+        /// <summary>The configurator with the given <paramref name="agentId"/>, or null when absent / id is empty.</summary>
+        public static GodotAgentConfigurator? GetByAgentId(string? agentId)
+        {
+            if (string.IsNullOrEmpty(agentId))
+                return null;
+
+            return _configurators.FirstOrDefault(c => c.AgentId == agentId);
+        }
+
+        /// <summary>The registry index of <paramref name="agentId"/>, or -1 when absent / id is empty.</summary>
+        public static int GetIndexByAgentId(string? agentId)
+        {
+            if (string.IsNullOrEmpty(agentId))
+                return -1;
+
+            for (int i = 0; i < _configurators.Count; i++)
+            {
+                if (_configurators[i].AgentId == agentId)
+                    return i;
+            }
+            return -1;
+        }
+    }
+}

--- a/addons/godot_mcp/UI/Agents/Impl/ClaudeCodeConfigurator.cs
+++ b/addons/godot_mcp/UI/Agents/Impl/ClaudeCodeConfigurator.cs
@@ -1,0 +1,27 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+
+namespace com.IvanMurzak.Godot.MCP.UI.Agents.Impl
+{
+    /// <summary>
+    /// Configurator for Claude Code. Project-local config at <c>&lt;projectRoot&gt;/.mcp.json</c>, servers under
+    /// <c>mcpServers</c>. Pure-managed (no Godot native types, no <c>#if TOOLS</c>) — CI-unit-tested via the registry.
+    /// </summary>
+    public sealed class ClaudeCodeConfigurator : GodotAgentConfigurator
+    {
+        public override string AgentName => "Claude Code";
+        public override string AgentId => "claude-code";
+        public override string DownloadUrl => "https://docs.anthropic.com/en/docs/claude-code/overview";
+
+        public override string? ConfigFilePath(AgentOs os, string home, string appData, string projectRoot) =>
+            AgentConfigPaths.ClaudeCode(projectRoot);
+    }
+}

--- a/addons/godot_mcp/UI/Agents/Impl/ClaudeDesktopConfigurator.cs
+++ b/addons/godot_mcp/UI/Agents/Impl/ClaudeDesktopConfigurator.cs
@@ -1,0 +1,28 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+
+namespace com.IvanMurzak.Godot.MCP.UI.Agents.Impl
+{
+    /// <summary>
+    /// Configurator for Claude Desktop. Per-OS user config (Windows <c>%APPDATA%/Claude/claude_desktop_config.json</c>,
+    /// macOS <c>~/Library/Application Support/Claude/...</c>, Linux <c>~/.config/Claude/...</c>), servers under
+    /// <c>mcpServers</c>. Pure-managed — CI-unit-tested via the registry + path resolver.
+    /// </summary>
+    public sealed class ClaudeDesktopConfigurator : GodotAgentConfigurator
+    {
+        public override string AgentName => "Claude Desktop";
+        public override string AgentId => "claude-desktop";
+        public override string DownloadUrl => "https://claude.ai/download";
+
+        public override string? ConfigFilePath(AgentOs os, string home, string appData, string projectRoot) =>
+            AgentConfigPaths.ClaudeDesktop(os, home, appData);
+    }
+}

--- a/addons/godot_mcp/UI/Agents/Impl/CursorConfigurator.cs
+++ b/addons/godot_mcp/UI/Agents/Impl/CursorConfigurator.cs
@@ -1,0 +1,27 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+
+namespace com.IvanMurzak.Godot.MCP.UI.Agents.Impl
+{
+    /// <summary>
+    /// Configurator for Cursor. Project-local config at <c>&lt;projectRoot&gt;/.cursor/mcp.json</c>, servers under
+    /// <c>mcpServers</c>. Pure-managed — CI-unit-tested via the registry.
+    /// </summary>
+    public sealed class CursorConfigurator : GodotAgentConfigurator
+    {
+        public override string AgentName => "Cursor";
+        public override string AgentId => "cursor";
+        public override string DownloadUrl => "https://www.cursor.com/";
+
+        public override string? ConfigFilePath(AgentOs os, string home, string appData, string projectRoot) =>
+            AgentConfigPaths.Cursor(projectRoot);
+    }
+}

--- a/addons/godot_mcp/UI/Agents/Impl/CustomConfigurator.cs
+++ b/addons/godot_mcp/UI/Agents/Impl/CustomConfigurator.cs
@@ -1,0 +1,28 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+
+namespace com.IvanMurzak.Godot.MCP.UI.Agents.Impl
+{
+    /// <summary>
+    /// Configurator for any "Other / Custom" MCP client. Has NO config file the addon can write
+    /// (<see cref="ConfigFilePath"/> returns null) — the panel shows the copyable HTTP snippet only, with no
+    /// Configure/Remove buttons. Always LAST in the registry. Pure-managed — CI-unit-tested via the registry.
+    /// </summary>
+    public sealed class CustomConfigurator : GodotAgentConfigurator
+    {
+        public override string AgentName => "Other - Custom";
+        public override string AgentId => "other-custom";
+        public override string DownloadUrl => "https://modelcontextprotocol.io/";
+
+        /// <summary>Null = snippet-only; no on-disk config the addon can read/write for an arbitrary client.</summary>
+        public override string? ConfigFilePath(AgentOs os, string home, string appData, string projectRoot) => null;
+    }
+}

--- a/addons/godot_mcp/UI/Agents/Impl/VisualStudioCodeConfigurator.cs
+++ b/addons/godot_mcp/UI/Agents/Impl/VisualStudioCodeConfigurator.cs
@@ -1,0 +1,31 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+
+namespace com.IvanMurzak.Godot.MCP.UI.Agents.Impl
+{
+    /// <summary>
+    /// Configurator for Visual Studio Code (MCP). Project-local config at <c>&lt;projectRoot&gt;/.vscode/mcp.json</c>.
+    /// UNLIKE the other agents, VS Code lists servers under <c>servers</c> (NOT <c>mcpServers</c>) — overridden via
+    /// <see cref="BodyPath"/>. Pure-managed — CI-unit-tested via the registry.
+    /// </summary>
+    public sealed class VisualStudioCodeConfigurator : GodotAgentConfigurator
+    {
+        public override string AgentName => "Visual Studio Code";
+        public override string AgentId => "vscode";
+        public override string DownloadUrl => "https://code.visualstudio.com/";
+
+        /// <summary>VS Code's MCP config nests servers under <c>servers</c>, not the usual <c>mcpServers</c>.</summary>
+        public override string BodyPath => "servers";
+
+        public override string? ConfigFilePath(AgentOs os, string home, string appData, string projectRoot) =>
+            AgentConfigPaths.VisualStudioCode(projectRoot);
+    }
+}

--- a/addons/godot_mcp/UI/GodotMcpDock.cs
+++ b/addons/godot_mcp/UI/GodotMcpDock.cs
@@ -51,6 +51,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         readonly GodotMcpConnection? _connection;
         ConnectionPanel? _connectionPanel;
         FeaturesPanel? _featuresPanel;
+        AgentConfiguratorsPanel? _agentConfiguratorsPanel;
         SupportFooter? _supportFooter;
 
         // Log Level selector (header). Only built when a live connection was threaded in (it reads/writes
@@ -129,6 +130,14 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 // a live connection, so it shares the connection-null guard with the connection panel.
                 _featuresPanel = new FeaturesPanel(_connection);
                 Body.AddChild(_featuresPanel);
+
+                // AI-agent section — the dropdown of AI-agent configurators + the selected agent's HTTP-config
+                // snippet / Configure / Remove. Inserted BETWEEN the features panel and the support footer, wired
+                // to the live connection (it reads the resolved MCP-client URL + token off the config and persists
+                // the selected agent via Save). Only meaningful with a live connection, so it shares the
+                // connection-null guard with the connection + features panels.
+                _agentConfiguratorsPanel = new AgentConfiguratorsPanel(_connection);
+                Body.AddChild(_agentConfiguratorsPanel);
             }
 
             // Support/footer section — static links + thanks, appended BELOW the connection panel. It holds
@@ -218,6 +227,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         {
             _connectionPanel?.Refresh();
             _featuresPanel?.Refresh();
+            _agentConfiguratorsPanel?.Refresh();
             SyncLogLevelSelector();
         }
     }


### PR DESCRIPTION
## Summary
- Port Unity-MCP's AI-agent-configurator pattern to Godot, **HTTP-only** (Godot ships no server binary — the plugin is a client of the shared/cloud MCP server, so each configurator emits only the HTTP MCP-client form pointing at the same server + bearer).
- Pure-managed, CI-unit-tested core: `GodotAgentConfigurator` base + `GodotAgentConfiguratorRegistry`, `AgentConfigJson` (read-merge-write http entry / snippet / configure / remove, token-masking), `AgentConfigPaths` (per-OS path resolver), and `GodotMcpConfig.ResolveMcpClientUrl` (Cloud `/mcp` vs Custom `<host>/mcp`).
- Concrete configurators: Claude Code, Claude Desktop, Cursor, VS Code (`servers` bodyPath), Custom (snippet-only, last). Adding an agent = one subclass + one registry line.
- Dock "AI agent" section (`#if TOOLS`): agent `OptionButton` + per-agent view (links, masked snippet with Reveal/Copy, Configure/Remove + status + config path), persisted `selectedAgentId`. On-screen snippet masks the token by default; Copy/Configure use the real token but it is never logged.

## Test plan
- [x] Suite 1 build (CI parity): `dotnet build Godot-MCP.sln` — 0 errors, 0 warnings.
- [x] Suite 2 unit tests: `dotnet test` — 436 passed (35 new: ResolveMcpClientUrl, snippet/entry shape + masking, Configure/IsConfigured/Remove round-trip + sibling-preservation + robustness, registry lookups, per-OS paths, selectedAgentId round-trip).
- [x] Suite 3 headless Godot smoke (operator): plugin loaded, deps resolved (McpPlugin 6.7.0), docks built with the AI-agent section, clean unload, no FileNotFound/exception.

Closes #44