### PR TITLE
feat(tools): assign Resource properties by ref via node-modify (#46)

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -40,6 +40,11 @@
     <Compile Include="..\addons\godot_mcp\Reflection\GodotStructReflectionConverters.cs" Link="Source\GodotStructReflectionConverters.cs" />
     <Compile Include="..\addons\godot_mcp\Reflection\GodotNodePathJsonConverter.cs" Link="Source\GodotNodePathJsonConverter.cs" />
     <Compile Include="..\addons\godot_mcp\Reflection\GodotReflectorFactory.cs" Link="Source\GodotReflectorFactory.cs" />
+    <!-- Resource reference converter — pure-managed (matches Godot.Resource + derived types by inheritance
+         distance; (de)serializes the ResourceRef shape). The native ResourceLoader.Load resolution is
+         injected under #if TOOLS (Tool_Resource.ReflectionResolver.cs, verified via the Suite-3 smoke); the
+         type-matching + ref shaping are unit-tested here. -->
+    <Compile Include="..\addons\godot_mcp\Reflection\Godot_Resource_ReflectionConverter.cs" Link="Source\Godot_Resource_ReflectionConverter.cs" />
     <!-- Connection config + ping tool are pure-managed (no Godot native types / no #if TOOLS), so they
          compile and run in this plain-xUnit host. GodotMcpConnection.cs is editor-only (#if TOOLS) and
          instantiates the SignalR client; it is verified via the headless Godot smoke, not here. -->

--- a/Godot-MCP.Tests/ResourceConverterTests.cs
+++ b/Godot-MCP.Tests/ResourceConverterTests.cs
@@ -1,0 +1,169 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Text.Json;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.Godot.MCP.Reflection;
+using com.IvanMurzak.ReflectorNet;
+using com.IvanMurzak.ReflectorNet.Model;
+using Godot;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Coverage for <see cref="Godot_Resource_ReflectionConverter"/>. These exercise only the pure-managed
+    /// surface — type matching (by inheritance distance over <see cref="Type"/> tokens) and deserialization
+    /// of the <see cref="ResourceRef"/> shape. Constructing a native Godot <c>Resource</c>/<c>Mesh</c> would
+    /// fault the test host (P/Invoke with no Godot runtime), so the live <c>ResourceLoader.Load</c> path and
+    /// the serialize-from-live-resource path are verified by the headless Godot smoke (test.md Suite 3), not
+    /// here. <c>typeof(BoxMesh)</c> etc. are safe — a Type token triggers no native call.
+    /// </summary>
+    public class ResourceConverterTests
+    {
+        static Reflector NewReflector() => GodotReflectorFactory.CreateDefaultReflector();
+
+        // The converter's SerializationPriority scores by inheritance distance from Godot.Resource, so it must
+        // produce a positive score for the exact Resource type AND every Resource-derived type. A non-Resource
+        // type must score 0 (cannot handle).
+        [Theory]
+        [InlineData(typeof(Resource))]
+        [InlineData(typeof(Mesh))]
+        [InlineData(typeof(BoxMesh))]
+        [InlineData(typeof(Material))]
+        [InlineData(typeof(Texture2D))]
+        [InlineData(typeof(PackedScene))]
+        public void Converter_Matches_ResourceAndDerivedTypes(System.Type type)
+        {
+            var converter = new Godot_Resource_ReflectionConverter();
+            Assert.True(converter.SerializationPriority(type) > 0,
+                $"Expected the Resource converter to match '{type.Name}'.");
+        }
+
+        [Theory]
+        [InlineData(typeof(Vector3))]
+        [InlineData(typeof(Color))]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(int))]
+        public void Converter_DoesNotMatch_NonResourceTypes(System.Type type)
+        {
+            var converter = new Godot_Resource_ReflectionConverter();
+            Assert.Equal(0, converter.SerializationPriority(type));
+        }
+
+        // The exact Resource type must outscore a derived type, so a more-specific converter (if ever added)
+        // can win by exact match while this one still covers the whole subtree.
+        [Fact]
+        public void Converter_ExactResource_OutscoresDerived()
+        {
+            var converter = new Godot_Resource_ReflectionConverter();
+            Assert.True(converter.SerializationPriority(typeof(Resource)) >
+                        converter.SerializationPriority(typeof(BoxMesh)));
+        }
+
+        // The registered reflector must actually pick THIS converter for a Resource-derived type — proving the
+        // registration in GodotReflectorFactory routes Mesh/BoxMesh through the reference converter instead of
+        // the generic instantiate-and-populate fallback that fails with "Instance creation failed".
+        [Theory]
+        [InlineData(typeof(Resource))]
+        [InlineData(typeof(BoxMesh))]
+        [InlineData(typeof(Material))]
+        public void Reflector_SelectsResourceConverter_ForResourceTypes(System.Type type)
+        {
+            var reflector = NewReflector();
+            var converter = reflector.Converters.GetConverter(type);
+            Assert.IsType<Godot_Resource_ReflectionConverter>(converter);
+        }
+
+        // A null/absent value clears the property (assign null) without throwing.
+        [Fact]
+        public void Deserialize_NullValue_ReturnsNull()
+        {
+            var reflector = NewReflector();
+            var data = new SerializedMember { typeName = typeof(BoxMesh).GetTypeId() };
+            var result = reflector.Deserialize(data, fallbackType: typeof(BoxMesh));
+            Assert.Null(result);
+        }
+
+        // An empty ref ({} with neither resourcePath nor instanceId) also clears the property.
+        [Fact]
+        public void Deserialize_EmptyRef_ReturnsNull()
+        {
+            var reflector = NewReflector();
+            var emptyRefJson = JsonSerializer.SerializeToElement(new ResourceRef());
+            var data = SerializedMember.FromJson(typeof(BoxMesh), emptyRefJson);
+            var result = reflector.Deserialize(data, fallbackType: typeof(BoxMesh));
+            Assert.Null(result);
+        }
+
+        // With NO resolver installed (the plain unit-test host), a non-empty ref does not throw — it degrades
+        // to null. The live resolution is wired only under #if TOOLS and verified by the Suite-3 smoke.
+        [Fact]
+        public void Deserialize_NonEmptyRef_NoResolver_ReturnsNullWithoutThrowing()
+        {
+            // Ensure no resolver leaks in from another test.
+            Godot_Resource_ReflectionConverter.ResourceResolver = null;
+
+            var reflector = NewReflector();
+            var refJson = JsonSerializer.SerializeToElement(new ResourceRef("res://box_mesh.tres"));
+            var data = SerializedMember.FromJson(typeof(BoxMesh), refJson);
+
+            var logs = new Logs();
+            var result = reflector.Deserialize(data, fallbackType: typeof(BoxMesh), logs: logs);
+            Assert.Null(result);
+        }
+
+        // With a resolver installed, a non-empty ref is handed to it and its result is returned. We stand in a
+        // plain object for the "live resource" and pass typeof(object) as the target type so the converter's
+        // assignability guard (targetType.IsInstanceOfType(resolved)) passes — this exercises the resolver
+        // wiring end-to-end with NO native Godot type. The static delegate is shared across the converter's
+        // closed generic types, so setting it on the base entry reaches the instance under test.
+        [Fact]
+        public void Deserialize_NonEmptyRef_WithResolver_ReturnsResolved()
+        {
+            ResourceRef? seenRef = null;
+            var standIn = new object();
+            Godot_Resource_ReflectionConverter.ResourceResolver = (ResourceRef r, out object? res, out string? err) =>
+            {
+                seenRef = r;
+                res = standIn;
+                err = null;
+                return true;
+            };
+            try
+            {
+                var converter = new Godot_Resource_ReflectionConverter();
+                var reflector = NewReflector();
+                var refJson = JsonSerializer.SerializeToElement(new ResourceRef("res://wood.tres"));
+                var data = SerializedMember.FromJson(typeof(object), refJson);
+
+                // typeof(object) as the target makes the assignability guard accept the plain stand-in.
+                var result = converter.Deserialize(reflector, data, fallbackType: typeof(object));
+
+                Assert.Same(standIn, result);
+                Assert.NotNull(seenRef);
+                Assert.Equal("res://wood.tres", seenRef!.ResourcePath);
+            }
+            finally
+            {
+                Godot_Resource_ReflectionConverter.ResourceResolver = null;
+            }
+        }
+
+        // ToResourceRef on a null resource yields an empty (invalid) ref — the pure-managed slice of the
+        // serialize side (the live-resource branch needs a native Resource → Suite 3).
+        [Fact]
+        public void ToResourceRef_Null_YieldsEmptyRef()
+        {
+            var resourceRef = Godot_Resource_ReflectionConverter<Resource>.ToResourceRef(null);
+            Assert.False(resourceRef.IsValid());
+        }
+    }
+}

