### PR TITLE
feat(editor): filterable Tools/Prompts/Resources windows with per-row cards

### DIFF
--- a/Godot-MCP.Tests/DockThemeTests.cs
+++ b/Godot-MCP.Tests/DockThemeTests.cs
@@ -71,11 +71,59 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             AssertRgb8(DockTheme.Link, 79, 195, 247); // #4FC3F7
         }
 
+        [Fact]
+        public void RowTint_MapsEnabledToGreenDisabledToRed()
+        {
+            Assert.Equal(DockTheme.RowEnabledTint, DockTheme.RowTint(enabled: true));
+            Assert.Equal(DockTheme.RowDisabledTint, DockTheme.RowTint(enabled: false));
+        }
+
+        [Fact]
+        public void RowTints_MatchBriefRgbaSourceValues()
+        {
+            // enabled soft green Color(80/255,160/255,80/255, 0.18)
+            AssertRgba8(DockTheme.RowEnabledTint, 80, 160, 80, 0.18f);
+            // disabled soft red Color(160/255,80/255,80/255, 0.18)
+            AssertRgba8(DockTheme.RowDisabledTint, 160, 80, 80, 0.18f);
+        }
+
+        [Fact]
+        public void RowSizing_MatchesBrief()
+        {
+            Assert.Equal(8, DockTheme.RowCornerRadius);
+            Assert.Equal(8, DockTheme.RowContentPadding);
+        }
+
+        [Fact]
+        public void MetadataColors_MatchBrief8BitSourceValues()
+        {
+            // prompt Role: Color8(143,170,220)
+            AssertRgb8(DockTheme.RoleLabel, 143, 170, 220);
+            // resource URI: Color8(154,205,50)
+            AssertRgb8(DockTheme.ResourceUri, 154, 205, 50);
+            // resource MimeType: Color8(221,160,221)
+            AssertRgb8(DockTheme.ResourceMimeType, 221, 160, 221);
+        }
+
+        [Fact]
+        public void RowIdMuted_ReusesDescriptionMutedGray()
+        {
+            Assert.Equal(DockTheme.ColorDescriptionMuted, DockTheme.RowIdMuted);
+        }
+
         static void AssertRgb8((float R, float G, float B) c, int r8, int g8, int b8)
         {
             Assert.Equal(r8 / 255f, c.R, 5);
             Assert.Equal(g8 / 255f, c.G, 5);
             Assert.Equal(b8 / 255f, c.B, 5);
+        }
+
+        static void AssertRgba8((float R, float G, float B, float A) c, int r8, int g8, int b8, float a)
+        {
+            Assert.Equal(r8 / 255f, c.R, 5);
+            Assert.Equal(g8 / 255f, c.G, 5);
+            Assert.Equal(b8 / 255f, c.B, 5);
+            Assert.Equal(a, c.A, 5);
         }
     }
 }

