### PR TITLE
feat(editor): Dock — Tools/Prompts/Resources restyle + AI-agent alert panel & icon (Unity-MCP 1:1)

### DIFF
--- a/Godot-MCP.Tests/AgentAlertViewTests.cs
+++ b/Godot-MCP.Tests/AgentAlertViewTests.cs
@@ -1,0 +1,76 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using com.IvanMurzak.Godot.MCP.UI.Agents;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the pure-managed AI-agent alert presentation (<see cref="AgentAlertView"/>) that drives the dock's
+    /// "Setup Required" / "Reconfiguration Required" amber panel: the show/hide rule and the title/message copy per
+    /// <see cref="AgentConfigState"/>. The editor wiring (<c>AgentConfiguratorsPanel.RefreshAlert</c>, <c>#if TOOLS</c>)
+    /// builds the live <c>DockStyle.AlertPanel</c> Control and is verified via the headless Godot smoke
+    /// (test.md Suite 3) — NOT here.
+    /// </summary>
+    public class AgentAlertViewTests
+    {
+        [Theory]
+        [InlineData(AgentConfigState.Missing, true)]
+        [InlineData(AgentConfigState.Stale, true)]
+        [InlineData(AgentConfigState.UpToDate, false)]
+        public void ShowAlert_OnlyWhenNotUpToDate(AgentConfigState state, bool expected)
+        {
+            Assert.Equal(expected, AgentAlertView.ShowAlert(state));
+        }
+
+        [Fact]
+        public void Title_Missing_IsSetupRequired()
+        {
+            Assert.Equal("Setup Required", AgentAlertView.Title(AgentConfigState.Missing));
+            Assert.Equal(AgentAlertView.SetupRequiredTitle, AgentAlertView.Title(AgentConfigState.Missing));
+        }
+
+        [Fact]
+        public void Title_Stale_IsReconfigurationRequired()
+        {
+            Assert.Equal("Reconfiguration Required", AgentAlertView.Title(AgentConfigState.Stale));
+            Assert.Equal(AgentAlertView.ReconfigurationRequiredTitle, AgentAlertView.Title(AgentConfigState.Stale));
+        }
+
+        [Fact]
+        public void Title_UpToDate_IsEmpty()
+        {
+            // The alert is hidden when up-to-date; the title is empty (callers check ShowAlert first).
+            Assert.Equal(string.Empty, AgentAlertView.Title(AgentConfigState.UpToDate));
+        }
+
+        [Theory]
+        [InlineData(AgentConfigState.Missing)]
+        [InlineData(AgentConfigState.Stale)]
+        public void Message_ShownStates_CarryTheMcpConfigurationBullet(AgentConfigState state)
+        {
+            Assert.Equal("• MCP Configuration", AgentAlertView.Message(state));
+            Assert.Equal(AgentAlertView.McpConfigurationBullet, AgentAlertView.Message(state));
+        }
+
+        [Fact]
+        public void Message_UpToDate_IsEmpty()
+        {
+            Assert.Equal(string.Empty, AgentAlertView.Message(AgentConfigState.UpToDate));
+        }
+
+        [Fact]
+        public void ButtonText_IsConfigure()
+        {
+            Assert.Equal("Configure", AgentAlertView.ButtonText);
+        }
+    }
+}

--- a/Godot-MCP.Tests/AgentConfiguratorTests.cs
+++ b/Godot-MCP.Tests/AgentConfiguratorTests.cs
@@ -164,6 +164,71 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             }
         }
 
+        // --- ConfigState classifier (Missing / Stale / UpToDate) drives the dock's Setup/Reconfiguration alert ---
+
+        [Fact]
+        public void ConfigState_Missing_WhenFileAbsentOrEntryAbsent()
+        {
+            var agent = ClaudeCode();
+            var path = TempFile();
+            try
+            {
+                // No file on disk yet → Missing.
+                Assert.Equal(AgentConfigState.Missing, agent.ConfigState(path, Url));
+
+                // A file that exists but holds an unrelated server (no addon entry) → still Missing.
+                File.WriteAllText(path, "{\"mcpServers\":{\"someone-else\":{\"type\":\"http\",\"url\":\"https://x/mcp\"}}}");
+                Assert.Equal(AgentConfigState.Missing, agent.ConfigState(path, Url));
+            }
+            finally
+            {
+                Cleanup(path);
+            }
+        }
+
+        [Fact]
+        public void ConfigState_UpToDate_WhenEntryMatchesUrl_StaleWhenUrlDiffers()
+        {
+            var agent = ClaudeCode();
+            var path = TempFile();
+            try
+            {
+                agent.Configure(path, Url, Token);
+
+                // Same url → UpToDate (and exactly the IsConfigured==true case).
+                Assert.Equal(AgentConfigState.UpToDate, agent.ConfigState(path, Url));
+                Assert.True(agent.IsConfigured(path, Url));
+
+                // A different current url → Stale (entry exists but points elsewhere).
+                Assert.Equal(AgentConfigState.Stale, agent.ConfigState(path, "http://localhost:8080/mcp"));
+                Assert.False(agent.IsConfigured(path, "http://localhost:8080/mcp"));
+            }
+            finally
+            {
+                Cleanup(path);
+            }
+        }
+
+        [Theory]
+        [InlineData("")]                       // empty file
+        [InlineData("   ")]                     // whitespace
+        [InlineData("{ not valid json ")]       // malformed
+        [InlineData("[1,2,3]")]                 // valid json but not an object
+        public void ConfigState_Missing_OnBadFile(string content)
+        {
+            var agent = ClaudeCode();
+            var path = TempFile();
+            try
+            {
+                File.WriteAllText(path, content);
+                Assert.Equal(AgentConfigState.Missing, agent.ConfigState(path, Url));
+            }
+            finally
+            {
+                Cleanup(path);
+            }
+        }
+
         [Theory]
         [InlineData("")]                       // empty file
         [InlineData("   ")]                     // whitespace