--- a/Godot-MCP.Tests/ResourceFsToolTests.cs
+++ b/Godot-MCP.Tests/ResourceFsToolTests.cs
@@ -227,6 +227,26 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.DoesNotContain("not a directory", ex.Message);
         }
 
+        // ---- ResPathNormalizer.ParentDir (mkdir-parents derivation) ------------------------------
+
+        [Theory]
+        [InlineData("res://scenes/level.tscn", "res://scenes/")]
+        [InlineData("res://a/b/c.tres", "res://a/b/")]
+        [InlineData("res://thing.tres", "res://")] // file directly under the project root
+        [InlineData("  res://scenes/level.tscn  ", "res://scenes/")] // trims
+        public void ParentDir_DerivesParentDirectory(string filePath, string expected)
+        {
+            Assert.Equal(expected, ResPathNormalizer.ParentDir(filePath));
+        }
+
+        [Fact]
+        public void ParentDir_Rejects_NonResAndDirectory()
+        {
+            Assert.Throws<ArgumentException>(() => ResPathNormalizer.ParentDir("/abs/level.tscn"));
+            Assert.Throws<ArgumentException>(() => ResPathNormalizer.ParentDir("res://scenes/")); // a dir, not a file
+            Assert.Throws<ArgumentException>(() => ResPathNormalizer.ParentDir(null));
+        }
+
         [Fact]
         public void RequireResFilePath_Rejects_ParentTraversalSegment()
         {

--- a/Godot-MCP.Tests/SceneNodeToolTests.cs
+++ b/Godot-MCP.Tests/SceneNodeToolTests.cs
@@ -142,6 +142,39 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Equal("position/[0]", restored!.Path);
         }
 