--- a/Godot-MCP.Tests/FeatureFilterTests.cs
+++ b/Godot-MCP.Tests/FeatureFilterTests.cs
@@ -1,0 +1,205 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak)             │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+using com.IvanMurzak.Godot.MCP.Connection;
+using com.IvanMurzak.Godot.MCP.UI;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the pure-managed feature list filter chain (<see cref="FeatureFilter"/>): the status×text matrix, the
+    /// per-type text fields (resource URI match), case-insensitivity, empty-text = status-only, the empty result,
+    /// the "Filtered: X, Total: Y" stat, and the JSON-schema argument parser. The editor window Control wiring
+    /// (FeatureListWindow.cs, <c>#if TOOLS</c>) and the live-manager → <see cref="FeatureRowItem"/> mapping
+    /// (FeatureManagerAdapters.cs) are verified via the headless Godot smoke (test.md Suite 3) — NOT here.
+    /// </summary>
+    public class FeatureFilterTests
+    {
+        static FeatureRowItem Tool(string name, bool enabled, string? title = null, string? desc = null) =>
+            new() { Name = name, Title = title, Description = desc, Enabled = enabled };
+
+        static FeatureRowItem Resource(string name, bool enabled, string? uri = null) =>
+            new() { Name = name, Enabled = enabled, Uri = uri };
+
+        static List<FeatureRowItem> Sample() => new()
+        {
+            Tool("alpha-tool", enabled: true, title: "Alpha", desc: "first tool"),
+            Tool("beta-tool", enabled: false, title: "Beta", desc: "second tool"),
+            Tool("gamma-tool", enabled: true, title: null, desc: "third tool"),
+        };
+
+        // --- Status filter ------------------------------------------------------------------------------------
+
+        [Fact]
+        public void Apply_All_status_returns_every_item()
+        {
+            var result = FeatureFilter.Apply(Sample(), FeatureStatusFilter.All, null, GodotMcpFeatureKind.Tools);
+            Assert.Equal(3, result.Count);
+        }
+
+        [Fact]
+        public void Apply_Enabled_status_keeps_only_enabled()
+        {
+            var result = FeatureFilter.Apply(Sample(), FeatureStatusFilter.Enabled, null, GodotMcpFeatureKind.Tools);
+            Assert.Equal(new[] { "alpha-tool", "gamma-tool" }, result.Select(i => i.Name));
+        }
+
+        [Fact]
+        public void Apply_Disabled_status_keeps_only_disabled()
+        {
+            var result = FeatureFilter.Apply(Sample(), FeatureStatusFilter.Disabled, null, GodotMcpFeatureKind.Tools);
+            Assert.Equal(new[] { "beta-tool" }, result.Select(i => i.Name));
+        }
+
+        // --- Text filter (Name / Title / Description) ---------------------------------------------------------
+
+        [Fact]
+        public void Apply_text_matches_name()
+        {
+            var result = FeatureFilter.Apply(Sample(), FeatureStatusFilter.All, "beta", GodotMcpFeatureKind.Tools);
+            Assert.Equal(new[] { "beta-tool" }, result.Select(i => i.Name));
+        }
+
+        [Fact]
+        public void Apply_text_matches_title()
+        {
+            var result = FeatureFilter.Apply(Sample(), FeatureStatusFilter.All, "Alpha", GodotMcpFeatureKind.Tools);
+            Assert.Equal(new[] { "alpha-tool" }, result.Select(i => i.Name));
+        }
+
+        [Fact]
+        public void Apply_text_matches_description()
+        {
+            var result = FeatureFilter.Apply(Sample(), FeatureStatusFilter.All, "third", GodotMcpFeatureKind.Tools);
+            Assert.Equal(new[] { "gamma-tool" }, result.Select(i => i.Name));
+        }
+
+        [Fact]
+        public void Apply_text_is_case_insensitive()
+        {
+            var lower = FeatureFilter.Apply(Sample(), FeatureStatusFilter.All, "ALPHA", GodotMcpFeatureKind.Tools);
+            Assert.Equal(new[] { "alpha-tool" }, lower.Select(i => i.Name));
+        }
+
+        [Fact]
+        public void Apply_empty_text_applies_status_only()
+        {
+            var blank = FeatureFilter.Apply(Sample(), FeatureStatusFilter.Enabled, "   ", GodotMcpFeatureKind.Tools);
+            Assert.Equal(new[] { "alpha-tool", "gamma-tool" }, blank.Select(i => i.Name));
+        }
+
+        [Fact]
+        public void Apply_no_match_returns_empty()
+        {
+            var result = FeatureFilter.Apply(Sample(), FeatureStatusFilter.All, "zzz-nope", GodotMcpFeatureKind.Tools);
+            Assert.Empty(result);
+        }
+
+        // --- Status THEN text combined ------------------------------------------------------------------------
+
+        [Fact]
+        public void Apply_status_and_text_combine_status_first()
+        {
+            // "tool" matches all three by name; Enabled status narrows to the two enabled ones.
+            var result = FeatureFilter.Apply(Sample(), FeatureStatusFilter.Enabled, "tool", GodotMcpFeatureKind.Tools);
+            Assert.Equal(new[] { "alpha-tool", "gamma-tool" }, result.Select(i => i.Name));
+        }
+
+        // --- Resource URI text match (per-type field) ---------------------------------------------------------
+
+        [Fact]
+        public void Apply_resource_text_matches_uri()
+        {
+            var items = new List<FeatureRowItem>
+            {
+                Resource("res-a", enabled: true, uri: "godot://scene/main"),
+                Resource("res-b", enabled: true, uri: "godot://project/settings"),
+            };
+            var result = FeatureFilter.Apply(items, FeatureStatusFilter.All, "settings", GodotMcpFeatureKind.Resources);
+            Assert.Equal(new[] { "res-b" }, result.Select(i => i.Name));
+        }
+
+        [Fact]
+        public void Apply_non_resource_kind_does_not_match_uri()
+        {
+            // A tool-kind item with a Uri set (unusual) must NOT be matched by URI text — only resources match URI.
+            var items = new List<FeatureRowItem>
+            {
+                new() { Name = "tool-x", Enabled = true, Uri = "godot://only-here" },
+            };
+            var asTool = FeatureFilter.Apply(items, FeatureStatusFilter.All, "only-here", GodotMcpFeatureKind.Tools);
+            Assert.Empty(asTool);
+
+            var asResource = FeatureFilter.Apply(items, FeatureStatusFilter.All, "only-here", GodotMcpFeatureKind.Resources);
+            Assert.Single(asResource);
+        }
+
+        // --- Stats formatting ---------------------------------------------------------------------------------
+
+        [Fact]
+        public void FormatStats_renders_filtered_and_total()
+        {
+            Assert.Equal("Filtered: 2, Total: 7", FeatureFilter.FormatStats(2, 7));
+            Assert.Equal("Filtered: 0, Total: 0", FeatureFilter.FormatStats(0, 0));
+        }
+
+        // --- Schema argument parsing --------------------------------------------------------------------------
+
+        [Fact]
+        public void ParseSchemaArguments_null_schema_is_empty()
+        {
+            Assert.Empty(FeatureFilter.ParseSchemaArguments(null));
+        }
+
+        [Fact]
+        public void ParseSchemaArguments_no_properties_is_empty()
+        {
+            var schema = JsonNode.Parse("""{ "type": "object" }""");
+            Assert.Empty(FeatureFilter.ParseSchemaArguments(schema));
+        }
+
+        [Fact]
+        public void ParseSchemaArguments_extracts_names_and_descriptions()
+        {
+            var schema = JsonNode.Parse("""
+            {
+              "type": "object",
+              "properties": {
+                "path": { "type": "string", "description": "the resource path" },
+                "force": { "type": "boolean" }
+              }
+            }
+            """);
+
+            var args = FeatureFilter.ParseSchemaArguments(schema);
+            Assert.Equal(2, args.Count);
+
+            var path = args.Single(a => a.Name == "path");
+            Assert.Equal("the resource path", path.Description);
+
+            var force = args.Single(a => a.Name == "force");
+            Assert.Null(force.Description);
+        }
+
+        // --- Row view-model display title ---------------------------------------------------------------------
+
+        [Fact]
+        public void DisplayTitle_prefers_title_else_falls_back_to_name()
+        {
+            Assert.Equal("Alpha", Tool("alpha-tool", true, title: "Alpha").DisplayTitle);
+            Assert.Equal("gamma-tool", Tool("gamma-tool", true, title: null).DisplayTitle);
+            Assert.Equal("blank-tool", Tool("blank-tool", true, title: "").DisplayTitle);
+        }
+    }
+}

--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -152,6 +152,14 @@
          The editor Control wiring (FeaturesPanel.cs / FeatureRow.cs / FeatureListWindow.cs) is #if TOOLS and
          verified via the headless Godot smoke (test.md Suite 3); the label formatting is unit-tested here. -->
     <Compile Include="..\addons\godot_mcp\UI\FeaturesPanelView.cs" Link="Source\FeaturesPanelView.cs" />
