### PR TITLE
feat(addon): Skills generation feature + Skills UI card (Unity-MCP parity)

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -170,6 +170,12 @@
          The dock UI (AgentConfiguratorsPanel.cs) is #if TOOLS and verified via the headless Godot smoke
          (test.md Suite 3); the snippet/configure/remove/path/registry logic is unit-tested here. -->
     <Compile Include="..\addons\godot_mcp\UI\Agents\GodotAgentConfigurator.cs" Link="Source\GodotAgentConfigurator.cs" />
+    <!-- Skills card presentation model — pure-managed (no Godot native types, no #if TOOLS): the supported/path
+         resolution (SkillsPlan) the dock's Skills card renders, plus the per-agent skills-dir resolver +
+         in-project relative-path safety guard added to AgentConfigPaths and the SupportsSkills/SkillsDir capability
+         on GodotAgentConfigurator/ClaudeCodeConfigurator. The editor Control wiring (SkillsPanel.cs) is #if TOOLS and
+         verified via the headless Godot smoke (test.md Suite 3); the plan/path/capability logic is unit-tested here. -->
+    <Compile Include="..\addons\godot_mcp\UI\SkillsPlan.cs" Link="Source\SkillsPlan.cs" />
     <Compile Include="..\addons\godot_mcp\UI\Agents\AgentConfigJson.cs" Link="Source\AgentConfigJson.cs" />
     <Compile Include="..\addons\godot_mcp\UI\Agents\AgentAlertView.cs" Link="Source\AgentAlertView.cs" />
     <Compile Include="..\addons\godot_mcp\UI\Agents\AgentConfigPaths.cs" Link="Source\AgentConfigPaths.cs" />

--- a/Godot-MCP.Tests/SkillsTests.cs
+++ b/Godot-MCP.Tests/SkillsTests.cs
@@ -68,10 +68,17 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         }
 
         [Theory]
-        [InlineData("/etc/passwd")]
-        [InlineData(@"C:\Windows\System32")]
+        [InlineData("/etc/passwd")]            // POSIX absolute
+        [InlineData(@"C:\Windows\System32")]   // Windows drive-letter (backslash) — must reject on Linux too
+        [InlineData("C:/Windows")]             // Windows drive-letter (forward slash)
+        [InlineData("c:/windows")]             // lowercase drive letter
+        [InlineData("C:relative")]             // drive-letter with no separator (still drive-rooted)
+        [InlineData(@"\\server\share")]        // UNC path
+        [InlineData(@"\rooted")]               // single leading backslash (Windows root-of-current-drive)
         public void IsSafeRelativeSkillsPath_RejectsAbsolutePaths(string path)
         {
+            // The rejection MUST be OS-independent — these are all absolute/rooted forms regardless of host OS.
+            // (Regression guard for the CI failure where Path.IsPathRooted("C:\\Windows") was false on Linux.)
             Assert.False(AgentConfigPaths.IsSafeRelativeSkillsPath(path));
         }
 

