### PR TITLE
feat(editor): AI Game Developer dock overhaul + per-agent Configure/Remove

### DIFF
--- a/Godot-MCP.Tests/AgentConfiguratorTests.cs
+++ b/Godot-MCP.Tests/AgentConfiguratorTests.cs
@@ -263,6 +263,94 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Null(custom.ConfigFilePath(AgentOs.Windows, @"C:\Users\u", @"C:\Users\u\AppData\Roaming", @"C:\proj"));
         }
 
+        // --- Config-vs-JSON decision predicate (ShouldShowJson) ---
+
+        [Fact]
+        public void ShouldShowJson_TrueOnlyWhenPathIsNullOrEmpty()
+        {
+            Assert.True(GodotAgentConfigurator.ShouldShowJson(null));
+            Assert.True(GodotAgentConfigurator.ShouldShowJson(""));
+            Assert.False(GodotAgentConfigurator.ShouldShowJson("/proj/.mcp.json"));
+        }
+
+        [Fact]
+        public void ShouldShowJson_True_ForCustom_False_ForPathHavingAgents()
+        {
+            const string home = "/home/u";
+            const string appData = "/appdata";
+            const string proj = "/proj";
+
+            // Custom: no path → show JSON.
+            var custom = new CustomConfigurator();
+            Assert.True(GodotAgentConfigurator.ShouldShowJson(
+                custom.ConfigFilePath(AgentOs.Linux, home, appData, proj)));
+
+            // Every path-having agent: has a path → show Configure/Remove (NOT JSON).
+            foreach (var agent in new GodotAgentConfigurator[]
+                     {
+                         new ClaudeCodeConfigurator(),
+                         new ClaudeDesktopConfigurator(),
+                         new CursorConfigurator(),
+                         new VisualStudioCodeConfigurator(),
+                     })
+            {
+                var path = agent.ConfigFilePath(AgentOs.Linux, home, appData, proj);
+                Assert.False(string.IsNullOrEmpty(path));
+                Assert.False(GodotAgentConfigurator.ShouldShowJson(path));
+            }
+        }
+
+        // --- Per-agent help metadata (parity with Unity) ---
+
+        [Fact]
+        public void PathHavingAgents_ReportNonNullConfigPath_CustomReportsNull()
+        {
+            // Exactly one agent (Custom) is snippet-only; the rest have a config path.
+            var snippetOnly = 0;
+            var pathHaving = 0;
+            foreach (var agent in GodotAgentConfiguratorRegistry.All)
+            {
+                var path = agent.ConfigFilePath(AgentOs.Linux, "/home/u", "/appdata", "/proj");
+                if (string.IsNullOrEmpty(path))
+                    snippetOnly++;
+                else
+                    pathHaving++;
+            }
+            Assert.Equal(1, snippetOnly);          // only Custom
+            Assert.True(pathHaving >= 4);          // Claude Code/Desktop, Cursor, VS Code at minimum
+        }
+
+        [Fact]
+        public void EveryRegisteredAgent_CarriesPortedHelp_StepsAndTroubleshooting()
+        {
+            // Every agent in the registry was given ported help content (non-empty Manual Steps +
+            // Troubleshooting) so the dock's foldouts are never blank for a shipped agent.
+            foreach (var agent in GodotAgentConfiguratorRegistry.All)
+            {
+                Assert.NotEmpty(agent.ManualSteps);
+                Assert.NotEmpty(agent.Troubleshooting);
+                Assert.All(agent.ManualSteps, s => Assert.False(string.IsNullOrWhiteSpace(s)));
+                Assert.All(agent.Troubleshooting, s => Assert.False(string.IsNullOrWhiteSpace(s)));
+            }
+        }
+
+        [Fact]
+        public void ClaudeDesktop_And_VsCode_CarryWarningText()
+        {
+            // The two agents that need a prominent caveat in Unity carry a warning banner here too.
+            Assert.False(string.IsNullOrEmpty(new ClaudeDesktopConfigurator().WarningText));
+            Assert.False(string.IsNullOrEmpty(new VisualStudioCodeConfigurator().WarningText));
+        }
+
+        [Fact]
+        public void DefaultConfigurator_HelpMembers_AreEmptyNotNull()
+        {
+            // The base defaults are safe to read without null checks (empty lists / null strings).
+            var custom = new CustomConfigurator();
+            Assert.NotNull(custom.ManualSteps);
+            Assert.NotNull(custom.Troubleshooting);
+        }
+
         // --- Per-OS path resolution (injected OS / home / appData / projectRoot) ---
 
         [Fact]

--- a/Godot-MCP.Tests/DockThemeTests.cs
+++ b/Godot-MCP.Tests/DockThemeTests.cs
@@ -1,0 +1,81 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using com.IvanMurzak.Godot.MCP.UI;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the pure-managed dock design palette (<see cref="DockTheme"/>): the brief's status-dot colours, the
+    /// <see cref="ConnectionStatus"/> → dot-colour mapping, and a couple of the load-bearing 8-bit→float
+    /// translations. The editor StyleBox/Theme wiring (<c>DockStyle.cs</c>, <c>#if TOOLS</c>) is verified via the
+    /// headless Godot smoke (test.md Suite 3) — NOT here.
+    /// </summary>
+    public class DockThemeTests
+    {
+        [Fact]
+        public void StatusDotColor_MapsStatesToBriefPalette()
+        {
+            Assert.Equal(DockTheme.StatusOnline, DockTheme.StatusDotColor(ConnectionStatus.Connected));
+            Assert.Equal(DockTheme.StatusConnecting, DockTheme.StatusDotColor(ConnectionStatus.Connecting));
+            Assert.Equal(DockTheme.StatusDisconnected, DockTheme.StatusDotColor(ConnectionStatus.Disconnected));
+        }
+
+        [Fact]
+        public void StatusColors_Match8BitSourceValues()
+        {
+            // online green Color8(111,226,101)
+            AssertRgb8(DockTheme.StatusOnline, 111, 226, 101);
+            // disconnected orange Color8(220,76,9)
+            AssertRgb8(DockTheme.StatusDisconnected, 220, 76, 9);
+        }
+
+        [Fact]
+        public void CardBackground_IsDarkBlueTint_WithExpectedAlpha()
+        {
+            // Color(20/255, 40/255, 69/255, 0.2)
+            Assert.Equal(20f / 255f, DockTheme.CardBackground.R, 5);
+            Assert.Equal(40f / 255f, DockTheme.CardBackground.G, 5);
+            Assert.Equal(69f / 255f, DockTheme.CardBackground.B, 5);
+            Assert.Equal(0.2f, DockTheme.CardBackground.A, 5);
+        }
+
+        [Fact]
+        public void CardSizing_MatchesBrief()
+        {
+            Assert.Equal(16, DockTheme.CardCornerRadius);
+            Assert.Equal(8, DockTheme.CardContentPadding);
+            Assert.Equal(8, DockTheme.CardMargin);
+            Assert.Equal(14, DockTheme.StatusDotSize);
+        }
+
+        [Fact]
+        public void Typography_FontSizes_MatchBrief()
+        {
+            Assert.Equal(20, DockTheme.FontSizeHeader);
+            Assert.Equal(16, DockTheme.FontSizeSectionTitle);
+            Assert.Equal(13, DockTheme.FontSizeSubLabel);
+        }
+
+        [Fact]
+        public void LinkColor_Is4FC3F7()
+        {
+            AssertRgb8(DockTheme.Link, 79, 195, 247); // #4FC3F7
+        }
+
+        static void AssertRgb8((float R, float G, float B) c, int r8, int g8, int b8)
+        {
+            Assert.Equal(r8 / 255f, c.R, 5);
+            Assert.Equal(g8 / 255f, c.G, 5);
+            Assert.Equal(b8 / 255f, c.B, 5);
+        }
+    }
+}

--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -127,6 +127,11 @@
          via the headless Godot smoke (test.md Suite 3); the view logic is unit-tested here. The SignalR
          HubConnectionState enum it switches on is provided transitively by com.IvanMurzak.McpPlugin. -->
     <Compile Include="..\addons\godot_mcp\UI\ConnectionPanelView.cs" Link="Source\ConnectionPanelView.cs" />