+    <!-- Feature list filter + row view-model — pure-managed (no Godot native types, no #if TOOLS): the
+         FeatureStatusFilter enum, the FeatureRowItem/FeatureArgument records, the status+text filter chain
+         (FeatureFilter.Apply), the "Filtered: X, Total: Y" stat formatter, and the JSON-schema argument parser
+         (uses System.Text.Json.Nodes + ReflectorNet's JsonSchema key constants). The live IToolManager/
+         IPromptManager/IResourceManager → FeatureRowItem mapping (FeatureManagerAdapters.cs) and the editor
+         window Control wiring (FeatureListWindow.cs) are #if TOOLS and verified via the headless Godot smoke
+         (test.md Suite 3); the filter/stat/parse logic is unit-tested here. -->
+    <Compile Include="..\addons\godot_mcp\UI\FeatureFilter.cs" Link="Source\FeatureFilter.cs" />
     <!-- AI-agent configurators — pure-managed (no Godot native types, no #if TOOLS): the abstract base, the
          JSON read-merge-write helper, the per-OS path resolver, the concrete configurators, and the registry.
          The dock UI (AgentConfiguratorsPanel.cs) is #if TOOLS and verified via the headless Godot smoke

--- a/addons/godot_mcp/Connection/FeatureManagerAdapters.cs
+++ b/addons/godot_mcp/Connection/FeatureManagerAdapters.cs
@@ -11,6 +11,7 @@
 #nullable enable
 using System.Collections.Generic;
 using System.Linq;
+using com.IvanMurzak.Godot.MCP.UI;
 using com.IvanMurzak.McpPlugin;
 
 namespace com.IvanMurzak.Godot.MCP.Connection
@@ -22,16 +23,22 @@ namespace com.IvanMurzak.Godot.MCP.Connection
     /// to one surface so <see cref="GodotMcpConnection"/> and the dock's features UI can address any kind
     /// generically via <see cref="GodotMcpFeatureKind"/>. Editor-only (<c>#if TOOLS</c>): it depends on the
     /// reused client types, which are only present once the connection assembly is loaded. The map merge/
-    /// capture decisions stay pure-managed in <see cref="GodotMcpFeatureStateMerge"/>; this adapter is just the
-    /// thin live-manager binding (verified via the headless Godot smoke, not the plain-xUnit host).
+    /// capture decisions stay pure-managed in <see cref="GodotMcpFeatureStateMerge"/> and the filter/row
+    /// view-model shaping in <see cref="FeatureFilter"/> / <see cref="FeatureRowItem"/>; this adapter is the
+    /// thin live-manager binding that maps each live descriptor into a pure-managed <see cref="FeatureRowItem"/>
+    /// (verified via the headless Godot smoke, not the plain-xUnit host).
     /// </summary>
     public interface IFeatureManagerAdapter
     {
         /// <summary>Live item names of this kind.</summary>
         IEnumerable<string> GetNames();
 
-        /// <summary>Live items as (name, description, enabled) tuples.</summary>
-        IEnumerable<(string Name, string? Description, bool Enabled)> GetItems();
+        /// <summary>
+        /// Live items as pure-managed <see cref="FeatureRowItem"/> view-models — the common
+        /// name/title/description/enabled plus the kind-specific metadata (tools: token count + input args;
+        /// prompts: role + arguments; resources: uri + mimetype).
+        /// </summary>
+        IEnumerable<FeatureRowItem> GetItems();
 
         /// <summary>(enabled, total, enabledTokenCount) — token count is non-zero only for tools.</summary>
         (int Enabled, int Total, int EnabledTokenCount) GetCounts();
@@ -40,7 +47,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         void SetEnabled(string name, bool enabled);
     }
 
-    /// <summary>Adapter over <see cref="IToolManager"/> (the only kind with a token count).</summary>
+    /// <summary>Adapter over <see cref="IToolManager"/> (the only kind with a token count + input-schema args).</summary>
     public sealed class ToolManagerAdapter : IFeatureManagerAdapter
     {
         readonly IToolManager _manager;
@@ -49,9 +56,17 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         public IEnumerable<string> GetNames() =>
             _manager.GetAllTools().Where(t => t != null).Select(t => t.Name);
 
-        public IEnumerable<(string Name, string? Description, bool Enabled)> GetItems() =>
+        public IEnumerable<FeatureRowItem> GetItems() =>
             _manager.GetAllTools().Where(t => t != null)
-                .Select(t => (t.Name, t.Description, _manager.IsToolEnabled(t.Name)));
+                .Select(t => new FeatureRowItem
+                {
+                    Name = t.Name,
+                    Title = t.Title,
+                    Description = t.Description,
+                    Enabled = _manager.IsToolEnabled(t.Name),
+                    TokenCount = t.TokenCount,
+                    Inputs = FeatureFilter.ParseSchemaArguments(t.InputSchema)
+                });
 
         public (int Enabled, int Total, int EnabledTokenCount) GetCounts() =>
             (_manager.EnabledToolsCount, _manager.TotalToolsCount, _manager.EnabledToolsTokenCount);
@@ -59,7 +74,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         public void SetEnabled(string name, bool enabled) => _manager.SetToolEnabled(name, enabled);
     }
 
-    /// <summary>Adapter over <see cref="IPromptManager"/> (no token count → reports 0).</summary>
+    /// <summary>Adapter over <see cref="IPromptManager"/> (role + prompt arguments; no token count → reports 0).</summary>
     public sealed class PromptManagerAdapter : IFeatureManagerAdapter
     {
         readonly IPromptManager _manager;
@@ -68,9 +83,17 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         public IEnumerable<string> GetNames() =>
             _manager.GetAllPrompts().Where(p => p != null).Select(p => p.Name);
 
-        public IEnumerable<(string Name, string? Description, bool Enabled)> GetItems() =>
+        public IEnumerable<FeatureRowItem> GetItems() =>
             _manager.GetAllPrompts().Where(p => p != null)
-                .Select(p => (p.Name, p.Description, _manager.IsPromptEnabled(p.Name)));
+                .Select(p => new FeatureRowItem
+                {
+                    Name = p.Name,
+                    Title = p.Title,
+                    Description = p.Description,
+                    Enabled = _manager.IsPromptEnabled(p.Name),
+                    Role = p.Role.ToString(),
+                    Arguments = FeatureFilter.ParseSchemaArguments(p.InputSchema)
+                });
 
         public (int Enabled, int Total, int EnabledTokenCount) GetCounts() =>
             (_manager.EnabledPromptsCount, _manager.TotalPromptsCount, 0);
@@ -78,7 +101,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         public void SetEnabled(string name, bool enabled) => _manager.SetPromptEnabled(name, enabled);
     }
 
-    /// <summary>Adapter over <see cref="IResourceManager"/> (no token count → reports 0).</summary>
+    /// <summary>Adapter over <see cref="IResourceManager"/> (uri + mimetype; no token count → reports 0).</summary>
     public sealed class ResourceManagerAdapter : IFeatureManagerAdapter
     {
         readonly IResourceManager _manager;
@@ -87,9 +110,18 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         public IEnumerable<string> GetNames() =>
             _manager.GetAllResources().Where(r => r != null).Select(r => r.Name);
 
-        public IEnumerable<(string Name, string? Description, bool Enabled)> GetItems() =>
+        public IEnumerable<FeatureRowItem> GetItems() =>
             _manager.GetAllResources().Where(r => r != null)
-                .Select(r => (r.Name, r.Description, _manager.IsResourceEnabled(r.Name)));
+                .Select(r => new FeatureRowItem
+                {
+                    Name = r.Name,
+                    // IRunResource carries no Title; fall back to the name for the row heading.
+                    Title = null,
+                    Description = r.Description,
+                    Enabled = _manager.IsResourceEnabled(r.Name),
+                    Uri = r.Route,
+                    MimeType = r.MimeType
+                });
 
         public (int Enabled, int Total, int EnabledTokenCount) GetCounts() =>
             (_manager.EnabledResourcesCount, _manager.TotalResourcesCount, 0);

--- a/addons/godot_mcp/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConnection.cs
@@ -448,15 +448,17 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         }
 
         /// <summary>
-        /// Enumerate the live items of a feature kind as (name, description, enabled) tuples for the list
-        /// window. Empty when the plugin/managers are not yet available. Reads the LIVE enabled-state off the
-        /// manager (which reflects any reapplied persisted disable).
+        /// Enumerate the live items of a feature kind as pure-managed <see cref="FeatureRowItem"/> view-models
+        /// for the list window — the common name/title/description/enabled plus the kind-specific metadata
+        /// (tools: token count + input args; prompts: role + arguments; resources: uri + mimetype). Empty when
+        /// the plugin/managers are not yet available. Reads the LIVE enabled-state off the manager (which
+        /// reflects any reapplied persisted disable). The window filters this list via <see cref="FeatureFilter"/>.
         /// </summary>
-        public IReadOnlyList<(string Name, string? Description, bool Enabled)> GetFeatureItems(GodotMcpFeatureKind kind)
+        public IReadOnlyList<FeatureRowItem> GetFeatureItems(GodotMcpFeatureKind kind)
         {
             var manager = FeatureManager(kind, _plugin);
             return manager == null
-                ? Array.Empty<(string, string?, bool)>()
+                ? Array.Empty<FeatureRowItem>()
                 : manager.GetItems().ToList();
         }
 

--- a/addons/godot_mcp/UI/DockStyle.cs
+++ b/addons/godot_mcp/UI/DockStyle.cs
@@ -265,6 +265,67 @@ namespace com.IvanMurzak.Godot.MCP.UI
             };
         }
 
+        // --- Feature list rows (Tools / Prompts / Resources windows) -------------------------------------------
+
+        /// <summary>
+        /// Build the per-row "card" <see cref="StyleBoxFlat"/> for a feature item: rounded
+        /// (<see cref="DockTheme.RowCornerRadius"/>), padded (<see cref="DockTheme.RowContentPadding"/>), and tinted
+        /// by enabled-state — soft green when <paramref name="enabled"/>, soft red otherwise
+        /// (<see cref="DockTheme.RowTint"/>).
+        /// </summary>
+        public static StyleBoxFlat RowStyleBox(bool enabled)
+        {
+            var box = new StyleBoxFlat
+            {
+                BgColor = Rgba(DockTheme.RowTint(enabled))
+            };
+            box.SetCornerRadiusAll(DockTheme.RowCornerRadius);
+            box.ContentMarginLeft = DockTheme.RowContentPadding;
+            box.ContentMarginRight = DockTheme.RowContentPadding;
+            box.ContentMarginTop = DockTheme.RowContentPadding;
+            box.ContentMarginBottom = DockTheme.RowContentPadding;
+            return box;
+        }
+
+        /// <summary>
+        /// Wrap a feature row's <paramref name="content"/> in a tinted, rounded <see cref="PanelContainer"/> card
+        /// (<see cref="RowStyleBox"/>) whose tint reflects <paramref name="enabled"/>. The caller adds the returned
+        /// panel to the list; the content is reparented INTO the card.
+        /// </summary>
+        public static PanelContainer RowCard(Control content, string name, bool enabled)
+        {
+            var panel = new PanelContainer { Name = name, SizeFlagsHorizontal = Control.SizeFlags.ExpandFill };
+            panel.AddThemeStyleboxOverride("panel", RowStyleBox(enabled));
+            panel.AddChild(content);
+            return panel;
+        }
+
+        /// <summary>Apply the 16px bold row-title look + a coloured metadata-label colour to a <see cref="Label"/>.</summary>
+        public static void ApplyRowTitle(Label label)
+        {
+            label.AddThemeFontSizeOverride("font_size", DockTheme.FontSizeSectionTitle);
+        }
+
+        /// <summary>Apply the muted-gray row-id (sub-label) look to a <see cref="Label"/>.</summary>
+        public static void ApplyRowId(Label label)
+        {
+            label.AddThemeColorOverride("font_color", Rgb(DockTheme.RowIdMuted));
+        }
+
+        /// <summary>Tint a metadata <see cref="Label"/> (role / uri / mimetype / token) with an arbitrary palette RGB.</summary>
+        public static void ApplyMetadataColor(Label label, (float R, float G, float B) color)
+        {
+            label.AddThemeColorOverride("font_color", Rgb(color));
+        }
+
+        // --- Filter bar (search field + status dropdown + stats label) ----------------------------------------
+
+        /// <summary>Skin an <see cref="OptionButton"/> (the status filter) with the input style.</summary>
+        public static void ApplyOptionButton(OptionButton option)
+        {
+            option.AddThemeStyleboxOverride("normal", InputStyleBox());
+        }
+
         // --- Foldout (collapsible section: a toggle Button + a child VBox shown/hidden) ------------------------
 
         /// <summary>

--- a/addons/godot_mcp/UI/DockTheme.cs
+++ b/addons/godot_mcp/UI/DockTheme.cs
@@ -153,5 +153,45 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
         /// <summary>Divider colour — 1px <c>Color8(26,26,26)</c> separator between sections.</summary>
         public static readonly (float R, float G, float B) Divider = (26f / 255f, 26f / 255f, 26f / 255f);
+
+        // --- Feature list rows (Tools / Prompts / Resources windows) -------------------------------------------
+
+        /// <summary>
+        /// Per-row card tint for an ENABLED feature item — soft translucent green <c>rgba(80,160,80, 0.18)</c>
+        /// (Unity's list item ".checked" tint). The editor maps this onto the row's <c>StyleBoxFlat</c> bg.
+        /// </summary>
+        public static readonly (float R, float G, float B, float A) RowEnabledTint = (80f / 255f, 160f / 255f, 80f / 255f, 0.18f);
+
+        /// <summary>
+        /// Per-row card tint for a DISABLED feature item — soft translucent red <c>rgba(160,80,80, 0.18)</c>
+        /// (Unity's un-checked / disabled list item tint). The editor maps this onto the row's <c>StyleBoxFlat</c> bg.
+        /// </summary>
+        public static readonly (float R, float G, float B, float A) RowDisabledTint = (160f / 255f, 80f / 255f, 80f / 255f, 0.18f);
+
+        /// <summary>Feature-row card corner radius (px).</summary>
+        public const int RowCornerRadius = 8;
+
+        /// <summary>Feature-row card inner content padding (px), applied on all four sides.</summary>
+        public const int RowContentPadding = 8;
+
+        /// <summary>Muted gray for a feature row's id sub-label (under the title). Reuses the description muted gray.</summary>
+        public static readonly (float R, float G, float B) RowIdMuted = ColorDescriptionMuted;
+
+        /// <summary>Prompt-row "Role: X" label colour — soft blue <c>Color8(143,170,220)</c>.</summary>
+        public static readonly (float R, float G, float B) RoleLabel = (143f / 255f, 170f / 255f, 220f / 255f);
+
+        /// <summary>Resource-row URI label colour — yellow-green <c>Color8(154,205,50)</c>.</summary>
+        public static readonly (float R, float G, float B) ResourceUri = (154f / 255f, 205f / 255f, 50f / 255f);
+
+        /// <summary>Resource-row "MimeType: X" label colour — plum <c>Color8(221,160,221)</c>.</summary>
+        public static readonly (float R, float G, float B) ResourceMimeType = (221f / 255f, 160f / 255f, 221f / 255f);
+
+        /// <summary>
+        /// Map a feature row's enabled-state to its card tint: enabled → soft green, disabled → soft red. Pure-managed
+        /// (no Godot types) so the row-tint rule is unit-testable; the editor maps the returned tuple onto a
+        /// Godot <c>Color</c> / <c>StyleBoxFlat</c>.
+        /// </summary>
+        public static (float R, float G, float B, float A) RowTint(bool enabled) =>
+            enabled ? RowEnabledTint : RowDisabledTint;
     }
 }