--- a/Godot-MCP.Tests/DockThemeTests.cs
+++ b/Godot-MCP.Tests/DockThemeTests.cs
@@ -72,6 +72,24 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         }
 
         [Fact]
+        public void OpenButton_Palette_MatchesBriefReferenceValues()
+        {
+            // btn-secondary: gray fill rgb(70,70,70), border rgb(100,100,100), 30px tall, 6px radius.
+            AssertRgb8(DockTheme.ButtonSecondary, 70, 70, 70);
+            AssertRgb8(DockTheme.ButtonOpenBorder, 100, 100, 100);
+            Assert.Equal(30, DockTheme.ButtonOpenHeight);
+            Assert.Equal(6, DockTheme.ButtonOpenCornerRadius);
+        }
+
+        [Fact]
+        public void TokenSubLabel_Palette_MatchesBriefReferenceValues()
+        {
+            // "~N tokens total" sub-label: gray rgb(150,150,150), 11px.
+            AssertRgb8(DockTheme.ColorTokenSubLabel, 150, 150, 150);
+            Assert.Equal(11, DockTheme.FontSizeTokenSubLabel);
+        }
+
+        [Fact]
         public void RowTint_MapsEnabledToGreenDisabledToRed()
         {
             Assert.Equal(DockTheme.RowEnabledTint, DockTheme.RowTint(enabled: true));

--- a/Godot-MCP.Tests/FeaturesPanelViewTests.cs
+++ b/Godot-MCP.Tests/FeaturesPanelViewTests.cs
@@ -75,5 +75,21 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         {
             Assert.Equal("~— tokens", FeaturesPanelView.UnavailableTokenLabel());
         }
+
+        [Fact]
+        public void TokenTotalLabel_formats_with_tilde_total_suffix_and_k_abbrev()
+        {
+            Assert.Equal("~999 tokens total", FeaturesPanelView.TokenTotalLabel(999));
+            Assert.Equal("~0 tokens total", FeaturesPanelView.TokenTotalLabel(0));
+            // Shares FormatTokenCount with TokenLabel, so the k-abbreviation is identical.
+            Assert.Equal("~1.5k tokens total", FeaturesPanelView.TokenTotalLabel(1500));
+            Assert.Equal("~12.3k tokens total", FeaturesPanelView.TokenTotalLabel(12345));
+        }
+
+        [Fact]
+        public void UnavailableTokenTotalLabel_uses_the_dash_placeholder()
+        {
+            Assert.Equal("~— tokens total", FeaturesPanelView.UnavailableTokenTotalLabel());
+        }
     }
 }

--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -171,6 +171,7 @@
          (test.md Suite 3); the snippet/configure/remove/path/registry logic is unit-tested here. -->
     <Compile Include="..\addons\godot_mcp\UI\Agents\GodotAgentConfigurator.cs" Link="Source\GodotAgentConfigurator.cs" />
     <Compile Include="..\addons\godot_mcp\UI\Agents\AgentConfigJson.cs" Link="Source\AgentConfigJson.cs" />
+    <Compile Include="..\addons\godot_mcp\UI\Agents\AgentAlertView.cs" Link="Source\AgentAlertView.cs" />
     <Compile Include="..\addons\godot_mcp\UI\Agents\AgentConfigPaths.cs" Link="Source\AgentConfigPaths.cs" />
     <Compile Include="..\addons\godot_mcp\UI\Agents\GodotAgentConfiguratorRegistry.cs" Link="Source\GodotAgentConfiguratorRegistry.cs" />
     <Compile Include="..\addons\godot_mcp\UI\Agents\Impl\ClaudeCodeConfigurator.cs" Link="Source\ClaudeCodeConfigurator.cs" />

--- a/addons/godot_mcp/UI/Agents/AgentAlertView.cs
+++ b/addons/godot_mcp/UI/Agents/AgentAlertView.cs
@@ -1,0 +1,65 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+
+namespace com.IvanMurzak.Godot.MCP.UI.Agents
+{
+    /// <summary>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) presentation logic for the dock's AI-agent
+    /// "Setup Required" / "Reconfiguration Required" alert panel — the Godot analog of Unity-MCP's per-agent
+    /// configure-status alert. It maps an <see cref="AgentConfigState"/> onto the alert's VISIBILITY + title +
+    /// message + button text, so the editor-only <see cref="AgentConfiguratorsPanel"/> only decides whether to
+    /// show the (reused <c>DockStyle.AlertPanel</c>) frame and which copy to put in it. Keeping these strings here
+    /// makes every alert decision unit-testable in the plain-xUnit <c>Godot-MCP.Tests</c> host without building a
+    /// Godot <see cref="Godot.Control"/>.
+    /// </summary>
+    public static class AgentAlertView
+    {
+        /// <summary>Alert title shown when the agent's MCP config is missing entirely (first-time setup).</summary>
+        public const string SetupRequiredTitle = "Setup Required";
+
+        /// <summary>Alert title shown when the agent's MCP config exists on disk but is stale vs the current server URL.</summary>
+        public const string ReconfigurationRequiredTitle = "Reconfiguration Required";
+
+        /// <summary>The single bullet shown under the title (mirrors Unity's "• MCP Configuration" line).</summary>
+        public const string McpConfigurationBullet = "• MCP Configuration";
+
+        /// <summary>The alert action button label (writes / rewrites the addon's entry into the agent's config).</summary>
+        public const string ButtonText = "Configure";
+
+        /// <summary>
+        /// True when the alert panel should be shown for the given <paramref name="state"/>: shown for
+        /// <see cref="AgentConfigState.Missing"/> (Setup Required) and <see cref="AgentConfigState.Stale"/>
+        /// (Reconfiguration Required), hidden for <see cref="AgentConfigState.UpToDate"/> (nothing to do). Only
+        /// agents WITH a config-file path reach this — the caller suppresses the alert for the Custom snippet agent.
+        /// </summary>
+        public static bool ShowAlert(AgentConfigState state) => state != AgentConfigState.UpToDate;
+
+        /// <summary>
+        /// The alert title for the given <paramref name="state"/>: "Setup Required" when the config is
+        /// <see cref="AgentConfigState.Missing"/>, "Reconfiguration Required" when it is
+        /// <see cref="AgentConfigState.Stale"/>. Returns an empty string for <see cref="AgentConfigState.UpToDate"/>
+        /// (the alert is hidden in that case; the caller checks <see cref="ShowAlert"/> first).
+        /// </summary>
+        public static string Title(AgentConfigState state) => state switch
+        {
+            AgentConfigState.Missing => SetupRequiredTitle,
+            AgentConfigState.Stale => ReconfigurationRequiredTitle,
+            _ => string.Empty
+        };
+
+        /// <summary>
+        /// The alert message body for the given <paramref name="state"/> — the "• MCP Configuration" bullet for both
+        /// shown states. Returns an empty string for <see cref="AgentConfigState.UpToDate"/>.
+        /// </summary>
+        public static string Message(AgentConfigState state) =>
+            ShowAlert(state) ? McpConfigurationBullet : string.Empty;
+    }
+}