--- a/Godot-MCP.Tests/SkillsTests.cs
+++ b/Godot-MCP.Tests/SkillsTests.cs
@@ -1,0 +1,188 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.IO;
+using System.Linq;
+using com.IvanMurzak.Godot.MCP.Connection;
+using com.IvanMurzak.Godot.MCP.UI;
+using com.IvanMurzak.Godot.MCP.UI.Agents;
+using com.IvanMurzak.Godot.MCP.UI.Agents.Impl;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the pure-managed Skills-generation surface (issue #64): the per-agent skills-dir resolver
+    /// (<see cref="AgentConfigPaths.ClaudeCodeSkills"/>), the relative-path safety guard
+    /// (<see cref="AgentConfigPaths.IsSafeRelativeSkillsPath"/>), the <see cref="GodotAgentConfigurator.SupportsSkills"/>
+    /// / <see cref="GodotAgentConfigurator.SkillsDir"/> capability (overridden only for Claude Code), the registry's
+    /// skills-capability set, the <see cref="SkillsPlan"/> resolution, and the auto-generate-ON config default. The
+    /// dock UI (<c>SkillsPanel.cs</c>, <c>#if TOOLS</c>) is verified via the headless Godot smoke (test.md Suite 3) —
+    /// NOT here.
+    /// </summary>
+    public class SkillsTests
+    {
+        const string ProjectRoot = "/home/dev/MyGodotProject";
+        const string Home = "/home/dev";
+        const string AppData = @"C:\Users\dev\AppData\Roaming";
+
+        // --- AgentConfigPaths.ClaudeCodeSkills ---------------------------------------------------------------
+
+        [Fact]
+        public void ClaudeCodeSkills_ResolvesProjectLocalDotClaudeSkills()
+        {
+            var dir = AgentConfigPaths.ClaudeCodeSkills(ProjectRoot);
+            var expected = Path.Combine(ProjectRoot, ".claude", "skills");
+            Assert.Equal(expected, dir);
+        }
+
+        // --- AgentConfigPaths.IsSafeRelativeSkillsPath -------------------------------------------------------
+
+        [Theory]
+        [InlineData(null)]            // null → falls back to default (safe)
+        [InlineData("")]             // empty → falls back to default (safe)
+        [InlineData(".claude/skills")]
+        [InlineData("skills")]
+        [InlineData("a/b/c")]
+        public void IsSafeRelativeSkillsPath_AllowsCleanRelativePaths(string? path)
+        {
+            Assert.True(AgentConfigPaths.IsSafeRelativeSkillsPath(path));
+        }
+
+        [Theory]
+        [InlineData("..")]
+        [InlineData("../escape")]
+        [InlineData("a/../../escape")]
+        [InlineData("a/..")]
+        [InlineData(@"..\escape")]   // backslash traversal normalized
+        public void IsSafeRelativeSkillsPath_RejectsTraversal(string path)
+        {
+            Assert.False(AgentConfigPaths.IsSafeRelativeSkillsPath(path));
+        }
+
+        [Theory]
+        [InlineData("/etc/passwd")]
+        [InlineData(@"C:\Windows\System32")]
+        public void IsSafeRelativeSkillsPath_RejectsAbsolutePaths(string path)
+        {
+            Assert.False(AgentConfigPaths.IsSafeRelativeSkillsPath(path));
+        }
+
+        // --- Per-agent capability (SupportsSkills / SkillsDir) ----------------------------------------------
+
+        [Fact]
+        public void ClaudeCode_SupportsSkills_AndResolvesSkillsDir()
+        {
+            var agent = new ClaudeCodeConfigurator();
+            Assert.True(agent.SupportsSkills);
+
+            var dir = agent.SkillsDir(AgentOs.Linux, Home, AppData, ProjectRoot);
+            Assert.Equal(Path.Combine(ProjectRoot, ".claude", "skills"), dir);
+        }
+
+        [Fact]
+        public void NonClaudeCodeAgents_DoNotSupportSkills_AndReturnNullSkillsDir()
+        {
+            foreach (var agent in GodotAgentConfiguratorRegistry.All.Where(a => a.AgentId != "claude-code"))
+            {
+                Assert.False(agent.SupportsSkills);
+                Assert.Null(agent.SkillsDir(AgentOs.Linux, Home, AppData, ProjectRoot));
+            }
+        }
+
+        /// <summary>
+        /// The registry's skills-capable set is EXACTLY {claude-code} for v1 (owner-approved Claude-Code-only). A
+        /// non-null SkillsDir lines up with SupportsSkills for every agent (no half-implemented capability).
+        /// </summary>
+        [Fact]
+        public void Registry_ExactlyClaudeCodeSupportsSkills_WithNonNullDir()
+        {
+            var skillsCapable = GodotAgentConfiguratorRegistry.All
+                .Where(a => a.SupportsSkills)
+                .Select(a => a.AgentId)
+                .ToList();
+
+            Assert.Equal(new[] { "claude-code" }, skillsCapable);
+
+            foreach (var agent in GodotAgentConfiguratorRegistry.All)
+            {
+                var dir = agent.SkillsDir(AgentOs.Linux, Home, AppData, ProjectRoot);
+                // SkillsDir is non-null EXACTLY when the agent supports skills.
+                Assert.Equal(agent.SupportsSkills, dir != null);
+            }
+        }
+
+        // --- SkillsPlan.Resolve ------------------------------------------------------------------------------
+
+        [Fact]
+        public void SkillsPlan_Resolve_ClaudeCode_IsSupported_WithDir()
+        {
+            var plan = SkillsPlan.Resolve(new ClaudeCodeConfigurator(), AgentOs.Linux, Home, AppData, ProjectRoot);
+            Assert.True(plan.Supported);
+            Assert.Equal(Path.Combine(ProjectRoot, ".claude", "skills"), plan.SkillsDir);
+        }
+
+        [Fact]
+        public void SkillsPlan_Resolve_NullAgent_IsUnsupported()
+        {
+            var plan = SkillsPlan.Resolve(null, AgentOs.Linux, Home, AppData, ProjectRoot);
+            Assert.False(plan.Supported);
+            Assert.Null(plan.SkillsDir);
+        }
+
+        [Fact]
+        public void SkillsPlan_Resolve_UnsupportedAgent_IsUnsupported()
+        {
+            var cursor = GodotAgentConfiguratorRegistry.GetByAgentId("cursor");
+            Assert.NotNull(cursor);
+
+            var plan = SkillsPlan.Resolve(cursor, AgentOs.Linux, Home, AppData, ProjectRoot);
+            Assert.False(plan.Supported);
+            Assert.Null(plan.SkillsDir);
+        }
+
+        // --- Config default (auto-generate ON) ---------------------------------------------------------------
+
+        [Fact]
+        public void GodotMcpConfig_DefaultsAutoGenerateSkillsOn()
+        {
+            var config = new GodotMcpConfig();
+            Assert.True(config.GenerateSkillFiles);
+        }
+
+        /// <summary>
+        /// A persisted OFF override survives a round-trip through the config store's serialized layer (without this,
+        /// the constructor's ON default would silently re-win on every boot). Verifies ApplyPersisted copies the flag.
+        /// </summary>
+        [Fact]
+        public void GodotMcpConfig_PersistedAutoGenerateOff_IsHonoured()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "godot-mcp-skills-test-" + System.Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            var path = Path.Combine(tempDir, "config.json");
+            try
+            {
+                var saved = new GodotMcpConfig { GenerateSkillFiles = false };
+                GodotMcpConfigStore.Save(path, saved);
+
+                var loaded = GodotMcpConfigStore.Load(path);
+                Assert.NotNull(loaded);
+
+                var target = new GodotMcpConfig(); // constructor seeds ON
+                GodotMcpConfigStore.ApplyPersisted(target, loaded);
+                Assert.False(target.GenerateSkillFiles); // persisted OFF wins
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort cleanup */ }
+            }
+        }
+    }
+}

--- a/addons/godot_mcp/Connection/GodotMcpConfig.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConfig.cs
@@ -216,7 +216,12 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             // KeepConnected is true (it drives a FixedRetryPolicy on the underlying HubConnection).
             // We do not reimplement transport — we just opt into staying connected.
             KeepConnected = true;
-            GenerateSkillFiles = false;
+
+            // Auto-generate skills is ON by default (owner-approved v1 default): on a fresh install the addon
+            // regenerates the skills-capable agent's SKILL.md files on boot via GenerateSkillFilesIfNeeded(), so the
+            // AI agent sees up-to-date per-tool skills with no manual step. The dock's Skills card exposes a toggle
+            // that persists an override (GenerateSkillFiles is a serialized field on the base ConnectionConfig).
+            GenerateSkillFiles = true;
         }
 
         // --- Pure resolution helpers (unit-testable; no Godot / SignalR dependency). ---

--- a/addons/godot_mcp/Connection/GodotMcpConfigStore.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConfigStore.cs
@@ -133,6 +133,11 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             target.ConnectionMode = persisted.ConnectionMode;
             target.AuthOption = persisted.AuthOption;
             target.LogLevel = persisted.LogLevel;
+            // The auto-generate-skills toggle (a serialized bool on the base ConnectionConfig). Honoured here so a
+            // user's persisted choice survives a restart and overrides the constructor's ON default — without this
+            // copy the boot path would always re-seed ON and silently drop a user's OFF. The skills card writes this
+            // (+ Save) when toggled; SkillsPath/ProjectRootPath are runtime-only (swap-and-restore) and not persisted.
+            target.GenerateSkillFiles = persisted.GenerateSkillFiles;
             // The persisted feature enable-map (tools/prompts/resources). A missing `features` key in an older
             // config file deserializes to a non-null empty map (the property initializer), so this is always safe.
             target.Features = persisted.Features ?? new GodotMcpFeatureMap();