--- a/addons/godot_mcp/UI/FeatureFilter.cs
+++ b/addons/godot_mcp/UI/FeatureFilter.cs
@@ -1,0 +1,195 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json.Nodes;
+using com.IvanMurzak.Godot.MCP.Connection;
+using com.IvanMurzak.ReflectorNet.Utils;
+
+namespace com.IvanMurzak.Godot.MCP.UI
+{
+    /// <summary>Which enabled-status a feature list window currently shows. The Godot analog of Unity-MCP's
+    /// <c>McpFilterType</c> (its Tools/Prompts/Resources list windows' All/Enabled/Disabled dropdown).</summary>
+    public enum FeatureStatusFilter
+    {
+        /// <summary>Show every item regardless of enabled-state.</summary>
+        All,
+
+        /// <summary>Show only items whose <see cref="FeatureRowItem.Enabled"/> is <c>true</c>.</summary>
+        Enabled,
+
+        /// <summary>Show only items whose <see cref="FeatureRowItem.Enabled"/> is <c>false</c>.</summary>
+        Disabled
+    }
+
+    /// <summary>
+    /// One argument of a tool (input schema) or prompt — a name + optional description, parsed out of the
+    /// item's JSON input/output schema. The Godot analog of Unity-MCP's <c>ArgumentData</c>. Pure-managed (no
+    /// Godot native types) so the window's per-row argument foldout content is unit-testable.
+    /// </summary>
+    public sealed record FeatureArgument(string Name, string? Description);
+
+    /// <summary>
+    /// The pure-managed row view-model for ONE MCP feature item (a tool, prompt, or resource). Carries every
+    /// field the list window renders: the common <see cref="Name"/> / <see cref="Title"/> / <see cref="Description"/>
+    /// / <see cref="Enabled"/>, plus the type-specific metadata — tools: <see cref="TokenCount"/> +
+    /// <see cref="Inputs"/>; prompts: <see cref="Role"/> + <see cref="Arguments"/>; resources: <see cref="Uri"/>
+    /// + <see cref="MimeType"/>. The Godot analog of Unity-MCP's per-window <c>ToolViewModel</c> /
+    /// <c>PromptViewModel</c> / <c>ResourceViewModel</c>, collapsed to one record so the filter/window can address
+    /// any kind generically.
+    ///
+    /// <para>
+    /// No Godot native types and no <c>#if TOOLS</c>: the live descriptors are read off the McpPlugin managers in
+    /// the editor-only <see cref="Connection.FeatureManagerAdapters"/> wiring, which maps each one into this
+    /// record — keeping the filter/format logic (<see cref="FeatureFilter"/>) pure and unit-testable.
+    /// </para>
+    /// </summary>
+    public sealed record FeatureRowItem
+    {
+        /// <summary>The item's stable id (tool/prompt/resource name) — always present, also the toggle key.</summary>
+        public required string Name { get; init; }
+
+        /// <summary>Optional human title; falls back to <see cref="Name"/> for display when null/empty.</summary>
+        public string? Title { get; init; }
+
+        /// <summary>Optional human description (shown in the per-row Description foldout).</summary>
+        public string? Description { get; init; }
+
+        /// <summary>The item's current enabled-state on the live manager (drives the status filter + toggle).</summary>
+        public bool Enabled { get; init; }
+
+        /// <summary>Tools only: approximate token cost of this tool's schema (0 for prompts/resources).</summary>
+        public int TokenCount { get; init; }
+
+        /// <summary>Tools only: the parsed input-schema arguments (empty for prompts/resources).</summary>
+        public IReadOnlyList<FeatureArgument> Inputs { get; init; } = Array.Empty<FeatureArgument>();
+
+        /// <summary>Prompts only: the prompt role (e.g. "User" / "Assistant"); null for tools/resources.</summary>
+        public string? Role { get; init; }
+
+        /// <summary>Prompts only: the parsed prompt arguments (empty for tools/resources).</summary>
+        public IReadOnlyList<FeatureArgument> Arguments { get; init; } = Array.Empty<FeatureArgument>();
+
+        /// <summary>Resources only: the resource URI / route; null for tools/prompts. ALSO matched by text filter.</summary>
+        public string? Uri { get; init; }
+
+        /// <summary>Resources only: the resource MIME type; null for tools/prompts.</summary>
+        public string? MimeType { get; init; }
+
+        /// <summary>The label shown as the row title — <see cref="Title"/> when set, else <see cref="Name"/>.</summary>
+        public string DisplayTitle => string.IsNullOrEmpty(Title) ? Name : Title!;
+    }
+
+    /// <summary>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) filter + stats logic for the MCP feature list
+    /// windows (tools / prompts / resources). The Godot analog of Unity-MCP's <c>McpListWindowBase.FilterItems</c>
+    /// + <c>FilterByText</c> + the "Filtered: X, Total: Y" stats label, collapsed into one kind-parameterized
+    /// static surface so the whole filter chain is unit-testable in the plain-xUnit host (the editor Control
+    /// wiring in <see cref="FeatureListWindow"/> is verified via the headless Godot smoke instead).
+    /// </summary>
+    public static class FeatureFilter
+    {
+        /// <summary>
+        /// Apply the STATUS filter first (Enabled → only enabled, Disabled → only disabled, All → unchanged) then
+        /// the live TEXT filter (case-insensitive ordinal <c>Contains</c> over Name / Title / Description; for the
+        /// <see cref="GodotMcpFeatureKind.Resources"/> kind ALSO over the resource <see cref="FeatureRowItem.Uri"/>).
+        /// An empty/whitespace <paramref name="text"/> applies the status filter only. Returns a new list in source
+        /// order; never mutates <paramref name="items"/>. Mirrors the Unity reference's filter chain (status then
+        /// text), with the resource-URI text match that the Unity <c>ResourceViewModel.FilterByText</c> adds.
+        /// </summary>
+        public static IReadOnlyList<FeatureRowItem> Apply(
+            IEnumerable<FeatureRowItem> items,
+            FeatureStatusFilter status,
+            string? text,
+            GodotMcpFeatureKind kind)
+        {
+            IEnumerable<FeatureRowItem> filtered = items ?? Enumerable.Empty<FeatureRowItem>();
+
+            filtered = status switch
+            {
+                FeatureStatusFilter.Enabled => filtered.Where(i => i.Enabled),
+                FeatureStatusFilter.Disabled => filtered.Where(i => !i.Enabled),
+                _ => filtered
+            };
+
+            var trimmed = text?.Trim();
+            if (!string.IsNullOrEmpty(trimmed))
+            {
+                bool matchUri = kind == GodotMcpFeatureKind.Resources;
+                filtered = filtered.Where(i => MatchesText(i, trimmed!, matchUri));
+            }
+
+            return filtered.ToList();
+        }
+
+        /// <summary>
+        /// Whether <paramref name="item"/> matches <paramref name="text"/> by a case-insensitive ordinal substring
+        /// over Name / Title / Description (and, when <paramref name="matchUri"/>, the resource URI). Used by
+        /// <see cref="Apply"/>; <paramref name="text"/> is assumed already trimmed and non-empty.
+        /// </summary>
+        public static bool MatchesText(FeatureRowItem item, string text, bool matchUri)
+        {
+            return Contains(item.Name, text)
+                || Contains(item.Title, text)
+                || Contains(item.Description, text)
+                || (matchUri && Contains(item.Uri, text));
+        }
+
+        static bool Contains(string? value, string text) =>
+            value != null && value.Contains(text, StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Format the right-aligned "Filtered: X, Total: Y" stat shown beside the filter bar — X = visible after
+        /// filtering, Y = total items of this kind. Mirrors Unity-MCP's <c>"Filtered: {0}, Total: {1}"</c>. Uses
+        /// the invariant culture so the integers render identically regardless of editor locale.
+        /// </summary>
+        public static string FormatStats(int filteredCount, int totalCount) =>
+            string.Format(CultureInfo.InvariantCulture, "Filtered: {0}, Total: {1}", filteredCount, totalCount);
+
+        /// <summary>
+        /// Parse a tool/prompt JSON input (or output) schema into its named arguments — one
+        /// <see cref="FeatureArgument"/> per entry under the schema's <c>properties</c> object, carrying the
+        /// property name and (when present) its <c>description</c>. A null schema, a non-object schema, or a schema
+        /// with no <c>properties</c> object yields an empty list. The Godot analog of Unity-MCP's
+        /// <c>ParseSchemaArguments</c>; pure-managed (System.Text.Json.Nodes + ReflectorNet's
+        /// <see cref="JsonSchema"/> key constants), so it is unit-testable without a Godot binary.
+        /// </summary>
+        public static IReadOnlyList<FeatureArgument> ParseSchemaArguments(JsonNode? schema)
+        {
+            if (schema is not JsonObject schemaObject)
+                return Array.Empty<FeatureArgument>();
+
+            if (!schemaObject.TryGetPropertyValue(JsonSchema.Properties, out var propertiesNode))
+                return Array.Empty<FeatureArgument>();
+
+            if (propertiesNode is not JsonObject propertiesObject)
+                return Array.Empty<FeatureArgument>();
+
+            var arguments = new List<FeatureArgument>();
+            foreach (var (name, element) in propertiesObject)
+            {
+                string? description = null;
+                if (element is JsonObject propertyObject &&
+                    propertyObject.TryGetPropertyValue(JsonSchema.Description, out var descriptionNode) &&
+                    descriptionNode != null)
+                {
+                    description = descriptionNode.ToString();
+                }
+
+                arguments.Add(new FeatureArgument(name, description));
+            }
+
+            return arguments;
+        }
+    }
+}

--- a/addons/godot_mcp/UI/FeatureListWindow.cs
+++ b/addons/godot_mcp/UI/FeatureListWindow.cs
@@ -9,24 +9,29 @@
 */
 #if TOOLS
 #nullable enable
+using System.Collections.Generic;
 using com.IvanMurzak.Godot.MCP.Connection;
 using Godot;
 
 namespace com.IvanMurzak.Godot.MCP.UI
 {
     /// <summary>
-    /// A nested editor <see cref="Window"/> listing every item of one <see cref="GodotMcpFeatureKind"/> with a
-    /// per-item enable/disable <see cref="CheckBox"/> — the Godot analog of Unity-MCP's <c>McpToolsWindow</c>
-    /// (and its prompts/resources siblings), collapsed to ONE reusable class parameterized by kind. Each row
-    /// shows the item name + description and a checkbox reflecting the live enabled-state; toggling pushes the
-    /// change to the live manager AND persists it via <see cref="GodotMcpConnection.SetFeatureEnabled"/> (the
-    /// enable-map in <see cref="GodotMcpConfig"/>). A "Close" button (and the window-manager close request)
-    /// frees the window — no leaks.
+    /// A nested editor <see cref="Window"/> listing every item of one <see cref="GodotMcpFeatureKind"/>, with a
+    /// live TEXT filter + an All/Enabled/Disabled STATUS filter + a "Filtered: X, Total: Y" stat + an empty-state
+    /// + per-row "card" styling — the Godot analog of Unity-MCP's <c>McpListWindowBase</c> (and its
+    /// tools/prompts/resources subclasses), collapsed to ONE reusable class parameterized by kind. Each row is a
+    /// tinted rounded card (soft green when enabled, soft red when disabled) showing the title + id + the
+    /// kind-specific metadata (Tools: "~N tokens" + an "Input arguments (N)" foldout; Prompts: "Role: X" + an
+    /// "Arguments (N)" foldout; Resources: the URI + "MimeType: …") + a Description foldout + a per-row
+    /// enable/disable <see cref="CheckButton"/>. Toggling pushes the change to the live manager AND persists it via
+    /// <see cref="GodotMcpConnection.SetFeatureEnabled"/> (the enable-map in <see cref="GodotMcpConfig"/>), then
+    /// re-filters so a toggle under a non-All status hides/shows the row. A "Close" button (and the window-manager
+    /// close request) frees the window — no leaks.
     ///
     /// <para>
     /// Editor-only (<c>#if TOOLS</c>): it builds live Godot UI <see cref="Node"/>s, so it is verified via the
-    /// headless Godot smoke (test.md Suite 3), not the plain-xUnit host. The enable-map merge/persist logic it
-    /// drives is pure-managed (<see cref="GodotMcpFeatureStateMerge"/>) and unit-tested separately.
+    /// headless Godot smoke (test.md Suite 3), not the plain-xUnit host. The filter chain + stat formatting it
+    /// drives is pure-managed (<see cref="FeatureFilter"/>) and unit-tested separately.
     /// </para>
     /// </summary>
     [Tool]
@@ -35,8 +40,14 @@ namespace com.IvanMurzak.Godot.MCP.UI
         readonly GodotMcpConnection _connection;
         readonly GodotMcpFeatureKind _kind;
 
+        LineEdit _searchField = null!;
+        OptionButton _statusOption = null!;
+        Label _statsLabel = null!;
         VBoxContainer _list = null!;
         Label _emptyLabel = null!;
+
+        /// <summary>The full, unfiltered item set for this kind, captured on (re)populate; the filter runs over it.</summary>
+        IReadOnlyList<FeatureRowItem> _allItems = System.Array.Empty<FeatureRowItem>();
 
         public FeatureListWindow(GodotMcpConnection connection, GodotMcpFeatureKind kind)
         {
@@ -44,14 +55,14 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _kind = kind;
             Name = $"{FeaturesPanelView.Title(kind)}Window";
             Title = $"MCP {FeaturesPanelView.Title(kind)}";
-            Size = new Vector2I(420, 480);
+            Size = new Vector2I(480, 560);
             Unresizable = false;
 
             // Free the window when the OS/editor close button (the X) is pressed.
             CloseRequested += OnClosePressed;
 
             BuildUi();
-            PopulateList();
+            ReloadItems();
         }
 
         void BuildUi()
@@ -68,11 +79,18 @@ namespace com.IvanMurzak.Godot.MCP.UI
             root.AddThemeConstantOverride("separation", 6);
             margin.AddChild(root);
 
+            var header = new Label { Name = "Header", Text = $"MCP {FeaturesPanelView.Title(_kind)}" };
+            DockStyle.ApplyHeader(header);
+            root.AddChild(header);
+
+            root.AddChild(BuildFilterBar());
+
             var scroll = new ScrollContainer
             {
                 Name = "Scroll",
                 SizeFlagsVertical = Control.SizeFlags.ExpandFill,
-                SizeFlagsHorizontal = Control.SizeFlags.ExpandFill
+                SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
+                HorizontalScrollMode = ScrollContainer.ScrollMode.Disabled
             };
             root.AddChild(scroll);
 
@@ -81,70 +99,245 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 Name = "List",
                 SizeFlagsHorizontal = Control.SizeFlags.ExpandFill
             };
-            _list.AddThemeConstantOverride("separation", 4);
+            _list.AddThemeConstantOverride("separation", 6);
             scroll.AddChild(_list);
 
             _emptyLabel = new Label
             {
                 Name = "EmptyLabel",
-                Text = "No items (connect to populate the registry).",
-                Visible = false
+                Text = $"No {FeaturesPanelView.Title(_kind).ToLowerInvariant()} by current filter.",
+                Visible = false,
+                HorizontalAlignment = HorizontalAlignment.Center
             };
-            _list.AddChild(_emptyLabel);
+            DockStyle.ApplyDescription(_emptyLabel);
+            root.AddChild(_emptyLabel);
 
             var closeButton = new Button { Name = "CloseButton", Text = "Close" };
             closeButton.Pressed += OnClosePressed;
             root.AddChild(closeButton);
         }
 