--- a/addons/godot_mcp/UI/Agents/AgentConfigJson.cs
+++ b/addons/godot_mcp/UI/Agents/AgentConfigJson.cs
@@ -29,6 +29,24 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents
     /// buttons) lives behind <c>#if TOOLS</c> in <c>AgentConfiguratorsPanel.cs</c>.
     /// </para>
     /// </summary>
+    /// <summary>
+    /// The three states the addon's entry in an agent's on-disk config can be in, relative to the CURRENT MCP
+    /// client URL. Drives the dock's AI-agent alert panel: <see cref="Missing"/> → "Setup Required",
+    /// <see cref="Stale"/> → "Reconfiguration Required", <see cref="UpToDate"/> → no alert. Pure-managed so the
+    /// alert decision is unit-testable without a Godot Control.
+    /// </summary>
+    public enum AgentConfigState
+    {
+        /// <summary>No addon entry exists in the config file (missing / empty / invalid file, or entry absent).</summary>
+        Missing,
+
+        /// <summary>An addon entry exists but its <c>url</c> does NOT match the current MCP client URL (stale config).</summary>
+        Stale,
+
+        /// <summary>An addon entry exists and its <c>url</c> matches the current MCP client URL (nothing to do).</summary>
+        UpToDate
+    }
+
     public static class AgentConfigJson
     {
         /// <summary>The masked stand-in shown on-screen in place of a real bearer token (never copied/written).</summary>
@@ -104,6 +122,37 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents
             var url = entry["url"]?.GetValue<string>();
             return !string.IsNullOrEmpty(url)
                 && string.Equals(url, mcpUrl, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Classify the addon's entry in the file at <paramref name="configPath"/> relative to the current
+        /// <paramref name="mcpUrl"/>: <see cref="AgentConfigState.Missing"/> when no entry exists (missing / empty /
+        /// invalid file, or the <paramref name="bodyPath"/> → <paramref name="serverKey"/> entry is absent),
+        /// <see cref="AgentConfigState.Stale"/> when an entry exists but its <c>url</c> differs (ordinal-ignore-case)
+        /// from <paramref name="mcpUrl"/>, and <see cref="AgentConfigState.UpToDate"/> when an entry exists with a
+        /// matching url. This is the pure-managed source of truth for the dock's AI-agent alert panel; it shares the
+        /// same parse + nav rules as <see cref="IsConfigured"/> (which is exactly <c>state == UpToDate</c>) so the
+        /// two never disagree.
+        /// </summary>
+        public static AgentConfigState ConfigState(string configPath, string bodyPath, string serverKey, string mcpUrl)
+        {
+            var root = TryReadObject(configPath);
+            if (root == null)
+                return AgentConfigState.Missing;
+
+            if (root[bodyPath] is not JsonObject body)
+                return AgentConfigState.Missing;
+
+            if (body[serverKey] is not JsonObject entry)
+                return AgentConfigState.Missing;
+
+            var url = entry["url"]?.GetValue<string>();
+            if (string.IsNullOrEmpty(url))
+                return AgentConfigState.Missing;
+
+            return string.Equals(url, mcpUrl, StringComparison.OrdinalIgnoreCase)
+                ? AgentConfigState.UpToDate
+                : AgentConfigState.Stale;
         }
 
         /// <summary>

--- a/addons/godot_mcp/UI/Agents/AgentConfiguratorsPanel.cs
+++ b/addons/godot_mcp/UI/Agents/AgentConfiguratorsPanel.cs
@@ -42,6 +42,17 @@ namespace com.IvanMurzak.Godot.MCP.UI
         OptionButton? _agentSelector;
         VBoxContainer? _agentView;
 
+        // The body column (right of the optional 32px agent icon) that the per-agent sub-views are built into.
+        // Distinct from _agentView (the outer swappable container) so the icon sits to the LEFT of the body.
+        VBoxContainer? _agentBody;
+
+        /// <summary>
+        /// The addon-relative directory holding the optional per-agent icon assets. A configurator's
+        /// <see cref="GodotAgentConfigurator.IconFileName"/> is resolved against this; a missing file falls back to
+        /// no-icon (never crashes — see <see cref="LoadAgentIcon"/>).
+        /// </summary>
+        const string IconsDir = "res://addons/godot_mcp/Icons/";
+
         // Live state for the currently-shown configurator's view.
         GodotAgentConfigurator? _current;
         bool _revealToken;
@@ -51,6 +62,10 @@ namespace com.IvanMurzak.Godot.MCP.UI
         Label? _configPathLabel;
         Button? _configureButton;
         Button? _removeButton;
+
+        // The AI-agent "Setup Required" / "Reconfiguration Required" alert panel (reused DockStyle.AlertPanel),
+        // rebuilt by RefreshStatus off the live AgentConfigState. Null for the Custom snippet agent (no config path).
+        Control? _alertPanel;
 
         /// <summary>
         /// Construct the section wired to the live <paramref name="connection"/> (it reads the resolved MCP-client
@@ -148,6 +163,8 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _configPathLabel = null;
             _configureButton = null;
             _removeButton = null;
+            _alertPanel = null;
+            _agentBody = null;
 
             BuildAgentView(_current);
         }
@@ -157,20 +174,34 @@ namespace com.IvanMurzak.Godot.MCP.UI
             if (_agentView == null)
                 return;
 
-            // NOTE: the selected agent's name is intentionally NOT repeated here as a separate label — it is
-            // already shown in the agent OptionButton above (mirrors Unity, which does not duplicate it).
+            // NOTE: the selected agent's name is intentionally NOT repeated here as a separate label (it is shown in
+            // the agent OptionButton above — mirrors Unity, and the standalone name label was removed in #58).
+
+            // --- Icon (left) + body (right) layout: a 32px per-agent icon, gracefully omitted when missing. ---
+            var iconRow = new HBoxContainer { Name = "AgentIconRow", SizeFlagsHorizontal = SizeFlags.ExpandFill };
+            iconRow.AddThemeConstantOverride("separation", 8);
+            iconRow.Alignment = BoxContainer.AlignmentMode.Begin;
+            _agentView.AddChild(iconRow);
+
+            var icon = LoadAgentIcon(agent);
+            if (icon != null)
+                iconRow.AddChild(icon);
+
+            _agentBody = new VBoxContainer { Name = "AgentBody", SizeFlagsHorizontal = SizeFlags.ExpandFill };
+            _agentBody.AddThemeConstantOverride("separation", 4);
+            iconRow.AddChild(_agentBody);
 
             // --- Per-agent description (muted). ---
             if (!string.IsNullOrEmpty(agent.Description))
             {
                 var desc = new Label { Name = "Description", Text = agent.Description! };
                 DockStyle.ApplyDescription(desc);
-                _agentView.AddChild(desc);
+                _agentBody.AddChild(desc);
             }
 
             // --- Per-agent warning banner (styled amber frame). ---
             if (!string.IsNullOrEmpty(agent.WarningText))
-                _agentView.AddChild(DockStyle.WarningFrame(agent.WarningText!));
+                _agentBody.AddChild(DockStyle.WarningFrame(agent.WarningText!));
 
             // --- Links: Download (+ optional Tutorial), as flat link buttons separated by "•". ---
             var linkDefs = new List<(string Name, string Text, string Url)>
@@ -179,14 +210,22 @@ namespace com.IvanMurzak.Godot.MCP.UI
             };
             if (!string.IsNullOrEmpty(agent.TutorialUrl))
                 linkDefs.Add(("Tutorial", "Tutorial", agent.TutorialUrl!));
