### PR TITLE
feat(connection): port dock Connection section to Unity-MCP timeline design

### DIFF
--- a/Godot-MCP.Tests/ConnectionPanelViewTests.cs
+++ b/Godot-MCP.Tests/ConnectionPanelViewTests.cs
@@ -197,6 +197,83 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             }
         }
 
+        // --- Timeline circle state (ConnectionStatus -> TimelinePointState) ---
+
+        [Theory]
+        [InlineData(ConnectionStatus.Connected, ConnectionPanelView.TimelinePointState.Online)]
+        [InlineData(ConnectionStatus.Connecting, ConnectionPanelView.TimelinePointState.Connecting)]
+        [InlineData(ConnectionStatus.Disconnected, ConnectionPanelView.TimelinePointState.Disconnected)]
+        public void PointState_MapsEachStatus(ConnectionStatus status, ConnectionPanelView.TimelinePointState expected)
+        {
+            Assert.Equal(expected, ConnectionPanelView.PointState(status));
+        }
+
+        // --- AgentLabel ---
+
+        [Fact]
+        public void AgentLabel_NoAgent_IsConnectsOnDemand()
+        {
+            Assert.Equal("AI agent (connects on demand)", ConnectionPanelView.AgentLabel(null, null));
+            Assert.Equal("AI agent (connects on demand)", ConnectionPanelView.AgentLabel("", "1.0"));
+            Assert.Equal("AI agent (connects on demand)", ConnectionPanelView.AgentLabel("   ", null));
+        }
+
+        [Fact]
+        public void AgentLabel_NameOnly_OmitsVersionParens()
+        {
+            Assert.Equal("AI agent: Cursor", ConnectionPanelView.AgentLabel("Cursor", null));
+            Assert.Equal("AI agent: Cursor", ConnectionPanelView.AgentLabel(" Cursor ", "  "));
+        }
+
+        [Fact]
+        public void AgentLabel_NameAndVersion_IncludesParens()
+        {
+            Assert.Equal("AI agent: Claude (1.2.0)", ConnectionPanelView.AgentLabel("Claude", "1.2.0"));
+            Assert.Equal("AI agent: Claude (1.2.0)", ConnectionPanelView.AgentLabel(" Claude ", " 1.2.0 "));
+        }
+
+        // --- Alert visibility: Authorization Required (Cloud, no token) ---
+
+        [Theory]
+        [InlineData(true, false, true)]    // cloud + no token -> show
+        [InlineData(true, true, false)]    // cloud + token -> hide
+        [InlineData(false, false, false)]  // custom -> hide regardless
+        [InlineData(false, true, false)]
+        public void ShowAuthorizationRequired_OnlyCloudWithoutToken(bool cloud, bool hasToken, bool expected)
+        {
+            Assert.Equal(expected, ConnectionPanelView.ShowAuthorizationRequired(cloud, hasToken));
+        }
+
+        // --- Alert visibility: Connection Required (ready but disconnected) ---
+
+        [Theory]
+        // Custom mode, disconnected -> show (Custom never needs a cloud token).
+        [InlineData(false, false, ConnectionStatus.Disconnected, true)]
+        // Custom mode, connecting / connected -> hide.
+        [InlineData(false, false, ConnectionStatus.Connecting, false)]
+        [InlineData(false, false, ConnectionStatus.Connected, false)]
+        // Cloud + token, disconnected -> show.
+        [InlineData(true, true, ConnectionStatus.Disconnected, true)]
+        // Cloud + token, connected -> hide.
+        [InlineData(true, true, ConnectionStatus.Connected, false)]
+        // Cloud WITHOUT token -> the Authorization alert owns this; Connection alert stays hidden.
+        [InlineData(true, false, ConnectionStatus.Disconnected, false)]
+        [InlineData(true, false, ConnectionStatus.Connecting, false)]
+        public void ShowConnectionRequired_RespectsModeTokenAndStatus(
+            bool cloud, bool hasToken, ConnectionStatus status, bool expected)
+        {
+            Assert.Equal(expected, ConnectionPanelView.ShowConnectionRequired(cloud, hasToken, status));
+        }
+
+        [Fact]
+        public void Alerts_AreMutuallyExclusive_InCloudWithoutToken()
+        {
+            // In Cloud-mode-without-token the Authorization alert shows and the Connection alert must NOT,
+            // so the two never stack on the same condition.
+            Assert.True(ConnectionPanelView.ShowAuthorizationRequired(true, false));
+            Assert.False(ConnectionPanelView.ShowConnectionRequired(true, false, ConnectionStatus.Disconnected));
+        }
+
         [Fact]
         public void CustomHost_PersistsAndReloads()
         {

--- a/Godot-MCP.Tests/DockThemeTests.cs
+++ b/Godot-MCP.Tests/DockThemeTests.cs
@@ -111,6 +111,71 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Equal(DockTheme.ColorDescriptionMuted, DockTheme.RowIdMuted);
         }
 