+        // ---- NodePropertyPatch.IsStructuralNoOp (no-op warning detection) ------------------------
+
+        [Fact]
+        public void IsStructuralNoOp_NullValue_IsNoOp()
+        {
+            Assert.True(NodePropertyPatch.IsStructuralNoOp(null));
+        }
+
+        [Fact]
+        public void IsStructuralNoOp_TypeNameOnly_IsNoOp()
+        {
+            // A '{typeName}'-only entry (no value, no fields, no props) cannot change anything.
+            var value = new ReflectorNet.Model.SerializedMember { typeName = "Godot.BoxMesh" };
+            Assert.True(NodePropertyPatch.IsStructuralNoOp(value));
+        }
+
+        [Fact]
+        public void IsStructuralNoOp_WithValue_IsNotNoOp()
+        {
+            var reflector = GodotReflectorFactory.CreateDefaultReflector();
+            var value = ReflectorNet.Model.SerializedMember.FromValue(reflector, typeof(int), 42, name: "n");
+            Assert.False(NodePropertyPatch.IsStructuralNoOp(value));
+        }
+
+        [Fact]
+        public void IsStructuralNoOp_WithFields_IsNotNoOp()
+        {
+            var reflector = GodotReflectorFactory.CreateDefaultReflector();
+            var value = new ReflectorNet.Model.SerializedMember { typeName = "Some.Type" }
+                .AddField(ReflectorNet.Model.SerializedMember.FromValue(reflector, typeof(int), 1, name: "x"));
+            Assert.False(NodePropertyPatch.IsStructuralNoOp(value));
+        }
+
         // ---- NodePathNormalizer ------------------------------------------------------------------
 
         [Theory]

--- a/addons/godot_mcp/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConnection.cs
@@ -188,6 +188,11 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
             Reflector reflector = GodotReflectorFactory.CreateDefaultReflector();
 
+            // Wire the editor-side ResourceLoader.Load resolution into the (pure-managed) Resource
+            // reflection converter so node-modify can assign a Resource-typed property by ref (res:// path /
+            // instance id). The converter lives outside #if TOOLS; this installs the native resolver.
+            Tools.Tool_Resource.InstallReflectionResolver();
+
             // Publish the connection's reflector as the ambient one so tool handlers (e.g. node-modify)
             // share the exact converter set registered here instead of building their own.
             GodotMcpReflector.Current = reflector;