-            _agentView.AddChild(DockStyle.LinkRow("Links", linkDefs));
+            _agentBody.AddChild(DockStyle.LinkRow("Links", linkDefs));
 
             // --- The KEY decision: Configure/Remove for agents with a config-file path; copyable JSON otherwise. ---
             var configPath = ResolveConfigPath(agent);
             if (GodotAgentConfigurator.ShouldShowJson(configPath))
+            {
                 BuildSnippetView(agent);
+            }
             else
+            {
+                // Only config-path agents (not the Custom snippet agent) get the Setup/Reconfiguration alert. The
+                // alert frame is (re)built per state by RefreshStatus; an empty host slot reserves its position
+                // ABOVE the configure/remove row, matching the Unity reference order.
+                _agentBody.AddChild(new VBoxContainer { Name = "AlertHost", SizeFlagsHorizontal = SizeFlags.ExpandFill });
                 BuildConfigureRemoveView(agent, configPath!);
+            }
 
             // --- Per-agent help foldouts (Manual Configuration Steps / Troubleshooting). ---
             BuildHelpFoldouts(agent);
@@ -196,12 +235,43 @@ namespace com.IvanMurzak.Godot.MCP.UI
         }
 
         /// <summary>
+        /// Load the optional 32px <see cref="TextureRect"/> icon for <paramref name="agent"/> from
+        /// <see cref="IconsDir"/> + the agent's <see cref="GodotAgentConfigurator.IconFileName"/>. Returns null
+        /// (no icon, the body fills the full width) when the agent declares no icon file OR the asset is missing /
+        /// not a texture — this NEVER crashes the dock on a missing asset.
+        /// </summary>
+        TextureRect? LoadAgentIcon(GodotAgentConfigurator agent)
+        {
+            var fileName = agent.IconFileName;
+            if (string.IsNullOrEmpty(fileName))
+                return null;
+
+            var path = IconsDir + fileName;
+            if (!ResourceLoader.Exists(path))
+                return null;
+
+            // Load defensively: a corrupt / non-texture asset must not crash the dock.
+            if (ResourceLoader.Load(path) is not Texture2D texture)
+                return null;
+
+            return new TextureRect
+            {
+                Name = "AgentIcon",
+                Texture = texture,
+                CustomMinimumSize = new Vector2(32, 32),
+                ExpandMode = TextureRect.ExpandModeEnum.IgnoreSize,
+                StretchMode = TextureRect.StretchModeEnum.KeepAspectCentered,
+                SizeFlagsVertical = SizeFlags.ShrinkBegin
+            };
+        }
+
+        /// <summary>
         /// For an agent WITHOUT a writable config-file path (Custom): show the copyable HTTP snippet (read-only,
         /// token MASKED by default) + Reveal/Copy. No Configure/Remove buttons.
         /// </summary>
         void BuildSnippetView(GodotAgentConfigurator agent)
         {
-            if (_agentView == null)
+            if (_agentBody == null)
                 return;
 
             var snippetLabel = new Label
@@ -210,7 +280,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 Text = "Copy this into your MCP client config:"
             };
             DockStyle.ApplyDescription(snippetLabel);
