### PR TITLE
feat(extensions): Extensions dock section + NuGet PackageReference install infra

### DIFF
--- a/Godot-MCP.Tests/ExtensionInstallTests.cs
+++ b/Godot-MCP.Tests/ExtensionInstallTests.cs
@@ -1,0 +1,391 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Collections.Generic;
+using System.Xml.Linq;
+using com.IvanMurzak.Godot.MCP.Extensions;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the pure-managed Extensions install infrastructure: the descriptor + (empty) registry, the
+    /// <see cref="ExtensionInstallPlanner"/> XML transform (add-when-absent, bump-when-lower, no-op-when-equal,
+    /// preserve other PackageReferences + XML), the <see cref="InstalledStateDetector"/> (parse / missing /
+    /// version-compare), and the <see cref="ExtensionInstaller"/> flow over an in-memory <see cref="IConsumerProjectFile"/>
+    /// fake. The dock UI (<c>ExtensionsPanel.cs</c> / <c>ExtensionRow.cs</c> / <c>ConsumerProjectFile.cs</c>,
+    /// <c>#if TOOLS</c>) is verified via the headless Godot smoke (test.md Suite 3) — NOT here. All logic is pure
+    /// string/XML so the assertions are identical on Windows dev + Linux CI.
+    /// </summary>
+    public class ExtensionInstallTests
+    {
+        // A representative SDK-style consumer .csproj with two existing PackageReferences in one ItemGroup, plus an
+        // unrelated ItemGroup — the things the planner must preserve.
+        const string SampleCsproj =
+@"<Project Sdk=""Godot.NET.Sdk/4.3.0"">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""com.IvanMurzak.ReflectorNet"" Version=""5.3.1"" />
+    <PackageReference Include=""com.IvanMurzak.McpPlugin"" Version=""6.7.0"" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove=""Godot-MCP.Tests/**/*.cs"" />
+  </ItemGroup>
+</Project>";
+
+        static GodotExtensionDescriptor Descriptor(string id = "com.IvanMurzak.Godot.MCP.ProBuilder", string? Version = "1.2.0")
+            => new("ProBuilder Tools", "Mesh-editing MCP tools for Godot.", id, Version);
+
+        // --- Descriptor + registry -----------------------------------------------------------------------------
+
+        [Fact]
+        public void Registry_ShipsEmpty()
+        {
+            Assert.True(GodotExtensionRegistry.IsEmpty);
+            Assert.Empty(GodotExtensionRegistry.All);
+            Assert.Null(GodotExtensionRegistry.GetByPackageId("anything"));
+        }
+
+        [Fact]
+        public void Descriptor_DefaultsToEmptyTools_AndReportsVersionPresence()
+        {
+            var withVersion = Descriptor();
+            Assert.True(withVersion.HasVersion);
+            Assert.Empty(withVersion.Tools);
+
+            var noVersion = new GodotExtensionDescriptor("X", "desc", "com.x", Version: null);
+            Assert.False(noVersion.HasVersion);
+        }
+
+        // --- Planner: ADD --------------------------------------------------------------------------------------
+
+        [Fact]
+        public void Plan_AddsReference_WhenAbsent()
+        {
+            var plan = ExtensionInstallPlanner.Plan(Descriptor(), SampleCsproj);
+
+            Assert.Equal(ExtensionInstallAction.Add, plan.Action);
+            Assert.True(plan.RequiresWrite);
+            Assert.Null(plan.FromVersion);
+            Assert.Equal("1.2.0", plan.ToVersion);
+
+            var refs = InstalledStateDetector.ParsePackageReferences(plan.ResultingCsproj);
+            Assert.Equal("1.2.0", refs["com.IvanMurzak.Godot.MCP.ProBuilder"]);
+        }
+
+        [Fact]
+        public void Plan_Add_PreservesExistingPackageReferences_AndUnrelatedXml()
+        {
+            var plan = ExtensionInstallPlanner.Plan(Descriptor(), SampleCsproj);
+            var refs = InstalledStateDetector.ParsePackageReferences(plan.ResultingCsproj);
+
+            // Both originals survive, unchanged.
+            Assert.Equal("5.3.1", refs["com.IvanMurzak.ReflectorNet"]);
+            Assert.Equal("6.7.0", refs["com.IvanMurzak.McpPlugin"]);
+            // New one added.
+            Assert.Equal("1.2.0", refs["com.IvanMurzak.Godot.MCP.ProBuilder"]);
+
+            // The unrelated <Compile Remove> ItemGroup + PropertyGroup are still present.
+            var doc = XDocument.Parse(plan.ResultingCsproj);
+            Assert.Contains(doc.Descendants(), e => e.Name.LocalName == "Compile");
+            Assert.Contains(doc.Descendants(), e => e.Name.LocalName == "TargetFramework");
+
+            // The new reference joined the EXISTING package ItemGroup (not a brand-new group): exactly 2 ItemGroups
+            // remain (the package group now has 3 PackageReferences, the Compile group untouched).
+            var itemGroups = new List<XElement>();
+            foreach (var e in doc.Descendants())
+                if (e.Name.LocalName == "ItemGroup")
+                    itemGroups.Add(e);
+            Assert.Equal(2, itemGroups.Count);
+        }
+
+        [Fact]
+        public void Plan_Add_WithNoVersion_OmitsVersionAttribute()
+        {
+            var descriptor = new GodotExtensionDescriptor("X", "desc", "com.x", Version: null);
+            var plan = ExtensionInstallPlanner.Plan(descriptor, SampleCsproj);
+
+            Assert.Equal(ExtensionInstallAction.Add, plan.Action);
+            var refs = InstalledStateDetector.ParsePackageReferences(plan.ResultingCsproj);
+            Assert.True(refs.ContainsKey("com.x"));
+            Assert.Equal(string.Empty, refs["com.x"]);
+        }
+
+        [Fact]
+        public void Plan_Add_CreatesItemGroup_WhenProjectHasNoPackageReferences()
+        {
+            const string bare =
+@"<Project Sdk=""Godot.NET.Sdk/4.3.0"">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>";
+            var plan = ExtensionInstallPlanner.Plan(Descriptor(), bare);
+
+            Assert.Equal(ExtensionInstallAction.Add, plan.Action);
+            var refs = InstalledStateDetector.ParsePackageReferences(plan.ResultingCsproj);
+            Assert.Equal("1.2.0", refs["com.IvanMurzak.Godot.MCP.ProBuilder"]);
+        }
+
+        // --- Planner: UPDATE -----------------------------------------------------------------------------------
+
+        [Fact]
+        public void Plan_BumpsVersion_WhenInstalledIsLower()
+        {
+            // Install at 1.0.0, descriptor pins 1.2.0.
+            var first = ExtensionInstallPlanner.Plan(
+                Descriptor(Version: "1.0.0"), SampleCsproj).ResultingCsproj;
+
+            var plan = ExtensionInstallPlanner.Plan(Descriptor(Version: "1.2.0"), first);
+
+            Assert.Equal(ExtensionInstallAction.Update, plan.Action);
+            Assert.Equal("1.0.0", plan.FromVersion);
+            Assert.Equal("1.2.0", plan.ToVersion);
+
+            var refs = InstalledStateDetector.ParsePackageReferences(plan.ResultingCsproj);
+            Assert.Equal("1.2.0", refs["com.IvanMurzak.Godot.MCP.ProBuilder"]);
+            // Siblings still intact after the bump.
+            Assert.Equal("5.3.1", refs["com.IvanMurzak.ReflectorNet"]);
+            Assert.Equal("6.7.0", refs["com.IvanMurzak.McpPlugin"]);
+        }
+
+        [Fact]
+        public void Plan_Update_WhenInstalledHasNoVersion_ButDescriptorDoes()
+        {
+            const string unversioned =
+@"<Project Sdk=""Godot.NET.Sdk/4.3.0"">
+  <ItemGroup>
+    <PackageReference Include=""com.IvanMurzak.Godot.MCP.ProBuilder"" />
+  </ItemGroup>
+</Project>";
+            var plan = ExtensionInstallPlanner.Plan(Descriptor(Version: "1.2.0"), unversioned);
+
+            Assert.Equal(ExtensionInstallAction.Update, plan.Action);
+            var refs = InstalledStateDetector.ParsePackageReferences(plan.ResultingCsproj);
+            Assert.Equal("1.2.0", refs["com.IvanMurzak.Godot.MCP.ProBuilder"]);
+        }
+
+        [Fact]
+        public void Plan_UpdatesChildVersionElement_Form()
+        {
+            const string childElementForm =
+@"<Project Sdk=""Godot.NET.Sdk/4.3.0"">
+  <ItemGroup>
+    <PackageReference Include=""com.IvanMurzak.Godot.MCP.ProBuilder"">
+      <Version>1.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+</Project>";
+            var plan = ExtensionInstallPlanner.Plan(Descriptor(Version: "1.2.0"), childElementForm);
+
+            Assert.Equal(ExtensionInstallAction.Update, plan.Action);
+            var refs = InstalledStateDetector.ParsePackageReferences(plan.ResultingCsproj);
+            Assert.Equal("1.2.0", refs["com.IvanMurzak.Godot.MCP.ProBuilder"]);
+            // Still the child-element form (no Version attribute introduced).
+            Assert.DoesNotContain("Version=\"1.2.0\"", plan.ResultingCsproj);
+            Assert.Contains("<Version>1.2.0</Version>", plan.ResultingCsproj);
+        }
+
+        // --- Planner: NO-OP ------------------------------------------------------------------------------------
+
+        [Fact]
+        public void Plan_NoOp_WhenVersionsEqual()
+        {
+            var installed = ExtensionInstallPlanner.Plan(
+                Descriptor(Version: "1.2.0"), SampleCsproj).ResultingCsproj;
+
+            var plan = ExtensionInstallPlanner.Plan(Descriptor(Version: "1.2.0"), installed);
+
+            Assert.Equal(ExtensionInstallAction.NoOp, plan.Action);
+            Assert.False(plan.RequiresWrite);
+            // Resulting text is byte-identical to the input on a no-op (the IO can skip the write).
+            Assert.Equal(installed, plan.ResultingCsproj);
+        }
+
+        [Fact]
+        public void Plan_NoOp_WhenInstalledIsNewer()
+        {
+            var installed = ExtensionInstallPlanner.Plan(
+                Descriptor(Version: "2.0.0"), SampleCsproj).ResultingCsproj;
+
+            var plan = ExtensionInstallPlanner.Plan(Descriptor(Version: "1.2.0"), installed);
+            Assert.Equal(ExtensionInstallAction.NoOp, plan.Action);
+        }
+
+        [Fact]
+        public void Plan_NoOp_WhenDescriptorHasNoVersion_AndReferenceExists()
+        {
+            var installed = ExtensionInstallPlanner.Plan(
+                Descriptor(Version: "1.0.0"), SampleCsproj).ResultingCsproj;
+
+            var plan = ExtensionInstallPlanner.Plan(
+                new GodotExtensionDescriptor("X", "d", "com.IvanMurzak.Godot.MCP.ProBuilder", Version: null), installed);
+            Assert.Equal(ExtensionInstallAction.NoOp, plan.Action);
+        }
+
+        [Fact]
+        public void Plan_Throws_OnUnparseableCsproj()
+        {
+            Assert.Throws<System.ArgumentException>(
+                () => ExtensionInstallPlanner.Plan(Descriptor(), "<Project><not closed"));
+        }
+
+        // --- Detector: parse -----------------------------------------------------------------------------------
+
+        [Fact]
+        public void Detector_ParsesAttributeAndChildVersionForms()
+        {
+            const string mixed =
+@"<Project>
+  <ItemGroup>
+    <PackageReference Include=""A"" Version=""1.0.0"" />
+    <PackageReference Include=""B""><Version>2.3.4</Version></PackageReference>
+    <PackageReference Include=""C"" />
+  </ItemGroup>
+</Project>";
+            var refs = InstalledStateDetector.ParsePackageReferences(mixed);
+            Assert.Equal("1.0.0", refs["A"]);
+            Assert.Equal("2.3.4", refs["B"]);
+            Assert.Equal(string.Empty, refs["C"]);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("<Project><not valid xml")]
+        public void Detector_ReturnsEmpty_OnMissingOrInvalidCsproj(string? text)
+        {
+            Assert.Empty(InstalledStateDetector.ParsePackageReferences(text));
+        }
+
+        [Fact]
+        public void Detector_PackageIdMatch_IsCaseInsensitive()
+        {
+            var refs = InstalledStateDetector.ParsePackageReferences(SampleCsproj);
+            // NuGet ids are case-insensitive — the dictionary uses an ordinal-ignore-case comparer.
+            Assert.Equal("6.7.0", refs["COM.ivanmurzak.MCPPLUGIN"]);
+        }
+
+        // --- Detector: per-descriptor state --------------------------------------------------------------------
+
+        [Fact]
+        public void Detector_State_NotInstalled_WhenAbsent()
+        {
+            Assert.Equal(
+                ExtensionInstallState.NotInstalled,
+                InstalledStateDetector.StateFor(Descriptor(), SampleCsproj));
+        }
+
+        [Fact]
+        public void Detector_State_Installed_WhenEqualOrNewer()
+        {
+            var installed = ExtensionInstallPlanner.Plan(Descriptor(Version: "1.2.0"), SampleCsproj).ResultingCsproj;
+            Assert.Equal(
+                ExtensionInstallState.Installed,
+                InstalledStateDetector.StateFor(Descriptor(Version: "1.2.0"), installed));
+            Assert.Equal(
+                ExtensionInstallState.Installed,
+                InstalledStateDetector.StateFor(Descriptor(Version: "1.0.0"), installed));
+        }
+
+        [Fact]
+        public void Detector_State_UpdateAvailable_WhenDescriptorIsNewer()
+        {
+            var installed = ExtensionInstallPlanner.Plan(Descriptor(Version: "1.0.0"), SampleCsproj).ResultingCsproj;
+            Assert.Equal(
+                ExtensionInstallState.UpdateAvailable,
+                InstalledStateDetector.StateFor(Descriptor(Version: "1.2.0"), installed));
+        }
+
+        // --- Version compare -----------------------------------------------------------------------------------
+
+        [Theory]
+        [InlineData("1.2.0", "1.2.0", 0)]
+        [InlineData("1.10.0", "1.2.0", 1)]   // numeric, not ordinal — 10 > 2
+        [InlineData("1.2.0", "1.10.0", -1)]
+        [InlineData("2.0.0", "1.9.9", 1)]
+        [InlineData("1.0", "1.0.0", 0)]      // missing trailing component == 0
+        [InlineData("1.0.0-rc1", "1.0.0", 0)] // pre-release suffix tolerated (leading int only)
+        public void CompareVersions_IsNumericAndTolerant(string a, string b, int expectedSign)
+        {
+            Assert.Equal(expectedSign, System.Math.Sign(InstalledStateDetector.CompareVersions(a, b)));
+        }
+
+        // --- Installer flow over an in-memory IConsumerProjectFile fake ----------------------------------------
+
+        sealed class FakeProjectFile : IConsumerProjectFile
+        {
+            string? _text;
+            public FakeProjectFile(string? text) => _text = text;
+            public bool Exists => _text != null;
+            public string? Path => Exists ? "/fake/project.csproj" : null;
+            public int Writes { get; private set; }
+            public string? Read() => _text;
+            public bool Write(string csprojText) { _text = csprojText; Writes++; return true; }
+        }
+
+        [Fact]
+        public void Installer_Add_WritesAndRequestsRebuild()
+        {
+            var file = new FakeProjectFile(SampleCsproj);
+            var result = ExtensionInstaller.Install(Descriptor(), file);
+
+            Assert.Equal(ExtensionInstallOutcome.Added, result.Outcome);
+            Assert.True(result.RebuildRequired);
+            Assert.Equal(1, file.Writes);
+            Assert.Contains("Rebuild solutions", result.Message);
+
+            // The fake now reports the extension as installed.
+            Assert.Equal(ExtensionInstallState.Installed, InstalledStateDetector.StateFor(Descriptor(), file.Read()));
+        }
+
+        [Fact]
+        public void Installer_NoOp_DoesNotWrite()
+        {
+            var installed = ExtensionInstallPlanner.Plan(Descriptor(Version: "1.2.0"), SampleCsproj).ResultingCsproj;
+            var file = new FakeProjectFile(installed);
+
+            var result = ExtensionInstaller.Install(Descriptor(Version: "1.2.0"), file);
+
+            Assert.Equal(ExtensionInstallOutcome.AlreadyUpToDate, result.Outcome);
+            Assert.False(result.RebuildRequired);
+            Assert.Equal(0, file.Writes);
+        }
+
+        [Fact]
+        public void Installer_Update_BumpsAndRequestsRebuild()
+        {
+            var installed = ExtensionInstallPlanner.Plan(Descriptor(Version: "1.0.0"), SampleCsproj).ResultingCsproj;
+            var file = new FakeProjectFile(installed);
+
+            var result = ExtensionInstaller.Install(Descriptor(Version: "1.2.0"), file);
+
+            Assert.Equal(ExtensionInstallOutcome.Updated, result.Outcome);
+            Assert.True(result.RebuildRequired);
+            Assert.Equal(1, file.Writes);
+            Assert.Equal(ExtensionInstallState.Installed, InstalledStateDetector.StateFor(Descriptor(Version: "1.2.0"), file.Read()));
+        }
+
+        [Fact]
+        public void Installer_NoProjectFile_Fails_Gracefully()
+        {
+            var file = new FakeProjectFile(null);
+            var result = ExtensionInstaller.Install(Descriptor(), file);
+
+            Assert.Equal(ExtensionInstallOutcome.NoProjectFile, result.Outcome);
+            Assert.False(result.RebuildRequired);
+            Assert.Equal(0, file.Writes);
+        }
+    }
+}