+    <!-- Dock design palette — pure-managed (no Godot native types, no #if TOOLS): the colour/size/font
+         constants + the ConnectionStatus → status-dot colour mapping that DockStyle (#if TOOLS) consumes.
+         The editor StyleBox/Theme wiring (DockStyle.cs) is #if TOOLS and verified via the headless Godot
+         smoke (test.md Suite 3); the palette numbers + dot-colour rule are unit-tested here. -->
+    <Compile Include="..\addons\godot_mcp\UI\DockTheme.cs" Link="Source\DockTheme.cs" />
     <!-- Connection status tracker — pure-managed (no Godot native types, no #if TOOLS): the current-status
          holder + de-dup rule extracted out of GodotMcpConnection.PublishStatus (issue #42). The editor
          Timer/_Process wiring that drives the periodic re-sync stays in ConnectionPanel.cs (#if TOOLS,

--- a/addons/godot_mcp/UI/Agents/AgentConfiguratorsPanel.cs
+++ b/addons/godot_mcp/UI/Agents/AgentConfiguratorsPanel.cs
@@ -48,6 +48,8 @@ namespace com.IvanMurzak.Godot.MCP.UI
         TextEdit? _snippetText;
         Button? _revealButton;
         Label? _statusLabel;
+        Button? _configureButton;
+        Button? _removeButton;
 
         /// <summary>
         /// Construct the section wired to the live <paramref name="connection"/> (it reads the resolved MCP-client
@@ -66,8 +68,9 @@ namespace com.IvanMurzak.Godot.MCP.UI
             SizeFlagsHorizontal = SizeFlags.ExpandFill;
             AddThemeConstantOverride("separation", 4);
 
-            AddChild(new HSeparator { Name = "AgentSeparator" });
-            AddChild(new Label { Name = "AgentHeader", Text = "AI agent" });
+            var headerLabel = new Label { Name = "AgentHeader", Text = "AI agent" };
+            DockStyle.ApplySectionTitle(headerLabel);
+            AddChild(headerLabel);
 
             // Agent dropdown — populated from the registry, item id = registry index.
             var row = new HBoxContainer { Name = "AgentSelectorRow" };
@@ -138,6 +141,8 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _snippetText = null;
             _revealButton = null;
             _statusLabel = null;
+            _configureButton = null;
+            _removeButton = null;
 
             BuildAgentView(_current);
         }
@@ -147,21 +152,61 @@ namespace com.IvanMurzak.Godot.MCP.UI
             if (_agentView == null)
                 return;
 
-            _agentView.AddChild(new Label { Name = "AgentName", Text = agent.AgentName });
+            var nameLabel = new Label { Name = "AgentName", Text = agent.AgentName };
+            DockStyle.ApplySectionTitle(nameLabel);
+            _agentView.AddChild(nameLabel);
 
-            // --- Links: Download (+ optional Tutorial). Open externally via OS.ShellOpen. ---
-            var links = new HBoxContainer { Name = "Links" };
-            _agentView.AddChild(links);
-            links.AddChild(MakeLinkButton("Download", "Download", agent.DownloadUrl));
+            // --- Per-agent description (muted). ---
+            if (!string.IsNullOrEmpty(agent.Description))
+            {
+                var desc = new Label { Name = "Description", Text = agent.Description! };
+                DockStyle.ApplyDescription(desc);
+                _agentView.AddChild(desc);
+            }
+
+            // --- Per-agent warning banner (styled amber frame). ---
+            if (!string.IsNullOrEmpty(agent.WarningText))
+                _agentView.AddChild(DockStyle.WarningFrame(agent.WarningText!));
+
+            // --- Links: Download (+ optional Tutorial), as flat link buttons separated by "•". ---
+            var linkDefs = new List<(string Name, string Text, string Url)>
+            {
+                ("Download", "Download", agent.DownloadUrl)
+            };
             if (!string.IsNullOrEmpty(agent.TutorialUrl))
-                links.AddChild(MakeLinkButton("Tutorial", "Tutorial", agent.TutorialUrl!));
+                linkDefs.Add(("Tutorial", "Tutorial", agent.TutorialUrl!));
+            _agentView.AddChild(DockStyle.LinkRow("Links", linkDefs));
 
-            // --- Generated HTTP-config snippet (read-only, token masked by default). ---
-            _agentView.AddChild(new Label
+            // --- The KEY decision: Configure/Remove for agents with a config-file path; copyable JSON otherwise. ---
+            var configPath = ResolveConfigPath(agent);
+            if (GodotAgentConfigurator.ShouldShowJson(configPath))
+                BuildSnippetView(agent);
+            else
+                BuildConfigureRemoveView(agent, configPath!);
+
+            // --- Per-agent help foldouts (Manual Configuration Steps / Troubleshooting). ---
+            BuildHelpFoldouts(agent);
+
+            RefreshSnippet();
+            RefreshStatus();
+        }
+
+        /// <summary>
+        /// For an agent WITHOUT a writable config-file path (Custom): show the copyable HTTP snippet (read-only,
+        /// token MASKED by default) + Reveal/Copy. No Configure/Remove buttons.
+        /// </summary>
+        void BuildSnippetView(GodotAgentConfigurator agent)
+        {
+            if (_agentView == null)
+                return;
+
+            var snippetLabel = new Label
             {
                 Name = "SnippetLabel",
                 Text = "Copy this into your MCP client config:"
-            });
+            };
+            DockStyle.ApplyDescription(snippetLabel);
+            _agentView.AddChild(snippetLabel);
 
             _snippetText = new TextEdit
             {
@@ -177,45 +222,83 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _agentView.AddChild(snippetActions);
 
             _revealButton = new Button { Name = "Reveal", Text = "Reveal token" };
+            DockStyle.ApplySecondaryButton(_revealButton);
             _revealButton.Pressed += OnRevealToggled;
             snippetActions.AddChild(_revealButton);
 
             var copyButton = new Button { Name = "Copy", Text = "Copy" };
+            DockStyle.ApplySecondaryButton(copyButton);
             copyButton.Pressed += OnCopyPressed;
             snippetActions.AddChild(copyButton);
+        }
 
-            // --- Config-file controls (only for agents that have a writable config). ---
-            var configPath = ResolveConfigPath(agent);
-            if (configPath != null)
+        /// <summary>
+        /// For an agent WITH a writable config-file path (Claude Code/Desktop, Cursor, VS Code): show the
+        /// Unity-style Configure/Remove row — a status label ("Configured"/"Not configured"), a Configure /
+        /// Reconfigure primary button (writes the entry), a Remove alert button (visible only when configured),
+        /// and the config-file path. NO raw JSON snippet for these agents. The real token still flows into the
+        /// written file via Configure — it is never shown on-screen or logged.
+        /// </summary>
+        void BuildConfigureRemoveView(GodotAgentConfigurator agent, string configPath)
+        {
+            if (_agentView == null)
+                return;
+
+            _statusLabel = new Label { Name = "Status" };
+            _agentView.AddChild(_statusLabel);
+
+            var pathLabel = new Label
             {
-                _statusLabel = new Label { Name = "Status" };
-                _agentView.AddChild(_statusLabel);
+                Name = "ConfigPath",
+                Text = configPath,
+                AutowrapMode = TextServer.AutowrapMode.WordSmart
+            };
+            DockStyle.ApplyDescription(pathLabel);
+            _agentView.AddChild(pathLabel);
 
-                _agentView.AddChild(new Label
+            var configActions = new HBoxContainer { Name = "ConfigActions" };
+            _agentView.AddChild(configActions);
+
+            _configureButton = new Button { Name = "Configure", Text = "Configure" };
+            DockStyle.ApplyPrimaryButton(_configureButton);
+            _configureButton.Pressed += () => OnConfigurePressed(agent, configPath);
+            configActions.AddChild(_configureButton);
+
+            _removeButton = new Button { Name = "Remove", Text = "Remove" };
+            DockStyle.ApplyAlertButton(_removeButton);
+            _removeButton.Pressed += () => OnRemovePressed(agent, configPath);
+            configActions.AddChild(_removeButton);
+        }
+
+        /// <summary>Append the agent's "Manual Configuration Steps" / "Troubleshooting" collapsible foldouts when non-empty.</summary>
+        void BuildHelpFoldouts(GodotAgentConfigurator agent)
+        {
+            if (_agentView == null)
+                return;
+
+            if (agent.ManualSteps.Count > 0)
+            {
+                var (container, content) = DockStyle.Foldout("Manual Configuration Steps");
+                foreach (var step in agent.ManualSteps)
                 {
-                    Name = "ConfigPath",
-                    Text = configPath,
-                    AutowrapMode = TextServer.AutowrapMode.WordSmart
-                });
-
-                var configActions = new HBoxContainer { Name = "ConfigActions" };
-                _agentView.AddChild(configActions);
-
-                var configureButton = new Button { Name = "Configure", Text = "Configure" };
-                configureButton.Pressed += () => OnConfigurePressed(agent, configPath);
-                configActions.AddChild(configureButton);
-
-                var removeButton = new Button { Name = "Remove", Text = "Remove" };
-                removeButton.Pressed += () => OnRemovePressed(agent, configPath);
-                configActions.AddChild(removeButton);
+                    var label = new Label { Text = step };
+                    DockStyle.ApplyDescription(label);
+                    content.AddChild(label);
+                }
+                _agentView.AddChild(container);
             }
-            else
+
+            if (agent.Troubleshooting.Count > 0)
             {
-                _statusLabel = null;
+                var (container, content) = DockStyle.Foldout("Troubleshooting");
+                foreach (var tip in agent.Troubleshooting)
+                {
+                    var label = new Label { Text = tip };
+                    DockStyle.ApplyDescription(label);
+                    content.AddChild(label);
+                }
+                _agentView.AddChild(container);
             }
-
-            RefreshSnippet();
-            RefreshStatus();
         }
 
         void OnRevealToggled()
@@ -258,7 +341,12 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _snippetText.Text = _current.BuildSnippet(McpUrl, Token, maskToken: !_revealToken);
         }
 
-        /// <summary>Re-render the "Configured"/"Not configured" status label for the current agent.</summary>
+        /// <summary>
+        /// Re-render the Configure/Remove status for the current agent (only agents WITH a config-file path have
+        /// this row). Drives the "Configured"/"Not configured" label, flips the Configure button to "Reconfigure"
+        /// when already configured, and shows the Remove button only when an entry exists. Reads
+        /// <see cref="GodotAgentConfigurator.IsConfigured"/> — pure-managed, against the resolved config path.
+        /// </summary>
         void RefreshStatus()
         {
             if (_current == null || _statusLabel == null)
@@ -270,6 +358,14 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
             var configured = _current.IsConfigured(configPath, McpUrl);
             _statusLabel.Text = configured ? "Configured" : "Not configured";
+            _statusLabel.AddThemeColorOverride(
+                "font_color",
+                configured ? DockStyle.Rgb(DockTheme.StatusOnline) : DockStyle.Rgb(DockTheme.WarningText));
+
+            if (_configureButton != null)
+                _configureButton.Text = configured ? "Reconfigure" : "Configure";
+            if (_removeButton != null)
+                _removeButton.Visible = configured;
         }
 
         /// <summary>
@@ -310,13 +406,6 @@ namespace com.IvanMurzak.Godot.MCP.UI
             "macOS" => AgentOs.MacOS,
             _ => AgentOs.Linux,
         };