-            _agentView.AddChild(snippetLabel);
+            _agentBody.AddChild(snippetLabel);
 
             _snippetText = new TextEdit
             {
@@ -219,11 +289,11 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 CustomMinimumSize = new Vector2(0, 120),
                 SizeFlagsHorizontal = SizeFlags.ExpandFill
             };
-            _agentView.AddChild(_snippetText);
+            _agentBody.AddChild(_snippetText);
 
             // Snippet action buttons: Reveal token + Copy (copies the UNMASKED snippet).
             var snippetActions = new HBoxContainer { Name = "SnippetActions" };
-            _agentView.AddChild(snippetActions);
+            _agentBody.AddChild(snippetActions);
 
             _revealButton = new Button { Name = "Reveal", Text = "Reveal token" };
             DockStyle.ApplySecondaryButton(_revealButton);
@@ -245,7 +315,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// </summary>
         void BuildConfigureRemoveView(GodotAgentConfigurator agent, string configPath)
         {
-            if (_agentView == null)
+            if (_agentBody == null)
                 return;
 
             // Mirror Unity's TemplateConfigureStatus.uxml: a two-row block.
@@ -256,7 +326,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             // --- Row 1: MCP header + right-aligned ellipsis config path. ---
             var headerRow = new HBoxContainer { Name = "McpHeaderRow", SizeFlagsHorizontal = SizeFlags.ExpandFill };
             headerRow.Alignment = BoxContainer.AlignmentMode.Center;
-            _agentView.AddChild(headerRow);
+            _agentBody.AddChild(headerRow);
 
             var mcpHeader = new Label { Name = "McpHeader", Text = "Model Context Protocol (MCP)" };
             DockStyle.ApplySubLabel(mcpHeader);
@@ -276,7 +346,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             // --- Row 2: status text + right-aligned Remove/Configure buttons. ---
             var statusRow = new HBoxContainer { Name = "ConfigStatusRow", SizeFlagsHorizontal = SizeFlags.ExpandFill };
             statusRow.Alignment = BoxContainer.AlignmentMode.Center;
-            _agentView.AddChild(statusRow);
+            _agentBody.AddChild(statusRow);
 
             _statusLabel = new Label { Name = "Status", SizeFlagsHorizontal = SizeFlags.ExpandFill };
             DockStyle.ApplyDescription(_statusLabel);
@@ -302,7 +372,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// <summary>Append the agent's "Manual Configuration Steps" / "Troubleshooting" collapsible foldouts when non-empty.</summary>
         void BuildHelpFoldouts(GodotAgentConfigurator agent)
         {
-            if (_agentView == null)
+            if (_agentBody == null)
                 return;
 
             if (agent.ManualSteps.Count > 0)
@@ -314,7 +384,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
                     DockStyle.ApplyDescription(label);
                     content.AddChild(label);
                 }
-                _agentView.AddChild(container);
+                _agentBody.AddChild(container);
             }
 
             if (agent.Troubleshooting.Count > 0)
@@ -326,7 +396,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
                     DockStyle.ApplyDescription(label);
                     content.AddChild(label);
                 }
-                _agentView.AddChild(container);
+                _agentBody.AddChild(container);
             }
         }
 
@@ -371,10 +441,11 @@ namespace com.IvanMurzak.Godot.MCP.UI
         }
 
         /// <summary>