-        /// <summary>
-        /// Build one toggle row per live item of this kind. Reads items off the connection (name + description
-        /// + current enabled). When the registry is empty (no connection yet), shows the empty placeholder.
-        /// </summary>
-        void PopulateList()
+        /// <summary>Build the search field + status dropdown + right-aligned "Filtered: X, Total: Y" stat row.</summary>
+        Control BuildFilterBar()
         {
-            var items = _connection.GetFeatureItems(_kind);
-            _emptyLabel.Visible = items.Count == 0;
+            var bar = new HBoxContainer { Name = "FilterBar", SizeFlagsHorizontal = Control.SizeFlags.ExpandFill };
+            bar.AddThemeConstantOverride("separation", 6);
 
-            foreach (var item in items)
-                _list.AddChild(BuildItemRow(item.Name, item.Description, item.Enabled));
+            _searchField = new LineEdit
+            {
+                Name = "Search",
+                PlaceholderText = "Filter…",
+                SizeFlagsHorizontal = Control.SizeFlags.ExpandFill
+            };
+            DockStyle.ApplyInput(_searchField);
+            // Live (no debounce): every keystroke re-filters.
+            _searchField.TextChanged += _ => RebuildRows();
+            bar.AddChild(_searchField);
+
+            _statusOption = new OptionButton { Name = "Status" };
+            // Order matches the FeatureStatusFilter enum so the selected index IS the enum value.
+            _statusOption.AddItem("All", (int)FeatureStatusFilter.All);
+            _statusOption.AddItem("Enabled", (int)FeatureStatusFilter.Enabled);
+            _statusOption.AddItem("Disabled", (int)FeatureStatusFilter.Disabled);
+            _statusOption.Select((int)FeatureStatusFilter.All);
+            DockStyle.ApplyOptionButton(_statusOption);
+            _statusOption.ItemSelected += _ => RebuildRows();
+            bar.AddChild(_statusOption);
+
+            _statsLabel = new Label
+            {
+                Name = "Stats",
+                Text = FeatureFilter.FormatStats(0, 0),
+                HorizontalAlignment = HorizontalAlignment.Right
+            };
+            DockStyle.ApplyRowId(_statsLabel);
+            bar.AddChild(_statsLabel);
+
+            return bar;
         }
 