--- a/addons/godot_mcp/Data/NodePropertyPatch.cs
+++ b/addons/godot_mcp/Data/NodePropertyPatch.cs
@@ -38,5 +38,24 @@ namespace com.IvanMurzak.Godot.MCP.Data
         public SerializedMember? Value { get; set; } = null;
 
         public NodePropertyPatch() { }
+
+        /// <summary>
+        /// True when <paramref name="value"/> carries nothing the modifier could apply — no
+        /// <c>value</c> JSON, no <c>fields</c>, and no <c>props</c> (e.g. a <c>{typeName}</c>-only entry).
+        /// Such a patch is a guaranteed no-op: it would silently change nothing. <c>node-modify</c> uses this
+        /// to emit a WARNING naming the path rather than letting the no-op pass unremarked. Pure-managed (no
+        /// Godot API), so it is unit-testable. A <c>null</c> value also counts as a no-op.
+        /// </summary>
+        public static bool IsStructuralNoOp(SerializedMember? value)
+        {
+            if (value == null)
+                return true;
+
+            var hasValue = value.valueJsonElement.HasValue;
+            var hasFields = value.fields != null && value.fields.Count > 0;
+            var hasProps = value.props != null && value.props.Count > 0;
+
+            return !hasValue && !hasFields && !hasProps;
+        }
     }
 }

--- a/addons/godot_mcp/Reflection/GodotReflectorFactory.cs
+++ b/addons/godot_mcp/Reflection/GodotReflectorFactory.cs
@@ -45,6 +45,13 @@ namespace com.IvanMurzak.Godot.MCP.Reflection
             reflector.Converters.Add(new Godot_Vector3_ReflectionConverter());
             reflector.Converters.Add(new Godot_Color_ReflectionConverter());
 
+            // Resource reference converter — matches Godot.Resource and EVERY Resource-derived type
+            // (Mesh/Material/Texture2D/…) by inheritance distance, so a Resource-typed member is assigned
+            // by reference (res:// path / instance id) instead of falling back to instantiate-and-populate
+            // (which fails: "Instance creation failed for Godot.BoxMesh"). The live ResourceLoader.Load
+            // resolution is injected under #if TOOLS; see Godot_Resource_ReflectionConverter.ResourceResolver.
+            reflector.Converters.Add(new Godot_Resource_ReflectionConverter());
+
             // JSON converters — types best described as a single scalar (NodePath as its string form).
             reflector.JsonSerializer.AddConverter(new GodotNodePathJsonConverter());
         }