-        /// Re-render the Configure/Remove status for the current agent (only agents WITH a config-file path have
-        /// this row). Drives the "Configured"/"Not configured" label, flips the Configure button to "Reconfigure"
-        /// when already configured, and shows the Remove button only when an entry exists. Reads
-        /// <see cref="GodotAgentConfigurator.IsConfigured"/> — pure-managed, against the resolved config path.
+        /// Re-render the Configure/Remove status AND the Setup/Reconfiguration alert for the current agent (only
+        /// agents WITH a config-file path have these). Drives the "Configured"/"Not configured" label, flips the
+        /// Configure button to "Reconfigure" when already configured, shows the Remove button only when an entry
+        /// exists, and (re)builds the amber alert panel per the live <see cref="AgentConfigState"/>. Reads the
+        /// pure-managed <see cref="GodotAgentConfigurator.ConfigState"/> against the resolved config path.
         /// </summary>
         void RefreshStatus()
         {
@@ -385,7 +456,9 @@ namespace com.IvanMurzak.Godot.MCP.UI
             if (configPath == null)
                 return;
 
-            var configured = _current.IsConfigured(configPath, McpUrl);
+            var state = _current.ConfigState(configPath, McpUrl);
+            var configured = state == AgentConfigState.UpToDate;
+
             _statusLabel.Text = configured ? "Configured" : "Not configured";
             _statusLabel.AddThemeColorOverride(
                 "font_color",
@@ -403,6 +476,47 @@ namespace com.IvanMurzak.Godot.MCP.UI
             }
             if (_removeButton != null)
                 _removeButton.Visible = configured;
+
+            RefreshAlert(_current, configPath, state);
+        }
+
+        /// <summary>
+        /// (Re)build the AI-agent "Setup Required" / "Reconfiguration Required" amber alert into the reserved
+        /// <c>AlertHost</c> slot, driven by the pure-managed <see cref="AgentAlertView"/> off <paramref name="state"/>.
+        /// Cleared (no alert) when the config is <see cref="AgentConfigState.UpToDate"/>. The action button reuses
+        /// the same <see cref="OnConfigurePressed"/> path as the Configure button (writes the addon's entry, then
+        /// RefreshStatus re-evaluates and clears the alert). Reuses <see cref="DockStyle.AlertPanel"/> (PR #61's
+        /// amber frame) so the chrome is not duplicated.
+        /// </summary>
+        void RefreshAlert(GodotAgentConfigurator agent, string configPath, AgentConfigState state)
+        {
+            if (_agentBody == null)
+                return;
+
+            // The reserved host VBox sits ABOVE the configure/remove row (added in BuildAgentView for config-path
+            // agents). The Custom snippet agent has no host, so there is nothing to render the alert into.
+            var host = _agentBody.GetNodeOrNull<VBoxContainer>("AlertHost");
+            if (host == null)
+                return;
+
+            // Clear any prior alert (state may have just flipped, e.g. after a Configure write).
+            foreach (var child in host.GetChildren())
+            {
+                host.RemoveChild(child);
+                child.QueueFree();
+            }
+            _alertPanel = null;
+
+            if (!AgentAlertView.ShowAlert(state))
+                return;
+
+            _alertPanel = DockStyle.AlertPanel(
+                "AgentAlert",
+                AgentAlertView.Title(state),
+                AgentAlertView.Message(state),
+                AgentAlertView.ButtonText,
+                () => OnConfigurePressed(agent, configPath));
+            host.AddChild(_alertPanel);
         }
 
         /// <summary>

--- a/addons/godot_mcp/UI/Agents/GodotAgentConfigurator.cs
+++ b/addons/godot_mcp/UI/Agents/GodotAgentConfigurator.cs
@@ -131,6 +131,15 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents
         public bool IsConfigured(string configPath, string mcpUrl) =>
             AgentConfigJson.IsConfigured(configPath, BodyPath, ServerKey, mcpUrl);
 
+        /// <summary>
+        /// Classify this agent's on-disk config relative to <paramref name="mcpUrl"/>: <see cref="AgentConfigState.Missing"/>
+        /// (no entry → "Setup Required" alert), <see cref="AgentConfigState.Stale"/> (entry points at a different url →
+        /// "Reconfiguration Required" alert), or <see cref="AgentConfigState.UpToDate"/> (no alert). Delegates to the
+        /// pure-managed <see cref="AgentConfigJson.ConfigState"/>.
+        /// </summary>
+        public AgentConfigState ConfigState(string configPath, string mcpUrl) =>
+            AgentConfigJson.ConfigState(configPath, BodyPath, ServerKey, mcpUrl);
+
         /// <summary>READ-MERGE-WRITE the addon's HTTP entry into this agent's config file (real token), preserving siblings.</summary>
         public void Configure(string configPath, string mcpUrl, string? token) =>
             AgentConfigJson.Configure(configPath, BodyPath, ServerKey, mcpUrl, token);

--- a/addons/godot_mcp/UI/DockStyle.cs
+++ b/addons/godot_mcp/UI/DockStyle.cs
@@ -143,6 +143,40 @@ namespace com.IvanMurzak.Godot.MCP.UI
             button.CustomMinimumSize = new Vector2(0, DockTheme.ButtonSecondaryHeight);
         }
 