-        Control BuildItemRow(string name, string? description, bool enabled)
+        /// <summary>Re-read the live item set off the connection, then rebuild the filtered rows.</summary>
+        void ReloadItems()
         {
-            var row = new VBoxContainer { Name = $"Item_{name}" };
-            row.AddThemeConstantOverride("separation", 1);
+            _allItems = _connection.GetFeatureItems(_kind);
+            RebuildRows();
+        }
 
-            var checkBox = new CheckBox
+        /// <summary>The current status filter selected in the dropdown.</summary>
+        FeatureStatusFilter CurrentStatus()
+        {
+            int id = _statusOption.GetSelectedId();
+            return id >= 0 ? (FeatureStatusFilter)id : FeatureStatusFilter.All;
+        }
+
+        /// <summary>
+        /// Run the pure-managed <see cref="FeatureFilter.Apply"/> over the cached item set with the current text +
+        /// status, then rebuild the list rows. Updates the "Filtered: X, Total: Y" stat and toggles the
+        /// empty-state when nothing matches.
+        /// </summary>
+        void RebuildRows()
+        {
+            var filtered = FeatureFilter.Apply(_allItems, CurrentStatus(), _searchField.Text, _kind);
+
+            foreach (var child in _list.GetChildren())
+                ((Node)child).QueueFree();
+
+            foreach (var item in filtered)
+                _list.AddChild(BuildItemRow(item));
+
+            _statsLabel.Text = FeatureFilter.FormatStats(filtered.Count, _allItems.Count);
+
+            bool empty = filtered.Count == 0;
+            _emptyLabel.Visible = empty;
+            _list.Visible = !empty;
+        }
+
+        /// <summary>Build one styled card row for a single feature item.</summary>
+        Control BuildItemRow(FeatureRowItem item)
+        {
+            var content = new VBoxContainer { Name = "Content", SizeFlagsHorizontal = Control.SizeFlags.ExpandFill };
+            content.AddThemeConstantOverride("separation", 2);
+
+            // Header line: title (16px bold) on the left, enable/disable toggle on the right.
+            var headerLine = new HBoxContainer { SizeFlagsHorizontal = Control.SizeFlags.ExpandFill };
+            headerLine.AddThemeConstantOverride("separation", 8);
+
+            var titleLabel = new Label
             {
-                Name = "Toggle",
-                Text = name,
-                ButtonPressed = enabled
+                Name = "Title",
+                Text = item.DisplayTitle,
+                SizeFlagsHorizontal = Control.SizeFlags.ExpandFill
             };
-            // Capture the item name for the toggle callback; persist + push-live through the connection.
-            string itemName = name;
-            checkBox.Toggled += pressed => OnItemToggled(itemName, pressed);
-            row.AddChild(checkBox);
+            DockStyle.ApplyRowTitle(titleLabel);
+            headerLine.AddChild(titleLabel);
 
-            if (!string.IsNullOrEmpty(description))
+            var toggle = new CheckButton { Name = "Toggle", ButtonPressed = item.Enabled };
+            string itemName = item.Name;
+            toggle.Toggled += pressed => OnItemToggled(itemName, pressed);
+            headerLine.AddChild(toggle);
+            content.AddChild(headerLine);
+
+            // Id (muted), shown under the title when it differs from the title.
+            if (item.DisplayTitle != item.Name)
             {
-                var descLabel = new Label
-                {
-                    Name = "Description",
-                    Text = description,
-                    AutowrapMode = TextServer.AutowrapMode.WordSmart
-                };
-                descLabel.AddThemeColorOverride("font_color", new Color(0.65f, 0.65f, 0.65f));
-                row.AddChild(descLabel);
+                var idLabel = new Label { Name = "Id", Text = item.Name };
+                DockStyle.ApplyRowId(idLabel);
+                content.AddChild(idLabel);
             }
 
-            return row;
+            AddKindMetadata(content, item);
+
+            // Description foldout (only when a description exists).
+            if (!string.IsNullOrEmpty(item.Description))
+            {
+                var (foldout, body) = DockStyle.Foldout("Description");
+                var descLabel = new Label
+                {
+                    Name = "DescriptionText",
+                    Text = item.Description,
+                    AutowrapMode = TextServer.AutowrapMode.WordSmart
+                };
+                DockStyle.ApplyDescription(descLabel);
+                body.AddChild(descLabel);
+                content.AddChild(foldout);
+            }
+
+            return DockStyle.RowCard(content, $"Item_{item.Name}", item.Enabled);
+        }
+
+        /// <summary>Append the kind-specific metadata labels / argument foldouts to a row's content box.</summary>
+        void AddKindMetadata(VBoxContainer content, FeatureRowItem item)
+        {
+            switch (_kind)
+            {
+                case GodotMcpFeatureKind.Tools:
+                    var tokenLabel = new Label
+                    {
+                        Name = "Tokens",
+                        Text = FeaturesPanelView.TokenLabel(item.TokenCount)
+                    };
+                    DockStyle.ApplyMetadataColor(tokenLabel, DockTheme.RowIdMuted);
+                    content.AddChild(tokenLabel);
+                    AddArgumentFoldout(content, "Input arguments", item.Inputs);
+                    break;
+
+                case GodotMcpFeatureKind.Prompts:
+                    if (!string.IsNullOrEmpty(item.Role))
+                    {
+                        var roleLabel = new Label { Name = "Role", Text = $"Role: {item.Role}" };
+                        DockStyle.ApplyMetadataColor(roleLabel, DockTheme.RoleLabel);
+                        content.AddChild(roleLabel);
+                    }
+                    AddArgumentFoldout(content, "Arguments", item.Arguments);
+                    break;
+
+                default: // Resources
+                    if (!string.IsNullOrEmpty(item.Uri))
+                    {
+                        var uriLabel = new Label
+                        {
+                            Name = "Uri",
+                            Text = item.Uri,
+                            AutowrapMode = TextServer.AutowrapMode.WordSmart
+                        };
+                        DockStyle.ApplyMetadataColor(uriLabel, DockTheme.ResourceUri);
+                        content.AddChild(uriLabel);
+                    }
+                    if (!string.IsNullOrEmpty(item.MimeType))
+                    {
+                        var mimeLabel = new Label { Name = "MimeType", Text = $"MimeType: {item.MimeType}" };
+                        DockStyle.ApplyMetadataColor(mimeLabel, DockTheme.ResourceMimeType);
+                        content.AddChild(mimeLabel);
+                    }
+                    break;
+            }
+        }
+
+        /// <summary>Add a "&lt;Title&gt; (N)" foldout listing each argument's name + optional description. No-op when empty.</summary>
+        void AddArgumentFoldout(VBoxContainer content, string title, IReadOnlyList<FeatureArgument> arguments)
+        {
+            if (arguments.Count == 0)
+                return;
+
+            var (foldout, body) = DockStyle.Foldout($"{title} ({arguments.Count})");
+            foreach (var arg in arguments)
+            {
+                var nameLabel = new Label { Text = arg.Name };
+                DockStyle.ApplySubLabel(nameLabel);
+                body.AddChild(nameLabel);
+
+                if (!string.IsNullOrEmpty(arg.Description))
+                {
+                    var descLabel = new Label
+                    {
+                        Text = arg.Description,
+                        AutowrapMode = TextServer.AutowrapMode.WordSmart
+                    };
+                    DockStyle.ApplyDescription(descLabel);
+                    body.AddChild(descLabel);
+                }
+            }
+            content.AddChild(foldout);
         }
 
         void OnItemToggled(string name, bool enabled)
         {
             // Push to the live manager AND persist into the enable-map (survives restart).
             _connection.SetFeatureEnabled(_kind, name, enabled);
+
+            // Reflect the new enabled-state in the cached item set so a re-filter sees it, then re-filter — under a
+            // non-All status this hides/shows the just-toggled row; the row tint also updates on rebuild.
+            for (int i = 0; i < _allItems.Count; i++)
+            {
+                if (_allItems[i].Name == name)
+                {
+                    var updated = new List<FeatureRowItem>(_allItems);
+                    updated[i] = updated[i] with { Enabled = enabled };
+                    _allItems = updated;
+                    break;
+                }
+            }
+            RebuildRows();
         }
 
         /// <summary>Pop the window up centred and visible. Called by the panel after parenting it into the tree.</summary>