--- a/addons/godot_mcp/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConnection.cs
@@ -19,6 +19,7 @@ using com.IvanMurzak.Godot.MCP.MainThreadDispatch;
 using com.IvanMurzak.Godot.MCP.Reflection;
 using com.IvanMurzak.Godot.MCP.Tools;
 using com.IvanMurzak.Godot.MCP.UI;
+using com.IvanMurzak.Godot.MCP.UI.Agents;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet;
 using Godot;
@@ -233,6 +234,12 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             SubscribeToConnectionState(_plugin);
             SubscribeToFeatureUpdates(_plugin);
 
+            // Auto-generate the selected agent's skills (SKILL.md-per-tool) when the toggle is ON. Runs AFTER the
+            // plugin Build so the tool registry the engine reads from is populated. GenerateSkillFilesIfNeeded only
+            // regenerates when the on-disk skills are stale/missing, so this is cheap on a warm boot. Gated by the
+            // GenerateSkillFiles toggle (ON by default) and a no-op when the selected agent does not support skills.
+            MaybeAutoGenerateSkills(_plugin);
+
             var mode = _config.ActiveMode;
             var host = _config.Host;
             GD.Print($"[Godot-MCP] connecting (mode={mode}, host={host}) ...");
@@ -440,6 +447,79 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                     manager.SetEnabled(pair.Key, pair.Value);
             }
         }
+
+        /// <summary>
+        /// Auto-generate the selected AI agent's skills (a <c>SKILL.md</c>-per-tool directory) on addon load, gated by
+        /// the <see cref="GodotMcpConfig.GenerateSkillFiles"/> toggle. The Godot analog of Unity-MCP's boot-time
+        /// auto-generate (<c>MainWindowEditor.AiAgents</c>'s <c>GenerateSkillFiles</c> on configured skills). No-op
+        /// when the toggle is OFF or the selected agent does not support skills. Uses the engine's
+        /// <see cref="IMcpPlugin.GenerateSkillFilesIfNeeded"/> (which only writes when the on-disk skills are
+        /// stale/missing) via the same swap-and-restore pattern the dock's on-demand Generate uses: point the live
+        /// config's <c>SkillsPath</c> + <c>ProjectRootPath</c> at the resolved destination, generate, restore. The
+        /// only Godot dependencies are the path resolution (<c>OS</c>/<c>ProjectSettings</c>) and the destination
+        /// mkdir; the supported/path decision is the pure-managed <see cref="SkillsPlan"/>. Failures are caught and
+        /// logged so a generation error never blocks the connection boot.
+        /// </summary>
+        void MaybeAutoGenerateSkills(IMcpPlugin plugin)
+        {
+            if (!_config.GenerateSkillFiles)
+                return;
+
+            var agent = GodotAgentConfiguratorRegistry.GetByAgentId(_config.SelectedAgentId);
+            var os = MapAgentOs(OS.GetName());
+            var home = OS.GetEnvironment("USERPROFILE");
+            if (string.IsNullOrEmpty(home))
+                home = OS.GetEnvironment("HOME");
+            var appData = OS.GetEnvironment("APPDATA");
+            var projectRoot = ProjectSettings.GlobalizePath("res://").TrimEnd('/');
+
+            var plan = SkillsPlan.Resolve(agent, os, home, appData, projectRoot);
+            if (!plan.Supported || string.IsNullOrEmpty(plan.SkillsDir))
+                return;
+
+            var skillsDir = plan.SkillsDir!;
+
+            try
+            {
+                if (!DirAccess.DirExistsAbsolute(skillsDir))
+                {
+                    var mkdir = DirAccess.MakeDirRecursiveAbsolute(skillsDir);
+                    if (mkdir != Error.Ok)
+                    {
+                        GD.PushWarning($"[Godot-MCP] auto-generate skills: could not create folder {skillsDir} ({mkdir}).");
+                        return;
+                    }
+                }
+
+                var originalSkillsPath = _config.SkillsPath;
+                var originalProjectRoot = _config.ProjectRootPath;
+                try
+                {
+                    _config.SkillsPath = skillsDir;
+                    _config.ProjectRootPath = projectRoot;
+                    plugin.GenerateSkillFilesIfNeeded(skillsDir);
+                }
+                finally
+                {
+                    _config.SkillsPath = originalSkillsPath;
+                    _config.ProjectRootPath = originalProjectRoot;
+                }
+
+                GD.Print($"[Godot-MCP] auto-generate skills: ensured up-to-date skills in {skillsDir}.");
+            }
+            catch (Exception ex)
+            {
+                GD.PushError($"[Godot-MCP] auto-generate skills failed: {ex.Message}");
+            }
+        }
+
+        /// <summary>Map Godot's <c>OS.GetName()</c> ("Windows"/"macOS"/"Linux"/…) onto the injectable <see cref="AgentOs"/>.</summary>
+        static AgentOs MapAgentOs(string godotOsName) => godotOsName switch
+        {
+            "Windows" => AgentOs.Windows,
+            "macOS" => AgentOs.MacOS,
+            _ => AgentOs.Linux,
+        };
 
         /// <summary>
         /// Enumerate the live items of a feature kind as pure-managed <see cref="FeatureRowItem"/> view-models

--- a/addons/godot_mcp/UI/Agents/AgentConfigPaths.cs
+++ b/addons/godot_mcp/UI/Agents/AgentConfigPaths.cs
@@ -65,5 +65,36 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents
 
         /// <summary>VS Code project-local config: <c>&lt;projectRoot&gt;/.vscode/mcp.json</c>.</summary>
         public static string VisualStudioCode(string projectRoot) => Combine(projectRoot, ".vscode", "mcp.json");