+        /// <summary>
+        /// Skin <paramref name="button"/> as the MCP-features "Open" action (Unity's <c>.btn-secondary</c>): gray
+        /// <see cref="DockTheme.ButtonSecondary"/> fill, a <see cref="DockTheme.ButtonOpenBorder"/> 1px border,
+        /// <see cref="DockTheme.ButtonOpenCornerRadius"/> radius, and <see cref="DockTheme.ButtonOpenHeight"/> tall.
+        /// Distinct from <see cref="ApplySecondaryButton"/> (the compact 20px/4px-radius/no-border variant used by
+        /// the agent action row) so the dock's feature rows match the taller bordered Unity button exactly.
+        /// </summary>
+        public static void ApplyOpenButton(Button button)
+        {
+            var bg = Rgb(DockTheme.ButtonSecondary);
+            var border = Rgb(DockTheme.ButtonOpenBorder);
+            ApplyBorderedButtonBackground(button, bg, bg.Lightened(0.1f), border, DockTheme.ButtonOpenCornerRadius);
+            button.CustomMinimumSize = new Vector2(0, DockTheme.ButtonOpenHeight);
+        }
+
+        static void ApplyBorderedButtonBackground(Button button, Color normal, Color hover, Color border, int cornerRadius)
+        {
+            StyleBoxFlat Make(Color bg)
+            {
+                var box = new StyleBoxFlat { BgColor = bg, BorderColor = border };
+                box.SetCornerRadiusAll(cornerRadius);
+                box.SetBorderWidthAll(1);
+                box.ContentMarginLeft = 10;
+                box.ContentMarginRight = 10;
+                box.ContentMarginTop = 4;
+                box.ContentMarginBottom = 4;
+                return box;
+            }
+
+            button.AddThemeStyleboxOverride("normal", Make(normal));
+            button.AddThemeStyleboxOverride("hover", Make(hover));
+            button.AddThemeStyleboxOverride("pressed", Make(normal.Darkened(0.1f)));
+        }
+
         static void ApplyButtonBackground(Button button, Color normal, Color hover, int cornerRadius)
         {
             var normalBox = new StyleBoxFlat { BgColor = normal };

--- a/addons/godot_mcp/UI/DockTheme.cs
+++ b/addons/godot_mcp/UI/DockTheme.cs
@@ -55,6 +55,15 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// <summary>Muted gray for section descriptions (Unity's muted description text).</summary>
         public static readonly (float R, float G, float B) ColorDescriptionMuted = (0.6f, 0.6f, 0.6f);
 
+        /// <summary>
+        /// The MCP-features token sub-label colour — gray <c>Color8(150,150,150)</c> (Unity's "~N tokens total"
+        /// 11px sub-label). Distinct from <see cref="ColorDescriptionMuted"/> to match the Unity reference value.
+        /// </summary>
+        public static readonly (float R, float G, float B) ColorTokenSubLabel = (150f / 255f, 150f / 255f, 150f / 255f);
+
+        /// <summary>The MCP-features token sub-label font size (px) — Unity's 11px "~N tokens total".</summary>
+        public const int FontSizeTokenSubLabel = 11;
+
         // --- Status dot (Unity _status-indicators.uss) ---------------------------------------------------------
 
         /// <summary>Status-dot diameter (px).</summary>
@@ -103,6 +112,18 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
         /// <summary>Alert / Remove button hover background — brighter red.</summary>
         public static readonly (float R, float G, float B) ButtonAlertHover = (140f / 255f, 50f / 255f, 50f / 255f);
+
+        /// <summary>
+        /// The MCP-features "Open" button border colour — <c>Color8(100,100,100)</c> (Unity's <c>.btn-secondary</c>
+        /// border). The fill reuses <see cref="ButtonSecondary"/> gray.
+        /// </summary>
+        public static readonly (float R, float G, float B) ButtonOpenBorder = (100f / 255f, 100f / 255f, 100f / 255f);
+
+        /// <summary>The MCP-features "Open" button corner radius (px) — Unity's <c>.btn-secondary</c> 6px radius.</summary>
+        public const int ButtonOpenCornerRadius = 6;
+
+        /// <summary>The MCP-features "Open" button height (px) — Unity's <c>.btn-secondary</c> 30px.</summary>
+        public const int ButtonOpenHeight = 30;
 
         // --- Links (Unity _typography.uss / link style) --------------------------------------------------------
 

--- a/addons/godot_mcp/UI/FeatureRow.cs
+++ b/addons/godot_mcp/UI/FeatureRow.cs
@@ -16,11 +16,13 @@ using Godot;
 namespace com.IvanMurzak.Godot.MCP.UI
 {
     /// <summary>
-    /// One row of the dock's <see cref="FeaturesPanel"/> for a single <see cref="GodotMcpFeatureKind"/>: a
-    /// "&lt;Title&gt;: enabled / total" count label, an optional "~N tokens" sub-label (tools only), and an
-    /// "Open" button that raises the panel-supplied open callback. All text comes from the pure-managed
-    /// <see cref="FeaturesPanelView"/> so the formatting is unit-tested. Editor-only (<c>#if TOOLS</c>):
-    /// verified via the headless Godot smoke (test.md Suite 3).
+    /// One row of the dock's <see cref="FeaturesPanel"/> for a single <see cref="GodotMcpFeatureKind"/>, styled to
+    /// Unity-MCP's <c>row-top</c> layout (flex-start, space-between): a LEFT column with the "&lt;Title&gt;: X / Y"
+    /// count as a 20px-bold header (<see cref="DockStyle.ApplyHeader"/>) over an optional "~N tokens total" 11px
+    /// gray sub-label (tools only), and a RIGHT "Open" button skinned as Unity's <c>.btn-secondary</c>
+    /// (<see cref="DockStyle.ApplyOpenButton"/>) that raises the panel-supplied open callback. All text comes from
+    /// the pure-managed <see cref="FeaturesPanelView"/> so the formatting is unit-tested. Editor-only
+    /// (<c>#if TOOLS</c>): verified via the headless Godot smoke (test.md Suite 3).
     /// </summary>
     [Tool]
     public partial class FeatureRow : HBoxContainer
@@ -45,38 +47,59 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
         void BuildUi()
         {
+            // Unity's "row-top": align children to the TOP (flex-start) and let the LEFT column expand so the
+            // Open button hugs the right edge (space-between).
             AddThemeConstantOverride("separation", 8);
+            Alignment = AlignmentMode.Begin;
+
+            // --- LEFT: a column with the count header + (tools only) the "~N tokens total" sub-label. ---
+            var leftColumn = new VBoxContainer
+            {
+                Name = "CountColumn",
+                SizeFlagsHorizontal = SizeFlags.ExpandFill,
+                SizeFlagsVertical = SizeFlags.ShrinkBegin
+            };
+            leftColumn.AddThemeConstantOverride("separation", 2);
+            AddChild(leftColumn);
 
             _countLabel = new Label
             {
                 Name = "CountLabel",
-                Text = FeaturesPanelView.UnavailableLabel(Kind),
-                SizeFlagsHorizontal = SizeFlags.ExpandFill
+                Text = FeaturesPanelView.UnavailableLabel(Kind)
             };
-            AddChild(_countLabel);
+            DockStyle.ApplyHeader(_countLabel);
+            leftColumn.AddChild(_countLabel);
 
             if (_showTokens)
             {
                 _tokenLabel = new Label
                 {
                     Name = "TokenLabel",
-                    Text = FeaturesPanelView.UnavailableTokenLabel()
+                    Text = FeaturesPanelView.UnavailableTokenTotalLabel()
                 };
-                _tokenLabel.AddThemeColorOverride("font_color", new Color(0.60f, 0.60f, 0.60f));
-                AddChild(_tokenLabel);
+                _tokenLabel.AddThemeColorOverride("font_color", DockStyle.Rgb(DockTheme.ColorTokenSubLabel));
+                _tokenLabel.AddThemeFontSizeOverride("font_size", DockTheme.FontSizeTokenSubLabel);
+                leftColumn.AddChild(_tokenLabel);
             }
 
-            var openButton = new Button { Name = "OpenButton", Text = "Open" };
+            // --- RIGHT: the btn-secondary "Open" button, shrunk to the top-right (row-top, space-between). ---
+            var openButton = new Button
+            {
+                Name = "OpenButton",
+                Text = "Open",
+                SizeFlagsVertical = SizeFlags.ShrinkBegin
+            };
+            DockStyle.ApplyOpenButton(openButton);
             openButton.Pressed += () => _onOpen(Kind);
             AddChild(openButton);
         }
 
-        /// <summary>Show the "&lt;Title&gt;: enabled / total" counts (+ "~N tokens" for tools).</summary>
+        /// <summary>Show the "&lt;Title&gt;: enabled / total" counts (+ "~N tokens total" for tools).</summary>
         public void ShowCounts(int enabled, int total, int enabledTokenCount)
         {
             _countLabel.Text = FeaturesPanelView.CountLabel(Kind, enabled, total);
             if (_tokenLabel != null)
-                _tokenLabel.Text = FeaturesPanelView.TokenLabel(enabledTokenCount);
+                _tokenLabel.Text = FeaturesPanelView.TokenTotalLabel(enabledTokenCount);
         }
 
         /// <summary>Show the "—" placeholder (no connection/managers yet).</summary>
@@ -84,7 +107,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         {
             _countLabel.Text = FeaturesPanelView.UnavailableLabel(Kind);
             if (_tokenLabel != null)
-                _tokenLabel.Text = FeaturesPanelView.UnavailableTokenLabel();
+                _tokenLabel.Text = FeaturesPanelView.UnavailableTokenTotalLabel();
         }
     }
 }