--- a/addons/godot_mcp/Reflection/Godot_Resource_ReflectionConverter.cs
+++ b/addons/godot_mcp/Reflection/Godot_Resource_ReflectionConverter.cs
@@ -1,0 +1,210 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Reflection;
+using System.Text.Json;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.ReflectorNet;
+using com.IvanMurzak.ReflectorNet.Converter;
+using com.IvanMurzak.ReflectorNet.Model;
+using com.IvanMurzak.ReflectorNet.Utils;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+
+namespace com.IvanMurzak.Godot.MCP.Reflection
+{
+    /// <summary>
+    /// ReflectorNet converter for Godot <see cref="global::Godot.Resource"/> (and every <c>Resource</c>-derived
+    /// type — <c>Mesh</c>/<c>BoxMesh</c>/<c>Material</c>/<c>Texture2D</c>/…). The Godot analog of Unity-MCP's
+    /// <c>UnityEngine_Object_ReflectionConverter</c>: a Resource crosses the MCP boundary as a lightweight
+    /// REFERENCE (<see cref="ResourceRef"/> — a <c>res://</c> path or a loaded instance id), never a deep
+    /// serialization of the resource graph.
+    ///
+    /// <para>
+    /// Why this exists: without it, <c>Reflector.TryModify</c> falls back to instantiate-and-populate when
+    /// asked to set a <c>Resource</c>-typed member (e.g. <c>MeshInstance3D.Mesh</c>), which fails with
+    /// <c>Instance creation failed for Godot.BoxMesh</c> because Godot resources are not constructed that way.
+    /// Routing through this converter resolves the ref to the LIVE on-disk asset instead.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Type matching (derived types):</b> <see cref="BaseReflectionConverter{T}.SerializationPriority"/>
+    /// scores by inheritance distance from <c>T = Godot.Resource</c>, so this converter matches the exact
+    /// <c>Resource</c> type (highest) AND every subclass (a positive, distance-decayed score). A more specific
+    /// converter for a concrete subtype, if ever registered, still wins by exact-match priority.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>#if TOOLS split:</b> this type is pure-managed (it touches only a <see cref="Type"/> token for
+    /// matching and a <see cref="ResourceRef"/> data model). The actual <c>ResourceLoader.Load</c> /
+    /// <c>InstanceFromId</c> resolution — a native Godot call that must run on the editor main thread — is
+    /// injected via <see cref="ResourceResolver"/> by the editor boot (<c>#if TOOLS</c>). So the converter
+    /// registers + matches + (de)serializes the ref shape under CI with no Godot binary, while the live
+    /// resolution is exercised by the headless Godot smoke. When no resolver is installed (a plain unit run),
+    /// deserialization of a non-empty ref yields <c>null</c> with a logged note rather than throwing.
+    /// </para>
+    /// </summary>
+    public class Godot_Resource_ReflectionConverter : Godot_Resource_ReflectionConverter<global::Godot.Resource> { }
+
+    public class Godot_Resource_ReflectionConverter<T> : GenericReflectionConverter<T>
+        where T : global::Godot.GodotObject
+    {
+        /// <summary>
+        /// Resolves a <see cref="ResourceRef"/> to a live Godot <see cref="global::Godot.Resource"/> on the
+        /// editor main thread (via <c>ResourceLoader.Load</c> / <c>GodotObject.InstanceFromId</c>). Installed
+        /// by the editor boot under <c>#if TOOLS</c> (see <c>Tool_Resource.InstallReflectionResolver</c>). When
+        /// <c>null</c> (a plain unit-test host with no Godot runtime), <see cref="Deserialize"/> of a non-empty
+        /// ref returns <c>null</c> with a logged note instead of throwing.
+        /// </summary>
+        public static ResourceResolverDelegate? ResourceResolver { get; set; }
+
+        /// <param name="resourceRef">The reference to resolve (already validated as non-empty).</param>
+        /// <param name="resource">The resolved live resource on success; otherwise <c>null</c>.</param>
+        /// <param name="error">A human-readable failure reason when resolution fails; otherwise <c>null</c>.</param>
+        /// <returns><c>true</c> when a live resource was resolved; otherwise <c>false</c>.</returns>
+        public delegate bool ResourceResolverDelegate(ResourceRef resourceRef, out object? resource, out string? error);
+
+        // A Resource reference is a leaf — there is no nested object graph to descend into on the wire.
+        // Turning cascade off routes deserialization of the value through DeserializeValueAsJsonElement (which
+        // we override) instead of the field/property structural walk, matching how the ref is serialized.
+        public override bool AllowCascadeSerialization => false;
+        public override bool AllowSetValue => true;
+
+        // Treat a Resource-ref JSON node (e.g. {"resourcePath":"res://…"}) as atomic on the merge-patch
+        // (Reflector.TryPatch) path so it routes through SetValue/Deserialize and resolves to the live
+        // Resource, instead of being structurally descended key-by-key. Mirrors Unity-MCP's
+        // UnityEngine_Object_ReflectionConverter.TreatJsonObjectAsAtomicValue => true.
+        public override bool TreatJsonObjectAsAtomicValue(Type type) => true;
+
+        public override object? Deserialize(
+            Reflector reflector,
+            SerializedMember data,
+            Type? fallbackType = null,
+            string? fallbackName = null,
+            int depth = 0,
+            Logs? logs = null,
+            ILogger? logger = null,
+            DeserializationContext? context = null)
+        {
+            var targetType = fallbackType ?? typeof(T);
+            return ResolveFromJson(reflector, data.valueJsonElement, targetType, depth, logs);
+        }
+
+        protected override object? DeserializeValueAsJsonElement(
+            Reflector reflector,
+            SerializedMember data,
+            Type type,
+            int depth = 0,
+            Logs? logs = null,
+            ILogger? logger = null)
+        {
+            return ResolveFromJson(reflector, data.valueJsonElement, type, depth, logs);
+        }
+
+        /// <summary>
+        /// Map a <see cref="ResourceRef"/>-shaped JSON value to a live resource. A <c>null</c>/absent value or
+        /// an empty ref resolves to <c>null</c> (clearing the property — never throws). A non-empty ref is
+        /// handed to the injected <see cref="ResourceResolver"/>; with no resolver installed it returns
+        /// <c>null</c> with a logged note so a plain unit-test host degrades gracefully.
+        /// </summary>
+        object? ResolveFromJson(Reflector reflector, JsonElement? valueJsonElement, Type targetType, int depth, Logs? logs)
+        {
+            // No value (or explicit JSON null) => assign null, clearing the property.
+            if (valueJsonElement == null || valueJsonElement.Value.ValueKind == JsonValueKind.Null)
+                return null;
+
+            ResourceRef? resourceRef;
+            try
+            {
+                resourceRef = reflector.JsonSerializer.Deserialize<ResourceRef>(valueJsonElement.Value);
+            }
+            catch (Exception ex)
+            {
+                logs?.Error($"Failed to read a ResourceRef for '{targetType.GetTypeShortName()}': {ex.Message}", depth);
+                return null;
+            }
+
+            // An empty/absent ref clears the property (assign null) rather than failing.
+            if (resourceRef == null || !resourceRef.IsValid())
+                return null;
+
+            var resolver = ResourceResolver;
+            if (resolver == null)
+            {
+                // Pure-managed host (no Godot runtime): the live ResourceLoader.Load path is unavailable.
+                logs?.Warning(
+                    $"No ResourceResolver is installed; cannot resolve {resourceRef} to a live Resource " +
+                    $"for '{targetType.GetTypeShortName()}' (this is expected outside the editor).", depth);
+                return null;
+            }
+
+            if (!resolver(resourceRef, out var resolved, out var error))
+            {
+                logs?.Error($"Could not resolve {resourceRef}: {error ?? "unknown error"}.", depth);
+                return null;
+            }
+
+            if (resolved == null)
+                return null;
+
+            // Guard the inheritance: a res:// path could load a resource of an unrelated type.
+            if (!targetType.IsInstanceOfType(resolved))
+            {
+                logs?.Error(
+                    $"Resolved {resourceRef} to a '{resolved.GetType().GetTypeShortName()}', which is not " +
+                    $"assignable to '{targetType.GetTypeShortName()}'.", depth);
+                return null;
+            }
+
+            logs?.Success($"Resolved {resourceRef} to a live '{targetType.GetTypeShortName()}'.", depth);
+            return resolved;
+        }
+
+        protected override SerializedMember InternalSerialize(
+            Reflector reflector,
+            object? obj,
+            Type type,
+            string? name = null,
+            bool recursive = true,
+            BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            int depth = 0,
+            Logs? logs = null,
+            ILogger? logger = null,
+            SerializationContext? context = null)
+        {
+            if (obj == null)
+                return SerializedMember.Null(type, name);
+
+            // A Resource is described on the wire by a ResourceRef (res:// path preferred, else its loaded
+            // instance id) — never a deep serialization of the resource graph. Reading ResourcePath /
+            // GetInstanceId is a native Godot call, so this branch only runs against a real Resource at
+            // editor runtime; the pure-managed ResourceRef shaping is unit-tested via ToResourceRef below.
+            var resourceRef = ToResourceRef(obj as global::Godot.Resource);
+            return SerializedMember.FromValue(reflector, type, resourceRef, name);
+        }
+
+        /// <summary>
+        /// Build the wire <see cref="ResourceRef"/> for a live resource: its <c>res://</c> path when it has
+        /// one (the stable identity of an on-disk asset), else its loaded instance id. A <c>null</c> resource
+        /// maps to an empty ref. Reads native Godot members, so it runs only at editor runtime.
+        /// </summary>
+        public static ResourceRef ToResourceRef(global::Godot.Resource? resource)
+        {
+            if (resource == null)
+                return new ResourceRef();
+
+            var path = resource.ResourcePath;
+            if (!string.IsNullOrEmpty(path))
+                return new ResourceRef(path);
+
+            return new ResourceRef(resource.GetInstanceId());
+        }
+    }
+}