--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -185,6 +185,19 @@
     <Compile Include="..\addons\godot_mcp\UI\Agents\Impl\CursorConfigurator.cs" Link="Source\CursorConfigurator.cs" />
     <Compile Include="..\addons\godot_mcp\UI\Agents\Impl\VisualStudioCodeConfigurator.cs" Link="Source\VisualStudioCodeConfigurator.cs" />
     <Compile Include="..\addons\godot_mcp\UI\Agents\Impl\CustomConfigurator.cs" Link="Source\CustomConfigurator.cs" />
+    <!-- Extensions install infrastructure — pure-managed (no Godot native types, no #if TOOLS): the descriptor
+         record + empty registry, the install planner (PackageReference add / version-bump as a pure XML transform,
+         preserving siblings — the KEY tested seam), the installed-state detector (parse PackageReferences + per-
+         descriptor state + version compare), the IO seam interface + orchestrator, and the dock placeholder copy.
+         The editor wiring (ConsumerProjectFile.cs, ExtensionsPanel.cs, ExtensionRow.cs) is #if TOOLS and verified
+         via the headless Godot smoke (test.md Suite 3); the plan/detect/install logic is unit-tested here. -->
+    <Compile Include="..\addons\godot_mcp\Extensions\GodotExtensionDescriptor.cs" Link="Source\GodotExtensionDescriptor.cs" />
+    <Compile Include="..\addons\godot_mcp\Extensions\GodotExtensionRegistry.cs" Link="Source\GodotExtensionRegistry.cs" />
+    <Compile Include="..\addons\godot_mcp\Extensions\ExtensionInstallPlanner.cs" Link="Source\ExtensionInstallPlanner.cs" />
+    <Compile Include="..\addons\godot_mcp\Extensions\InstalledStateDetector.cs" Link="Source\InstalledStateDetector.cs" />
+    <Compile Include="..\addons\godot_mcp\Extensions\IConsumerProjectFile.cs" Link="Source\IConsumerProjectFile.cs" />
+    <Compile Include="..\addons\godot_mcp\Extensions\ExtensionInstaller.cs" Link="Source\ExtensionInstaller.cs" />
+    <Compile Include="..\addons\godot_mcp\Extensions\ExtensionsPanelText.cs" Link="Source\ExtensionsPanelText.cs" />
   </ItemGroup>
 
 </Project>

--- a/addons/godot_mcp/Extensions/ConsumerProjectFile.cs
+++ b/addons/godot_mcp/Extensions/ConsumerProjectFile.cs
@@ -1,0 +1,159 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Extensions
+{
+    /// <summary>
+    /// The editor-only (<c>#if TOOLS</c>) <see cref="IConsumerProjectFile"/> over the consumer's game
+    /// <c>.csproj</c>: it globalizes <c>res://</c> to the absolute project root and locates the single project
+    /// <c>.csproj</c> (the file Godot compiles every <c>.cs</c> into). Read/write go through <see cref="System.IO"/>
+    /// (the editor runs on the desktop, so this is reliable), keeping all the install LOGIC in the pure-managed
+    /// <see cref="ExtensionInstaller"/> / <see cref="ExtensionInstallPlanner"/> (CI-unit-tested); this class is the
+    /// thin filesystem shell, verified via the headless Godot smoke (<c>test.md</c> Suite 3).
+    ///
+    /// <para>
+    /// Locating the <c>.csproj</c>: Godot names the project assembly after the project's <c>.csproj</c>, which sits
+    /// at the project root. We pick the <c>.csproj</c> at the root whose name matches the project (when resolvable),
+    /// else the single root-level <c>.csproj</c>. If zero (a pure-GDScript project) or an ambiguous set is found,
+    /// <see cref="Exists"/> is false and the dock shows a "no project .csproj" notice rather than guessing.
+    /// </para>
+    /// </summary>
+    public sealed class ConsumerProjectFile : IConsumerProjectFile
+    {
+        readonly string? _path;
+
+        public ConsumerProjectFile()
+        {
+            _path = LocateProjectCsproj();
+        }
+
+        /// <summary>True when a single unambiguous consumer <c>.csproj</c> was located at the project root.</summary>
+        public bool Exists => _path != null;
+
+        /// <summary>The absolute path of the located consumer <c>.csproj</c>, or null when none.</summary>
+        public string? Path => _path;
+
+        /// <summary>Read the located <c>.csproj</c> text; null when none located or the read fails.</summary>
+        public string? Read()
+        {
+            if (_path == null)
+                return null;
+
+            try
+            {
+                return File.ReadAllText(_path);
+            }
+            catch (Exception ex)
+            {
+                GD.PushError($"[Godot-MCP] could not read consumer .csproj '{_path}': {ex.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>Write the updated <c>.csproj</c> text; false when none located or the write fails.</summary>
+        public bool Write(string csprojText)
+        {
+            if (_path == null)
+                return false;
+
+            try
+            {
+                File.WriteAllText(_path, csprojText);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                GD.PushError($"[Godot-MCP] could not write consumer .csproj '{_path}': {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Find the consumer's project <c>.csproj</c> at the globalized project root. Prefers the one whose file name
+        /// matches the project's configured C# assembly name (Godot's <c>dotnet/project/assembly_name</c> /
+        /// application name); falls back to the SINGLE root-level <c>.csproj</c>. Returns null when zero are present
+        /// (pure-GDScript project) or when several are present with no name match (ambiguous — never guess).
+        /// </summary>
+        static string? LocateProjectCsproj()
+        {
+            string projectRoot;
+            try
+            {
+                projectRoot = ProjectSettings.GlobalizePath("res://").TrimEnd('/');
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+
+            if (string.IsNullOrEmpty(projectRoot) || !Directory.Exists(projectRoot))
+                return null;
+
+            string[] candidates;
+            try
+            {
+                candidates = Directory.GetFiles(projectRoot, "*.csproj", SearchOption.TopDirectoryOnly);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+
+            if (candidates.Length == 0)
+                return null;
+
+            if (candidates.Length == 1)
+                return candidates[0];
+
+            // Multiple root-level .csproj — disambiguate by the project's assembly / application name when available.
+            var assemblyName = ResolveAssemblyName();
+            if (!string.IsNullOrEmpty(assemblyName))
+            {
+                var match = candidates.FirstOrDefault(
+                    c => string.Equals(
+                        System.IO.Path.GetFileNameWithoutExtension(c),
+                        assemblyName,
+                        StringComparison.OrdinalIgnoreCase));
+                if (match != null)
+                    return match;
+            }
+
+            // Ambiguous (several .csproj, no name match) → do not guess.
+            return null;
+        }
+
+        /// <summary>Read the project's C# assembly name from project settings (Godot 4 stores it under <c>dotnet/project/assembly_name</c>); empty when unset.</summary>
+        static string ResolveAssemblyName()
+        {
+            try
+            {
+                if (ProjectSettings.HasSetting("dotnet/project/assembly_name"))
+                {
+                    var name = ProjectSettings.GetSetting("dotnet/project/assembly_name").AsString();
+                    if (!string.IsNullOrEmpty(name))
+                        return name;
+                }
+            }
+            catch (Exception)
+            {
+                // fall through to empty
+            }
+
+            return string.Empty;
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Extensions/ExtensionInstallPlanner.cs
+++ b/addons/godot_mcp/Extensions/ExtensionInstallPlanner.cs
@@ -1,0 +1,228 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace com.IvanMurzak.Godot.MCP.Extensions
+{
+    /// <summary>The action an <see cref="ExtensionInstallPlan"/> represents.</summary>
+    public enum ExtensionInstallAction
+    {
+        /// <summary>No <c>&lt;PackageReference&gt;</c> exists for the package → add one.</summary>
+        Add,
+
+        /// <summary>A reference exists but pins an older version → bump its version to the descriptor's.</summary>
+        Update,
+
+        /// <summary>A reference already exists at the right version → nothing to write.</summary>
+        NoOp
+    }
+
+    /// <summary>
+    /// The result of <see cref="ExtensionInstallPlanner.Plan"/>: what to do (<see cref="Action"/>) and the resulting
+    /// <c>.csproj</c> text (<see cref="ResultingCsproj"/>) the editor IO writes back. For a
+    /// <see cref="ExtensionInstallAction.NoOp"/> the resulting text equals the original (the IO can skip the write).
+    /// Pure value object — no Godot types, no IO.
+    /// </summary>
+    /// <param name="Action">The add / update / no-op decision.</param>
+    /// <param name="ResultingCsproj">The full <c>.csproj</c> text after applying the action (== original for no-op).</param>
+    /// <param name="PackageId">The package id the plan targets (echoed for the UI / status line).</param>
+    /// <param name="FromVersion">The version currently referenced (null when not installed; empty string when referenced without a version).</param>
+    /// <param name="ToVersion">The descriptor's target version (null when the descriptor has no version pin).</param>
+    public sealed record ExtensionInstallPlan(
+        ExtensionInstallAction Action,
+        string ResultingCsproj,
+        string PackageId,
+        string? FromVersion,
+        string? ToVersion)
+    {
+        /// <summary>True when applying this plan changes the <c>.csproj</c> (i.e. not a <see cref="ExtensionInstallAction.NoOp"/>).</summary>
+        public bool RequiresWrite => Action != ExtensionInstallAction.NoOp;
+    }
+
+    /// <summary>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>, no IO) planner that, given a
+    /// <see cref="GodotExtensionDescriptor"/> and the CURRENT consumer <c>.csproj</c> text, computes the
+    /// install/update/no-op plan AND the resulting <c>.csproj</c> text — the way <c>AgentConfigJson</c> computes a
+    /// config edit as a pure transform. <b>This is the key tested seam.</b> The editor IO (locating + reading +
+    /// writing the consumer <c>.csproj</c>) is a thin shell over this; the transform itself is deterministic and
+    /// unit-tested.
+    ///
+    /// <para>
+    /// The transform is done with <see cref="System.Xml.Linq"/> so it is identical on every host OS (no
+    /// platform-dependent path/rooting logic). It PRESERVES every other <c>&lt;PackageReference&gt;</c>, every other
+    /// <c>ItemGroup</c>, and all unrelated XML — only the targeted package's reference is added or its
+    /// <c>Version</c> attribute bumped. A brand-new reference is appended to the FIRST <c>ItemGroup</c> that already
+    /// holds a <c>&lt;PackageReference&gt;</c> (so it joins the existing package list); if the project has none, a
+    /// fresh <c>&lt;ItemGroup&gt;</c> is appended to the root.
+    /// </para>
+    /// </summary>
+    public static class ExtensionInstallPlanner
+    {
+        /// <summary>
+        /// Compute the install plan for <paramref name="descriptor"/> against <paramref name="csprojText"/>.
+        /// <list type="bullet">
+        ///   <item>No reference present → <see cref="ExtensionInstallAction.Add"/> (append a new one).</item>
+        ///   <item>
+        ///     Reference present but older than the descriptor's pinned version (or present with no version while the
+        ///     descriptor pins one) → <see cref="ExtensionInstallAction.Update"/> (set the <c>Version</c> attribute).
+        ///   </item>
+        ///   <item>Reference present and already up to date (or descriptor has no version pin) → <see cref="ExtensionInstallAction.NoOp"/>.</item>
+        /// </list>
+        /// Throws <see cref="ArgumentException"/> only on a genuinely unparseable <c>.csproj</c> (the editor surfaces
+        /// that as an error rather than silently corrupting the project file — distinct from the DETECTOR, which
+        /// tolerates bad XML as "nothing installed").
+        /// </summary>
+        public static ExtensionInstallPlan Plan(GodotExtensionDescriptor descriptor, string csprojText)
+        {
+            if (descriptor == null)
+                throw new ArgumentNullException(nameof(descriptor));
+            if (csprojText == null)
+                throw new ArgumentNullException(nameof(csprojText));
+
+            XDocument doc;
+            try
+            {
+                doc = XDocument.Parse(csprojText, LoadOptions.PreserveWhitespace);
+            }
+            catch (System.Xml.XmlException ex)
+            {
+                throw new ArgumentException(
+                    "The consumer .csproj is not valid XML; refusing to edit it.", nameof(csprojText), ex);
+            }
+
+            if (doc.Root == null)
+                throw new ArgumentException("The consumer .csproj has no root element.", nameof(csprojText));
+
+            var existing = doc.Descendants()
+                .FirstOrDefault(e => e.Name.LocalName == "PackageReference"
+                    && string.Equals((string?)e.Attribute("Include"), descriptor.PackageId, StringComparison.OrdinalIgnoreCase));
+
+            // --- No existing reference → ADD ---
+            if (existing == null)
+            {
+                AppendPackageReference(doc, descriptor);
+                return new ExtensionInstallPlan(
+                    ExtensionInstallAction.Add,
+                    Serialize(doc),
+                    descriptor.PackageId,
+                    FromVersion: null,
+                    ToVersion: descriptor.HasVersion ? descriptor.Version : null);
+            }
+
+            // --- Existing reference → decide UPDATE vs NO-OP ---
+            var currentVersion = ReadReferenceVersion(existing);
+
+            // Descriptor pins no version → leave the existing reference untouched (no target to compare to).
+            if (!descriptor.HasVersion)
+            {
+                return new ExtensionInstallPlan(
+                    ExtensionInstallAction.NoOp, csprojText, descriptor.PackageId, currentVersion, ToVersion: null);
+            }
+
+            var target = descriptor.Version!;
+            var needsBump = string.IsNullOrEmpty(currentVersion)
+                || InstalledStateDetector.CompareVersions(target, currentVersion) > 0;
+
+            if (!needsBump)
+            {
+                return new ExtensionInstallPlan(
+                    ExtensionInstallAction.NoOp, csprojText, descriptor.PackageId, currentVersion, target);
+            }
+
+            SetReferenceVersion(existing, target);
+            return new ExtensionInstallPlan(
+                ExtensionInstallAction.Update,
+                Serialize(doc),
+                descriptor.PackageId,
+                currentVersion,
+                target);
+        }
+
+        // --- internals --------------------------------------------------------------------------------------
+
+        /// <summary>Read the version off an existing <c>&lt;PackageReference&gt;</c> (attribute form, else child element). Empty string when unversioned.</summary>
+        static string ReadReferenceVersion(XElement reference)
+        {
+            var attr = (string?)reference.Attribute("Version");
+            if (!string.IsNullOrEmpty(attr))
+                return attr!.Trim();
+
+            var child = reference.Elements().FirstOrDefault(e => e.Name.LocalName == "Version");
+            return (child?.Value ?? string.Empty).Trim();
+        }
+
+        /// <summary>Set the version on an existing reference, honouring whichever form it already uses (child element vs attribute).</summary>
+        static void SetReferenceVersion(XElement reference, string version)
+        {
+            var child = reference.Elements().FirstOrDefault(e => e.Name.LocalName == "Version");
+            if (child != null)
+            {
+                child.Value = version;
+                return;
+            }
+
+            reference.SetAttributeValue("Version", version);
+        }
+
+        /// <summary>
+        /// Append a new <c>&lt;PackageReference&gt;</c> for the descriptor, in the SAME XML namespace as the root (so
+        /// the element is valid whether or not the project uses an explicit MSBuild namespace). It joins the first
+        /// <c>ItemGroup</c> that already contains a <c>&lt;PackageReference&gt;</c>; if none exists, a fresh
+        /// <c>&lt;ItemGroup&gt;</c> is appended to the root.
+        /// </summary>
+        static void AppendPackageReference(XDocument doc, GodotExtensionDescriptor descriptor)
+        {
+            var ns = doc.Root!.Name.Namespace;
+
+            var reference = new XElement(ns + "PackageReference",
+                new XAttribute("Include", descriptor.PackageId));
+            if (descriptor.HasVersion)
+                reference.SetAttributeValue("Version", descriptor.Version);
+
+            var targetGroup = doc.Descendants()
+                .FirstOrDefault(e => e.Name.LocalName == "ItemGroup"
+                    && e.Elements().Any(c => c.Name.LocalName == "PackageReference"));
+
+            if (targetGroup == null)
+            {
+                targetGroup = new XElement(ns + "ItemGroup");
+                doc.Root.Add(targetGroup);
+            }
+
+            targetGroup.Add(reference);
+        }
+
+        /// <summary>
+        /// Serialize the document back to text. Disables the XML declaration (SDK-style csproj files have none) and
+        /// uses <see cref="SaveOptions.DisableFormatting"/> so the preserved whitespace (loaded with
+        /// <see cref="LoadOptions.PreserveWhitespace"/>) is emitted verbatim rather than re-indented — keeping the
+        /// diff minimal and untouched siblings byte-stable.
+        /// </summary>
+        static string Serialize(XDocument doc)
+        {
+            using var writer = new System.IO.StringWriter();
+            var settings = new System.Xml.XmlWriterSettings
+            {
+                OmitXmlDeclaration = true,
+                Indent = false,
+                // Emit a trailing newline-free body; PreserveWhitespace already carries the source's own newlines.
+                NewLineHandling = System.Xml.NewLineHandling.None
+            };
+            using (var xmlWriter = System.Xml.XmlWriter.Create(writer, settings))
+            {
+                doc.Save(xmlWriter);
+            }
+            return writer.ToString();
+        }
+    }
+}

--- a/addons/godot_mcp/Extensions/ExtensionInstaller.cs
+++ b/addons/godot_mcp/Extensions/ExtensionInstaller.cs
@@ -1,0 +1,116 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+
+namespace com.IvanMurzak.Godot.MCP.Extensions
+{
+    /// <summary>The outcome of an <see cref="ExtensionInstaller.Install"/> attempt — drives the dock's status line.</summary>
+    public enum ExtensionInstallOutcome
+    {
+        /// <summary>The reference was added — the consumer must REBUILD solutions to restore + compile the new package.</summary>
+        Added,
+
+        /// <summary>The reference's version was bumped — the consumer must REBUILD solutions to restore the new version.</summary>
+        Updated,
+
+        /// <summary>Already up to date — no write was performed.</summary>
+        AlreadyUpToDate,
+
+        /// <summary>No consumer <c>.csproj</c> could be located — nothing was written.</summary>
+        NoProjectFile,
+
+        /// <summary>The <c>.csproj</c> could not be read / parsed / written — nothing was changed (see <see cref="ExtensionInstallResult.Message"/>).</summary>
+        Failed
+    }
+
+    /// <summary>The result of an install attempt: the <see cref="Outcome"/>, a human-readable <see cref="Message"/>, and whether a rebuild is now needed.</summary>
+    /// <param name="Outcome">The classified outcome.</param>
+    /// <param name="Message">A short status message safe to show in the dock (never contains secrets).</param>
+    /// <param name="RebuildRequired">True when a <c>.csproj</c> write happened, so the consumer must rebuild solutions (Godot has no programmatic restore).</param>
+    public sealed record ExtensionInstallResult(ExtensionInstallOutcome Outcome, string Message, bool RebuildRequired);
+
+    /// <summary>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) orchestrator that performs an extension install by
+    /// composing the <see cref="ExtensionInstallPlanner"/> (pure transform) with an injected
+    /// <see cref="IConsumerProjectFile"/> (the IO seam): read current <c>.csproj</c> → plan add/update/no-op → write
+    /// the resulting text → return a classified <see cref="ExtensionInstallResult"/> that tells the dock whether a
+    /// rebuild is now required. Because the IO is an injected interface, the WHOLE flow (including the
+    /// rebuild-needed signalling and the no-op short-circuit) is unit-tested with an in-memory fake — no Godot, no
+    /// filesystem. The editor wiring just constructs a real <c>ConsumerProjectFile</c> and surfaces the message.
+    /// </summary>
+    public static class ExtensionInstaller
+    {
+        /// <summary>
+        /// Install (or update) <paramref name="descriptor"/> into the consumer project behind <paramref name="file"/>.
+        /// Never throws on an expected failure (missing/unreadable/unwritable/invalid <c>.csproj</c>) — those map to
+        /// <see cref="ExtensionInstallOutcome.NoProjectFile"/> / <see cref="ExtensionInstallOutcome.Failed"/> with a
+        /// safe message. A genuine no-op (already up to date) performs no write.
+        /// </summary>
+        public static ExtensionInstallResult Install(GodotExtensionDescriptor descriptor, IConsumerProjectFile file)
+        {
+            if (descriptor == null)
+                throw new ArgumentNullException(nameof(descriptor));
+            if (file == null)
+                throw new ArgumentNullException(nameof(file));
+
+            if (!file.Exists)
+                return new ExtensionInstallResult(
+                    ExtensionInstallOutcome.NoProjectFile,
+                    "No project .csproj was found to install into.",
+                    RebuildRequired: false);
+
+            var current = file.Read();
+            if (current == null)
+                return new ExtensionInstallResult(
+                    ExtensionInstallOutcome.Failed,
+                    "Could not read the project .csproj.",
+                    RebuildRequired: false);
+
+            ExtensionInstallPlan plan;
+            try
+            {
+                plan = ExtensionInstallPlanner.Plan(descriptor, current);
+            }
+            catch (ArgumentException ex)
+            {
+                // Unparseable / malformed .csproj — refuse to write, surface the reason.
+                return new ExtensionInstallResult(
+                    ExtensionInstallOutcome.Failed,
+                    $"Could not edit the project .csproj: {ex.Message}",
+                    RebuildRequired: false);
+            }
+
+            if (!plan.RequiresWrite)
+                return new ExtensionInstallResult(
+                    ExtensionInstallOutcome.AlreadyUpToDate,
+                    $"{descriptor.Name} is already installed and up to date.",
+                    RebuildRequired: false);
+
+            if (!file.Write(plan.ResultingCsproj))
+                return new ExtensionInstallResult(
+                    ExtensionInstallOutcome.Failed,
+                    "Could not write the updated project .csproj.",
+                    RebuildRequired: false);
+
+            return plan.Action == ExtensionInstallAction.Add
+                ? new ExtensionInstallResult(
+                    ExtensionInstallOutcome.Added,
+                    $"Added {descriptor.PackageId}"
+                        + (descriptor.HasVersion ? $" {descriptor.Version}" : string.Empty)
+                        + ". Rebuild solutions to restore and compile the extension.",
+                    RebuildRequired: true)
+                : new ExtensionInstallResult(
+                    ExtensionInstallOutcome.Updated,
+                    $"Updated {descriptor.PackageId} to {plan.ToVersion}. Rebuild solutions to restore the new version.",
+                    RebuildRequired: true);
+        }
+    }
+}

--- a/addons/godot_mcp/Extensions/ExtensionsPanelText.cs
+++ b/addons/godot_mcp/Extensions/ExtensionsPanelText.cs
@@ -1,0 +1,49 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+
+namespace com.IvanMurzak.Godot.MCP.Extensions
+{
+    /// <summary>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) holder for the static copy + URLs the dock's
+    /// <c>ExtensionsPanel</c> shows — the header, the "coming soon" placeholder line (rendered while the
+    /// <see cref="GodotExtensionRegistry"/> is empty), and the docs / template-repo link. Kept out of the editor
+    /// guard so the strings are CI-unit-tested (mirroring <c>SupportFooterLinks</c>); the editor Control wiring is
+    /// <c>#if TOOLS</c> and verified via the headless Godot smoke (test.md Suite 3).
+    /// </summary>
+    public static class ExtensionsPanelText
+    {
+        /// <summary>The section header shown above the extension rows / placeholder.</summary>
+        public const string Header = "Extensions";
+
+        /// <summary>
+        /// The honest placeholder shown while no extension package exists yet (the registry ships empty). Matches
+        /// Unity-MCP's extensions look but does not pretend an installable extension exists.
+        /// </summary>
+        public const string ComingSoonText =
+            "Extensions add more AI tool families to Godot — coming soon.";
+
+        /// <summary>The text of the docs / template-repo link shown under the placeholder.</summary>
+        public const string DocsLinkText = "Learn more";
+
+        /// <summary>
+        /// The docs / template-repo URL the placeholder link opens. Points at the Godot-MCP repository for now (the
+        /// dedicated <c>Godot-AI-Tools-Template</c> repo + extensions docs are a SEPARATE follow-up task — swap this
+        /// to that repo / docs page once it exists).
+        /// </summary>
+        public const string DocsUrl = "https://github.com/IvanMurzak/Godot-MCP";
+
+        /// <summary>
+        /// The notice shown (in place of an enabled Install button) when no consumer <c>.csproj</c> could be located —
+        /// e.g. a pure-GDScript project, or the published-addon-only context where there is nothing to install into.
+        /// </summary>
+        public const string NoProjectFileNotice =
+            "No project .csproj found — open this addon inside a Godot C# project to install extensions.";
+    }
+}

--- a/addons/godot_mcp/Extensions/GodotExtensionDescriptor.cs
+++ b/addons/godot_mcp/Extensions/GodotExtensionDescriptor.cs
@@ -1,0 +1,61 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Collections.Generic;
+
+namespace com.IvanMurzak.Godot.MCP.Extensions
+{
+    /// <summary>
+    /// One tool family the dock's "Extensions" section offers to install into the CONSUMER's Godot project. The
+    /// Godot analog of Unity-MCP's <c>ExtensionData</c> (in <c>MainWindowEditor.Extensions.cs</c>), except the
+    /// distribution mechanism is a NuGet <c>&lt;PackageReference&gt;</c> in the consumer's game <c>.csproj</c>
+    /// (Godot compiles every <c>.cs</c> under the project into one assembly, so adding the package makes the
+    /// extension's <c>[AiToolType]</c> tool family compile into the consumer's project) rather than Unity's UPM
+    /// <c>manifest.json</c> entry.
+    ///
+    /// <para>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) so the descriptor + the install/detect logic that
+    /// consumes it are CI-unit-tested. The editor wiring (the dock panel, the consumer-<c>.csproj</c> read/write)
+    /// lives behind <c>#if TOOLS</c>.
+    /// </para>
+    /// </summary>
+    /// <param name="Name">Human-readable display name shown as the row title (e.g. "ProBuilder Tools").</param>
+    /// <param name="Description">One-line description shown muted under the title.</param>
+    /// <param name="PackageId">
+    /// The NuGet package id added as a <c>&lt;PackageReference Include="..." /&gt;</c> to the consumer's
+    /// <c>.csproj</c> (e.g. <c>com.IvanMurzak.Godot.MCP.ProBuilder</c>). This is the install IDENTITY — installed
+    /// state is detected by matching this id against the consumer's existing package references.
+    /// </param>
+    /// <param name="Version">
+    /// The package version to pin in the <c>&lt;PackageReference&gt;</c> (e.g. <c>1.0.0</c>). Optional: when null/empty
+    /// the reference is added WITHOUT a <c>Version</c> attribute (floating / centrally-managed). When set, it also
+    /// drives the up-to-date / update-available decision against the consumer's currently-referenced version.
+    /// </param>
+    /// <param name="GitUrl">Optional repository / docs URL surfaced as a link in the row (mirrors Unity's <c>gitUrl</c>).</param>
+    /// <param name="Tools">
+    /// The tool entries this extension contributes, each a <c>(Name, Description)</c> pair — shown as the
+    /// extension's tool list (mirrors Unity's per-extension tool enumeration). May be empty.
+    /// </param>
+    public sealed record GodotExtensionDescriptor(
+        string Name,
+        string Description,
+        string PackageId,
+        string? Version = null,
+        string? GitUrl = null,
+        IReadOnlyList<(string Name, string Description)>? Tools = null)
+    {
+        /// <summary>The tool entries this extension contributes, never null (an absent list reads as empty).</summary>
+        public IReadOnlyList<(string Name, string Description)> Tools { get; init; }
+            = Tools ?? System.Array.Empty<(string Name, string Description)>();
+
+        /// <summary>True when a concrete <see cref="Version"/> pin is present (drives the up-to-date / update decision).</summary>
+        public bool HasVersion => !string.IsNullOrWhiteSpace(Version);
+    }
+}

--- a/addons/godot_mcp/Extensions/GodotExtensionRegistry.cs
+++ b/addons/godot_mcp/Extensions/GodotExtensionRegistry.cs
@@ -1,0 +1,58 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+
+namespace com.IvanMurzak.Godot.MCP.Extensions
+{
+    /// <summary>
+    /// Static registry of every <see cref="GodotExtensionDescriptor"/> the dock's "Extensions" section offers to
+    /// install. The Godot analog of Unity-MCP's hardcoded extension list in <c>MainWindowEditor.Extensions.cs</c>.
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) so the list + lookups are CI-unit-tested, and so the
+    /// dock panel binds to <see cref="All"/> generically.
+    ///
+    /// <para>
+    /// <b>Ships EMPTY for now.</b> No Godot-MCP extension package exists on nuget.org yet — creating the first real
+    /// extension package + a <c>Godot-AI-Tools-Template</c> repo + the NuGet publish is a SEPARATE follow-up task. The
+    /// dock renders an honest "coming soon" placeholder while <see cref="All"/> is empty (see the
+    /// <c>ExtensionsPanel</c>). To add a real extension once it is published: append ONE
+    /// <see cref="GodotExtensionDescriptor"/> to <see cref="_descriptors"/> below — no other file needs to change.
+    /// </para>
+    /// </summary>
+    public static class GodotExtensionRegistry
+    {
+        // The extension descriptor list. EMPTY until the first extension package is published (follow-up task). To
+        // add one, append a `new GodotExtensionDescriptor(...)` line here.
+        static readonly IReadOnlyList<GodotExtensionDescriptor> _descriptors = new GodotExtensionDescriptor[]
+        {
+            // (none yet — see the type doc-comment)
+        };
+
+        /// <summary>Every registered extension descriptor, in display order. Empty until the first package ships.</summary>
+        public static IReadOnlyList<GodotExtensionDescriptor> All => _descriptors;
+
+        /// <summary>True when no extensions are registered yet — drives the dock's "coming soon" placeholder.</summary>
+        public static bool IsEmpty => _descriptors.Count == 0;
+
+        /// <summary>
+        /// The descriptor whose <see cref="GodotExtensionDescriptor.PackageId"/> equals <paramref name="packageId"/>
+        /// (ordinal-ignore-case, matching NuGet's case-insensitive package ids), or null when absent / id is empty.
+        /// </summary>
+        public static GodotExtensionDescriptor? GetByPackageId(string? packageId)
+        {
+            if (string.IsNullOrEmpty(packageId))
+                return null;
+
+            return _descriptors.FirstOrDefault(
+                d => string.Equals(d.PackageId, packageId, System.StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/addons/godot_mcp/Extensions/IConsumerProjectFile.cs
+++ b/addons/godot_mcp/Extensions/IConsumerProjectFile.cs
@@ -1,0 +1,42 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+
+namespace com.IvanMurzak.Godot.MCP.Extensions
+{
+    /// <summary>
+    /// The thin IO seam over the CONSUMER's game <c>.csproj</c> — the file an extension install reads, transforms
+    /// via the pure <see cref="ExtensionInstallPlanner"/>, and writes back. Kept behind this interface so the
+    /// planner stays pure (no Godot / no IO) and so the install flow is unit-testable with an in-memory fake. The
+    /// real editor implementation (<c>ConsumerProjectFile</c>, <c>#if TOOLS</c>) globalizes <c>res://</c> and
+    /// locates the project <c>.csproj</c>; the in-memory test double exercises the same flow with no filesystem.
+    ///
+    /// <para>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) so it lives in the CI-unit-testable layer alongside
+    /// the planner/detector.
+    /// </para>
+    /// </summary>
+    public interface IConsumerProjectFile
+    {
+        /// <summary>
+        /// True when a consumer <c>.csproj</c> could be located (a real project, not a published-addon-only context).
+        /// When false, the dock disables the install buttons + shows a "no .csproj found" notice rather than writing.
+        /// </summary>
+        bool Exists { get; }
+
+        /// <summary>The absolute path of the located consumer <c>.csproj</c> (for the status line), or null when none.</summary>
+        string? Path { get; }
+
+        /// <summary>Read the current <c>.csproj</c> text, or null when no consumer <c>.csproj</c> could be located / read.</summary>
+        string? Read();
+
+        /// <summary>Write <paramref name="csprojText"/> back to the consumer <c>.csproj</c>. Returns true on success.</summary>
+        bool Write(string csprojText);
+    }
+}

--- a/addons/godot_mcp/Extensions/InstalledStateDetector.cs
+++ b/addons/godot_mcp/Extensions/InstalledStateDetector.cs
@@ -1,0 +1,191 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace com.IvanMurzak.Godot.MCP.Extensions
+{
+    /// <summary>
+    /// The install state of a single <see cref="GodotExtensionDescriptor"/> relative to a consumer's
+    /// <c>.csproj</c>. The Godot analog of the per-extension state Unity derives from <c>Client.List</c>: drives the
+    /// dock row's button (NotInstalled → "Install", UpdateAvailable → "Update", Installed → disabled "Installed").
+    /// </summary>
+    public enum ExtensionInstallState
+    {
+        /// <summary>No <c>&lt;PackageReference&gt;</c> for this extension's package id exists in the consumer <c>.csproj</c>.</summary>
+        NotInstalled,
+
+        /// <summary>A reference exists and is up to date (no descriptor version pin, or the referenced version is &gt;= the descriptor's).</summary>
+        Installed,
+
+        /// <summary>A reference exists but the descriptor pins a NEWER version than the consumer currently references.</summary>
+        UpdateAvailable
+    }
+
+    /// <summary>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) parser of a consumer <c>.csproj</c>'s
+    /// <c>&lt;PackageReference&gt;</c> items into an installed <c>{packageId → version}</c> map (the analog of
+    /// consuming Unity's <c>Client.List</c> result), plus the per-descriptor <see cref="ExtensionInstallState"/>
+    /// decision. All XML is parsed with <see cref="System.Xml.Linq"/> so the result is deterministic and identical
+    /// on every host OS (Windows dev + Linux CI); no platform-dependent path / rooting logic is involved.
+    ///
+    /// <para>
+    /// Robust to a missing / empty / malformed <c>.csproj</c> text: those parse to an EMPTY installed map (every
+    /// descriptor then reads as <see cref="ExtensionInstallState.NotInstalled"/>), never throwing — the same
+    /// "no usable existing config → start fresh" discipline as <c>AgentConfigJson</c>.
+    /// </para>
+    /// </summary>
+    public static class InstalledStateDetector
+    {
+        /// <summary>
+        /// Parse every <c>&lt;PackageReference&gt;</c> in <paramref name="csprojText"/> into a
+        /// <c>{packageId → version}</c> map. The key is the <c>Include</c> (NuGet package ids are case-insensitive,
+        /// so the map uses <see cref="StringComparer.OrdinalIgnoreCase"/>); the value is the <c>Version</c> attribute
+        /// (or, when absent, a child <c>&lt;Version&gt;</c> element — both MSBuild forms), or the empty string when no
+        /// version is declared (a floating / centrally-managed reference). A reference with no <c>Include</c> is
+        /// skipped. On duplicate ids the LAST one wins (matches MSBuild's last-write evaluation).
+        ///
+        /// <para>Returns an EMPTY map for null / whitespace / unparseable XML — never throws.</para>
+        /// </summary>
+        public static IReadOnlyDictionary<string, string> ParsePackageReferences(string? csprojText)
+        {
+            var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            if (string.IsNullOrWhiteSpace(csprojText))
+                return map;
+
+            XDocument doc;
+            try
+            {
+                doc = XDocument.Parse(csprojText);
+            }
+            catch (System.Xml.XmlException)
+            {
+                return map;
+            }
+
+            if (doc.Root == null)
+                return map;
+
+            // Match by LOCAL name so an (unusual) MSBuild XML namespace doesn't hide the items. The csproj uses the
+            // SDK-style default (no namespace), but matching on LocalName is the robust, namespace-agnostic choice.
+            foreach (var item in doc.Descendants().Where(e => e.Name.LocalName == "PackageReference"))
+            {
+                var include = (string?)item.Attribute("Include");
+                if (string.IsNullOrWhiteSpace(include))
+                    continue;
+
+                var version = (string?)item.Attribute("Version");
+                if (string.IsNullOrEmpty(version))
+                {
+                    // MSBuild also allows <PackageReference Include="X"><Version>1.0.0</Version></PackageReference>.
+                    var versionElement = item.Elements().FirstOrDefault(e => e.Name.LocalName == "Version");
+                    version = versionElement?.Value;
+                }
+
+                map[include!.Trim()] = (version ?? string.Empty).Trim();
+            }
+
+            return map;
+        }
+
+        /// <summary>
+        /// Decide the <see cref="ExtensionInstallState"/> of <paramref name="descriptor"/> against the
+        /// <paramref name="installed"/> map produced by <see cref="ParsePackageReferences"/>:
+        /// <list type="bullet">
+        ///   <item><see cref="ExtensionInstallState.NotInstalled"/> — the descriptor's package id is absent.</item>
+        ///   <item>
+        ///     <see cref="ExtensionInstallState.UpdateAvailable"/> — the id is present, the descriptor pins a concrete
+        ///     version, and that version is strictly GREATER than the installed one (an installed reference with no
+        ///     version also counts as update-available when the descriptor pins a version, since the descriptor's pin
+        ///     is the known-good target).
+        ///   </item>
+        ///   <item><see cref="ExtensionInstallState.Installed"/> — otherwise (present and up to date, or no descriptor version pin).</item>
+        /// </list>
+        /// </summary>
+        public static ExtensionInstallState StateFor(
+            GodotExtensionDescriptor descriptor,
+            IReadOnlyDictionary<string, string> installed)
+        {
+            if (descriptor == null)
+                throw new ArgumentNullException(nameof(descriptor));
+            if (installed == null)
+                throw new ArgumentNullException(nameof(installed));
+
+            if (!installed.TryGetValue(descriptor.PackageId, out var installedVersion))
+                return ExtensionInstallState.NotInstalled;
+
+            // No target version on the descriptor → any present reference is "installed" (nothing to compare to).
+            if (!descriptor.HasVersion)
+                return ExtensionInstallState.Installed;
+
+            // Installed reference has no version pin but the descriptor does → offer the descriptor's pin as an update.
+            if (string.IsNullOrEmpty(installedVersion))
+                return ExtensionInstallState.UpdateAvailable;
+
+            var cmp = CompareVersions(descriptor.Version!, installedVersion);
+            return cmp > 0 ? ExtensionInstallState.UpdateAvailable : ExtensionInstallState.Installed;
+        }
+
+        /// <summary>Convenience: <see cref="StateFor(GodotExtensionDescriptor, IReadOnlyDictionary{string, string})"/> straight off raw <c>.csproj</c> text.</summary>
+        public static ExtensionInstallState StateFor(GodotExtensionDescriptor descriptor, string? csprojText)
+            => StateFor(descriptor, ParsePackageReferences(csprojText));
+
+        /// <summary>
+        /// Compare two dotted numeric version strings (e.g. <c>1.2.0</c> vs <c>1.10.0</c>) component-by-component as
+        /// integers (so <c>1.10.0</c> &gt; <c>1.2.0</c>, unlike an ordinal string compare). A trailing pre-release /
+        /// build suffix on a component (<c>1.0.0-rc1</c>) is tolerated — only the leading integer of each dotted
+        /// component is read; a non-numeric component reads as 0. Missing trailing components are treated as 0
+        /// (<c>1.0</c> == <c>1.0.0</c>). Returns &gt;0 when <paramref name="a"/> is newer, &lt;0 when older, 0 when
+        /// equal. Pure string/integer arithmetic → identical on every host OS.
+        /// </summary>
+        public static int CompareVersions(string a, string b)
+        {
+            var pa = SplitComponents(a);
+            var pb = SplitComponents(b);
+            var n = Math.Max(pa.Length, pb.Length);
+            for (int i = 0; i < n; i++)
+            {
+                var ca = i < pa.Length ? pa[i] : 0;
+                var cb = i < pb.Length ? pb[i] : 0;
+                if (ca != cb)
+                    return ca.CompareTo(cb);
+            }
+            return 0;
+        }
+
+        static int[] SplitComponents(string? version)
+        {
+            if (string.IsNullOrWhiteSpace(version))
+                return Array.Empty<int>();
+
+            var parts = version!.Trim().Split('.');
+            var result = new int[parts.Length];
+            for (int i = 0; i < parts.Length; i++)
+                result[i] = LeadingInt(parts[i]);
+            return result;
+        }
+
+        static int LeadingInt(string component)
+        {
+            int end = 0;
+            while (end < component.Length && char.IsDigit(component[end]))
+                end++;
+
+            if (end == 0)
+                return 0;
+
+            return int.TryParse(component.Substring(0, end), out var value) ? value : 0;
+        }
+    }
+}

--- a/addons/godot_mcp/UI/ExtensionRow.cs
+++ b/addons/godot_mcp/UI/ExtensionRow.cs
@@ -1,0 +1,117 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using com.IvanMurzak.Godot.MCP.Extensions;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.UI
+{
+    /// <summary>
+    /// One row of the dock's <see cref="ExtensionsPanel"/> for a single <see cref="GodotExtensionDescriptor"/> —
+    /// the Godot <see cref="Control"/> analog of Unity-MCP's <c>ExtensionPanel</c> row. Styled like
+    /// <see cref="FeatureRow"/>'s row-top layout (flex-start, space-between): a LEFT column with the extension name
+    /// as a 16px section title over a muted, wrapping description, and a RIGHT action button whose label + skin
+    /// follow the install state — "Install" / "Update" (primary cyan), "Installed" (disabled), or "Checking…"
+    /// (disabled, transient). Editor-only (<c>#if TOOLS</c>): verified via the headless Godot smoke (test.md
+    /// Suite 3). Holds NO live connection-event subscriptions — its state is read synchronously by the panel.
+    /// </summary>
+    [Tool]
+    public partial class ExtensionRow : HBoxContainer
+    {
+        /// <summary>The extension descriptor this row represents.</summary>
+        public GodotExtensionDescriptor Descriptor { get; }
+
+        readonly Action<GodotExtensionDescriptor> _onAction;
+
+        Button _actionButton = null!;
+
+        public ExtensionRow(GodotExtensionDescriptor descriptor, Action<GodotExtensionDescriptor> onAction)
+        {
+            Descriptor = descriptor;
+            _onAction = onAction;
+            Name = $"{descriptor.PackageId}Row";
+            BuildUi();
+        }
+
+        void BuildUi()
+        {
+            AddThemeConstantOverride("separation", 8);
+            Alignment = AlignmentMode.Begin;
+
+            // --- LEFT: name (section title) over a muted, wrapping description (+ optional tool count). ---
+            var leftColumn = new VBoxContainer
+            {
+                Name = "InfoColumn",
+                SizeFlagsHorizontal = SizeFlags.ExpandFill,
+                SizeFlagsVertical = SizeFlags.ShrinkBegin
+            };
+            leftColumn.AddThemeConstantOverride("separation", 2);
+            AddChild(leftColumn);
+
+            var nameLabel = new Label { Name = "NameLabel", Text = Descriptor.Name };
+            DockStyle.ApplySectionTitle(nameLabel);
+            leftColumn.AddChild(nameLabel);
+
+            var descriptionLabel = new Label
+            {
+                Name = "DescriptionLabel",
+                Text = Descriptor.Description,
+                SizeFlagsHorizontal = SizeFlags.ExpandFill
+            };
+            DockStyle.ApplyDescription(descriptionLabel);
+            leftColumn.AddChild(descriptionLabel);
+
+            // --- RIGHT: the install/update/installed action button (state set via ShowState). ---
+            _actionButton = new Button
+            {
+                Name = "ActionButton",
+                Text = "Checking…",
+                Disabled = true,
+                SizeFlagsVertical = SizeFlags.ShrinkBegin
+            };
+            DockStyle.ApplyPrimaryButton(_actionButton);
+            _actionButton.Pressed += () => _onAction(Descriptor);
+            AddChild(_actionButton);
+        }
+
+        /// <summary>
+        /// Reflect <paramref name="state"/> in the action button: NotInstalled → enabled "Install",
+        /// UpdateAvailable → enabled "Update", Installed → disabled "Installed". Primary (cyan) skin for the
+        /// actionable states; the disabled "Installed" reads as inert.
+        /// </summary>
+        public void ShowState(ExtensionInstallState state)
+        {
+            switch (state)
+            {
+                case ExtensionInstallState.NotInstalled:
+                    _actionButton.Text = "Install";
+                    _actionButton.Disabled = false;
+                    break;
+                case ExtensionInstallState.UpdateAvailable:
+                    _actionButton.Text = "Update";
+                    _actionButton.Disabled = false;
+                    break;
+                default:
+                    _actionButton.Text = "Installed";
+                    _actionButton.Disabled = true;
+                    break;
+            }
+        }
+
+        /// <summary>Show the transient "Checking…" (disabled) state while the consumer <c>.csproj</c> is re-read.</summary>
+        public void ShowChecking()
+        {
+            _actionButton.Text = "Checking…";
+            _actionButton.Disabled = true;
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/UI/ExtensionsPanel.cs
+++ b/addons/godot_mcp/UI/ExtensionsPanel.cs
@@ -1,0 +1,205 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System.Collections.Generic;
+using com.IvanMurzak.Godot.MCP.Extensions;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.UI
+{
+    /// <summary>
+    /// The dock's "Extensions" section — the Godot <see cref="Control"/> analog of Unity-MCP's
+    /// <c>ExtensionPanel</c> / <c>MainWindowEditor.Extensions</c>. A <see cref="VBoxContainer"/> the
+    /// <see cref="GodotMcpDock"/> inserts as a card BETWEEN the Skills card and the support footer. It lists every
+    /// <see cref="GodotExtensionRegistry"/> entry as an <see cref="ExtensionRow"/> (name + description + an
+    /// Install/Update/Installed button); when the registry is EMPTY (no extension package ships yet) it renders an
+    /// honest "coming soon" placeholder + a docs link instead.
+    ///
+    /// <para>
+    /// Install distribution is a NuGet <c>&lt;PackageReference&gt;</c> in the CONSUMER's game <c>.csproj</c>
+    /// (Godot compiles every <c>.cs</c> under the project into one assembly): the button runs the pure-managed
+    /// <see cref="ExtensionInstaller"/> (planner + the <see cref="IConsumerProjectFile"/> IO seam) and, since Godot
+    /// has no programmatic restore, surfaces a "rebuild solutions" notice on a successful write. Install STATE is
+    /// read SYNCHRONOUSLY from the consumer <c>.csproj</c> via the <see cref="InstalledStateDetector"/> — this panel
+    /// holds NO live connection-event subscriptions, so it neither needs nor adds the <c>_EnterTree</c> re-subscribe
+    /// dance the connection-bound panels use (it cannot regress the #56 FeaturesPanel re-subscription because it
+    /// never subscribes to anything).
+    /// </para>
+    ///
+    /// <para>
+    /// Editor-only (<c>#if TOOLS</c>): it constructs live Godot UI nodes. ALL the install/detect/plan LOGIC lives in
+    /// the pure-managed <c>Extensions/</c> types (CI-unit-tested); this class is verified via the headless Godot
+    /// smoke (test.md Suite 3).
+    /// </para>
+    /// </summary>
+    [Tool]
+    public partial class ExtensionsPanel : VBoxContainer
+    {
+        readonly IConsumerProjectFile _projectFile;
+
+        VBoxContainer? _body;
+        Label? _statusLabel;
+        readonly List<ExtensionRow> _rows = new();
+
+        /// <summary>Construct with the default editor <see cref="ConsumerProjectFile"/> (globalizes <c>res://</c>, locates the game <c>.csproj</c>).</summary>
+        public ExtensionsPanel() : this(new ConsumerProjectFile())
+        {
+        }
+
+        /// <summary>
+        /// Construct with an injected <paramref name="projectFile"/> — the production path uses the real
+        /// <see cref="ConsumerProjectFile"/>; the seam exists so the install flow stays testable in the pure layer.
+        /// </summary>
+        public ExtensionsPanel(IConsumerProjectFile projectFile)
+        {
+            _projectFile = projectFile;
+            Name = "ExtensionsPanel";
+            BuildUi();
+        }
+
+        void BuildUi()
+        {
+            SizeFlagsHorizontal = SizeFlags.ExpandFill;
+            AddThemeConstantOverride("separation", 6);
+
+            var header = new Label { Name = "ExtensionsHeader", Text = ExtensionsPanelText.Header };
+            DockStyle.ApplyHeader(header);
+            AddChild(header);
+
+            _body = new VBoxContainer { Name = "ExtensionsBody", SizeFlagsHorizontal = SizeFlags.ExpandFill };
+            _body.AddThemeConstantOverride("separation", 6);
+            AddChild(_body);
+
+            // Status line (muted; turns amber on a failed install). Lives under the body so it is visible in both
+            // the placeholder and the rows layouts.
+            _statusLabel = new Label { Name = "ExtensionsStatus", SizeFlagsHorizontal = SizeFlags.ExpandFill, Visible = false };
+            DockStyle.ApplyDescription(_statusLabel);
+            AddChild(_statusLabel);
+
+            RebuildBody();
+        }
+
+        /// <summary>
+        /// Rebuild the body for the current registry + consumer-project state. EMPTY registry → the "coming soon"
+        /// placeholder + docs link. Non-empty → one <see cref="ExtensionRow"/> per descriptor, each seeded with its
+        /// install state read synchronously from the consumer <c>.csproj</c>. Clears the previous controls first so a
+        /// refresh starts empty.
+        /// </summary>
+        void RebuildBody()
+        {
+            if (_body == null)
+                return;
+
+            foreach (var child in _body.GetChildren())
+            {
+                _body.RemoveChild(child);
+                child.QueueFree();
+            }
+            _rows.Clear();
+
+            if (GodotExtensionRegistry.IsEmpty)
+            {
+                BuildPlaceholder(_body);
+                return;
+            }
+
+            // Read the consumer .csproj ONCE and derive every row's state from the same parsed map (synchronous).
+            var csproj = _projectFile.Exists ? _projectFile.Read() : null;
+            var installed = InstalledStateDetector.ParsePackageReferences(csproj);
+
+            foreach (var descriptor in GodotExtensionRegistry.All)
+            {
+                var row = new ExtensionRow(descriptor, OnRowAction);
+                _body.AddChild(DockStyle.RowCard(row, $"{descriptor.PackageId}Card", enabled: true));
+                row.ShowState(InstalledStateDetector.StateFor(descriptor, installed));
+                _rows.Add(row);
+            }
+
+            // When there is no consumer .csproj to install into, disable the actions + explain why.
+            if (!_projectFile.Exists)
+            {
+                foreach (var row in _rows)
+                    row.ShowChecking();
+                SetStatus(ExtensionsPanelText.NoProjectFileNotice, error: true);
+            }
+        }
+
+        /// <summary>Render the honest "coming soon" placeholder + a docs / template-repo link (registry empty).</summary>
+        void BuildPlaceholder(Container parent)
+        {
+            var comingSoon = new Label
+            {
+                Name = "ComingSoon",
+                Text = ExtensionsPanelText.ComingSoonText,
+                SizeFlagsHorizontal = SizeFlags.ExpandFill
+            };
+            DockStyle.ApplyDescription(comingSoon);
+            parent.AddChild(comingSoon);
+
+            parent.AddChild(DockStyle.LinkRow("ExtensionsDocsLinkRow", new[]
+            {
+                ("ExtensionsDocsLink", ExtensionsPanelText.DocsLinkText, ExtensionsPanelText.DocsUrl)
+            }));
+        }
+
+        /// <summary>
+        /// Install / update the row's extension: re-read the consumer <c>.csproj</c>, run the pure
+        /// <see cref="ExtensionInstaller"/> (plan → write), surface the result message, and re-seed every row's state
+        /// from the (now possibly changed) <c>.csproj</c>. A successful write tells the user to rebuild solutions
+        /// (Godot has no programmatic restore). Failures never throw out of the handler — they show in the status.
+        /// </summary>
+        void OnRowAction(GodotExtensionDescriptor descriptor)
+        {
+            // Optimistic "Checking…" while we re-read + write.
+            foreach (var row in _rows)
+            {
+                if (row.Descriptor.PackageId == descriptor.PackageId)
+                    row.ShowChecking();
+            }
+
+            var result = ExtensionInstaller.Install(descriptor, _projectFile);
+            var error = result.Outcome == ExtensionInstallOutcome.Failed
+                || result.Outcome == ExtensionInstallOutcome.NoProjectFile;
+            SetStatus(result.Message, error);
+
+            // Re-seed every row from the current .csproj so the buttons reflect the new state.
+            RefreshStates();
+        }
+
+        /// <summary>Re-read the consumer <c>.csproj</c> and re-apply each row's install state (no full rebuild — rows persist).</summary>
+        void RefreshStates()
+        {
+            var csproj = _projectFile.Exists ? _projectFile.Read() : null;
+            var installed = InstalledStateDetector.ParsePackageReferences(csproj);
+            foreach (var row in _rows)
+                row.ShowState(InstalledStateDetector.StateFor(row.Descriptor, installed));
+        }
+
+        void SetStatus(string text, bool error)
+        {
+            if (_statusLabel == null)
+                return;
+
+            _statusLabel.Text = text;
+            _statusLabel.Visible = !string.IsNullOrEmpty(text);
+            _statusLabel.AddThemeColorOverride(
+                "font_color",
+                error ? DockStyle.Rgb(DockTheme.WarningText) : DockStyle.Rgb(DockTheme.ColorDescriptionMuted));
+        }
+
+        /// <summary>
+        /// Re-render the section from current state — rebuilds the body so a registry change (a future extension being
+        /// added) or a consumer-<c>.csproj</c> change outside the dock is reflected. Safe to call any number of times.
+        /// Forwarded from <see cref="GodotMcpDock.Refresh"/>.
+        /// </summary>
+        public void Refresh() => RebuildBody();
+    }
+}
+#endif

--- a/addons/godot_mcp/UI/GodotMcpDock.cs
+++ b/addons/godot_mcp/UI/GodotMcpDock.cs
@@ -53,6 +53,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         FeaturesPanel? _featuresPanel;
         AgentConfiguratorsPanel? _agentConfiguratorsPanel;
         SkillsPanel? _skillsPanel;
+        ExtensionsPanel? _extensionsPanel;
         SupportFooter? _supportFooter;
 
         // Log Level selector (header). Only built when a live connection was threaded in (it reads/writes
@@ -191,6 +192,14 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 _agentConfiguratorsPanel.AgentSelectionChanged += () => _skillsPanel?.Refresh();
             }
 
+            // Extensions section — install/update more AI tool families into the consumer's Godot project via NuGet
+            // PackageReference (read-modify-write the consumer .csproj). Inserted BETWEEN the Skills card and the
+            // support footer. It reads its state SYNCHRONOUSLY from the consumer .csproj (no live connection /
+            // subscriptions), so — like the footer — it builds UNCONDITIONALLY (independent of the connection); the
+            // registry ships empty today, so it renders an honest "coming soon" placeholder.
+            _extensionsPanel = new ExtensionsPanel();
+            Body.AddChild(DockStyle.Card(_extensionsPanel, "Extensions"));
+
             // Support/footer section — static links + thanks, appended BELOW the connection panel. It holds
             // no live state / subscriptions, so it builds unconditionally (independent of the connection).
             _supportFooter = new SupportFooter();
@@ -280,6 +289,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _featuresPanel?.Refresh();
             _agentConfiguratorsPanel?.Refresh();
             _skillsPanel?.Refresh();
+            _extensionsPanel?.Refresh();
             SyncLogLevelSelector();
         }
     }


### PR DESCRIPTION
## Summary
- Adds an **Extensions** section to the Godot dock (Unity-MCP parity) as a `DockStyle.Card` between the Skills card and the footer. While the registry ships **empty**, it renders an honest "coming soon" placeholder + a docs link.
- Adds the pure-managed install/detect/plan infrastructure (`addons/godot_mcp/Extensions/`): a `GodotExtensionDescriptor` record + empty `GodotExtensionRegistry`, the `ExtensionInstallPlanner` (the key tested seam — add/update/no-op `.csproj` transform via `System.Xml.Linq`, preserving siblings), the `InstalledStateDetector` (parse `<PackageReference>` → state + numeric version compare), and an `IConsumerProjectFile` IO seam + `ExtensionInstaller` orchestrator.
- Distribution = NuGet `<PackageReference>` in the **consumer's** game `.csproj` (the Godot analog of Unity editing `manifest.json`); after a write the UI surfaces a "rebuild solutions" notice (Godot has no programmatic restore). The editor `ConsumerProjectFile` globalizes `res://` and locates the game `.csproj`.
- `ExtensionsPanel` reads state **synchronously** — it holds no live connection-event subscriptions, so it cannot regress the #56 FeaturesPanel re-subscription, and it builds unconditionally like the footer.
- Does **not** touch the addon's own `Godot-MCP.csproj` pins (McpPlugin 6.7.0 / ReflectorNet 5.3.1) and does **not** create any repo or publish any package — the first real extension package + `Godot-AI-Tools-Template` repo + NuGet publish are a separate follow-up.

## Test plan
- [x] `dotnet build Godot-MCP.sln --configuration Debug` — 0 errors, 0 warnings (compiles `#if TOOLS`, CI parity).
- [x] `dotnet test Godot-MCP.Tests` — **614 passed** (+32 new): planner add/bump/no-op + sibling/XML preservation, detector parse/missing/version-compare, installer flow over an in-memory fake. All logic is deterministic string/XML so it passes on Linux CI too.
- [x] Headless Godot 4.5.1 smoke: `[Godot-MCP] plugin loaded`, dock built (ExtensionsPanel card constructed), no `FileNotFoundException`/exception in the dock-construction path.

Closes #66