--- a/addons/godot_mcp/UI/FeaturesPanelView.cs
+++ b/addons/godot_mcp/UI/FeaturesPanelView.cs
@@ -56,6 +56,17 @@ namespace com.IvanMurzak.Godot.MCP.UI
         public static string TokenLabel(int enabledTokenCount) => $"~{FormatTokenCount(enabledTokenCount)} tokens";
 
         /// <summary>
+        /// Format the tools-only "~N tokens total" sub-label shown under the count in the restyled MCP-features
+        /// row (Unity's "~N tokens total" 11px gray sub-label). Uses the same k-abbreviated
+        /// <see cref="FormatTokenCount"/> as <see cref="TokenLabel"/>, with a "total" suffix: <c>1500</c> →
+        /// "~1.5k tokens total".
+        /// </summary>
+        public static string TokenTotalLabel(int enabledTokenCount) => $"~{FormatTokenCount(enabledTokenCount)} tokens total";
+
+        /// <summary>The "~N tokens total" sub-label shown when the plugin/managers are not yet available — "~— tokens total".</summary>
+        public static string UnavailableTokenTotalLabel() => $"~{Unavailable} tokens total";
+
+        /// <summary>
         /// Abbreviate a token count: values under 1000 render as-is; 1000+ render as <c>{value/1000}k</c> with
         /// one decimal place and a trimmed trailing <c>.0</c> (e.g. 1000 → "1k", 1500 → "1.5k", 2000 → "2k").
         /// Uses the invariant culture so the decimal separator is always a dot regardless of editor locale.


### PR DESCRIPTION
## Summary
- Restyle the MCP-Features rows (Tools/Prompts/Resources) to Unity-MCP's `row-top` layout: a LEFT column with the "N / M" count as a 20px-bold header over a tools-only "~N tokens total" 11px gray sub-label, and a RIGHT `btn-secondary` "Open" button (gray rgb(70,70,70), 30px, radius 6, border rgb(100,100,100)). Counts, k-abbrev token formatting, Open-window behavior, and the #56 dead-subscriber fix are all preserved.
- Add the AI-agent alert panel (reusing PR #61's `DockStyle.AlertPanel`): "Setup Required" when the selected config-path agent's MCP config is missing, "Reconfiguration Required" when it exists on disk but is stale vs the current server URL. Not shown for the Custom snippet agent.
- Add an optional 32px agent icon to the left of the agent body (`GodotAgentConfigurator.IconFileName`, loaded from `addons/godot_mcp/Icons/`), gracefully omitted when the asset is missing — no crash.
- Did NOT re-add the #58-removed standalone agent-name label.
- Pure-managed staleness/view logic (OUTSIDE `#if TOOLS`, xUnit-tested): `AgentConfigJson.ConfigState`/`AgentConfigState`, `AgentAlertView`, `FeaturesPanelView.TokenTotalLabel`, and new `DockTheme` constants pinned to the brief's reference values. NuGet pins frozen (McpPlugin 6.7.0 / ReflectorNet 5.3.1).

## Test plan
- [x] `dotnet build Godot-MCP.sln --configuration Debug` — 0 errors, 0 warnings (compiles `#if TOOLS`, same as CI).
- [x] `dotnet test Godot-MCP.Tests` — 556 passed, 0 failed (+20 new tests).
- [x] Headless Godot 4.5.1 mono smoke (testbed): `[Godot-MCP] plugin loaded`, dock built clean, all deps resolved, no FileNotFoundException / UI-construction exception.

Closes #62