--- a/addons/godot_mcp/Tools/ResPathNormalizer.cs
+++ b/addons/godot_mcp/Tools/ResPathNormalizer.cs
@@ -80,6 +80,29 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             => !string.IsNullOrEmpty(path) && path!.StartsWith(ResScheme, StringComparison.Ordinal);
 
         /// <summary>
+        /// Derive the parent directory (trailing-slash form) of a <c>res://</c> file path. For
+        /// <c>res://scenes/level.tscn</c> this returns <c>res://scenes/</c>; for a file directly under the
+        /// project root (<c>res://thing.tres</c>) it returns the bare scheme <c>res://</c>. Pure string logic
+        /// (no Godot API) so the slash math is unit-testable; the editor handlers pass the result to
+        /// <c>DirAccess.MakeDirRecursiveAbsolute</c> before saving so a nested target dir is created instead
+        /// of failing with <c>CantOpen</c>. Throws for a non-<c>res://</c> or directory path.
+        /// </summary>
+        public static string ParentDir(string? filePath)
+        {
+            var p = (filePath ?? string.Empty).Trim();
+            if (!IsResPath(p))
+                throw new ArgumentException($"Path must be a '{ResScheme}' path; got '{filePath}'.", nameof(filePath));
+            if (p.EndsWith("/", StringComparison.Ordinal))
+                throw new ArgumentException($"Path must be a file path, not a directory; got '{filePath}'.", nameof(filePath));
+
+            // The last '/' lies at or after the scheme's own slashes ("res://" ends at index 5), so the
+            // substring up to and including it is the parent dir in trailing-slash form. A file directly under
+            // the root has its last '/' inside the scheme, so this yields the bare scheme 'res://'.
+            var lastSlash = p.LastIndexOf('/');
+            return p.Substring(0, lastSlash + 1);
+        }
+
+        /// <summary>
         /// Validate that <paramref name="path"/> is a <c>res://</c> file path, throwing
         /// <see cref="ArgumentException"/> (with <paramref name="paramName"/>) otherwise. Returns the
         /// trimmed path on success.