+
+        /// <summary>
+        /// Claude Code project-local skills directory: <c>&lt;projectRoot&gt;/.claude/skills</c>. The destination the
+        /// skill-generation engine (<c>IMcpPlugin.GenerateSkillFiles</c>) writes a <c>SKILL.md</c>-per-tool into. The
+        /// Godot analog of Unity-MCP's <c>ClaudeCodeConfigurator.SkillsPath = ".claude/skills"</c> resolved against the
+        /// project root. Pure-managed (the project root is injected) so it is unit-testable.
+        /// </summary>
+        public static string ClaudeCodeSkills(string projectRoot) => Combine(projectRoot, ".claude", "skills");
+
+        /// <summary>
+        /// Validate a user-or-config-supplied skills path is a SAFE in-project relative path: rejects an absolute /
+        /// rooted path and any <c>..</c> traversal segment (mirrors Unity-MCP's <c>Tool_Skills.GenerateAll</c> guard).
+        /// Returns <c>true</c> when <paramref name="relativePath"/> is null/empty (the resolver falls back to the
+        /// per-agent default) OR a clean relative path; <c>false</c> when it is rooted or escapes the project root.
+        /// Pure-managed (no IO, no Godot types) so it is unit-testable; the editor calls this before resolving an
+        /// override against the project root.
+        /// </summary>
+        public static bool IsSafeRelativeSkillsPath(string? relativePath)
+        {
+            if (string.IsNullOrEmpty(relativePath))
+                return true;
+
+            if (Path.IsPathRooted(relativePath))
+                return false;
+
+            var normalized = relativePath!.Replace('\\', '/');
+            if (normalized == ".." || normalized.StartsWith("../") || normalized.Contains("/../") || normalized.EndsWith("/.."))
+                return false;
+
+            return true;
+        }
     }
 }

--- a/addons/godot_mcp/UI/Agents/AgentConfigPaths.cs
+++ b/addons/godot_mcp/UI/Agents/AgentConfigPaths.cs
@@ -87,10 +87,28 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents
             if (string.IsNullOrEmpty(relativePath))
                 return true;
 
+            // Reject absolute / rooted forms with a PURELY STRING-BASED test so the result is identical on every
+            // host OS. System.IO.Path.IsPathRooted is platform-dependent — on Linux it returns false for a Windows
+            // drive-letter path like "C:\Windows" (a drive letter is not a Linux root), which would let such a path
+            // slip past the guard on a Linux CI runner while being rejected on Windows. Cover all absolute shapes:
+            //   - POSIX absolute:        leading '/'
+            //   - Windows UNC / rooted:  leading '\' (single or "\\server\share")
+            //   - Windows drive-letter:  "<letter>:" prefix, with '\' OR '/' or nothing after (C:\, C:/, C:foo)
+            var normalized = relativePath!.Replace('\\', '/');
+
+            if (normalized.StartsWith("/"))
+                return false;
+
+            if (normalized.Length >= 2 &&
+                normalized[1] == ':' &&
+                ((normalized[0] >= 'A' && normalized[0] <= 'Z') || (normalized[0] >= 'a' && normalized[0] <= 'z')))
+                return false;
+
+            // Belt-and-suspenders: still honour the platform check too (catches any rooted form not covered above).
             if (Path.IsPathRooted(relativePath))
                 return false;
 
-            var normalized = relativePath!.Replace('\\', '/');
+            // Reject '..' traversal segments (after backslash normalization above).
             if (normalized == ".." || normalized.StartsWith("../") || normalized.Contains("/../") || normalized.EndsWith("/.."))
                 return false;
 

--- a/addons/godot_mcp/UI/Agents/AgentConfiguratorsPanel.cs
+++ b/addons/godot_mcp/UI/Agents/AgentConfiguratorsPanel.cs
@@ -9,6 +9,7 @@
 */
 #if TOOLS
 #nullable enable
+using System;
 using System.Collections.Generic;
 using com.IvanMurzak.Godot.MCP.Connection;
 using com.IvanMurzak.Godot.MCP.UI.Agents;
@@ -38,6 +39,15 @@ namespace com.IvanMurzak.Godot.MCP.UI
     public partial class AgentConfiguratorsPanel : VBoxContainer
     {
         readonly GodotMcpConnection _connection;
+
+        /// <summary>
+        /// Raised after the user picks a DIFFERENT AI agent in the dropdown (the persisted
+        /// <see cref="GodotMcpConfig.SelectedAgentId"/> changed + was Saved). The dock subscribes so dependent
+        /// sections — notably the Skills card, whose supported-state/path follow the selected agent — re-render. Fired
+        /// on the editor main thread (the selection callback runs there), carries no payload (subscribers re-read the
+        /// persisted selection). Not fired when the user re-picks the already-selected agent.
+        /// </summary>
+        public event Action? AgentSelectionChanged;
 
         OptionButton? _agentSelector;
         VBoxContainer? _agentView;
@@ -127,13 +137,19 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
             // Persist the selected agent id so the choice survives a restart.
             var selected = all[i];
-            if (_connection.Config.SelectedAgentId != selected.AgentId)
+            var changed = _connection.Config.SelectedAgentId != selected.AgentId;
+            if (changed)
             {
                 _connection.Config.SelectedAgentId = selected.AgentId;
                 _connection.Save();
             }
 
             ShowAgent(i);
+
+            // Notify dependent sections (the Skills card follows the selected agent) AFTER the persisted selection +
+            // this panel's own view are updated, so a subscriber re-reading SelectedAgentId sees the new value.
+            if (changed)
+                AgentSelectionChanged?.Invoke();
         }
 
         /// <summary>Rebuild the per-agent view for the configurator at registry index <paramref name="index"/>.</summary>

--- a/addons/godot_mcp/UI/Agents/GodotAgentConfigurator.cs
+++ b/addons/godot_mcp/UI/Agents/GodotAgentConfigurator.cs
@@ -108,6 +108,34 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents
         /// <param name="projectRoot">The absolute Godot project root (<c>ProjectSettings.GlobalizePath("res://")</c>).</param>
         public abstract string? ConfigFilePath(AgentOs os, string home, string appData, string projectRoot);
 