### PR DESCRIPTION
## Summary
- Overhaul the shared `FeatureListWindow` (tools/prompts/resources) to mimic Unity-MCP's `McpListWindowBase`: a live text search + an All/Enabled/Disabled status filter + a "Filtered: X, Total: Y" stat + an empty-state, with per-row card styling (soft-green enabled / soft-red disabled) and per-type metadata (tools: ~N tokens + Input-arguments foldout; prompts: Role + Arguments foldout; resources: URI + MimeType), plus a Description foldout and a per-row enable/disable `CheckButton`.
- New pure-managed `FeatureFilter` (status×text filter chain, `FeatureRowItem`/`FeatureArgument` records, stat formatter, JSON-schema argument parser) — all xUnit-tested. `DockTheme`/`DockStyle` extended with row tints, metadata colours, the row-card builder, and OptionButton styling.
- Enable/disable wired end-to-end: the toggle pushes to the live McpPlugin manager AND persists via `GodotMcpConnection.SetFeatureEnabled`, then re-filters so a toggle under a non-All status hides/shows the row.

## Test plan
- [x] Suite 1 (`dotnet build Godot-MCP.sln`) — 0 errors, 0 warnings.
- [x] Suite 2 (`dotnet test Godot-MCP.Tests`) — 498/498 pass (+34 new FeatureFilter + DockTheme tests).
- [x] Suite 3 headless smoke (Godot 4.5.1 mono, testbed junction → worktree addon) — `[Godot-MCP] plugin loaded`, deps resolved to 6.7.0/5.3.1, "Loading docks" OK, no FileNotFoundException.

Closes #51