--- a/addons/godot_mcp/Tools/Tool_Node.Modify.cs
+++ b/addons/godot_mcp/Tools/Tool_Node.Modify.cs
@@ -111,10 +111,28 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                             logs.Error($"{nameof(pathPatches)}[{i}] ('{patch.Path}') with null value skipped.");
                             continue;
                         }
+                        // A value carrying nothing settable (no 'value', no 'fields', no 'props' — e.g. a
+                        // '{typeName}'-only entry) cannot change anything. Warn naming the path instead of
+                        // letting the no-op pass silently, then skip it.
+                        if (NodePropertyPatch.IsStructuralNoOp(patch.Value))
+                        {
+                            logs.Warning($"{nameof(pathPatches)}[{i}] ('{patch.Path}') has no value/fields/props " +
+                                "to apply — nothing to set; skipped (no-op).");
+                            continue;
+                        }
                         try
                         {
                             if (reflector.TryModifyAt(ref objToModify, patch.Path, patch.Value, logs: logs))
+                            {
                                 anyChange = true;
+                            }
+                            else
+                            {
+                                // TryModifyAt accumulates its own errors into 'logs', but a plain false can
+                                // also mean the patch resolved to a no-op (e.g. an unresolved path or a value
+                                // that changed nothing). Surface a path-named warning so the no-op is visible.
+                                logs.Warning($"{nameof(pathPatches)}[{i}] ('{patch.Path}') did not modify the Node (no-op).");
+                            }
                         }
                         catch (Exception ex)
                         {

--- a/addons/godot_mcp/Tools/Tool_Resource.Create.cs
+++ b/addons/godot_mcp/Tools/Tool_Resource.Create.cs
@@ -72,7 +72,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
 
                 // ResourceSaver.Save does NOT create missing parent directories — create them first so a
                 // nested target path (e.g. 'res://materials/wood.tres') works like Unity's CreateAsset.
-                var targetDir = resPath.Substring(0, resPath.LastIndexOf('/') + 1);
+                var targetDir = ResPathNormalizer.ParentDir(resPath);
                 if (!DirAccess.DirExistsAbsolute(targetDir))
                 {
                     var mkErr = DirAccess.MakeDirRecursiveAbsolute(targetDir);

--- a/addons/godot_mcp/Tools/Tool_Resource.ReflectionResolver.cs
+++ b/addons/godot_mcp/Tools/Tool_Resource.ReflectionResolver.cs
@@ -1,0 +1,42 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.Godot.MCP.Reflection;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Resource
+    {
+        /// <summary>
+        /// Wire the editor-side resource resolution into <see cref="Godot_Resource_ReflectionConverter{T}"/>
+        /// so that converter — which is pure-managed and lives outside <c>#if TOOLS</c> — can turn a
+        /// <see cref="ResourceRef"/> into a LIVE <see cref="Resource"/> when <c>node-modify</c> assigns a
+        /// <c>Resource</c>-typed property. The load itself (<see cref="ResolveResource"/> →
+        /// <c>ResourceLoader.Load</c> / <c>InstanceFromId</c>) is a native Godot call; the converter is only
+        /// ever invoked from inside a tool's <c>MainThread.Instance.Run</c> (e.g. <c>node-modify</c>), so the
+        /// delegate runs on the editor main thread without an extra marshal. Called once from
+        /// <c>GodotMcpConnection.Start</c> after the reflector is built; idempotent (re-assigns the same
+        /// delegate).
+        /// </summary>
+        internal static void InstallReflectionResolver()
+        {
+            Godot_Resource_ReflectionConverter.ResourceResolver = static (ResourceRef resourceRef, out object? resource, out string? error) =>
+            {
+                var resolved = ResolveResource(resourceRef, out _, out error);
+                resource = resolved;
+                return resource != null;
+            };
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Scene.Create.cs
+++ b/addons/godot_mcp/Tools/Tool_Scene.Create.cs
@@ -71,10 +71,20 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                     if (packErr != Error.Ok)
                         throw new Exception($"Failed to pack new scene root: {packErr}.");
 
+                    // ResourceSaver.Save does NOT create missing parent directories — create them first so a
+                    // nested target path (e.g. 'res://levels/level_2.tscn') saves instead of failing with
+                    // CantOpen, matching Tool_Resource.Create and Unity's CreateAsset behavior.
+                    var targetDir = ResPathNormalizer.ParentDir(resourcePath);
+                    if (!DirAccess.DirExistsAbsolute(targetDir))
+                    {
+                        var mkErr = DirAccess.MakeDirRecursiveAbsolute(targetDir);
+                        if (mkErr != Error.Ok)
+                            throw new Exception($"Failed to create target directory '{targetDir}': {mkErr}.");
+                    }
+
                     var saveErr = ResourceSaver.Save(packed, resourcePath);
                     if (saveErr != Error.Ok)
-                        throw new Exception($"Failed to save new scene to '{resourcePath}': {saveErr}. " +
-                            "Ensure the target directory exists.");
+                        throw new Exception($"Failed to save new scene to '{resourcePath}': {saveErr}.");
                 }
                 finally
                 {


### PR DESCRIPTION
## Summary
- Add `Godot_Resource_ReflectionConverter` (Godot analog of Unity-MCP's `UnityEngine_Object_ReflectionConverter`): matches `Godot.Resource` and every Resource-derived type by inheritance distance, serializes a Resource member as a lightweight `ResourceRef` (res:// path / instance id), and deserializes a `ResourceRef` to the LIVE on-disk asset via an injected resolver. Fixes `node-modify` of a `Resource`-typed property (e.g. `MeshInstance3D.Mesh`) failing with `Instance creation failed for Godot.BoxMesh`. The converter is pure-managed (registered/matched/ref-shaped under CI); the native `ResourceLoader.Load` resolution is injected under `#if TOOLS`, main-thread by construction.
- `Tool_Scene.Create` now creates missing parent dirs before saving (mkdir-parents), matching `Tool_Resource.Create`; both share the new pure-managed `ResPathNormalizer.ParentDir`.
- `node-modify` emits a path-named WARNING when a patch resolves to a no-op (structural no-op via `NodePropertyPatch.IsStructuralNoOp`, or `TryModifyAt` returning false) instead of silently ignoring it.

## Test plan
- [x] Suite 1 (build): `dotnet build Godot-MCP.sln` — 0 errors / 0 warnings.
- [x] Suite 2 (xUnit): 464 pass (converter type-matching incl. derived `Mesh`/`BoxMesh`/`Material`; reflector selects this converter; ResourceRef null/empty-clear + resolver wiring; `ParentDir` derivation; no-op detection).
- [x] Suite 3 (headless Godot 4.5.1 live): `node-modify` assigned `res://box_mesh.tres` to a fresh `MeshInstance3D.Mesh` — resolver logged `Resolved Resource resourcePath='res://box_mesh.tres' to a live 'BoxMesh'`; saved `.tscn` shows `mesh = ExtResource(...)` pointing at `box_mesh.tres` (assigned by REFERENCE, not an embedded copy). Null-clear also verified.

Pins unchanged: `com.IvanMurzak.ReflectorNet` 5.3.1 / `com.IvanMurzak.McpPlugin` 6.7.0.

Closes #46