+        // --- Skills capability (parity with Unity-MCP's AiAgentConfigurator.SkillsPath / SupportsSkills) ---------
+
+        /// <summary>
+        /// Whether this agent supports auto-generated MCP "skills" (a <c>SKILL.md</c>-per-tool directory the
+        /// skill-generation engine writes). Defaults to <c>false</c> (most agents do not); the Claude Code
+        /// configurator overrides it to <c>true</c>. Mirrors the <see cref="ShouldShowJson"/> / <see cref="ConfigFilePath"/>
+        /// capability pattern: the dock gates the Skills section's visibility on this (showing a "not supported" line
+        /// otherwise), exactly like Unity-MCP gates its skills UI to Claude. Pure-managed so the registry's
+        /// skills-capability set is unit-testable.
+        /// </summary>
+        public virtual bool SupportsSkills => false;
+
+        /// <summary>
+        /// The per-OS absolute skills directory the addon's skill-generation engine writes into for this agent, or
+        /// <c>null</c> when the agent does not support skills (the default — see <see cref="SupportsSkills"/>). The
+        /// Godot analog of Unity-MCP's project-relative <c>SkillsPath = ".claude/skills"</c>, resolved here to an
+        /// absolute path so the engine's swap-and-restore call receives a concrete destination. Implementations
+        /// resolve from the injected project root via <see cref="AgentConfigPaths"/> so they stay pure-managed and
+        /// unit-testable; the editor passes <c>ProjectSettings.GlobalizePath("res://")</c> as <paramref name="projectRoot"/>.
+        /// The signature mirrors <see cref="ConfigFilePath"/> for a uniform editor call site, though only the
+        /// project root is consulted today.
+        /// </summary>
+        /// <param name="os">The host OS family (injected; the editor maps <c>Godot.OS.GetName()</c> onto it).</param>
+        /// <param name="home">The user home directory (USERPROFILE / HOME).</param>
+        /// <param name="appData">The Windows %APPDATA% directory (ignored on macOS/Linux).</param>
+        /// <param name="projectRoot">The absolute Godot project root (<c>ProjectSettings.GlobalizePath("res://")</c>).</param>
+        public virtual string? SkillsDir(AgentOs os, string home, string appData, string projectRoot) => null;
+
         /// <summary>
         /// The dock's Config-vs-JSON decision predicate: TRUE when the panel should show the copyable JSON snippet
         /// for this agent (because it has NO writable config-file path the addon can drive), FALSE when the panel

--- a/addons/godot_mcp/UI/Agents/Impl/ClaudeCodeConfigurator.cs
+++ b/addons/godot_mcp/UI/Agents/Impl/ClaudeCodeConfigurator.cs
@@ -43,5 +43,12 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents.Impl
 
         public override string? ConfigFilePath(AgentOs os, string home, string appData, string projectRoot) =>
             AgentConfigPaths.ClaudeCode(projectRoot);
+
+        // Claude Code is the only skills-capable agent in v1 (owner-approved): it reads auto-generated SKILL.md files
+        // from `<projectRoot>/.claude/skills`. Mirrors Unity-MCP's ClaudeCodeConfigurator.SkillsPath = ".claude/skills".
+        public override bool SupportsSkills => true;
+
+        public override string? SkillsDir(AgentOs os, string home, string appData, string projectRoot) =>
+            AgentConfigPaths.ClaudeCodeSkills(projectRoot);
     }
 }

--- a/addons/godot_mcp/UI/GodotMcpDock.cs
+++ b/addons/godot_mcp/UI/GodotMcpDock.cs
@@ -52,6 +52,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         ConnectionPanel? _connectionPanel;
         FeaturesPanel? _featuresPanel;
         AgentConfiguratorsPanel? _agentConfiguratorsPanel;
+        SkillsPanel? _skillsPanel;
         SupportFooter? _supportFooter;
 
         // Log Level selector (header). Only built when a live connection was threaded in (it reads/writes
@@ -176,6 +177,18 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 // so it shares the connection-null guard with the connection + features panels.
                 _agentConfiguratorsPanel = new AgentConfiguratorsPanel(_connection);
                 Body.AddChild(DockStyle.Card(_agentConfiguratorsPanel, "AiAgent"));
+
+                // Skills section — auto-generated SKILL.md output for the selected skills-capable agent: the resolved
+                // skills path, an Auto-generate toggle (persisted via GenerateSkillFiles), and an on-demand Generate
+                // button. Inserted BETWEEN the AI-agent card and the support footer, wired to the live connection (it
+                // reads the persisted selected agent + drives the live plugin's GenerateSkillFiles). Only meaningful
+                // with a live connection, so it shares the connection-null guard with the panels above.
+                _skillsPanel = new SkillsPanel(_connection);
+                Body.AddChild(DockStyle.Card(_skillsPanel, "Skills"));
+
+                // The Skills card's supported-state + output path follow the selected AI agent, so re-render it when
+                // the AI-agent dropdown selection changes (the panel persists the new SelectedAgentId first).
+                _agentConfiguratorsPanel.AgentSelectionChanged += () => _skillsPanel?.Refresh();
             }
 
             // Support/footer section — static links + thanks, appended BELOW the connection panel. It holds
@@ -266,6 +279,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _connectionPanel?.Refresh();
             _featuresPanel?.Refresh();
             _agentConfiguratorsPanel?.Refresh();
+            _skillsPanel?.Refresh();
             SyncLogLevelSelector();
         }
     }