+        // --- Segmented control palette (Unity-MCP's segmented toggle) ---
+
+        [Fact]
+        public void SegmentTrack_MatchesBriefRgbaAndSizing()
+        {
+            // track bg rgba(255,255,255, 0.05)
+            AssertRgba8(DockTheme.SegmentTrackBackground, 255, 255, 255, 0.05f);
+            Assert.Equal(6, DockTheme.SegmentTrackCornerRadius);
+            Assert.Equal(2, DockTheme.SegmentTrackPadding);
+        }
+
+        [Fact]
+        public void SegmentSelected_MatchesBriefRgbaAndSizing()
+        {
+            // selected highlight rgba(0,0,0, 0.4)
+            AssertRgba8(DockTheme.SegmentSelectedBackground, 0, 0, 0, 0.4f);
+            Assert.Equal(4, DockTheme.SegmentSelectedCornerRadius);
+        }
+
+        [Fact]
+        public void SegmentText_SelectedIsCyanPrimary_UnselectedIsMutedGray()
+        {
+            // selected text = primary cyan Color8(175,232,230)
+            Assert.Equal(DockTheme.ButtonPrimary, DockTheme.SegmentSelectedText);
+            AssertRgb8(DockTheme.SegmentSelectedText, 175, 232, 230);
+            // unselected text = muted gray (reuses the description muted gray)
+            Assert.Equal(DockTheme.ColorDescriptionMuted, DockTheme.SegmentUnselectedText);
+        }
+
+        [Fact]
+        public void SegmentSizing_MatchesBrief()
+        {
+            Assert.Equal(40, DockTheme.SegmentMinWidth);
+            Assert.Equal(12, DockTheme.SegmentFontSize);
+        }
+
+        // --- Vertical timeline ---
+
+        [Fact]
+        public void TimelineLine_MatchesBrief8BitAndWidth()
+        {
+            // connecting line rgb(80,80,80), 2px wide.
+            AssertRgb8(DockTheme.TimelineLine, 80, 80, 80);
+            Assert.Equal(2, DockTheme.TimelineLineWidth);
+        }
+
+        [Fact]
+        public void TimelineIndicatorAndRing_MatchBrief()
+        {
+            Assert.Equal(20, DockTheme.TimelineIndicatorWidth);
+            Assert.Equal(2, DockTheme.TimelineRingBorderWidth);
+        }
+
+        [Fact]
+        public void WarningFrame_MatchesBriefRgbaAndColors()
+        {
+            // amber warning frame: bg rgba(180,120,40, 0.12), border rgba(220,160,60, 0.45),
+            // title Color8(255,200,100), message Color8(210,180,130).
+            AssertRgba8(DockTheme.WarningBackground, 180, 120, 40, 0.12f);
+            AssertRgba8(DockTheme.WarningBorder, 220, 160, 60, 0.45f);
+            AssertRgb8(DockTheme.WarningTitle, 255, 200, 100);
+            AssertRgb8(DockTheme.WarningMessage, 210, 180, 130);
+            Assert.Equal(10, DockTheme.WarningCornerRadius);
+        }
+
         static void AssertRgb8((float R, float G, float B) c, int r8, int g8, int b8)
         {
             Assert.Equal(r8 / 255f, c.R, 5);

--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -132,6 +132,11 @@
          via the headless Godot smoke (test.md Suite 3); the view logic is unit-tested here. The SignalR
          HubConnectionState enum it switches on is provided transitively by com.IvanMurzak.McpPlugin. -->
     <Compile Include="..\addons\godot_mcp\UI\ConnectionPanelView.cs" Link="Source\ConnectionPanelView.cs" />
+    <!-- Segmented-control state model — pure-managed (no Godot native types, no #if TOOLS): the
+         value→index / selected-predicate / clamp rules for the reusable segmented control (Custom|Cloud,
+         none|required). The editor builder (DockStyle.SegmentedControl, #if TOOLS) consumes these and is
+         verified via the headless Godot smoke (test.md Suite 3); the index/selection logic is unit-tested here. -->
+    <Compile Include="..\addons\godot_mcp\UI\SegmentedControlModel.cs" Link="Source\SegmentedControlModel.cs" />
     <!-- Dock design palette — pure-managed (no Godot native types, no #if TOOLS): the colour/size/font
          constants + the ConnectionStatus → status-dot colour mapping that DockStyle (#if TOOLS) consumes.
          The editor StyleBox/Theme wiring (DockStyle.cs) is #if TOOLS and verified via the headless Godot

--- a/Godot-MCP.Tests/SegmentedControlModelTests.cs
+++ b/Godot-MCP.Tests/SegmentedControlModelTests.cs
@@ -1,0 +1,74 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using com.IvanMurzak.Godot.MCP.UI;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the pure-managed state logic of the dock's reusable segmented control
+    /// (<see cref="SegmentedControlModel"/>): value→index resolution, the selected predicate, and the
+    /// out-of-range clamp. The editor builder (<c>DockStyle.SegmentedControl</c>, <c>#if TOOLS</c>) consumes
+    /// these and is verified via the headless Godot smoke (test.md Suite 3) — NOT here.
+    /// </summary>
+    public class SegmentedControlModelTests
+    {
+        static readonly string[] Modes = { "Custom", "Cloud" };
+
+        [Theory]
+        [InlineData("Custom", 0)]
+        [InlineData("Cloud", 1)]
+        public void IndexOf_ReturnsMatchingIndex(string value, int expected)
+        {
+            Assert.Equal(expected, SegmentedControlModel.IndexOf(Modes, value));
+        }
+
+        [Fact]
+        public void IndexOf_UnknownValue_FallsBackToFirstSegment()
+        {
+            // Unknown value must still yield a stable in-range selection so the control never renders empty.
+            Assert.Equal(0, SegmentedControlModel.IndexOf(Modes, "Nope"));
+        }
+
+        [Fact]
+        public void IndexOf_EmptyOptions_ReturnsMinusOne()
+        {
+            Assert.Equal(-1, SegmentedControlModel.IndexOf(System.Array.Empty<string>(), "x"));
+        }
+
+        [Theory]
+        [InlineData(0, 0, true)]
+        [InlineData(1, 0, false)]
+        [InlineData(1, 1, true)]
+        public void IsSelected_MatchesIndex(int index, int selectedIndex, bool expected)
+        {
+            Assert.Equal(expected, SegmentedControlModel.IsSelected(index, selectedIndex));
+        }
+
+        [Theory]
+        [InlineData(0, 2, 0)]
+        [InlineData(1, 2, 1)]
+        [InlineData(5, 2, 0)]    // out of range -> first
+        [InlineData(-1, 2, 0)]   // "no value" -> first
+        public void ClampSelected_KeepsSelectionInRange(int selected, int count, int expected)
+        {
+            Assert.Equal(expected, SegmentedControlModel.ClampSelected(selected, count));
+        }
+
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(3, 0)]
+        public void ClampSelected_EmptySet_ReturnsMinusOne(int selected, int _)
+        {
+            Assert.Equal(-1, SegmentedControlModel.ClampSelected(selected, 0));
+        }
+    }
+}

--- a/addons/godot_mcp/UI/ConnectionPanel.cs
+++ b/addons/godot_mcp/UI/ConnectionPanel.cs
@@ -9,6 +9,7 @@
 */
 #if TOOLS
 #nullable enable
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using com.IvanMurzak.Godot.MCP.Connection;
 using com.IvanMurzak.Godot.MCP.MainThreadDispatch;
@@ -18,23 +19,28 @@ namespace com.IvanMurzak.Godot.MCP.UI
 {
     /// <summary>
     /// The connection section of the Godot-MCP editor dock — the Godot <see cref="Control"/> analog of
-    /// Unity-MCP's <c>MainWindowEditor.Connection</c>. A <see cref="VBoxContainer"/> the
-    /// <see cref="GodotMcpDock"/> drops into its Body, wired to a <see cref="GodotMcpConnection"/>. It
-    /// renders, top to bottom:
+    /// Unity-MCP's <c>MainWindowEditor.Connection</c>, ported 1:1 to Unity-MCP's vertical TIMELINE design. A
+    /// <see cref="VBoxContainer"/> the <see cref="GodotMcpDock"/> drops into its Body, wired to a
+    /// <see cref="GodotMcpConnection"/>. It renders, top to bottom:
     /// <list type="bullet">
-    ///   <item>A status row — a coloured dot + a "Godot: …" label, live from
-    ///   <see cref="GodotMcpConnection.ConnectionStatus"/>.</item>
-    ///   <item>A Connect/Disconnect button whose text + enabled-state reflect the status.</item>
-    ///   <item>A Custom|Cloud mode selector that persists the choice and reconnects.</item>
-    ///   <item>A Server URL field (Custom mode only) bound to the custom host, with validation.</item>
-    ///   <item>A simplified Godot → MCP server → AI agent timeline of status dots.</item>
+    ///   <item>A "Connection" header (20px bold) with a right-aligned Custom|Cloud segmented control.</item>
+    ///   <item>Amber alert panels — "Authorization Required" (Cloud, no token) / "Connection Required"
+    ///   (ready but not connected).</item>
+    ///   <item>A vertical timeline of three points — Godot, MCP server, AI agent — each with a status circle
+    ///   (filled green online / green ring connecting / filled orange disconnected) in a 20px indicator column
+    ///   joined by a 2px connecting line, an underlined 13px label, and the point's content.</item>
+    ///   <item>The Godot point: a right-aligned Connect/Disconnect button.</item>
+    ///   <item>The MCP-server point: a frame-group card holding the Server URL (Custom mode) / cloud auth row
+    ///   (Cloud mode) and the Authorization segmented + masked token field.</item>
+    ///   <item>The AI-agent point: a status circle + label (no connecting line below).</item>
     /// </list>
     ///
     /// <para>
     /// Editor-only (<c>#if TOOLS</c>): it builds live Godot UI <see cref="Node"/>s, so it is verified via
     /// the headless Godot smoke (<c>test.md</c> Suite 3), not the plain-xUnit host. ALL presentation
-    /// decisions (status reduction, label/button text, dot colour, URL validation) live in the
-    /// pure-managed <see cref="ConnectionPanelView"/> so they ARE unit-tested.
+    /// decisions (status reduction, label/button text, circle state, segmented index/selection, alert
+    /// visibility, URL validation) live in the pure-managed <see cref="ConnectionPanelView"/> /
+    /// <see cref="SegmentedControlModel"/> / <see cref="DockTheme"/> so they ARE unit-tested.
     /// </para>
     /// </summary>
     [Tool]
@@ -42,16 +48,41 @@ namespace com.IvanMurzak.Godot.MCP.UI
     {
         readonly GodotMcpConnection _connection;
 
-        // Status row.
-        ColorRect _statusDot = null!;
+        // Header: Custom|Cloud mode segmented control.
+        Control _modeSegmented = null!;
+        static readonly IReadOnlyList<string> ModeOptions = new[] { ModeLabelCustom, ModeLabelCloud };
+        const string ModeLabelCustom = "Custom";
+        const string ModeLabelCloud = "Cloud";
+
+        // Alert panels (amber WarningFrame): shown/hidden per ConnectionPanelView rules.
+        PanelContainer _authRequiredAlert = null!;
+        PanelContainer _connectionRequiredAlert = null!;
+
+        // Timeline circles (re-styled in place per status change).
+        Panel _timelineGodotCircle = null!;
+        Panel _timelineServerCircle = null!;
+        Panel _timelineAgentCircle = null!;
+
+        // Godot point: status label + Connect/Disconnect.
         Label _statusLabel = null!;
         Button _connectButton = null!;
 
-        // Mode selector + custom-host row.
-        OptionButton _modeSelector = null!;
+        // MCP-server point content.
+        Label _agentLabel = null!;
+
+        // Custom-mode server-URL + auth.
         VBoxContainer _customHostRow = null!;
         LineEdit _hostField = null!;
         Label _overrideNote = null!;
+
+        // Custom-mode authorization segmented (none|required) + masked token + Generate.
+        Control _authSegmented = null!;
+        VBoxContainer _tokenRow = null!;
+        LineEdit _tokenField = null!;
+        Button _generateTokenButton = null!;
+        static readonly IReadOnlyList<string> AuthOptions = new[] { AuthLabelNone, AuthLabelRequired };
+        const string AuthLabelNone = "none";
+        const string AuthLabelRequired = "required";
 
         // Cloud-mode auth section (device-code flow): masked token + Authorize/Revoke + status.
         VBoxContainer _cloudAuthRow = null!;
@@ -62,21 +93,6 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
         // The in-flight device-auth flow (null when none has run). Recreated per Authorize click.
         GodotDeviceAuthFlow? _deviceAuthFlow;
-
-        // Custom-mode authorization row (auth option + masked token + Generate).
-        OptionButton _authSelector = null!;
-        VBoxContainer _tokenRow = null!;
-        LineEdit _tokenField = null!;
-        Button _generateTokenButton = null!;
-
-        // Index of the two Authorization OptionButton entries — kept stable so a selection maps to a value.
-        const int AuthIdNone = 0;
-        const int AuthIdRequired = 1;
-
-        // Timeline dots.
-        ColorRect _timelineGodotDot = null!;
-        ColorRect _timelineServerDot = null!;
-        ColorRect _timelineAgentDot = null!;
 
         // The last status the panel actually RENDERED, so the periodic re-sync only re-applies (and traces)
         // when the live status has drifted from what is on screen — keeping the per-tick check cheap and quiet.
@@ -93,10 +109,6 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
         /// <summary>Re-sync cadence: re-read + re-apply the live connection status this often (seconds).</summary>
         const double ResyncIntervalSeconds = 0.5;
-
-        // Index of the two OptionButton entries — kept stable so a selection maps back to a mode.
-        const int ModeIdCustom = 0;
-        const int ModeIdCloud = 1;
 
         public ConnectionPanel(GodotMcpConnection connection)
         {
@@ -151,39 +163,93 @@ namespace com.IvanMurzak.Godot.MCP.UI
         void BuildUi()
         {
             SizeFlagsHorizontal = SizeFlags.ExpandFill;
-            AddThemeConstantOverride("separation", 6);
+            AddThemeConstantOverride("separation", 8);
 
-            // --- Status row: dot + label ---
-            var statusRow = new HBoxContainer { Name = "StatusRow" };
-            AddChild(statusRow);
+            // --- Header row: "Connection" (20px bold) + right-aligned Custom|Cloud segmented ---
+            var headerRow = new HBoxContainer { Name = "HeaderRow" };
+            AddChild(headerRow);
 
-            _statusDot = MakeDot("StatusDot");
-            statusRow.AddChild(_statusDot);
+            var headerLabel = new Label { Name = "HeaderLabel", Text = "Connection" };
+            DockStyle.ApplyHeader(headerLabel);
+            headerRow.AddChild(headerLabel);
 
-            _statusLabel = new Label { Name = "StatusLabel" };
+            headerRow.AddChild(new Control { Name = "HeaderSpacer", SizeFlagsHorizontal = SizeFlags.ExpandFill });
+
+            _modeSegmented = DockStyle.SegmentedControl(
+                "ModeSegmented",
+                ModeOptions,
+                SegmentedControlModel.IndexOf(ModeOptions, ModeLabelForMode(_connection.Config.ConnectionMode)),
+                OnModeSegmentSelected);
+            headerRow.AddChild(_modeSegmented);
+
+            // --- Alert panels (shown/hidden per ConnectionPanelView rules) ---
+            _authRequiredAlert = DockStyle.AlertPanel(
+                "AuthRequiredAlert",
+                ConnectionPanelView.AuthorizationRequiredTitle,
+                ConnectionPanelView.AuthorizationRequiredMessage,
+                ConnectionPanelView.AuthorizeButtonText,
+                OnAuthorizeButtonPressed);
+            AddChild(_authRequiredAlert);
+
+            _connectionRequiredAlert = DockStyle.AlertPanel(
+                "ConnectionRequiredAlert",
+                ConnectionPanelView.ConnectionRequiredTitle,
+                ConnectionPanelView.ConnectionRequiredMessage,
+                ConnectionPanelView.ButtonTextConnect,
+                () => _connection.Connect());
+            AddChild(_connectionRequiredAlert);
+
+            // --- Vertical timeline: Godot -> MCP server -> AI agent ---
+            var timeline = new VBoxContainer { Name = "Timeline" };
+            timeline.AddThemeConstantOverride("separation", 0);
+            AddChild(timeline);
+
+            // Point 1 — Godot: label + right-aligned Connect/Disconnect.
+            _timelineGodotCircle = DockStyle.TimelineCircle("GodotCircle", ConnectionPanelView.TimelinePointState.Disconnected);
+            _statusLabel = new Label { Name = "GodotStatus" };
             DockStyle.ApplySubLabel(_statusLabel);
-            statusRow.AddChild(_statusLabel);
 
-            // --- Connect/Disconnect button ---
             _connectButton = new Button { Name = "ConnectButton" };
             _connectButton.Pressed += OnConnectButtonPressed;
-            AddChild(_connectButton);
 
-            // --- Mode selector ---
-            var modeRow = new HBoxContainer { Name = "ModeRow" };
-            AddChild(modeRow);
+            var godotContent = new HBoxContainer { Name = "GodotContent", SizeFlagsHorizontal = SizeFlags.ExpandFill };
+            godotContent.AddChild(DockStyle.TimelineLabel("GodotLabel", "Godot"));
+            godotContent.AddChild(_statusLabel);
+            godotContent.AddChild(new Control { SizeFlagsHorizontal = SizeFlags.ExpandFill });
+            godotContent.AddChild(_connectButton);
+            timeline.AddChild(MakeTimelinePoint(_timelineGodotCircle, godotContent, isLast: false));
 
-            modeRow.AddChild(new Label { Name = "ModeLabel", Text = "Mode" });
+            // Point 2 — MCP server: a frame-group card with the server URL / cloud auth + authorization rows.
+            _timelineServerCircle = DockStyle.TimelineCircle("ServerCircle", ConnectionPanelView.TimelinePointState.Disconnected);
+            var serverContent = new VBoxContainer { Name = "ServerContent", SizeFlagsHorizontal = SizeFlags.ExpandFill };
+            serverContent.AddThemeConstantOverride("separation", 4);
+            serverContent.AddChild(DockStyle.TimelineLabel("ServerLabel", "MCP server"));
+            BuildServerCard(serverContent);
+            timeline.AddChild(MakeTimelinePoint(_timelineServerCircle, serverContent, isLast: false));
 
-            _modeSelector = new OptionButton { Name = "ModeSelector" };
-            _modeSelector.AddItem("Custom", ModeIdCustom);
-            _modeSelector.AddItem("Cloud", ModeIdCloud);
-            _modeSelector.ItemSelected += OnModeSelected;
-            modeRow.AddChild(_modeSelector);
+            // Point 3 — AI agent: circle + label, LAST point (no connecting line below).
+            _timelineAgentCircle = DockStyle.TimelineCircle("AgentCircle", ConnectionPanelView.TimelinePointState.Disconnected);
+            _agentLabel = new Label { Name = "AgentLabel", Text = ConnectionPanelView.AgentLabel(null, null) };
+            DockStyle.ApplySubLabel(_agentLabel);
+            var agentContent = new HBoxContainer { Name = "AgentContent", SizeFlagsHorizontal = SizeFlags.ExpandFill };
+            agentContent.AddChild(_agentLabel);
+            timeline.AddChild(MakeTimelinePoint(_timelineAgentCircle, agentContent, isLast: true));
+        }
+
+        /// <summary>
+        /// Build the MCP-server point's frame-group card content: the Custom-mode server-URL row + override
+        /// note, the Cloud-mode device-auth row, and the Authorization (none|required) segmented + masked
+        /// token field. These are reparented INTO a styled card by <see cref="DockStyle.Card"/>.
+        /// </summary>
+        void BuildServerCard(VBoxContainer parent)
+        {
+            var card = new VBoxContainer { Name = "ServerCardContent", SizeFlagsHorizontal = SizeFlags.ExpandFill };
+            card.AddThemeConstantOverride("separation", 4);
 
             // --- Custom-mode server-URL row (shown only in Custom mode) ---
             _customHostRow = new VBoxContainer { Name = "CustomHostRow" };
-            AddChild(_customHostRow);
+            _customHostRow.AddThemeConstantOverride("separation", 4);
+            card.AddChild(_customHostRow);
 
             _customHostRow.AddChild(new Label { Name = "HostLabel", Text = "Server URL" });
 
@@ -199,23 +265,23 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _hostField.FocusExited += OnHostFocusExited;
             _customHostRow.AddChild(_hostField);
 
-            // --- Authorization (Custom mode only): none | required ---
-            var authRow = new HBoxContainer { Name = "AuthRow" };
-            _customHostRow.AddChild(authRow);
+            // --- Authorization (Custom mode only): none | required (segmented) ---
+            var authLine = new HBoxContainer { Name = "AuthLine" };
+            _customHostRow.AddChild(authLine);
 
-            authRow.AddChild(new Label { Name = "AuthLabel", Text = "Authorization" });
+            authLine.AddChild(new Label { Name = "AuthLabel", Text = "Authorization Token" });
+            authLine.AddChild(new Control { SizeFlagsHorizontal = SizeFlags.ExpandFill });
 
-            _authSelector = new OptionButton { Name = "AuthSelector" };
-            _authSelector.AddItem("none", AuthIdNone);
-            _authSelector.AddItem("required", AuthIdRequired);
-            _authSelector.ItemSelected += OnAuthOptionSelected;
-            authRow.AddChild(_authSelector);
+            _authSegmented = DockStyle.SegmentedControl(
+                "AuthSegmented",
+                AuthOptions,
+                SegmentedControlModel.IndexOf(AuthOptions, AuthLabelForOption(_connection.Config.AuthOption)),
+                OnAuthSegmentSelected);
+            authLine.AddChild(_authSegmented);
 
             // --- Token row (shown only when Authorization == required): masked field + Generate ---
             _tokenRow = new VBoxContainer { Name = "TokenRow" };
             _customHostRow.AddChild(_tokenRow);
-
-            _tokenRow.AddChild(new Label { Name = "TokenLabel", Text = "Token" });
 
             var tokenLine = new HBoxContainer { Name = "TokenLine" };
             _tokenRow.AddChild(tokenLine);
@@ -237,7 +303,8 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
             // --- Cloud-mode auth section (shown only in Cloud mode): device-code login ---
             _cloudAuthRow = new VBoxContainer { Name = "CloudAuthRow" };
-            AddChild(_cloudAuthRow);
+            _cloudAuthRow.AddThemeConstantOverride("separation", 4);
+            card.AddChild(_cloudAuthRow);
 
             _cloudAuthRow.AddChild(new Label { Name = "CloudTokenLabel", Text = "Cloud Token" });
 
@@ -279,67 +346,72 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 AutowrapMode = TextServer.AutowrapMode.WordSmart
             };
             _overrideNote.AddThemeColorOverride("font_color", new Color(0.92f, 0.74f, 0.20f));
-            AddChild(_overrideNote);
+            card.AddChild(_overrideNote);
 
-            AddChild(new HSeparator { Name = "TimelineSeparator" });
-
-            // --- Simplified timeline: Godot -> MCP server -> AI agent ---
-            var timeline = new VBoxContainer { Name = "Timeline" };
-            AddChild(timeline);
-
-            _timelineGodotDot = MakeDot("TimelineGodotDot");
-            timeline.AddChild(MakeTimelineRow(_timelineGodotDot, "Godot"));
-
-            _timelineServerDot = MakeDot("TimelineServerDot");
-            timeline.AddChild(MakeTimelineRow(_timelineServerDot, "MCP server"));
-
-            _timelineAgentDot = MakeDot("TimelineAgentDot");
-            timeline.AddChild(MakeTimelineRow(_timelineAgentDot, "AI agent (connects on demand)"));
-
-            // Sync the mode selector to the current config.
-            SyncModeSelector(_connection.Config.ActiveMode);
+            parent.AddChild(DockStyle.Card(card, "Server"));
         }
 
-        static ColorRect MakeDot(string name) => new ColorRect
+        /// <summary>
+        /// Compose one timeline point: a 20px indicator column (the status circle, and below it a 2px
+        /// connecting line that ExpandFills to span the gap to the next point — hidden on the LAST point) next
+        /// to the point's <paramref name="content"/>. Mirrors Unity-MCP's timeline row.
+        /// </summary>
+        static HBoxContainer MakeTimelinePoint(Panel circle, Control content, bool isLast)
         {
-            Name = name,
-            CustomMinimumSize = new Vector2(DockTheme.StatusDotSize, DockTheme.StatusDotSize),
-            SizeFlagsVertical = SizeFlags.ShrinkCenter,
-            Color = DockStyle.Rgb(DockTheme.StatusDisconnected)
-        };
+            var row = new HBoxContainer { SizeFlagsHorizontal = Control.SizeFlags.ExpandFill };
+            row.AddThemeConstantOverride("separation", 8);
 
-        static HBoxContainer MakeTimelineRow(ColorRect dot, string label)
-        {
-            var row = new HBoxContainer();
-            row.AddChild(dot);
-            row.AddChild(new Label { Text = label });
+            // Indicator column: circle on top, connecting line filling the rest (hidden on the last point).
+            var indicator = new VBoxContainer
+            {
+                Name = "Indicator",
+                CustomMinimumSize = new Vector2(DockTheme.TimelineIndicatorWidth, 0)
+            };
+            indicator.AddThemeConstantOverride("separation", 2);
+            indicator.AddChild(circle);
+
+            var line = DockStyle.TimelineLine();
+            line.Visible = !isLast;
+            indicator.AddChild(line);
+
+            row.AddChild(indicator);
+            row.AddChild(content);
             return row;
         }
+
+        static string ModeLabelForMode(GodotMcpConnectionMode mode) =>
+            mode == GodotMcpConnectionMode.Cloud ? ModeLabelCloud : ModeLabelCustom;
+
+        static string AuthLabelForOption(GodotMcpAuthOption option) =>
+            option == GodotMcpAuthOption.Required ? AuthLabelRequired : AuthLabelNone;
 
         void OnConnectionStatusChanged(ConnectionStatus status) => ApplyStatus(status);
 
         /// <summary>
-        /// Push a <see cref="ConnectionStatus"/> into the status row, button, and the Godot + MCP-server
-        /// timeline dots. All derived presentation comes from <see cref="ConnectionPanelView"/>. The
-        /// "Godot" and "MCP server" timeline dots track the same hub state (a single connection); the
-        /// "AI agent" dot is informational and stays neutral (the cloud-auth / agent-info task fills it in).
+        /// Push a <see cref="ConnectionStatus"/> into the Godot status label, the Connect button, the Godot +
+        /// MCP-server timeline circles, and the alert-panel visibility. All derived presentation comes from
+        /// <see cref="ConnectionPanelView"/>. The "Godot" and "MCP server" circles track the same hub state (a
+        /// single connection); the "AI agent" circle stays neutral (Godot is a server-less client with no live
+        /// agent-info channel — the label reads "AI agent (connects on demand)").
         /// </summary>
         void ApplyStatus(ConnectionStatus status)
         {
-            // Status-dot colour comes from the brief's dock palette (online green / connecting amber /
-            // disconnected orange); the status LABEL text still comes from ConnectionPanelView.
-            var color = DockStyle.Rgb(DockTheme.StatusDotColor(status));
+            var pointState = ConnectionPanelView.PointState(status);
 
-            _statusDot.Color = color;
             _statusLabel.Text = ConnectionPanelView.StatusLabel(status);
-
             _connectButton.Text = ConnectionPanelView.ButtonText(status);
             _connectButton.Disabled = ConnectionPanelView.ButtonDisabled(status);
+            // Primary (cyan) when the click connects; secondary (gray) when it disconnects.
+            if (status == ConnectionStatus.Connected)
+                DockStyle.ApplySecondaryButton(_connectButton);
+            else
+                DockStyle.ApplyPrimaryButton(_connectButton);
 
-            _timelineGodotDot.Color = color;
-            _timelineServerDot.Color = color;
+            DockStyle.ApplyTimelineCircle(_timelineGodotCircle, pointState);
+            DockStyle.ApplyTimelineCircle(_timelineServerCircle, pointState);
 
             _renderedStatus = status;
+            ApplyAlertVisibility(status);
 
             // Trace the actual render so a Trace smoke run shows the terminal Connected reaching the label
             // (pairs with the connection's "status: X -> Y" push trace — see GodotMcpConnection.PublishStatus).
@@ -347,11 +419,26 @@ namespace com.IvanMurzak.Godot.MCP.UI
         }
 
         /// <summary>
+        /// Show/hide the two amber alert panels per the pure-managed
+        /// <see cref="ConnectionPanelView.ShowAuthorizationRequired"/> /
+        /// <see cref="ConnectionPanelView.ShowConnectionRequired"/> rules, driven by the live mode, whether a
+        /// cloud token is stored, and the current status.
+        /// </summary>
+        void ApplyAlertVisibility(ConnectionStatus status)
+        {
+            var isCloud = _connection.Config.ActiveMode == GodotMcpConnectionMode.Cloud;
+            var hasCloudToken = !string.IsNullOrEmpty(_connection.Config.CloudToken);
+
+            _authRequiredAlert.Visible = ConnectionPanelView.ShowAuthorizationRequired(isCloud, hasCloudToken);
+            _connectionRequiredAlert.Visible = ConnectionPanelView.ShowConnectionRequired(isCloud, hasCloudToken, status);
+        }
+
+        /// <summary>
         /// Per-frame tick fired by the main-thread dispatcher. Accumulates <paramref name="delta"/> and runs
         /// the cheap <see cref="SyncFromConnection"/> drift check once every <see cref="ResyncIntervalSeconds"/>s.
         /// Driven by the dispatcher (a non-dock editor Node that always ticks) rather than this Control's own
         /// <see cref="Node._Process"/>, which Godot skips while the dock tab is hidden — see the registration
-        /// in the constructor.
+        /// in <see cref="_EnterTree"/>.
         /// </summary>
         void OnResyncTick(double delta)
         {
@@ -366,13 +453,12 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// <summary>
         /// Re-read the LIVE connection status DIRECTLY off <see cref="GodotMcpConnection.ConnectionStatus"/>
         /// (bypassing the <see cref="GodotMcpConnection.ConnectionStatusChanged"/> event) and re-apply it
-        /// when it differs from what the panel last rendered. Driven by the periodic <see cref="_Process"/>
-        /// re-sync so the label converges to the real status within ~<see cref="ResyncIntervalSeconds"/>s even
-        /// if a status push was lost to the off-thread marshalling / de-dup boundary OR to a dock-layout
-        /// reload that re-instantiated/detached the panel mid-handshake (the root cause of issue #42), or a
-        /// Reconnect rebuilt the connection. Cheap and quiet: when the live status already matches the
-        /// rendered one this is a single enum comparison and returns without touching any Control. Runs on
-        /// the editor main thread (Godot fires <see cref="_Process"/> there).
+        /// when it differs from what the panel last rendered. Driven by the periodic dispatcher re-sync so the
+        /// label converges to the real status within ~<see cref="ResyncIntervalSeconds"/>s even if a status push
+        /// was lost to the off-thread marshalling / de-dup boundary OR to a dock-layout reload that
+        /// re-instantiated/detached the panel mid-handshake (the root cause of issue #42), or a Reconnect
+        /// rebuilt the connection. Cheap and quiet: when the live status already matches the rendered one this
+        /// is a single enum comparison and returns without touching any Control. Runs on the editor main thread.
         /// </summary>
         void SyncFromConnection()
         {
@@ -393,24 +479,24 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 _connection.Connect();
         }
 
-        void OnModeSelected(long index)
+        /// <summary>
+        /// Handle a Custom|Cloud segment click: persist the chosen PERSISTED mode and reconnect only when the
+        /// change actually moves the LIVE active mode (under an env override ActiveMode is pinned, so a
+        /// persisted-only edit must not tear down the current connection). Re-renders the segmented selection
+        /// and the mode-dependent sections afterward.
+        /// </summary>
+        void OnModeSegmentSelected(int index)
         {
-            var mode = index == ModeIdCloud
+            var mode = index == SegmentedControlModel.IndexOf(ModeOptions, ModeLabelCloud)
                 ? GodotMcpConnectionMode.Cloud
                 : GodotMcpConnectionMode.Custom;
 
             if (_connection.Config.ConnectionMode == mode)
             {
-                // No persisted change selected; just re-render.
                 ApplyModeVisibility(_connection.Config.ActiveMode);
                 return;
             }
 
-            // Persist the user's chosen PERSISTED mode regardless of any env/.env override. The selector
-            // is always enabled (the change "does something" — it updates the persisted layer that takes
-            // effect once the override is removed). Only RECONNECT when the change actually moves the LIVE
-            // active mode: under an env override ActiveMode is pinned, so a persisted-only edit must not
-            // tear down the current connection.
             var liveModeBefore = _connection.Config.ActiveMode;
             _connection.Config.ConnectionMode = mode;
             _connection.Save();
@@ -426,9 +512,9 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// so the connection has a credential to send. Persists even under an env override (the override
         /// note explains the env value wins live); only reconnects when the live mode is Custom.
         /// </summary>
-        void OnAuthOptionSelected(long index)
+        void OnAuthSegmentSelected(int index)
         {
-            var authOption = index == AuthIdRequired
+            var authOption = index == SegmentedControlModel.IndexOf(AuthOptions, AuthLabelRequired)
                 ? GodotMcpAuthOption.Required
                 : GodotMcpAuthOption.None;
 
@@ -507,19 +593,23 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
         /// <summary>
         /// Drive the editable Custom section off the PERSISTED <see cref="GodotMcpConfig.ConnectionMode"/>
-        /// (so editing the selector / URL / auth always targets the layer the user can change), while the
-        /// override note surfaces when an env/.env value is forcing the LIVE active mode away from that
-        /// persisted choice. The selector + host field stay ENABLED even when overridden — a persisted
-        /// edit "does something" (it takes effect once the override is gone) and does NOT corrupt
-        /// precedence, since env/.env is read live by the config resolvers. The host field shows the
-        /// EFFECTIVE custom host (env override visible) for transparency.
+        /// (so editing the segmented control / URL / auth always targets the layer the user can change), while
+        /// the override note surfaces when an env/.env value is forcing the LIVE active mode away from that
+        /// persisted choice. The segmented control stays interactive even when overridden — a persisted edit
+        /// "does something" (it takes effect once the override is gone) and does NOT corrupt precedence, since
+        /// env/.env is read live by the config resolvers. The host field shows the EFFECTIVE custom host (env
+        /// override visible) for transparency. Re-renders the mode segmented selection + alert visibility too.
         /// </summary>
         void ApplyModeVisibility(GodotMcpConnectionMode activeMode)
         {
-            // Editable controls follow the PERSISTED mode (what the user is editing); the cloud-vs-custom
-            // SECTION the user can configure is the persisted one, not the env-forced live one.
+            // Editable controls follow the PERSISTED mode (what the user is editing).
             var persistedMode = _connection.Config.ConnectionMode;
             var persistedCustom = persistedMode == GodotMcpConnectionMode.Custom;
+
+            // Re-render the mode segmented to the persisted mode.
+            DockStyle.SetSegmentedSelection(
+                _modeSegmented,
+                SegmentedControlModel.IndexOf(ModeOptions, ModeLabelForMode(persistedMode)));
 
             _customHostRow.Visible = persistedCustom;
             _cloudAuthRow.Visible = !persistedCustom;
@@ -539,16 +629,12 @@ namespace com.IvanMurzak.Godot.MCP.UI
             var overridden = activeMode != persistedMode;
             _overrideNote.Visible = overridden;
 
-            // Keep BOTH the mode selector and the host field ENABLED even when an env/.env value currently
-            // forces the live mode/host: editing them updates the PERSISTED layer (it "does something"),
-            // which takes effect once the override is removed. The override note explains that the env
-            // value still wins for the live connection.
             _hostField.Editable = true;
-            _modeSelector.Disabled = false;
+            ApplyAlertVisibility(_connection.ConnectionStatus);
         }
 
         /// <summary>
-        /// Render the Custom-mode authorization controls from the persisted config: the auth selector
+        /// Render the Custom-mode authorization controls from the persisted config: the auth segmented
         /// reflects <see cref="GodotMcpConfig.AuthOption"/>, the masked token row is shown only when
         /// <c>Required</c>, and the field carries the stored Custom token (masked). The token is never
         /// shown in clear text or logged. Always reads/writes the PERSISTED layer (env auth override is
@@ -557,7 +643,9 @@ namespace com.IvanMurzak.Godot.MCP.UI
         void ApplyAuthVisibility()
         {
             var required = _connection.Config.AuthOption == GodotMcpAuthOption.Required;
-            _authSelector.Selected = required ? AuthIdRequired : AuthIdNone;
+            DockStyle.SetSegmentedSelection(
+                _authSegmented,
+                SegmentedControlModel.IndexOf(AuthOptions, required ? AuthLabelRequired : AuthLabelNone));
             _tokenRow.Visible = required;
             // Masked field carries the stored token; only meaningful when required.
             _tokenField.Text = required ? (_connection.Config.CustomToken ?? string.Empty) : string.Empty;
@@ -664,6 +752,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _connection.Config.CloudToken = token;
             _connection.Save();
             ApplyCloudAuthState();
+            ApplyAlertVisibility(_connection.ConnectionStatus);
 
             // Reconnect so the new bearer is used — only meaningful when the live mode is Cloud.
             if (_connection.Config.ActiveMode == GodotMcpConnectionMode.Cloud)
@@ -680,6 +769,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _connection.Save();
             _cloudAuthStatus.Text = "Token revoked.";
             ApplyCloudAuthState();
+            ApplyAlertVisibility(_connection.ConnectionStatus);
 
             if (_connection.Config.ActiveMode == GodotMcpConnectionMode.Cloud)
                 _connection.Disconnect();
@@ -701,17 +791,9 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _connection.Save();
             _cloudAuthStatus.Text = "Authorization rejected by server — press Authorize.";
             ApplyCloudAuthState();
+            ApplyAlertVisibility(_connection.ConnectionStatus);
 
             GD.PushWarning("[Godot-MCP] server rejected the authorization token; cleared — press Authorize.");
-        }
-
-        void SyncModeSelector(GodotMcpConnectionMode activeMode)
-        {
-            // Reflect the PERSISTED mode the user edits (not the env-forced live mode); the override note
-            // explains when the two diverge.
-            _modeSelector.Selected = _connection.Config.ConnectionMode == GodotMcpConnectionMode.Cloud
-                ? ModeIdCloud
-                : ModeIdCustom;
         }
 
         /// <summary>
@@ -720,7 +802,6 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// </summary>
         public void Refresh()
         {
-            SyncModeSelector(_connection.Config.ActiveMode);
             ApplyModeVisibility(_connection.Config.ActiveMode);
             ApplyStatus(_connection.ConnectionStatus);
         }

--- a/addons/godot_mcp/UI/ConnectionPanelView.cs
+++ b/addons/godot_mcp/UI/ConnectionPanelView.cs
@@ -162,5 +162,94 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// <summary>The Authorize/Cancel button text for a given flow state (Cancel while running).</summary>
         public static string CloudAuthButtonText(GodotDeviceAuthFlowState state) =>
             GodotDeviceAuthFlow.IsRunning(state) ? AuthorizeButtonCancelText : AuthorizeButtonText;
+
+        // --- Vertical timeline (Godot -> MCP server -> AI agent) presentation (pure-managed, unit-tested). ---
+
+        /// <summary>
+        /// The visual state of one timeline status circle, decoupled from <see cref="ConnectionStatus"/> so the
+        /// editor's circle painter maps it 1:1 to a Godot <c>StyleBoxFlat</c> (filled vs ring): a <c>Online</c>
+        /// circle is a filled green disc, <c>Connecting</c> is a green ring (transparent fill, 2px border), and
+        /// <c>Disconnected</c> is a filled orange disc. Mirrors Unity-MCP's status-indicator classes.
+        /// </summary>
+        public enum TimelinePointState
+        {
+            /// <summary>Filled orange disc — not connected.</summary>
+            Disconnected,
+
+            /// <summary>Green ring (transparent fill, 2px border) — mid-handshake / retrying.</summary>
+            Connecting,
+
+            /// <summary>Filled green disc — connected.</summary>
+            Online
+        }
+
+        /// <summary>
+        /// Map the dock's <see cref="ConnectionStatus"/> to the timeline circle's
+        /// <see cref="TimelinePointState"/>. The "Godot" and "MCP server" points both track this single hub
+        /// state (one connection); the editor paints the returned state as a filled disc or a ring.
+        /// </summary>
+        public static TimelinePointState PointState(ConnectionStatus status) => status switch
+        {
+            ConnectionStatus.Connected => TimelinePointState.Online,
+            ConnectionStatus.Connecting => TimelinePointState.Connecting,
+            _ => TimelinePointState.Disconnected
+        };
+
+        /// <summary>
+        /// The AI-agent timeline point's label. With no connected agent it reads
+        /// "AI agent (connects on demand)"; when an agent is connected the label carries its
+        /// <paramref name="clientName"/> and (when present) <paramref name="clientVersion"/> — e.g.
+        /// "AI agent: Claude (1.2.0)" or "AI agent: Cursor". Whitespace-only names are treated as none.
+        /// Mirrors Unity-MCP's "AI agent: &lt;client&gt; (&lt;ver&gt;)" line.
+        /// </summary>
+        public static string AgentLabel(string? clientName, string? clientVersion)
+        {
+            if (string.IsNullOrWhiteSpace(clientName))
+                return "AI agent (connects on demand)";
+
+            return string.IsNullOrWhiteSpace(clientVersion)
+                ? $"AI agent: {clientName!.Trim()}"
+                : $"AI agent: {clientName!.Trim()} ({clientVersion!.Trim()})";
+        }
+
+        // --- Alert panels (amber WarningFrame). Pure-managed visibility rules, unit-tested. ---
+
+        /// <summary>Title of the Cloud-mode "no token yet" alert.</summary>
+        public const string AuthorizationRequiredTitle = "Authorization Required";
+
+        /// <summary>Message body of the "Authorization Required" alert.</summary>
+        public const string AuthorizationRequiredMessage =
+            "Cloud mode needs an access token. Press Authorize to sign in.";
+
+        /// <summary>Title of the "authorized but not connected" alert.</summary>
+        public const string ConnectionRequiredTitle = "Connection Required";
+
+        /// <summary>Message body of the "Connection Required" alert.</summary>
+        public const string ConnectionRequiredMessage =
+            "Not connected to the MCP server. Press Connect to establish the connection.";
+
+        /// <summary>
+        /// True when the "Authorization Required" alert should show: the live mode is Cloud and no cloud
+        /// token is stored yet (the user must Authorize before a connection can succeed). Pure rule so the
+        /// editor only decides VISIBILITY here — the alert chrome is built in <c>DockStyle.WarningFrame</c>.
+        /// </summary>
+        public static bool ShowAuthorizationRequired(bool isCloudMode, bool hasCloudToken) =>
+            isCloudMode && !hasCloudToken;
+
+        /// <summary>
+        /// True when the "Connection Required" alert should show: the user is otherwise ready (in Custom
+        /// mode, or in Cloud mode WITH a token) but the live connection is not <see cref="ConnectionStatus.Connected"/>.
+        /// Suppressed in Cloud-mode-without-token (the "Authorization Required" alert owns that case) and while
+        /// <see cref="ConnectionStatus.Connecting"/> (a connection attempt is already underway).
+        /// </summary>
+        public static bool ShowConnectionRequired(bool isCloudMode, bool hasCloudToken, ConnectionStatus status)
+        {
+            // Authorization alert owns the cloud-no-token case; don't double-alert.
+            if (ShowAuthorizationRequired(isCloudMode, hasCloudToken))
+                return false;
+
+            // Only nag when fully disconnected — a Connecting attempt is already in flight.
+            return status == ConnectionStatus.Disconnected;
+        }
     }
 }

--- a/addons/godot_mcp/UI/DockStyle.cs
+++ b/addons/godot_mcp/UI/DockStyle.cs
@@ -241,6 +241,59 @@ namespace com.IvanMurzak.Godot.MCP.UI
             return panel;
         }
 
+        /// <summary>
+        /// Build a full amber ALERT panel (Unity's warning frame with an action): the same tinted amber bg /
+        /// border / radius as <see cref="WarningFrame"/>, but with a bold amber <paramref name="title"/> over a
+        /// warm <paramref name="message"/> and a primary (cyan) action button. Used for "Authorization Required"
+        /// and "Connection Required". The returned panel is shown/hidden by the caller per the pure-managed
+        /// <see cref="ConnectionPanelView.ShowAuthorizationRequired"/> / <see cref="ConnectionPanelView.ShowConnectionRequired"/>
+        /// rules. <paramref name="onPressed"/> wires the button.
+        /// </summary>
+        public static PanelContainer AlertPanel(string name, string title, string message, string buttonText, System.Action onPressed)
+        {
+            var box = new StyleBoxFlat
+            {
+                BgColor = Rgba(DockTheme.WarningBackground),
+                BorderColor = Rgba(DockTheme.WarningBorder)
+            };
+            box.SetCornerRadiusAll(DockTheme.WarningCornerRadius);
+            box.SetBorderWidthAll(1);
+            box.ContentMarginLeft = 8;
+            box.ContentMarginRight = 8;
+            box.ContentMarginTop = 6;
+            box.ContentMarginBottom = 6;
+
+            var panel = new PanelContainer { Name = name, SizeFlagsHorizontal = Control.SizeFlags.ExpandFill };
+            panel.AddThemeStyleboxOverride("panel", box);
+
+            var col = new VBoxContainer { Name = "AlertContent" };
+            col.AddThemeConstantOverride("separation", 4);
+            panel.AddChild(col);
+
+            var titleLabel = new Label { Name = "AlertTitle", Text = title };
+            titleLabel.AddThemeFontSizeOverride("font_size", DockTheme.FontSizeSubLabel);
+            titleLabel.AddThemeColorOverride("font_color", Rgb(DockTheme.WarningTitle));
+            col.AddChild(titleLabel);
+
+            var messageLabel = new Label
+            {
+                Name = "AlertMessage",
+                Text = message,
+                AutowrapMode = TextServer.AutowrapMode.WordSmart
+            };
+            messageLabel.AddThemeColorOverride("font_color", Rgb(DockTheme.WarningMessage));
+            messageLabel.AddThemeFontSizeOverride("font_size", DockTheme.FontSizeWarningMessage);
+            col.AddChild(messageLabel);
+
+            var button = new Button { Name = "AlertButton", Text = buttonText };
+            ApplyPrimaryButton(button);
+            button.SizeFlagsHorizontal = Control.SizeFlags.ShrinkBegin;
+            button.Pressed += () => onPressed();
+            col.AddChild(button);
+
+            return panel;
+        }
+
         // --- Inputs --------------------------------------------------------------------------------------------
 
         /// <summary>Build the input (LineEdit/OptionButton) normal <see cref="StyleBoxFlat"/>: translucent-black bg, 6px radius, subtle border.</summary>
@@ -339,6 +392,246 @@ namespace com.IvanMurzak.Godot.MCP.UI
         public static void ApplyOptionButton(OptionButton option)
         {
             option.AddThemeStyleboxOverride("normal", InputStyleBox());
+        }
+
+        // --- Segmented control (reusable Custom|Cloud / stdio|http / none|required toggle) ---------------------
+
+        /// <summary>
+        /// Build a horizontal SEGMENTED CONTROL: a track-skinned <see cref="HBoxContainer"/> holding one toggle
+        /// <see cref="Button"/> per option, where exactly one segment is "selected" (dark highlight + cyan text)
+        /// and the rest are muted. Mirrors Unity-MCP's segmented mode/transport/auth toggle. The numbers
+        /// (track/selected colours, radii, per-segment width/font) all come from <see cref="DockTheme"/>;
+        /// the index/selection rules come from the pure-managed (unit-tested) <see cref="SegmentedControlModel"/>.
+        ///
+        /// <para>
+        /// <paramref name="onSelected"/> fires with the chosen option index when the user clicks a NOT-already-
+        /// selected segment (clicking the active segment is a no-op). The caller owns the value→index mapping and
+        /// re-renders selection via <see cref="SetSegmentedSelection"/> after persisting; this builder does NOT
+        /// auto-toggle, so the visual selection never drifts from the backing config.
+        /// </para>
+        /// </summary>
+        public static PanelContainer SegmentedControl(
+            string name,
+            System.Collections.Generic.IReadOnlyList<string> options,
+            int selectedIndex,
+            System.Action<int> onSelected)
+        {
+            var track = new HBoxContainer { Name = name };
+            track.AddThemeConstantOverride("separation", 0);
+
+            var trackBox = new StyleBoxFlat { BgColor = Rgba(DockTheme.SegmentTrackBackground) };
+            trackBox.SetCornerRadiusAll(DockTheme.SegmentTrackCornerRadius);
+            trackBox.ContentMarginLeft = DockTheme.SegmentTrackPadding;
+            trackBox.ContentMarginRight = DockTheme.SegmentTrackPadding;
+            trackBox.ContentMarginTop = DockTheme.SegmentTrackPadding;
+            trackBox.ContentMarginBottom = DockTheme.SegmentTrackPadding;
+
+            // The track skin is applied via a PanelContainer wrapper so the pill background frames the segments.
+            var panel = new PanelContainer { Name = name + "Track" };
+            panel.AddThemeStyleboxOverride("panel", trackBox);
+            panel.AddChild(track);
+
+            var clamped = SegmentedControlModel.ClampSelected(selectedIndex, options.Count);
+            for (int i = 0; i < options.Count; i++)
+            {
+                int index = i; // capture for the lambda
+                var segment = new Button
+                {
+                    Name = "Segment" + i,
+                    Text = options[i],
+                    ToggleMode = true,
+                    ButtonPressed = SegmentedControlModel.IsSelected(i, clamped),
+                    Flat = true,
+                    CustomMinimumSize = new Vector2(DockTheme.SegmentMinWidth, 0)
+                };
+                segment.AddThemeFontSizeOverride("font_size", DockTheme.SegmentFontSize);
+                ApplySegmentStyle(segment, SegmentedControlModel.IsSelected(i, clamped));
+
+                segment.Pressed += () =>
+                {
+                    // Clicking the already-selected segment is a no-op (and we keep it visually pressed).
+                    if (SegmentedControlModel.IsSelected(index, GetSegmentedSelection(track)))
+                    {
+                        SetSegmentedSelection(track, GetSegmentedSelection(track));
+                        return;
+                    }
+                    onSelected(index);
+                };
+                track.AddChild(segment);
+            }
+
+            return panel;
+        }
+
+        /// <summary>
+        /// Re-render which segment of a <see cref="SegmentedControl"/> is selected — call after the backing
+        /// value changes (e.g. after persisting a mode toggle). <paramref name="track"/> is the inner
+        /// <see cref="HBoxContainer"/> returned indirectly by <see cref="SegmentedControl"/> (reach it via the
+        /// panel's first child); pass the panel and this resolves it.
+        /// </summary>
+        public static void SetSegmentedSelection(Control trackOrPanel, int selectedIndex)
+        {
+            var track = ResolveSegmentTrack(trackOrPanel);
+            if (track == null)
+                return;
+
+            var clamped = SegmentedControlModel.ClampSelected(selectedIndex, track.GetChildCount());
+            for (int i = 0; i < track.GetChildCount(); i++)
+            {
+                if (track.GetChild(i) is Button segment)
+                {
+                    var isSel = SegmentedControlModel.IsSelected(i, clamped);
+                    segment.ButtonPressed = isSel;
+                    ApplySegmentStyle(segment, isSel);
+                }
+            }
+        }
+
+        static int GetSegmentedSelection(HBoxContainer track)
+        {
+            for (int i = 0; i < track.GetChildCount(); i++)
+            {
+                if (track.GetChild(i) is Button segment && segment.ButtonPressed)
+                    return i;
+            }
+            return 0;
+        }
+
+        static HBoxContainer? ResolveSegmentTrack(Control trackOrPanel)
+        {
+            if (trackOrPanel is HBoxContainer hbox)
+                return hbox;
+            // SegmentedControl returns a PanelContainer wrapping the HBox track.
+            if (trackOrPanel.GetChildCount() > 0 && trackOrPanel.GetChild(0) is HBoxContainer inner)
+                return inner;
+            return null;
+        }
+
+        static void ApplySegmentStyle(Button segment, bool selected)
+        {
+            if (selected)
+            {
+                var box = new StyleBoxFlat { BgColor = Rgba(DockTheme.SegmentSelectedBackground) };
+                box.SetCornerRadiusAll(DockTheme.SegmentSelectedCornerRadius);
+                box.ContentMarginLeft = 8;
+                box.ContentMarginRight = 8;
+                box.ContentMarginTop = 2;
+                box.ContentMarginBottom = 2;
+                segment.AddThemeStyleboxOverride("normal", box);
+                segment.AddThemeStyleboxOverride("hover", box);
+                segment.AddThemeStyleboxOverride("pressed", box);
+
+                var text = Rgb(DockTheme.SegmentSelectedText);
+                segment.AddThemeColorOverride("font_color", text);
+                segment.AddThemeColorOverride("font_hover_color", text);
+                segment.AddThemeColorOverride("font_pressed_color", text);
+            }
+            else
+            {
+                // Unselected: transparent (track shows through) + muted text.
+                var empty = new StyleBoxEmpty();
+                segment.AddThemeStyleboxOverride("normal", empty);
+                segment.AddThemeStyleboxOverride("hover", empty);
+                segment.AddThemeStyleboxOverride("pressed", empty);
+
+                var muted = Rgb(DockTheme.SegmentUnselectedText);
+                segment.AddThemeColorOverride("font_color", muted);
+                segment.AddThemeColorOverride("font_hover_color", muted.Lightened(0.2f));
+                segment.AddThemeColorOverride("font_pressed_color", muted);
+            }
+        }
+
+        // --- Vertical timeline (Godot -> MCP server -> AI agent) ----------------------------------------------
+
+        /// <summary>
+        /// Build the status circle for a timeline point in a given <see cref="ConnectionPanelView.TimelinePointState"/>:
+        /// <c>Online</c> = filled green disc, <c>Connecting</c> = green RING (transparent fill, 2px green border),
+        /// <c>Disconnected</c> = filled orange disc. A <see cref="Panel"/> sized to <see cref="DockTheme.StatusDotSize"/>
+        /// with a fully-rounded <see cref="StyleBoxFlat"/>. Use <see cref="ApplyTimelineCircle"/> to re-style an
+        /// existing circle in place (the panel reuses one node across status changes).
+        /// </summary>
+        public static Panel TimelineCircle(string name, ConnectionPanelView.TimelinePointState state)
+        {
+            var circle = new Panel
+            {
+                Name = name,
+                CustomMinimumSize = new Vector2(DockTheme.StatusDotSize, DockTheme.StatusDotSize),
+                SizeFlagsVertical = Control.SizeFlags.ShrinkCenter,
+                SizeFlagsHorizontal = Control.SizeFlags.ShrinkCenter
+            };
+            ApplyTimelineCircle(circle, state);
+            return circle;
+        }
+
+        /// <summary>
+        /// Re-style an existing timeline circle <see cref="Panel"/> for the given
+        /// <see cref="ConnectionPanelView.TimelinePointState"/> in place (filled disc vs green ring). Called on
+        /// every status change so a single circle node tracks the live state.
+        /// </summary>
+        public static void ApplyTimelineCircle(Panel circle, ConnectionPanelView.TimelinePointState state)
+        {
+            var radius = DockTheme.StatusDotSize / 2;
+            StyleBoxFlat box;
+            switch (state)
+            {
+                case ConnectionPanelView.TimelinePointState.Online:
+                    box = new StyleBoxFlat { BgColor = Rgb(DockTheme.StatusOnline) };
+                    break;
+                case ConnectionPanelView.TimelinePointState.Connecting:
+                    // Green RING: transparent fill + 2px green border.
+                    box = new StyleBoxFlat { BgColor = new Color(0, 0, 0, 0), BorderColor = Rgb(DockTheme.StatusOnline) };
+                    box.SetBorderWidthAll(DockTheme.TimelineRingBorderWidth);
+                    break;
+                default:
+                    box = new StyleBoxFlat { BgColor = Rgb(DockTheme.StatusDisconnected) };
+                    break;
+            }
+            box.SetCornerRadiusAll(radius);
+            circle.AddThemeStyleboxOverride("panel", box);
+        }
+
+        /// <summary>
+        /// Build the 2px vertical connecting line drawn between consecutive timeline points
+        /// (<see cref="DockTheme.TimelineLine"/>). A thin <see cref="ColorRect"/> that ExpandFills vertically so
+        /// it spans the gap; the LAST point passes a hidden one (no line below the final point).
+        /// </summary>
+        public static ColorRect TimelineLine(string name = "TimelineLine")
+        {
+            return new ColorRect
+            {
+                Name = name,
+                Color = Rgb(DockTheme.TimelineLine),
+                CustomMinimumSize = new Vector2(DockTheme.TimelineLineWidth, 0),
+                SizeFlagsVertical = Control.SizeFlags.ExpandFill,
+                SizeFlagsHorizontal = Control.SizeFlags.ShrinkCenter
+            };
+        }
+
+        /// <summary>
+        /// Build a 13px timeline-point title (Unity's timeline label) WITH a thin underline: a
+        /// <see cref="VBoxContainer"/> holding the <see cref="Label"/> over a 1px divider-coloured underline rule.
+        /// Godot's plain <see cref="Label"/> has no font-underline override, so the underline is a real 1px
+        /// <see cref="ColorRect"/> that hugs the label width — reliable across Godot versions.
+        /// </summary>
+        public static VBoxContainer TimelineLabel(string name, string text)
+        {
+            var box = new VBoxContainer { Name = name };
+            box.AddThemeConstantOverride("separation", 1);
+            box.SizeFlagsHorizontal = Control.SizeFlags.ShrinkBegin;
+
+            var label = new Label { Name = "Text", Text = text };
+            label.AddThemeFontSizeOverride("font_size", DockTheme.FontSizeSubLabel);
+            box.AddChild(label);
+
+            var underline = new ColorRect
+            {
+                Name = "Underline",
+                Color = Rgb(DockTheme.Divider).Lightened(0.4f),
+                CustomMinimumSize = new Vector2(0, 1),
+                SizeFlagsHorizontal = Control.SizeFlags.ExpandFill
+            };
+            box.AddChild(underline);
+            return box;
         }
 
         // --- Foldout (collapsible section: a toggle Button + a child VBox shown/hidden) ------------------------

--- a/addons/godot_mcp/UI/DockTheme.cs
+++ b/addons/godot_mcp/UI/DockTheme.cs
@@ -154,6 +154,49 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// <summary>Divider colour — 1px <c>Color8(26,26,26)</c> separator between sections.</summary>
         public static readonly (float R, float G, float B) Divider = (26f / 255f, 26f / 255f, 26f / 255f);
 
+        // --- Segmented control (Unity-MCP's mode / transport / auth segmented toggle) ---------------------------
+
+        /// <summary>Segmented-control TRACK background — <c>rgba(255,255,255, 0.05)</c> (the pill the segments sit in).</summary>
+        public static readonly (float R, float G, float B, float A) SegmentTrackBackground = (1f, 1f, 1f, 0.05f);
+
+        /// <summary>Segmented-control track corner radius (px).</summary>
+        public const int SegmentTrackCornerRadius = 6;
+
+        /// <summary>Segmented-control track inner padding (px) around the segments.</summary>
+        public const int SegmentTrackPadding = 2;
+
+        /// <summary>SELECTED-segment highlight background — <c>rgba(0,0,0, 0.4)</c> (the dark pill under the active segment).</summary>
+        public static readonly (float R, float G, float B, float A) SegmentSelectedBackground = (0f, 0f, 0f, 0.4f);
+
+        /// <summary>Selected-segment highlight corner radius (px).</summary>
+        public const int SegmentSelectedCornerRadius = 4;
+
+        /// <summary>Selected-segment text colour — cyan <c>Color8(175,232,230)</c> (reuses the primary cyan).</summary>
+        public static readonly (float R, float G, float B) SegmentSelectedText = ButtonPrimary;
+
+        /// <summary>Unselected-segment text colour — muted gray (reuses the description muted gray).</summary>
+        public static readonly (float R, float G, float B) SegmentUnselectedText = ColorDescriptionMuted;
+
+        /// <summary>Per-segment minimum width (px).</summary>
+        public const int SegmentMinWidth = 40;
+
+        /// <summary>Per-segment font size (px).</summary>
+        public const int SegmentFontSize = 12;
+
+        // --- Vertical timeline (Godot -> MCP server -> AI agent) -----------------------------------------------
+
+        /// <summary>Width of the timeline indicator column holding the status circle + connecting line (px).</summary>
+        public const int TimelineIndicatorWidth = 20;
+
+        /// <summary>The connecting line drawn between consecutive timeline points — <c>Color8(80,80,80)</c>, 2px wide.</summary>
+        public static readonly (float R, float G, float B) TimelineLine = (80f / 255f, 80f / 255f, 80f / 255f);
+
+        /// <summary>Timeline connecting-line thickness (px).</summary>
+        public const int TimelineLineWidth = 2;
+
+        /// <summary>Status-circle border width for the "connecting" RING state (px).</summary>
+        public const int TimelineRingBorderWidth = 2;
+
         // --- Feature list rows (Tools / Prompts / Resources windows) -------------------------------------------
 
         /// <summary>

--- a/addons/godot_mcp/UI/SegmentedControlModel.cs
+++ b/addons/godot_mcp/UI/SegmentedControlModel.cs
@@ -1,0 +1,74 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Collections.Generic;
+
+namespace com.IvanMurzak.Godot.MCP.UI
+{
+    /// <summary>
+    /// PURE-MANAGED (no Godot native types, no <c>#if TOOLS</c>) state logic for the dock's reusable
+    /// horizontal SEGMENTED CONTROL — the Godot analog of Unity-MCP's segmented mode/transport/auth
+    /// toggle. A segmented control is a small set of mutually-exclusive options where exactly one is
+    /// selected; the selected segment is painted with the highlight + cyan text, the rest muted.
+    ///
+    /// <para>
+    /// Keeping the index/selection rules here (rather than inline in the <c>#if TOOLS</c>
+    /// <see cref="DockStyle"/> builder) makes them unit-testable in the plain-xUnit
+    /// <c>Godot-MCP.Tests</c> host without constructing a single Godot <c>Control</c>: which segment is
+    /// selected for a given value, what label each segment shows, and the
+    /// <see cref="IsSelected"/> styling predicate the editor uses to decide selected-vs-muted paint.
+    /// </para>
+    /// </summary>
+    public static class SegmentedControlModel
+    {
+        /// <summary>
+        /// Resolve the selected segment index for a <paramref name="value"/> within
+        /// <paramref name="options"/>. Returns the first matching index, or <c>0</c> when the value is not
+        /// present (a stable, in-range fallback so the control never renders with no selection). An empty
+        /// option set yields <c>-1</c> (nothing to select).
+        /// </summary>
+        public static int IndexOf(IReadOnlyList<string> options, string value)
+        {
+            if (options.Count == 0)
+                return -1;
+
+            for (int i = 0; i < options.Count; i++)
+            {
+                if (options[i] == value)
+                    return i;
+            }
+
+            // Unknown value: fall back to the first segment so the control always has exactly one selection.
+            return 0;
+        }
+
+        /// <summary>
+        /// The styling predicate the editor builder calls per segment: <c>true</c> when segment
+        /// <paramref name="index"/> is the <paramref name="selectedIndex"/> (paint it with the dark
+        /// highlight + cyan text), <c>false</c> for the muted, unselected look.
+        /// </summary>
+        public static bool IsSelected(int index, int selectedIndex) => index == selectedIndex;
+
+        /// <summary>
+        /// Clamp an arbitrary <paramref name="selectedIndex"/> into the valid range for
+        /// <paramref name="optionCount"/> segments. Out-of-range (including a <c>-1</c> "no value") collapses
+        /// to <c>0</c> when there is at least one segment, or stays <c>-1</c> for an empty set. Used to keep a
+        /// freshly-(re)built control from rendering a selection past its segment count.
+        /// </summary>
+        public static int ClampSelected(int selectedIndex, int optionCount)
+        {
+            if (optionCount <= 0)
+                return -1;
+            if (selectedIndex < 0 || selectedIndex >= optionCount)
+                return 0;
+            return selectedIndex;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Ports the dock's Connection section to Unity-MCP's vertical **timeline** design 1:1 (Godot → MCP server → AI agent), using the exact Unity reference colours already defined in `DockTheme`.
- Adds a reusable **segmented control** (replaces the Mode and Authorization `OptionButton` dropdowns; reused for Custom|Cloud and none|required), 14px status circles (filled green online / green ring connecting / filled orange disconnected) joined by a 2px `rgb(80,80,80)` connecting line, a "Connection" header (20px bold) + Custom|Cloud segmented, and two amber alert panels ("Authorization Required" / "Connection Required").
- New pure-managed view/segmented/palette logic (`SegmentedControlModel`, `ConnectionPanelView` timeline/agent/alert helpers, `DockTheme` segment/timeline values) lives OUTSIDE `#if TOOLS` and is unit-tested.

All behaviour stays wired to the existing `GodotMcpConnection` API — modes, Connect/Disconnect, `ConnectionStatusChanged`/`AuthorizationRejected` events, `AuthOption`, custom token + generate, cloud device-auth Authorize/Revoke/status, env-override note, periodic re-sync. The `_EnterTree` remove-then-add + re-seed / `_ExitTree` unsubscribe discipline (issue #42 dead-subscriber fix) is preserved.

**Scope note:** Godot-MCP is a server-less MCP *client* (no transport choice, no embedded server, no live agent-info channel). The issue's "Transport stdio|http" segmented and server Start/Stop are Unity affordances with no Godot backing, so they are intentionally NOT fabricated — the MCP-server timeline point shows the real Server-URL / cloud-auth / Authorization rows, and the AI-agent point reads "AI agent (connects on demand)". This follows `conventions.md` ("do NOT reimplement transport") over a literal control-for-control port.

## Test plan
- [x] `dotnet build Godot-MCP.sln --configuration Debug` → 0 errors, 0 warnings (compiles the `#if TOOLS` editor UI, same as CI).
- [x] `dotnet test Godot-MCP.Tests` → 0 failures (498 → 536 tests; +38 covering the new pure-managed logic).
- [x] Headless Godot 4.5.1 smoke (Suite 3): testbed junction repointed to this branch, `--build-solutions` built the C# assembly, `--editor` boot printed `[Godot-MCP] plugin loaded`, resolved McpPlugin 6.7.0, ran the `Loading docks...` reparent path (exercises `_ExitTree`/`_EnterTree`) and exited 0 with no `FileNotFoundException` / no dock-build exception.

Closes #60