-
-        static Button MakeLinkButton(string name, string text, string url)
-        {
-            var button = new Button { Name = name, Text = text, TooltipText = url };
-            button.Pressed += () => OS.ShellOpen(url);
-            return button;
-        }
     }
 }
 #endif

--- a/addons/godot_mcp/UI/Agents/GodotAgentConfigurator.cs
+++ b/addons/godot_mcp/UI/Agents/GodotAgentConfigurator.cs
@@ -8,6 +8,7 @@
 └──────────────────────────────────────────────────────────────────┘
 */
 #nullable enable
+using System.Collections.Generic;
 
 namespace com.IvanMurzak.Godot.MCP.UI.Agents
 {
@@ -48,6 +49,40 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents
         /// <summary>Optional icon file name for the panel (null = no icon). Display-only metadata.</summary>
         public virtual string? IconFileName => null;
 
+        // --- Per-agent help metadata (parity with Unity-MCP's *Configurator.OnUICreated) -----------------------
+        // Each member below carries the agent-specific guidance the dock's per-agent view renders: a short
+        // description, an optional warning banner, and the collapsible "Manual Configuration Steps" /
+        // "Troubleshooting" foldouts. PURE-MANAGED (plain strings/lists, no Godot native types, no #if TOOLS), so
+        // the panel reads them and the registry can be CI-unit-tested for "ported agents carry non-empty help".
+        // The strings are adapted from the corresponding Unity Impl/*Configurator.OnUICreated, dropping the
+        // stdio-only specifics (Godot-MCP is HTTP-only) and reworded Unity -> Godot.
+
+        /// <summary>
+        /// A short one-or-two-line description shown under the agent name (the analog of Unity's
+        /// <c>ContainerUnderHeader</c> description labels). Null = no description line.
+        /// </summary>
+        public virtual string? Description => null;
+
+        /// <summary>
+        /// An optional warning banner shown prominently under the agent name (the analog of Unity's
+        /// <c>TemplateWarningLabel</c> / <c>TemplateAlertLabel</c>). Null = no warning. Use this for "IMPORTANT: …"
+        /// guidance (e.g. Claude Desktop's "prefer Claude Code", VS Code's "start the server manually each time").
+        /// </summary>
+        public virtual string? WarningText => null;
+
+        /// <summary>
+        /// The ordered "Manual Configuration Steps" the panel renders inside a collapsible foldout. Empty = the
+        /// foldout is omitted. Each string is one step; they describe how to apply the addon's HTTP entry to this
+        /// agent's config file (the analog of Unity's <c>TemplateFoldout("Manual Configuration Steps")</c> body).
+        /// </summary>
+        public virtual IReadOnlyList<string> ManualSteps => System.Array.Empty<string>();
+
+        /// <summary>
+        /// The ordered "Troubleshooting" tips the panel renders inside a collapsible foldout. Empty = the foldout
+        /// is omitted. Each string is one tip (the analog of Unity's <c>TemplateFoldout("Troubleshooting")</c> body).
+        /// </summary>
+        public virtual IReadOnlyList<string> Troubleshooting => System.Array.Empty<string>();
+
         /// <summary>
         /// The entry name the addon's server is written under inside the client config (the key of the
         /// <see cref="BodyPath"/> object). Defaults to <c>ai-game-developer</c>; mirrors the product name so a user
@@ -72,6 +107,16 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents
         /// <param name="appData">The Windows %APPDATA% directory (ignored on macOS/Linux).</param>
         /// <param name="projectRoot">The absolute Godot project root (<c>ProjectSettings.GlobalizePath("res://")</c>).</param>
         public abstract string? ConfigFilePath(AgentOs os, string home, string appData, string projectRoot);
+
+        /// <summary>
+        /// The dock's Config-vs-JSON decision predicate: TRUE when the panel should show the copyable JSON snippet
+        /// for this agent (because it has NO writable config-file path the addon can drive), FALSE when the panel
+        /// should instead show the Configure / Remove buttons + status (because a config-file path exists). This is
+        /// the KEY behavior of the AI-agent section: agents with a known config file get a one-click Configure/Remove
+        /// row; only Custom / manual agents fall back to the raw JSON snippet. Pure-managed (the path is injected) so
+        /// it is unit-testable; the editor passes the per-OS resolved path from <see cref="ConfigFilePath"/>.
+        /// </summary>
+        public static bool ShouldShowJson(string? resolvedConfigPath) => string.IsNullOrEmpty(resolvedConfigPath);
 
         /// <summary>
         /// Build the JSON snippet a user copies into this agent's MCP client — the addon's HTTP entry under

--- a/addons/godot_mcp/UI/Agents/Impl/ClaudeCodeConfigurator.cs
+++ b/addons/godot_mcp/UI/Agents/Impl/ClaudeCodeConfigurator.cs
@@ -8,6 +8,7 @@
 └──────────────────────────────────────────────────────────────────┘
 */
 #nullable enable
+using System.Collections.Generic;
 
 namespace com.IvanMurzak.Godot.MCP.UI.Agents.Impl
 {
@@ -20,6 +21,25 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents.Impl
         public override string AgentName => "Claude Code";
         public override string AgentId => "claude-code";
         public override string DownloadUrl => "https://docs.anthropic.com/en/docs/claude-code/overview";
+        public override string? TutorialUrl => "https://youtu.be/Sknh2p12W8c";
+
+        public override string? Description =>
+            "The recommended way to use AI Game Developer with Godot — Claude Code is a CLI agent you launch from the project root.";
+
+        public override IReadOnlyList<string> ManualSteps => new[]
+        {
+            "Click 'Configure' above to write the AI Game Developer server into '.mcp.json' at the project root (or copy the snippet manually).",
+            "Open a terminal in the project root and run: claude",
+            "Restart Claude Code to apply the configuration.",
+        };
+
+        public override IReadOnlyList<string> Troubleshooting => new[]
+        {
+            "- Ensure the Claude Code CLI is installed and accessible from the terminal.",
+            "- Start Claude Code in the folder that contains the Godot project (the folder with 'project.godot').",
+            "- Check that the configuration file '.mcp.json' exists at the project root.",
+            "- Restart Claude Code after configuration changes.",
+        };
 
         public override string? ConfigFilePath(AgentOs os, string home, string appData, string projectRoot) =>
             AgentConfigPaths.ClaudeCode(projectRoot);

--- a/addons/godot_mcp/UI/Agents/Impl/ClaudeDesktopConfigurator.cs
+++ b/addons/godot_mcp/UI/Agents/Impl/ClaudeDesktopConfigurator.cs
@@ -8,6 +8,7 @@
 └──────────────────────────────────────────────────────────────────┘
 */
 #nullable enable
+using System.Collections.Generic;
 
 namespace com.IvanMurzak.Godot.MCP.UI.Agents.Impl
 {
@@ -21,6 +22,25 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents.Impl
         public override string AgentName => "Claude Desktop";
         public override string AgentId => "claude-desktop";
         public override string DownloadUrl => "https://claude.ai/download";
+
+        public override string? WarningText =>
+            "IMPORTANT: Highly recommended to use Claude Code instead — it shares the same subscription plan and is far more reliable with Godot.";
+
+        public override string? Description =>
+            "Claude Desktop is finicky and must be fully restarted (Quit from the tray) after the Godot connection becomes active.";
+
+        public override IReadOnlyList<string> ManualSteps => new[]
+        {
+            "Click 'Configure' above to write the AI Game Developer server into 'claude_desktop_config.json' (or copy the snippet manually).",
+            "Restart Claude Desktop. You may need to click 'Quit' in the apps tray — simply closing the window is not enough.",
+        };
+
+        public override IReadOnlyList<string> Troubleshooting => new[]
+        {
+            "- Claude Desktop may not detect runtime updates to MCP tools; ensure it reads the MCP tools on startup.",
+            "- Start Godot first; the connection status should read 'Connecting…' before you launch Claude Desktop.",
+            "- Restart Claude Desktop after any configuration change.",
+        };
 
         public override string? ConfigFilePath(AgentOs os, string home, string appData, string projectRoot) =>
             AgentConfigPaths.ClaudeDesktop(os, home, appData);

--- a/addons/godot_mcp/UI/Agents/Impl/CursorConfigurator.cs
+++ b/addons/godot_mcp/UI/Agents/Impl/CursorConfigurator.cs
@@ -8,6 +8,7 @@
 └──────────────────────────────────────────────────────────────────┘
 */
 #nullable enable
+using System.Collections.Generic;
 
 namespace com.IvanMurzak.Godot.MCP.UI.Agents.Impl
 {
@@ -20,6 +21,21 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents.Impl
         public override string AgentName => "Cursor";
         public override string AgentId => "cursor";
         public override string DownloadUrl => "https://www.cursor.com/";
+
+        public override string? Description =>
+            "Cursor reads MCP servers from a project-local '.cursor/mcp.json'.";
+
+        public override IReadOnlyList<string> ManualSteps => new[]
+        {
+            "Click 'Configure' above to write the AI Game Developer server into '.cursor/mcp.json' (or copy the snippet manually).",
+            "Open Cursor in this project; it picks up the server automatically.",
+        };
+
+        public override IReadOnlyList<string> Troubleshooting => new[]
+        {
+            "- The '.cursor/mcp.json' file must have no JSON syntax errors.",
+            "- Open Cursor settings → 'MCP Servers' to restart ai-game-developer or inspect the available MCP tools and server status.",
+        };
 
         public override string? ConfigFilePath(AgentOs os, string home, string appData, string projectRoot) =>
             AgentConfigPaths.Cursor(projectRoot);

--- a/addons/godot_mcp/UI/Agents/Impl/CustomConfigurator.cs
+++ b/addons/godot_mcp/UI/Agents/Impl/CustomConfigurator.cs
@@ -8,6 +8,7 @@
 └──────────────────────────────────────────────────────────────────┘
 */
 #nullable enable
+using System.Collections.Generic;
 
 namespace com.IvanMurzak.Godot.MCP.UI.Agents.Impl
 {
@@ -21,6 +22,22 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents.Impl
         public override string AgentName => "Other - Custom";
         public override string AgentId => "other-custom";
         public override string DownloadUrl => "https://modelcontextprotocol.io/";
+
+        public override string? Description =>
+            "Any other MCP client. Copy the HTTP snippet below into your client's own MCP server config — AI Game Developer cannot auto-write it.";
+
+        public override IReadOnlyList<string> ManualSteps => new[]
+        {
+            "Open (or create) your MCP client's server configuration.",
+            "Copy and paste the JSON snippet above into it, under the client's MCP servers section.",
+            "Restart or reload the client to pick up the new server.",
+        };
+
+        public override IReadOnlyList<string> Troubleshooting => new[]
+        {
+            "- The snippet uses the HTTP transport (type: http) pointing at the same server this plugin connects to.",
+            "- If your client requires a bearer token, the Authorization header carries it — keep it secret.",
+        };
 
         /// <summary>Null = snippet-only; no on-disk config the addon can read/write for an arbitrary client.</summary>
         public override string? ConfigFilePath(AgentOs os, string home, string appData, string projectRoot) => null;

--- a/addons/godot_mcp/UI/Agents/Impl/VisualStudioCodeConfigurator.cs
+++ b/addons/godot_mcp/UI/Agents/Impl/VisualStudioCodeConfigurator.cs
@@ -8,6 +8,7 @@
 └──────────────────────────────────────────────────────────────────┘
 */
 #nullable enable
+using System.Collections.Generic;
 
 namespace com.IvanMurzak.Godot.MCP.UI.Agents.Impl
 {
@@ -24,6 +25,27 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents.Impl
 
         /// <summary>VS Code's MCP config nests servers under <c>servers</c>, not the usual <c>mcpServers</c>.</summary>
         public override string BodyPath => "servers";
+
+        public override string? Description =>
+            "VS Code's GitHub Copilot operates as an AI agent in the IDE, reading MCP servers from '.vscode/mcp.json'.";
+
+        public override string? WarningText =>
+            "IMPORTANT: You must start the 'ai-game-developer' MCP server manually in VS Code each time after VS Code restarts.";
+
+        public override IReadOnlyList<string> ManualSteps => new[]
+        {
+            "Click 'Configure' above to write the AI Game Developer server into '.vscode/mcp.json' (or copy the snippet manually).",
+            "Click 'Extensions' in VS Code.",
+            "Open the 'MCP SERVERS - INSTALLED' category in the extensions list.",
+            "Click the settings icon next to 'ai-game-developer'.",
+            "Click 'Start Server'. Done — the MCP server is running and Godot should connect.",
+        };
+
+        public override IReadOnlyList<string> Troubleshooting => new[]
+        {
+            "- The '.vscode/mcp.json' file must have no JSON syntax errors.",
+            "- Restart VS Code after configuration changes.",
+        };
 
         public override string? ConfigFilePath(AgentOs os, string home, string appData, string projectRoot) =>
             AgentConfigPaths.VisualStudioCode(projectRoot);

--- a/addons/godot_mcp/UI/ConnectionPanel.cs
+++ b/addons/godot_mcp/UI/ConnectionPanel.cs
@@ -161,6 +161,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             statusRow.AddChild(_statusDot);
 
             _statusLabel = new Label { Name = "StatusLabel" };
+            DockStyle.ApplySubLabel(_statusLabel);
             statusRow.AddChild(_statusLabel);
 
             // --- Connect/Disconnect button ---
@@ -192,6 +193,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 PlaceholderText = GodotMcpConfig.DefaultCustomHost,
                 SizeFlagsHorizontal = SizeFlags.ExpandFill
             };
+            DockStyle.ApplyInput(_hostField);
             // Commit on Enter and on focus-out (mirrors the Unity reference's FocusOut commit).
             _hostField.TextSubmitted += OnHostSubmitted;
             _hostField.FocusExited += OnHostFocusExited;
@@ -301,9 +303,9 @@ namespace com.IvanMurzak.Godot.MCP.UI
         static ColorRect MakeDot(string name) => new ColorRect
         {
             Name = name,
-            CustomMinimumSize = new Vector2(10, 10),
+            CustomMinimumSize = new Vector2(DockTheme.StatusDotSize, DockTheme.StatusDotSize),
             SizeFlagsVertical = SizeFlags.ShrinkCenter,
-            Color = ToColor(ConnectionPanelView.ColorDisconnected)
+            Color = DockStyle.Rgb(DockTheme.StatusDisconnected)
         };
 
         static HBoxContainer MakeTimelineRow(ColorRect dot, string label)
@@ -313,8 +315,6 @@ namespace com.IvanMurzak.Godot.MCP.UI
             row.AddChild(new Label { Text = label });
             return row;
         }
-
-        static Color ToColor((float R, float G, float B) rgb) => new Color(rgb.R, rgb.G, rgb.B);
 
         void OnConnectionStatusChanged(ConnectionStatus status) => ApplyStatus(status);
 
@@ -326,7 +326,9 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// </summary>
         void ApplyStatus(ConnectionStatus status)
         {
-            var color = ToColor(ConnectionPanelView.StatusColor(status));
+            // Status-dot colour comes from the brief's dock palette (online green / connecting amber /
+            // disconnected orange); the status LABEL text still comes from ConnectionPanelView.
+            var color = DockStyle.Rgb(DockTheme.StatusDotColor(status));
 
             _statusDot.Color = color;
             _statusLabel.Text = ConnectionPanelView.StatusLabel(status);

--- a/addons/godot_mcp/UI/DockStyle.cs
+++ b/addons/godot_mcp/UI/DockStyle.cs
@@ -1,0 +1,306 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System.Collections.Generic;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.UI
+{
+    /// <summary>
+    /// Editor-only (<c>#if TOOLS</c>) styling helpers that translate the pure-managed <see cref="DockTheme"/> palette
+    /// into real Godot <see cref="Color"/> / <see cref="StyleBoxFlat"/> / control resources, and apply them across
+    /// the dock so it mimics Unity-MCP's MainWindow. This is the Godot analog of Unity-MCP's USS stylesheets: rather
+    /// than a `.uss` cascade, Godot styling is done in code via <see cref="StyleBox"/>es pushed as theme overrides on
+    /// individual controls (and reusable card / warning / foldout factory methods below).
+    ///
+    /// <para>
+    /// All decision NUMBERS (colours, radii, sizes) live in <see cref="DockTheme"/> (pure-managed, CI-unit-tested);
+    /// this class only constructs Godot resources from them, so it is verified via the headless Godot smoke
+    /// (<c>test.md</c> Suite 3), not the plain-xUnit host.
+    /// </para>
+    /// </summary>
+    internal static class DockStyle
+    {
+        // --- Color mapping (DockTheme tuple -> Godot Color) ---------------------------------------------------
+
+        public static Color Rgb((float R, float G, float B) c) => new Color(c.R, c.G, c.B);
+        public static Color Rgba((float R, float G, float B, float A) c) => new Color(c.R, c.G, c.B, c.A);
+
+        // --- Card / frame-group --------------------------------------------------------------------------------
+
+        /// <summary>
+        /// Build the dark-blue rounded "card" <see cref="StyleBoxFlat"/> (Unity's <c>.frame-group</c>): tinted bg,
+        /// 16px corner radius, 8px content padding on all sides.
+        /// </summary>
+        public static StyleBoxFlat CardStyleBox()
+        {
+            var box = new StyleBoxFlat
+            {
+                BgColor = Rgba(DockTheme.CardBackground)
+            };
+            box.SetCornerRadiusAll(DockTheme.CardCornerRadius);
+            box.ContentMarginLeft = DockTheme.CardContentPadding;
+            box.ContentMarginRight = DockTheme.CardContentPadding;
+            box.ContentMarginTop = DockTheme.CardContentPadding;
+            box.ContentMarginBottom = DockTheme.CardContentPadding;
+            return box;
+        }
+
+        /// <summary>
+        /// Wrap <paramref name="content"/> in a styled card: a <see cref="MarginContainer"/> (outer margin) holding a
+        /// <see cref="PanelContainer"/> skinned with <see cref="CardStyleBox"/>. The caller adds the returned
+        /// container to the dock body; the content is reparented INTO the card.
+        /// </summary>
+        public static MarginContainer Card(Control content, string name)
+        {
+            var margin = new MarginContainer { Name = name + "CardMargin", SizeFlagsHorizontal = Control.SizeFlags.ExpandFill };
+            margin.AddThemeConstantOverride("margin_left", DockTheme.CardMargin);
+            margin.AddThemeConstantOverride("margin_right", DockTheme.CardMargin);
+            margin.AddThemeConstantOverride("margin_top", DockTheme.CardMargin);
+            margin.AddThemeConstantOverride("margin_bottom", DockTheme.CardMargin);
+
+            var panel = new PanelContainer { Name = name + "Card", SizeFlagsHorizontal = Control.SizeFlags.ExpandFill };
+            panel.AddThemeStyleboxOverride("panel", CardStyleBox());
+            margin.AddChild(panel);
+            panel.AddChild(content);
+            return margin;
+        }
+
+        // --- Typography ----------------------------------------------------------------------------------------
+
+        /// <summary>Apply the 20px bold header look to a <see cref="Label"/>.</summary>
+        public static void ApplyHeader(Label label)
+        {
+            label.AddThemeFontSizeOverride("font_size", DockTheme.FontSizeHeader);
+        }
+
+        /// <summary>Apply the 16px bold section-title look to a <see cref="Label"/>.</summary>
+        public static void ApplySectionTitle(Label label)
+        {
+            label.AddThemeFontSizeOverride("font_size", DockTheme.FontSizeSectionTitle);
+        }
+
+        /// <summary>Apply the muted-gray description look to a <see cref="Label"/>.</summary>
+        public static void ApplyDescription(Label label)
+        {
+            label.AddThemeColorOverride("font_color", Rgb(DockTheme.ColorDescriptionMuted));
+            label.AutowrapMode = TextServer.AutowrapMode.WordSmart;
+        }
+
+        /// <summary>Apply the 13px bold sub/timeline label look to a <see cref="Label"/>.</summary>
+        public static void ApplySubLabel(Label label)
+        {
+            label.AddThemeFontSizeOverride("font_size", DockTheme.FontSizeSubLabel);
+        }
+
+        // --- Buttons -------------------------------------------------------------------------------------------
+
+        /// <summary>Skin <paramref name="button"/> as the PRIMARY action (cyan bg, dark text) — e.g. Configure when not configured.</summary>
+        public static void ApplyPrimaryButton(Button button)
+        {
+            var bg = Rgb(DockTheme.ButtonPrimary);
+            ApplyButtonBackground(button, bg, bg.Lightened(0.1f), DockTheme.ButtonSecondaryCornerRadius);
+            button.AddThemeColorOverride("font_color", Rgb(DockTheme.ButtonPrimaryText));
+            button.AddThemeColorOverride("font_hover_color", Rgb(DockTheme.ButtonPrimaryText));
+            button.AddThemeColorOverride("font_pressed_color", Rgb(DockTheme.ButtonPrimaryText));
+        }
+
+        /// <summary>Skin <paramref name="button"/> as a compact SECONDARY action (gray bg, 4px radius, ~20px tall).</summary>
+        public static void ApplySecondaryButton(Button button)
+        {
+            var bg = Rgb(DockTheme.ButtonSecondary);
+            ApplyButtonBackground(button, bg, bg.Lightened(0.1f), DockTheme.ButtonSecondaryCornerRadius);
+            button.CustomMinimumSize = new Vector2(0, DockTheme.ButtonSecondaryHeight);
+        }
+
+        /// <summary>Skin <paramref name="button"/> as an ALERT / Remove action (dark-red bg, brighter red hover).</summary>
+        public static void ApplyAlertButton(Button button)
+        {
+            ApplyButtonBackground(button, Rgb(DockTheme.ButtonAlert), Rgb(DockTheme.ButtonAlertHover), DockTheme.ButtonSecondaryCornerRadius);
+            button.CustomMinimumSize = new Vector2(0, DockTheme.ButtonSecondaryHeight);
+        }
+
+        static void ApplyButtonBackground(Button button, Color normal, Color hover, int cornerRadius)
+        {
+            var normalBox = new StyleBoxFlat { BgColor = normal };
+            normalBox.SetCornerRadiusAll(cornerRadius);
+            normalBox.ContentMarginLeft = 8;
+            normalBox.ContentMarginRight = 8;
+
+            var hoverBox = new StyleBoxFlat { BgColor = hover };
+            hoverBox.SetCornerRadiusAll(cornerRadius);
+            hoverBox.ContentMarginLeft = 8;
+            hoverBox.ContentMarginRight = 8;
+
+            var pressedBox = new StyleBoxFlat { BgColor = normal.Darkened(0.1f) };
+            pressedBox.SetCornerRadiusAll(cornerRadius);
+            pressedBox.ContentMarginLeft = 8;
+            pressedBox.ContentMarginRight = 8;
+
+            button.AddThemeStyleboxOverride("normal", normalBox);
+            button.AddThemeStyleboxOverride("hover", hoverBox);
+            button.AddThemeStyleboxOverride("pressed", pressedBox);
+        }
+
+        // --- Links ---------------------------------------------------------------------------------------------
+
+        /// <summary>
+        /// Build a flat, link-coloured <see cref="Button"/> that opens <paramref name="url"/> via
+        /// <see cref="OS.ShellOpen"/>. Flat (no button chrome) + light-blue text, mimicking an inline hyperlink.
+        /// </summary>
+        public static Button LinkButton(string name, string text, string url)
+        {
+            var button = new Button
+            {
+                Name = name,
+                Text = text,
+                TooltipText = url,
+                Flat = true,
+                MouseDefaultCursorShape = Control.CursorShape.PointingHand
+            };
+            var link = Rgb(DockTheme.Link);
+            button.AddThemeColorOverride("font_color", link);
+            button.AddThemeColorOverride("font_hover_color", link.Lightened(0.2f));
+            button.AddThemeColorOverride("font_pressed_color", link);
+            button.Pressed += () => OS.ShellOpen(url);
+            return button;
+        }
+
+        /// <summary>
+        /// Build a row of link buttons separated by the "•" glyph. <paramref name="links"/> is a list of
+        /// (name, text, url); separators are inserted between them. Returns the row to add into a parent.
+        /// </summary>
+        public static HBoxContainer LinkRow(string name, IReadOnlyList<(string Name, string Text, string Url)> links)
+        {
+            var row = new HBoxContainer { Name = name };
+            row.AddThemeConstantOverride("separation", 0);
+            for (int i = 0; i < links.Count; i++)
+            {
+                if (i > 0)
+                    row.AddChild(new Label { Text = DockTheme.LinkSeparator });
+                row.AddChild(LinkButton(links[i].Name, links[i].Text, links[i].Url));
+            }
+            return row;
+        }
+
+        // --- Alert / warning frame -----------------------------------------------------------------------------
+
+        /// <summary>
+        /// Build a styled warning/alert card holding the <paramref name="message"/> (Unity's warning frame): tinted
+        /// amber bg, amber border, 10px radius; the message text is the warm <see cref="DockTheme.WarningMessage"/>.
+        /// </summary>
+        public static PanelContainer WarningFrame(string message)
+        {
+            var box = new StyleBoxFlat
+            {
+                BgColor = Rgba(DockTheme.WarningBackground),
+                BorderColor = Rgba(DockTheme.WarningBorder)
+            };
+            box.SetCornerRadiusAll(DockTheme.WarningCornerRadius);
+            box.SetBorderWidthAll(1);
+            box.ContentMarginLeft = 8;
+            box.ContentMarginRight = 8;
+            box.ContentMarginTop = 6;
+            box.ContentMarginBottom = 6;
+
+            var panel = new PanelContainer { Name = "WarningFrame", SizeFlagsHorizontal = Control.SizeFlags.ExpandFill };
+            panel.AddThemeStyleboxOverride("panel", box);
+
+            var label = new Label
+            {
+                Name = "WarningMessage",
+                Text = message,
+                AutowrapMode = TextServer.AutowrapMode.WordSmart
+            };
+            label.AddThemeColorOverride("font_color", Rgb(DockTheme.WarningMessage));
+            label.AddThemeFontSizeOverride("font_size", DockTheme.FontSizeWarningMessage);
+            panel.AddChild(label);
+            return panel;
+        }
+
+        // --- Inputs --------------------------------------------------------------------------------------------
+
+        /// <summary>Build the input (LineEdit/OptionButton) normal <see cref="StyleBoxFlat"/>: translucent-black bg, 6px radius, subtle border.</summary>
+        public static StyleBoxFlat InputStyleBox()
+        {
+            var box = new StyleBoxFlat
+            {
+                BgColor = Rgba(DockTheme.InputBackground),
+                BorderColor = Rgba(DockTheme.InputBorder)
+            };
+            box.SetCornerRadiusAll(DockTheme.InputCornerRadius);
+            box.SetBorderWidthAll(1);
+            box.ContentMarginLeft = 6;
+            box.ContentMarginRight = 6;
+            box.ContentMarginTop = 4;
+            box.ContentMarginBottom = 4;
+            return box;
+        }
+
+        /// <summary>Skin a <see cref="LineEdit"/> with the input style.</summary>
+        public static void ApplyInput(LineEdit field)
+        {
+            field.AddThemeStyleboxOverride("normal", InputStyleBox());
+        }
+
+        // --- Divider -------------------------------------------------------------------------------------------
+
+        /// <summary>Build a 1px section divider <see cref="ColorRect"/> in the dark divider colour.</summary>
+        public static ColorRect Divider(string name = "Divider")
+        {
+            return new ColorRect
+            {
+                Name = name,
+                Color = Rgb(DockTheme.Divider),
+                CustomMinimumSize = new Vector2(0, 1),
+                SizeFlagsHorizontal = Control.SizeFlags.ExpandFill
+            };
+        }
+
+        // --- Foldout (collapsible section: a toggle Button + a child VBox shown/hidden) ------------------------
+
+        /// <summary>
+        /// Build a collapsible foldout: a toggle <see cref="Button"/> whose press shows/hides a returned content
+        /// <see cref="VBoxContainer"/>. The Godot analog of Unity's <c>TemplateFoldout</c>. The caller adds
+        /// <paramref name="container"/> (the OUTER VBox holding both the toggle and the content) to its parent, and
+        /// fills <c>content</c> with the foldout's children.
+        /// </summary>
+        public static (VBoxContainer Container, VBoxContainer Content) Foldout(string title, bool startExpanded = false)
+        {
+            var container = new VBoxContainer { Name = title.Replace(" ", string.Empty) + "Foldout" };
+            container.AddThemeConstantOverride("separation", 2);
+
+            var toggle = new Button
+            {
+                Name = "Toggle",
+                ToggleMode = true,
+                ButtonPressed = startExpanded,
+                Flat = true,
+                Alignment = HorizontalAlignment.Left,
+                Text = (startExpanded ? "▾ " : "▸ ") + title
+            };
+            container.AddChild(toggle);
+
+            var content = new VBoxContainer { Name = "Content", Visible = startExpanded };
+            content.AddThemeConstantOverride("separation", 2);
+            container.AddChild(content);
+
+            toggle.Toggled += pressed =>
+            {
+                content.Visible = pressed;
+                toggle.Text = (pressed ? "▾ " : "▸ ") + title;
+            };
+
+            return (container, content);
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/UI/DockTheme.cs
+++ b/addons/godot_mcp/UI/DockTheme.cs
@@ -1,0 +1,157 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+
+namespace com.IvanMurzak.Godot.MCP.UI
+{
+    /// <summary>
+    /// The Godot-MCP dock's PURE-MANAGED design palette — the single source of truth for the colours, corner radii,
+    /// padding, margins, and font sizes the dock's styled "card" sections use. The Godot analog of Unity-MCP's USS
+    /// variables (<c>MainWindow.uss</c> + <c>common/_base.uss</c> / <c>_buttons.uss</c> / <c>_status-indicators.uss</c>
+    /// / <c>_typography.uss</c> / <c>_forms.uss</c> / <c>_foldout.uss</c>), translated into plain RGBA tuples + ints.
+    ///
+    /// <para>
+    /// This file carries NO Godot native types (no <c>Color</c> / <c>StyleBox</c> / <c>Theme</c>) and is OUTSIDE
+    /// <c>#if TOOLS</c>, so the palette numbers are unit-testable in the plain-xUnit host. The editor-only
+    /// <c>DockStyle</c> (<c>#if TOOLS</c>) maps these tuples onto real Godot <c>Color</c> / <c>StyleBoxFlat</c> /
+    /// <c>Theme</c> resources. RGBA components are 0..1 floats (Godot's <c>Color</c> convention); the 8-bit source
+    /// values from the brief / Unity USS are pre-divided here so the editor wiring stays a 1:1 mapping.
+    /// </para>
+    /// </summary>
+    public static class DockTheme
+    {
+        // --- Card / frame-group (Unity .frame-group: dark-blue tint, rounded, padded) -------------------------
+
+        /// <summary>Card background — dark-blue tint <c>rgba(20,40,69, 0.2)</c> (Unity's <c>.frame-group</c> bg).</summary>
+        public static readonly (float R, float G, float B, float A) CardBackground = (20f / 255f, 40f / 255f, 69f / 255f, 0.2f);
+
+        /// <summary>Card corner radius (px).</summary>
+        public const int CardCornerRadius = 16;
+
+        /// <summary>Card inner content padding (px), applied on all four sides.</summary>
+        public const int CardContentPadding = 8;
+
+        /// <summary>Card outer margin (px), applied on all four sides between stacked cards.</summary>
+        public const int CardMargin = 8;
+
+        // --- Typography (Unity _typography.uss) ----------------------------------------------------------------
+
+        /// <summary>Header / window-title font size (px) — bold.</summary>
+        public const int FontSizeHeader = 20;
+
+        /// <summary>Section-title font size (px) — bold.</summary>
+        public const int FontSizeSectionTitle = 16;
+
+        /// <summary>Timeline / sub-label font size (px) — bold.</summary>
+        public const int FontSizeSubLabel = 13;
+
+        /// <summary>Muted gray for section descriptions (Unity's muted description text).</summary>
+        public static readonly (float R, float G, float B) ColorDescriptionMuted = (0.6f, 0.6f, 0.6f);
+
+        // --- Status dot (Unity _status-indicators.uss) ---------------------------------------------------------
+
+        /// <summary>Status-dot diameter (px).</summary>
+        public const int StatusDotSize = 14;
+
+        /// <summary>Online / connected green — <c>Color8(111,226,101)</c>.</summary>
+        public static readonly (float R, float G, float B) StatusOnline = (111f / 255f, 226f / 255f, 101f / 255f);
+
+        /// <summary>Disconnected orange — <c>Color8(220,76,9)</c>.</summary>
+        public static readonly (float R, float G, float B) StatusDisconnected = (220f / 255f, 76f / 255f, 9f / 255f);
+
+        /// <summary>Connecting amber/yellow — used for the mid-handshake state (Unity's "connecting" indicator).</summary>
+        public static readonly (float R, float G, float B) StatusConnecting = (0.92f, 0.74f, 0.20f);
+
+        /// <summary>
+        /// Map the dock's <see cref="ConnectionStatus"/> to a status-dot RGB colour, per the brief's palette:
+        /// online → green, connecting → amber, disconnected → orange. Pure-managed (no Godot types) so the dock's
+        /// status-dot colour rule is unit-testable; the editor maps the returned tuple onto a Godot <c>Color</c>.
+        /// </summary>
+        public static (float R, float G, float B) StatusDotColor(ConnectionStatus status) => status switch
+        {
+            ConnectionStatus.Connected => StatusOnline,
+            ConnectionStatus.Connecting => StatusConnecting,
+            _ => StatusDisconnected
+        };
+
+        // --- Buttons (Unity _buttons.uss) ----------------------------------------------------------------------
+
+        /// <summary>Primary button background — cyan <c>Color8(175,232,230)</c> (dark text on top).</summary>
+        public static readonly (float R, float G, float B) ButtonPrimary = (175f / 255f, 232f / 255f, 230f / 255f);
+
+        /// <summary>Dark text shown on a primary (cyan) button.</summary>
+        public static readonly (float R, float G, float B) ButtonPrimaryText = (0.08f, 0.08f, 0.08f);
+
+        /// <summary>Compact / secondary button background — gray <c>Color8(70,70,70)</c>.</summary>
+        public static readonly (float R, float G, float B) ButtonSecondary = (70f / 255f, 70f / 255f, 70f / 255f);
+
+        /// <summary>Compact / secondary button corner radius (px).</summary>
+        public const int ButtonSecondaryCornerRadius = 4;
+
+        /// <summary>Compact / secondary button height (px).</summary>
+        public const int ButtonSecondaryHeight = 20;
+
+        /// <summary>Alert / Remove button background — dark-red <c>Color8(88,44,44)</c> (hover brightens to red).</summary>
+        public static readonly (float R, float G, float B) ButtonAlert = (88f / 255f, 44f / 255f, 44f / 255f);
+
+        /// <summary>Alert / Remove button hover background — brighter red.</summary>
+        public static readonly (float R, float G, float B) ButtonAlertHover = (140f / 255f, 50f / 255f, 50f / 255f);
+
+        // --- Links (Unity _typography.uss / link style) --------------------------------------------------------
+
+        /// <summary>Link colour — light-blue <c>#4FC3F7</c> / <c>Color8(79,195,247)</c>, shown as flat buttons.</summary>
+        public static readonly (float R, float G, float B) Link = (79f / 255f, 195f / 255f, 247f / 255f);
+
+        /// <summary>The separator glyph placed between multiple links.</summary>
+        public const string LinkSeparator = " • ";
+
+        // --- Alert / warning frame (Unity warning/alert) -------------------------------------------------------
+
+        /// <summary>Warning frame background — <c>rgba(180,120,40, 0.12)</c>.</summary>
+        public static readonly (float R, float G, float B, float A) WarningBackground = (180f / 255f, 120f / 255f, 40f / 255f, 0.12f);
+
+        /// <summary>Warning frame border — <c>rgba(220,160,60, 0.45)</c>.</summary>
+        public static readonly (float R, float G, float B, float A) WarningBorder = (220f / 255f, 160f / 255f, 60f / 255f, 0.45f);
+
+        /// <summary>Warning frame corner radius (px).</summary>
+        public const int WarningCornerRadius = 10;
+
+        /// <summary>Warning title colour — <c>Color8(255,200,100)</c>, 13px bold.</summary>
+        public static readonly (float R, float G, float B) WarningTitle = (255f / 255f, 200f / 255f, 100f / 255f);
+
+        /// <summary>Warning message colour — <c>Color8(210,180,130)</c>, 12px.</summary>
+        public static readonly (float R, float G, float B) WarningMessage = (210f / 255f, 180f / 255f, 130f / 255f);
+
+        /// <summary>Warning message font size (px).</summary>
+        public const int FontSizeWarningMessage = 12;
+
+        /// <summary>Inline warning text colour — <c>#ffbf6b</c>.</summary>
+        public static readonly (float R, float G, float B) WarningText = (0xff / 255f, 0xbf / 255f, 0x6b / 255f);
+
+        /// <summary>Inline alert / error text colour — <c>#FF6B6B</c>.</summary>
+        public static readonly (float R, float G, float B) AlertText = (0xff / 255f, 0x6b / 255f, 0x6b / 255f);
+
+        // --- Inputs (Unity _forms.uss) -------------------------------------------------------------------------
+
+        /// <summary>Input (LineEdit / OptionButton) background — <c>rgba(0,0,0, 0.25)</c>.</summary>
+        public static readonly (float R, float G, float B, float A) InputBackground = (0f, 0f, 0f, 0.25f);
+
+        /// <summary>Input corner radius (px).</summary>
+        public const int InputCornerRadius = 6;
+
+        /// <summary>Input subtle border — <c>rgba(255,255,255, 0.08)</c>.</summary>
+        public static readonly (float R, float G, float B, float A) InputBorder = (1f, 1f, 1f, 0.08f);
+
+        // --- Divider (Unity section separator) -----------------------------------------------------------------
+
+        /// <summary>Divider colour — 1px <c>Color8(26,26,26)</c> separator between sections.</summary>
+        public static readonly (float R, float G, float B) Divider = (26f / 255f, 26f / 255f, 26f / 255f);
+    }
+}

--- a/addons/godot_mcp/UI/FeaturesPanel.cs
+++ b/addons/godot_mcp/UI/FeaturesPanel.cs
@@ -66,7 +66,9 @@ namespace com.IvanMurzak.Godot.MCP.UI
             SizeFlagsHorizontal = SizeFlags.ExpandFill;
             AddThemeConstantOverride("separation", 6);
 
-            AddChild(new Label { Name = "FeaturesHeader", Text = "MCP Features" });
+            var header = new Label { Name = "FeaturesHeader", Text = "MCP Features" };
+            DockStyle.ApplySectionTitle(header);
+            AddChild(header);
 
             _toolsRow = new FeatureRow(GodotMcpFeatureKind.Tools, showTokens: true, OnOpenPressed);
             AddChild(_toolsRow);

--- a/addons/godot_mcp/UI/GodotMcpDock.cs
+++ b/addons/godot_mcp/UI/GodotMcpDock.cs
@@ -82,15 +82,16 @@ namespace com.IvanMurzak.Godot.MCP.UI
             SizeFlagsHorizontal = SizeFlags.ExpandFill;
             SizeFlagsVertical = SizeFlags.ExpandFill;
 
-            // --- Header section ---
+            // --- Header card (title + version + Log Level), wrapped in the styled card chrome. ---
             var header = new VBoxContainer { Name = "Header" };
-            AddChild(header);
+            header.AddThemeConstantOverride("separation", 4);
 
             var title = new Label
             {
                 Name = "Title",
                 Text = DockTitle
             };
+            DockStyle.ApplyHeader(title);
             header.AddChild(title);
 
             var version = new Label
@@ -98,6 +99,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 Name = "Version",
                 Text = $"v{AddonVersion}"
             };
+            DockStyle.ApplyDescription(version);
             header.AddChild(version);
 
             // Log Level selector — routes the reused framework's verbosity (connection / handshake logs) to
@@ -106,11 +108,12 @@ namespace com.IvanMurzak.Godot.MCP.UI
             if (_connection != null)
                 BuildLogLevelRow(header, _connection);
 
-            header.AddChild(new HSeparator { Name = "HeaderSeparator" });
+            AddChild(DockStyle.Card(header, "Header"));
 
             // --- Body ---
             // Hosts the connection section now; later tasks (features list, footer, cloud auth) add their
-            // sections as further children of Body.
+            // sections as further children of Body. Each major section is wrapped in a styled card so the dock
+            // mimics Unity-MCP's MainWindow (dark-blue rounded frame-groups).
             Body = new VBoxContainer
             {
                 Name = "Body",
@@ -122,28 +125,28 @@ namespace com.IvanMurzak.Godot.MCP.UI
             if (_connection != null)
             {
                 _connectionPanel = new ConnectionPanel(_connection);
-                Body.AddChild(_connectionPanel);
+                Body.AddChild(DockStyle.Card(_connectionPanel, "Connection"));
 
                 // MCP-features section — tools/prompts/resources counts + per-item enable/disable windows.
                 // Inserted BETWEEN the connection panel and the support footer, wired to the live connection
                 // (it reads the plugin's managers and subscribes to their update streams). Only meaningful with
                 // a live connection, so it shares the connection-null guard with the connection panel.
                 _featuresPanel = new FeaturesPanel(_connection);
-                Body.AddChild(_featuresPanel);
+                Body.AddChild(DockStyle.Card(_featuresPanel, "Features"));
 
-                // AI-agent section — the dropdown of AI-agent configurators + the selected agent's HTTP-config
-                // snippet / Configure / Remove. Inserted BETWEEN the features panel and the support footer, wired
-                // to the live connection (it reads the resolved MCP-client URL + token off the config and persists
-                // the selected agent via Save). Only meaningful with a live connection, so it shares the
-                // connection-null guard with the connection + features panels.
+                // AI-agent section — the dropdown of AI-agent configurators + the selected agent's Configure /
+                // Remove (or, for Custom, the HTTP-config snippet). Inserted BETWEEN the features panel and the
+                // support footer, wired to the live connection (it reads the resolved MCP-client URL + token off
+                // the config and persists the selected agent via Save). Only meaningful with a live connection,
+                // so it shares the connection-null guard with the connection + features panels.
                 _agentConfiguratorsPanel = new AgentConfiguratorsPanel(_connection);
-                Body.AddChild(_agentConfiguratorsPanel);
+                Body.AddChild(DockStyle.Card(_agentConfiguratorsPanel, "AiAgent"));
             }
 
             // Support/footer section — static links + thanks, appended BELOW the connection panel. It holds
             // no live state / subscriptions, so it builds unconditionally (independent of the connection).
             _supportFooter = new SupportFooter();
-            Body.AddChild(_supportFooter);
+            Body.AddChild(DockStyle.Card(_supportFooter, "Footer"));
         }
 
         /// <summary>

--- a/addons/godot_mcp/UI/SupportFooter.cs
+++ b/addons/godot_mcp/UI/SupportFooter.cs
@@ -46,21 +46,21 @@ namespace com.IvanMurzak.Godot.MCP.UI
             SizeFlagsHorizontal = SizeFlags.ExpandFill;
             AddThemeConstantOverride("separation", 4);
 
-            AddChild(new HSeparator { Name = "FooterSeparator" });
-
-            AddChild(new Label
+            var prompt = new Label
             {
                 Name = "Prompt",
                 Text = SupportFooterLinks.PromptText
-            });
+            };
+            DockStyle.ApplyDescription(prompt);
+            AddChild(prompt);
 
-            // --- Support links: open externally; no live state. ---
-            var links = new HBoxContainer { Name = "Links" };
-            AddChild(links);
-
-            links.AddChild(MakeLinkButton("Discord", "Help / Talk", SupportFooterLinks.DiscordUrl));
-            links.AddChild(MakeLinkButton("Issues", "Bug Report", SupportFooterLinks.IssuesUrl));
-            links.AddChild(MakeLinkButton("Star", "Star", SupportFooterLinks.RepositoryUrl));
+            // --- Support links: open externally; no live state. Styled as flat link buttons separated by "•". ---
+            AddChild(DockStyle.LinkRow("Links", new System.Collections.Generic.List<(string, string, string)>
+            {
+                ("Discord", "Help / Talk", SupportFooterLinks.DiscordUrl),
+                ("Issues", "Bug Report", SupportFooterLinks.IssuesUrl),
+                ("Star", "Star", SupportFooterLinks.RepositoryUrl),
+            }));
 
             // --- Thanks line (RichTextLabel so the product name can be emphasised). ---
             var thanks = new RichTextLabel
@@ -72,22 +72,6 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 Text = $"[i]{SupportFooterLinks.ThanksText}[/i]"
             };
             AddChild(thanks);
-        }
-
-        /// <summary>
-        /// Build a button that opens <paramref name="url"/> in the user's default handler. <see cref="OS.ShellOpen"/>
-        /// is the Godot way to hand a URL/path to the OS (browser for http/https).
-        /// </summary>
-        static Button MakeLinkButton(string name, string text, string url)
-        {
-            var button = new Button
-            {
-                Name = name,
-                Text = text,
-                TooltipText = url
-            };
-            button.Pressed += () => OS.ShellOpen(url);
-            return button;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Restyle the AI Game Developer dock to mimic Unity-MCP's MainWindow: a shared styling layer (pure-managed `DockTheme` palette + `#if TOOLS` `DockStyle` StyleBox/card/warning/foldout/link/button builders) wraps each section (header, connection, features, AI-agent, footer) in a dark-blue rounded card, with styled status dot, inputs, links, and dividers.
- Give each AI-agent configurator its own helpful info (parity with Unity): new `Description`/`WarningText`/`ManualSteps`/`Troubleshooting` virtuals on `GodotAgentConfigurator`, overridden in all 5 agents (text ported from the Unity `Impl/*Configurator.OnUICreated`, reworded Unity→Godot, HTTP-only).
- KEY change: agents WITH a config-file path (Claude Code/Desktop, Cursor, VS Code) now show a one-click **Configure/Reconfigure + Remove** row with a Configured/Not-configured status — NOT raw JSON. Only Custom keeps the copyable masked JSON snippet. Decision driven by the pure-managed `GodotAgentConfigurator.ShouldShowJson(path)` predicate.
- Security unchanged: token masked on screen, never logged; the real token still flows into the written config file via Configure.

## Test plan
- [x] Suite 1 — `dotnet build` 0-error / 0-warning.
- [x] Suite 2 — `dotnet test` 448 passed (was 436; +12 for help metadata, `ShouldShowJson`, `DockTheme` palette).
- [x] Suite 3 — headless Godot 4.5.1 smoke: `[Godot-MCP] plugin loaded`, all deps resolved (pins 6.7.0 / 5.3.1), config loaded, styled dock + AI-agent Config/Remove panel build with NO UI errors (the only stderr is connection-refused teardown noise from the connection layer, which is out of scope).
- NuGet pins untouched (6.7.0 / 5.3.1). Changes scoped to `UI/` + `Godot-MCP.Tests/` only.

Closes #47