--- a/addons/godot_mcp/UI/SkillsPanel.cs
+++ b/addons/godot_mcp/UI/SkillsPanel.cs
@@ -1,0 +1,339 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using com.IvanMurzak.Godot.MCP.Connection;
+using com.IvanMurzak.Godot.MCP.UI.Agents;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.UI
+{
+    /// <summary>
+    /// The dock's "Skills" section — the Godot <see cref="Control"/> analog of Unity-MCP's <c>TemplateSkillsSection</c>
+    /// / <c>SetupSkillsUI</c>. A <see cref="VBoxContainer"/> the <see cref="GodotMcpDock"/> inserts into its Body
+    /// BETWEEN the AI-agent card and the support footer. It reflects the SELECTED AI agent (read from the persisted
+    /// <see cref="GodotMcpConfig.SelectedAgentId"/>): when that agent supports skills it renders a "Skills" header +
+    /// the resolved skills output path (right-aligned, ellipsis, muted), an "Auto-generate" toggle bound to
+    /// <see cref="GodotMcpConfig.GenerateSkillFiles"/> (persist + Save), a "Generate" button, and a last-result status
+    /// line; when the agent does NOT support skills it shows a single muted "Skills not supported by this agent" line
+    /// (gated on <see cref="GodotAgentConfigurator.SupportsSkills"/>, exactly like Unity gates its skills UI to Claude).
+    ///
+    /// <para>
+    /// The generation ENGINE ships in the reused <c>com.IvanMurzak.McpPlugin</c> pin
+    /// (<see cref="com.IvanMurzak.McpPlugin.IMcpPlugin.GenerateSkillFiles"/>); this panel only drives it. Manual
+    /// Generate uses the swap-and-restore pattern (temporarily set the live config's <c>SkillsPath</c> +
+    /// <c>ProjectRootPath</c> to the resolved destination, call the engine, restore) — mirroring Unity's
+    /// <c>Tool_Skills.GenerateAll</c>. Auto-generate on addon load is driven separately from
+    /// <see cref="GodotMcpConnection.Start"/> via <c>GenerateSkillFilesIfNeeded</c>.
+    /// </para>
+    ///
+    /// <para>
+    /// Editor-only (<c>#if TOOLS</c>): it constructs live Godot UI nodes and reads the live config off the threaded-in
+    /// connection. The supported/path DECISION lives in the pure-managed <see cref="SkillsPlan"/> +
+    /// <see cref="AgentConfigPaths"/> (CI-unit-tested); this class is verified via the headless Godot smoke
+    /// (<c>test.md</c> Suite 3).
+    /// </para>
+    /// </summary>
+    [Tool]
+    public partial class SkillsPanel : VBoxContainer
+    {
+        readonly GodotMcpConnection _connection;
+
+        VBoxContainer? _body;
+        CheckBox? _autoGenerateToggle;
+        Label? _pathLabel;
+        Label? _statusLabel;
+
+        /// <summary>
+        /// Construct the section wired to the live <paramref name="connection"/> (it reads the selected agent + the
+        /// auto-generate toggle off the connection's <see cref="GodotMcpConfig"/>, persists the toggle via the
+        /// connection's <c>Save</c>, and drives the connection's live plugin to generate). Only built by the dock when
+        /// a live connection exists (the AI-agent / features cards share the same connection-null guard).
+        /// </summary>
+        public SkillsPanel(GodotMcpConnection connection)
+        {
+            _connection = connection;
+            Name = "Skills";
+            BuildUi();
+        }
+
+        void BuildUi()
+        {
+            SizeFlagsHorizontal = SizeFlags.ExpandFill;
+            AddThemeConstantOverride("separation", 4);
+
+            // --- Header row: "Skills" sub-label on the LEFT + the resolved path on the RIGHT (right-aligned,
+            //     ellipsis, muted) — mirrors the AI-agent card's MCP-header row layout. ---
+            var headerRow = new HBoxContainer { Name = "SkillsHeaderRow", SizeFlagsHorizontal = SizeFlags.ExpandFill };
+            headerRow.Alignment = BoxContainer.AlignmentMode.Center;
+            AddChild(headerRow);
+
+            var header = new Label { Name = "SkillsHeader", Text = "Skills" };
+            DockStyle.ApplySubLabel(header);
+            headerRow.AddChild(header);
+
+            _pathLabel = new Label
+            {
+                Name = "SkillsPath",
+                SizeFlagsHorizontal = SizeFlags.ExpandFill,
+                HorizontalAlignment = HorizontalAlignment.Right
+            };
+            DockStyle.ApplyConfigPath(_pathLabel);
+            headerRow.AddChild(_pathLabel);
+
+            // --- Swappable body: either the supported controls (toggle + Generate + status) or the unsupported line.
+            _body = new VBoxContainer { Name = "SkillsBody", SizeFlagsHorizontal = SizeFlags.ExpandFill };
+            _body.AddThemeConstantOverride("separation", 4);
+            AddChild(_body);
+
+            RebuildBody();
+        }
+
+        /// <summary>
+        /// Rebuild the body for the currently-selected agent's skills plan. Clears the previous controls synchronously
+        /// (detach + free so a rebuild starts empty) and either renders the supported controls or the "not supported"
+        /// muted line. Reads the selected agent off the persisted <see cref="GodotMcpConfig.SelectedAgentId"/> so the
+        /// card always reflects the AI-agent card's dropdown selection (the dock's <see cref="GodotMcpDock.Refresh"/>
+        /// re-runs this after a selection change persists).
+        /// </summary>
+        void RebuildBody()
+        {
+            if (_body == null)
+                return;
+
+            foreach (var child in _body.GetChildren())
+            {
+                _body.RemoveChild(child);
+                child.QueueFree();
+            }
+            _autoGenerateToggle = null;
+            _statusLabel = null;
+
+            var plan = ResolvePlan();
+
+            if (!plan.Supported)
+            {
+                if (_pathLabel != null)
+                {
+                    _pathLabel.Text = string.Empty;
+                    _pathLabel.TooltipText = string.Empty;
+                }
+
+                var unsupported = new Label
+                {
+                    Name = "SkillsUnsupported",
+                    Text = "Skills not supported by this agent."
+                };
+                DockStyle.ApplyDescription(unsupported);
+                _body.AddChild(unsupported);
+                return;
+            }
+
+            // Show the resolved skills output path in the header (full path as tooltip; the label ellipsis-truncates).
+            if (_pathLabel != null)
+            {
+                _pathLabel.Text = plan.SkillsDir!;
+                _pathLabel.TooltipText = plan.SkillsDir!;
+            }
+
+            // --- Auto-generate row: label on the LEFT + a CheckBox on the RIGHT bound to GenerateSkillFiles. ---
+            var toggleRow = new HBoxContainer { Name = "AutoGenerateRow", SizeFlagsHorizontal = SizeFlags.ExpandFill };
+            toggleRow.Alignment = BoxContainer.AlignmentMode.Center;
+            _body.AddChild(toggleRow);
+
+            var toggleLabel = new Label { Name = "AutoGenerateLabel", Text = "Auto-generate", SizeFlagsHorizontal = SizeFlags.ExpandFill };
+            DockStyle.ApplyDescription(toggleLabel);
+            toggleLabel.AutowrapMode = TextServer.AutowrapMode.Off;
+            toggleRow.AddChild(toggleLabel);
+
+            _autoGenerateToggle = new CheckBox
+            {
+                Name = "AutoGenerateToggle",
+                ButtonPressed = _connection.Config.GenerateSkillFiles
+            };
+            _autoGenerateToggle.Toggled += OnAutoGenerateToggled;
+            toggleRow.AddChild(_autoGenerateToggle);
+
+            // --- Generate button row (right-aligned primary action). ---
+            var actionRow = new HBoxContainer { Name = "SkillsActionRow", SizeFlagsHorizontal = SizeFlags.ExpandFill };
+            actionRow.Alignment = BoxContainer.AlignmentMode.End;
+            _body.AddChild(actionRow);
+
+            var generateButton = new Button { Name = "Generate", Text = "Generate" };
+            DockStyle.ApplyPrimaryButton(generateButton);
+            generateButton.Pressed += OnGeneratePressed;
+            actionRow.AddChild(generateButton);
+
+            // --- Last-result status line (muted; turns amber on failure). ---
+            _statusLabel = new Label { Name = "SkillsStatus", SizeFlagsHorizontal = SizeFlags.ExpandFill };
+            DockStyle.ApplyDescription(_statusLabel);
+            _body.AddChild(_statusLabel);
+        }
+
+        /// <summary>
+        /// Persist the auto-generate toggle (the serialized <see cref="GodotMcpConfig.GenerateSkillFiles"/>) + Save.
+        /// No generation is triggered here — the toggle only governs the BOOT-time
+        /// <c>GenerateSkillFilesIfNeeded</c> path (in <see cref="GodotMcpConnection.Start"/>); the on-demand Generate
+        /// button is the explicit action. Mirrors the dock's other persisted toggles (e.g. the Log Level dropdown).
+        /// </summary>
+        void OnAutoGenerateToggled(bool pressed)
+        {
+            if (_connection.Config.GenerateSkillFiles == pressed)
+                return;
+
+            _connection.Config.GenerateSkillFiles = pressed;
+            _connection.Save();
+        }
+
+        /// <summary>
+        /// On-demand "Generate": resolve the selected agent's skills directory, validate it, then call the live
+        /// <see cref="com.IvanMurzak.McpPlugin.IMcpPlugin.GenerateSkillFiles"/> via the swap-and-restore pattern
+        /// (temporarily point the live config's <c>SkillsPath</c> + <c>ProjectRootPath</c> at the resolved
+        /// destination, generate, restore in <c>finally</c>) — mirroring Unity's <c>Tool_Skills.GenerateAll</c>. The
+        /// destination directory is created if missing. The result is surfaced in the status line; failures never
+        /// throw out of the UI handler.
+        /// </summary>
+        void OnGeneratePressed()
+        {
+            var plan = ResolvePlan();
+            if (!plan.Supported || string.IsNullOrEmpty(plan.SkillsDir))
+            {
+                SetStatus("Skills are not supported by the selected agent.", error: true);
+                return;
+            }
+
+            var skillsDir = plan.SkillsDir!;
+            var projectRoot = ProjectRoot();
+
+            // Defense-in-depth: the resolved dir is a fixed in-project relative path (`.claude/skills`), but validate
+            // it stays inside the project root before writing (rejects an absolute-escape / `..` traversal).
+            if (!IsSkillsDirInsideProject(skillsDir, projectRoot))
+            {
+                SetStatus("Refusing to generate: skills path escapes the project root.", error: true);
+                return;
+            }
+
+            var plugin = _connection.Plugin;
+            if (plugin == null)
+            {
+                SetStatus("Cannot generate: the MCP plugin is not initialized yet.", error: true);
+                return;
+            }
+
+            try
+            {
+                if (!DirAccess.DirExistsAbsolute(skillsDir))
+                {
+                    var mkdir = DirAccess.MakeDirRecursiveAbsolute(skillsDir);
+                    if (mkdir != Error.Ok)
+                    {
+                        SetStatus($"Could not create skills folder ({mkdir}).", error: true);
+                        return;
+                    }
+                }
+
+                var config = _connection.Config;
+                var originalSkillsPath = config.SkillsPath;
+                var originalProjectRoot = config.ProjectRootPath;
+                bool ok;
+                try
+                {
+                    config.SkillsPath = skillsDir;
+                    config.ProjectRootPath = projectRoot;
+                    ok = plugin.GenerateSkillFiles(skillsDir);
+                }
+                finally
+                {
+                    config.SkillsPath = originalSkillsPath;
+                    config.ProjectRootPath = originalProjectRoot;
+                }
+
+                if (ok)
+                    SetStatus($"Generated skills in {skillsDir}.", error: false);
+                else
+                    SetStatus("Skill generation reported no changes (or failed) — check the Output.", error: true);
+            }
+            catch (Exception ex)
+            {
+                // Never let a generation failure escape the editor UI handler; surface it in the status + Output.
+                GD.PushError($"[Godot-MCP] skill generation failed: {ex.Message}");
+                SetStatus($"Skill generation failed: {ex.Message}", error: true);
+            }
+        }
+
+        /// <summary>Set the last-result status line text + colour (muted on success, amber on failure).</summary>
+        void SetStatus(string text, bool error)
+        {
+            if (_statusLabel == null)
+                return;
+
+            _statusLabel.Text = text;
+            _statusLabel.AddThemeColorOverride(
+                "font_color",
+                error ? DockStyle.Rgb(DockTheme.WarningText) : DockStyle.Rgb(DockTheme.ColorDescriptionMuted));
+        }
+
+        /// <summary>
+        /// Re-sync the card when the selected agent (or anything it depends on) changes — forwarded from
+        /// <see cref="GodotMcpDock.Refresh"/>, which the AI-agent card's selection-change path triggers. Rebuilds the
+        /// body so a switch to/from a skills-capable agent flips the supported-state, path, and controls. The
+        /// last-result status is intentionally reset by the rebuild (a stale "generated" line would be misleading
+        /// after switching agents).
+        /// </summary>
+        public void Refresh() => RebuildBody();
+
+        // --- live resolution off the connection config / editor ----------------------------------------------
+
+        /// <summary>Resolve the skills plan for the persisted-selected agent against the live editor path values.</summary>
+        SkillsPlan ResolvePlan()
+        {
+            var agent = GodotAgentConfiguratorRegistry.GetByAgentId(_connection.Config.SelectedAgentId);
+            var os = MapOs(OS.GetName());
+            var home = OS.GetEnvironment("USERPROFILE");
+            if (string.IsNullOrEmpty(home))
+                home = OS.GetEnvironment("HOME");
+            var appData = OS.GetEnvironment("APPDATA");
+            var projectRoot = ProjectRoot();
+
+            return SkillsPlan.Resolve(agent, os, home, appData, projectRoot);
+        }
+
+        /// <summary>The absolute Godot project root (<c>res://</c> globalized, trailing slash stripped).</summary>
+        static string ProjectRoot() => ProjectSettings.GlobalizePath("res://").TrimEnd('/');
+
+        /// <summary>
+        /// True when <paramref name="skillsDir"/> resolves to a location INSIDE <paramref name="projectRoot"/>. A
+        /// last-line guard against an absolute-escape / <c>..</c> traversal before writing (the resolved dir is the
+        /// fixed `.claude/skills` today, so this is belt-and-suspenders). Compares normalized full paths.
+        /// </summary>
+        static bool IsSkillsDirInsideProject(string skillsDir, string projectRoot)
+        {
+            try
+            {
+                var rootFull = System.IO.Path.GetFullPath(projectRoot).Replace('\\', '/').TrimEnd('/');
+                var dirFull = System.IO.Path.GetFullPath(skillsDir).Replace('\\', '/').TrimEnd('/');
+                return dirFull == rootFull || dirFull.StartsWith(rootFull + "/", StringComparison.Ordinal);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>Map Godot's <c>OS.GetName()</c> ("Windows"/"macOS"/"Linux"/…) onto the injectable <see cref="AgentOs"/>.</summary>
+        static AgentOs MapOs(string godotOsName) => godotOsName switch
+        {
+            "Windows" => AgentOs.Windows,
+            "macOS" => AgentOs.MacOS,
+            _ => AgentOs.Linux,
+        };
+    }
+}
+#endif

--- a/addons/godot_mcp/UI/SkillsPlan.cs
+++ b/addons/godot_mcp/UI/SkillsPlan.cs
@@ -1,0 +1,60 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using com.IvanMurzak.Godot.MCP.UI.Agents;
+
+namespace com.IvanMurzak.Godot.MCP.UI
+{
+    /// <summary>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) presentation model for the dock's Skills card — the
+    /// Godot analog of the supported/path/state decisions Unity-MCP's <c>SetupSkillsUI</c> makes inline. Given the
+    /// selected agent and the injected editor path values, it resolves whether skills are supported and the absolute
+    /// destination directory, so the <c>#if TOOLS</c> <see cref="SkillsPanel"/> only renders the result. Resolving
+    /// this here (rather than in the panel) keeps the supported/path logic CI-unit-testable in the plain-xUnit host.
+    /// </summary>
+    public readonly struct SkillsPlan
+    {
+        /// <summary>Whether the selected agent supports skills (the card shows its controls; otherwise a muted "not supported" line).</summary>
+        public bool Supported { get; }
+
+        /// <summary>
+        /// The absolute skills directory the engine writes into, or <c>null</c> when the agent does not support skills
+        /// (or no agent is selected). Non-null exactly when <see cref="Supported"/> is true.
+        /// </summary>
+        public string? SkillsDir { get; }
+
+        SkillsPlan(bool supported, string? skillsDir)
+        {
+            Supported = supported;
+            SkillsDir = skillsDir;
+        }
+
+        /// <summary>The "no skills" plan — agent absent or skills unsupported.</summary>
+        public static readonly SkillsPlan Unsupported = new(false, null);
+
+        /// <summary>
+        /// Resolve the Skills plan for <paramref name="agent"/> against the injected editor path values (the same
+        /// quadruple <see cref="GodotAgentConfigurator.SkillsDir"/> takes). A null agent, an agent that does not
+        /// support skills, or one whose <see cref="GodotAgentConfigurator.SkillsDir"/> resolves null all yield
+        /// <see cref="Unsupported"/>. Pure-managed: the OS family / home / appData / projectRoot are injected, so the
+        /// editor's <c>Godot.OS</c> / <c>ProjectSettings</c> reads stay in the panel.
+        /// </summary>
+        public static SkillsPlan Resolve(GodotAgentConfigurator? agent, AgentOs os, string home, string appData, string projectRoot)
+        {
+            if (agent == null || !agent.SupportsSkills)
+                return Unsupported;
+
+            var dir = agent.SkillsDir(os, home, appData, projectRoot);
+            if (string.IsNullOrEmpty(dir))
+                return Unsupported;
+
+            return new SkillsPlan(true, dir);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a real Skills-generation feature to the Godot-MCP dock — the analog of Unity-MCP's auto-generated `.claude/skills`. The generation **engine already ships** in the frozen McpPlugin 6.7.0 pin (`IMcpPlugin.GenerateSkillFiles`/`GenerateSkillFilesIfNeeded`, `ConnectionConfig.GenerateSkillFiles`/`SkillsPath`/`ProjectRootPath`); this PR only adds the per-agent path resolver, the UI card, and the trigger hooks — the generator is NOT reimplemented.
- **Pure-managed (xUnit-tested):** `AgentConfigPaths.ClaudeCodeSkills` (`<projectRoot>/.claude/skills`) + `IsSafeRelativeSkillsPath` guard; `SupportsSkills`/`SkillsDir` capability on `GodotAgentConfigurator`, overridden only in `ClaudeCodeConfigurator` (Claude-Code-only v1); `SkillsPlan` supported/path resolution; `GenerateSkillFiles` default ON + persisted via `GodotMcpConfigStore`.
- **Editor UI (`#if TOOLS`):** a `SkillsPanel` `DockStyle.Card` between the AI-agent card and the footer — "Skills" header + resolved path (right-aligned ellipsis muted), an Auto-generate toggle (bound + persisted), a Generate button, a last-result status line, and a "not supported" line gated on `SupportsSkills`. Reflects the selected agent via the AI-agent card's new `AgentSelectionChanged` event.
- **Triggers:** manual Generate uses the swap-and-restore pattern against the live `IMcpPlugin.GenerateSkillFiles` with in-project path validation (mirrors Unity's `Skills.Generate`); auto-generate on addon load calls `GenerateSkillFilesIfNeeded()` after the plugin Build in `GodotMcpConnection.Start()`, gated by the toggle.

## v1 defaults (owner-approved)
- Claude-Code-only skills support; auto-generate default **ON**; engine's default call-block; skills derive from existing tool `[Description]`s (no `[AiSkillBody]` enrichment this PR).

## Constraints honored
- NuGet pins FROZEN (McpPlugin 6.7.0 / ReflectorNet 5.3.1 — not bumped). Apache-2.0 ASCII header on new files; conventional commit; `#if TOOLS` for editor UI; pure-managed logic outside `#if TOOLS` + xUnit-tested; token never logged; explicit staging (no `git add -A`). No regression to the #56 FeaturesPanel re-subscription or the panels' dock-reparent discipline.

## Test plan
- [x] `dotnet build Godot-MCP.sln --configuration Debug` → 0 errors, 0 warnings (compiles `#if TOOLS`, CI parity).
- [x] `dotnet test Godot-MCP.Tests` → 577 passed, 0 failed (adds `SkillsTests` for the path resolver, capability, registry, plan, and persisted-toggle round-trip).
- [x] Headless Godot 4.5.1 smoke (testbed junction → worktree addon): `[Godot-MCP] plugin loaded`, dock built with the new SkillsPanel, auto-generate hook ran with no `FileNotFoundException`, clean unload. Live click-through of the Generate button + on-disk SKILL.md output remains an operator/reviewer check (Suite 3).

Closes #64