### PR TITLE
fix(dock): refresh feature counts on per-row toggle

### DIFF
--- a/addons/godot_mcp/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConnection.cs
@@ -317,13 +317,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             }
 
             _featuresSubscription.Disposable = Observable.Merge(streams)
-                .Subscribe(_ =>
-                {
-                    if (MainThreadDispatcher.Instance != null && !MainThreadDispatcher.IsMainThread)
-                        MainThreadDispatcher.Enqueue(() => FeaturesUpdated?.Invoke());
-                    else
-                        FeaturesUpdated?.Invoke();
-                });
+                .Subscribe(_ => RaiseFeaturesUpdated());
         }
 
         /// <summary>
@@ -488,7 +482,36 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             manager.SetEnabled(name, enabled);
             GodotMcpFeatureStateMerge.Upsert(_config.Features.For(kind), name, enabled);
             Save();
+
+            // Guarantee the dock's features panel recomputes after a per-row toggle (issue #54). Directly
+            // owning the refresh here makes the dock-count update a property of the toggle path itself rather
+            // than an incidental side effect of how the reused client's Set*Enabled happens to notify: with the
+            // pinned McpPlugin 6.7.0 the manager's Set*Enabled DOES fire its On*Updated stream (so the
+            // SubscribeToFeatureUpdates path also raises FeaturesUpdated), but that is an upstream
+            // implementation detail we must not depend on for a first-party UI invariant — older/newer client
+            // versions may treat an enable/disable as not-a-registry-change and stay silent. The raise is
+            // kind-generic: one call covers tools/prompts/resources because the panel re-reads every kind's
+            // counts. A duplicate refresh (when On*Updated also fires) is harmless — RefreshAll only re-reads
+            // counts and re-sets label text (idempotent), and the list window does not subscribe to
+            // FeaturesUpdated (it re-filters locally), so there is no feedback loop.
+            RaiseFeaturesUpdated();
             return true;
+        }
+
+        /// <summary>
+        /// Raise <see cref="FeaturesUpdated"/> on the editor main thread, mirroring the same dispatcher-guard
+        /// the managers' <c>On*Updated</c> subscription uses (see <see cref="SubscribeToFeatureUpdates"/>): hop
+        /// to the main thread when off it (and a dispatcher is in the tree), else invoke inline. The toggle
+        /// path (<see cref="SetFeatureEnabled"/>) already runs on the editor main thread, so it takes the inline
+        /// branch — but routing through the same guard keeps the event's "always marshalled onto the main
+        /// thread" contract true regardless of which thread a future caller raises from.
+        /// </summary>
+        void RaiseFeaturesUpdated()
+        {
+            if (MainThreadDispatcher.Instance != null && !MainThreadDispatcher.IsMainThread)
+                MainThreadDispatcher.Enqueue(() => FeaturesUpdated?.Invoke());
+            else
+                FeaturesUpdated?.Invoke();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- The dock 'MCP Features' panel recomputes counts only on `GodotMcpConnection.FeaturesUpdated`. Make the per-row toggle own that refresh: after a successful `SetFeatureEnabled` (manager set + persist + `Save()`), raise `FeaturesUpdated` via the same editor-main-thread dispatcher-guard the managers' `On*Updated` subscription uses, so `FeaturesPanel.RefreshAll` recomputes all three rows (36 → 35 → 36).
- One raise is kind-generic (tools/prompts/resources). No feedback loop: the list window re-filters locally and does not subscribe to `FeaturesUpdated`. Also dedups `SubscribeToFeatureUpdates` onto the shared `RaiseFeaturesUpdated` helper.

## Reviewer note — root-cause correction
The issue states `manager.SetEnabled` does NOT fire `On*Updated`. Decompiling the **pinned McpPlugin 6.7.0** shows the opposite: `SetToolEnabled`/`SetPromptEnabled`/`SetResourceEnabled` each call `_on*Updated.OnNext(Unit.Default)` unconditionally, so the existing subscription already raises `FeaturesUpdated` on a toggle. This change is nonetheless the issue's prescribed fix and is correct as a defensive, version-independent first-party UI invariant (a duplicate refresh is idempotent and harmless). The originally-described "stale count" may already be latent-fixed by the 6.5.5 → 6.7.0 dependency upgrade; live click-verify in a windowed editor is the remaining operator step.

## Test plan
- [x] Suite 1 build: 0 warnings / 0 errors
- [x] Suite 2 xUnit: 498 passed / 0 failed
- [x] Suite 3 headless smoke: `[Godot-MCP] plugin loaded`, deps resolve to McpPlugin 6.7.0, Custom-mode connect + server-side version handshake successful (Plugin 0.1.0, Godot 4.5.1), no `FileNotFoundException`
- [ ] Operator click-verify: toggle a tool in the list window → dock Tools count drops 36 → 35 → 36 (windowed editor; not reachable headlessly)

Closes #54