### PR TITLE
feat(cli): add godot-mcp-cli npm package + node CI

### DIFF
--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -1,0 +1,35 @@
+name: Test CLI
+
+# Reusable workflow that builds and tests the godot-mcp-cli npm package under
+# cli/ on a Node 20 & 22 matrix. Wiring it into the PR CI pipeline is a
+# follow-up task; this file only defines the reusable job.
+on:
+  workflow_call:
+
+jobs:
+  test-cli:
+    name: cli (node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['20', '22']
+    defaults:
+      run:
+        working-directory: ./cli
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+
+# The repo-root .gitignore excludes `bin/` (a C#/Godot build-output dir). This
+# package's bin/ holds the committed CLI entrypoint shim, so re-include it.
+!/bin/
+!/bin/*.js

--- a/cli/.npmignore
+++ b/cli/.npmignore
@@ -1,0 +1,7 @@
+src/
+tests/
+tsconfig.json
+*.ts
+!dist/**/*.js
+!dist/**/*.d.ts
+package-lock.json

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to `godot-mcp-cli` are documented in this file.
+
+## 0.1.0
+
+Initial release. A cross-platform CLI for Godot-MCP, mirroring `unity-mcp-cli`'s feature set and structure,
+adapted for Godot.
+
+- `open` — resolve the Godot editor binary (`GODOT_BIN`/`GODOT4_BIN` → PATH → per-OS common dirs) and
+  launch `--editor --path <project>` with the `GODOT_MCP_*` connection env vars.
+- `run-tool` / `run-system-tool` — POST to `<url>/api/tools/<name>` and `<url>/api/system-tools/<name>`.
+- `status` — detect a running Godot editor and probe MCP-server health.
+- `wait-for-ready` — poll the server until it answers `ping`.
+- `setup-mcp` — write an AI-agent MCP-client config (claude-code, claude-desktop, cursor, vscode, custom)
+  pointing at the Godot server's `<host>/mcp` URL.
+- `configure` — list / enable / disable tools, prompts, and resources in the project-local
+  `.godot-mcp/features.json`.
+- `close` — gracefully terminate the Godot editor for a project (`--force` to hard-kill).
+- `install-plugin` / `remove-plugin` — enable/disable the `godot_mcp` addon in `project.godot`
+  `[editor_plugins]`.
+- `update` — check npm for a newer version and install it.
+
+`setup-skills` is intentionally not ported: Godot skills are generated addon-side by the McpPlugin engine,
+and the Godot MCP server exposes no skill-generate HTTP endpoint.

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,101 @@
+# godot-mcp-cli
+
+Cross-platform CLI for **Godot-MCP** — the [Godot](https://godotengine.org/) editor addon that bridges
+LLMs (Claude, Cursor, Copilot, …) with the Godot editor via the
+[Model Context Protocol](https://modelcontextprotocol.io/).
+
+The CLI is the Godot analog of [`unity-mcp-cli`](https://www.npmjs.com/package/unity-mcp-cli): it resolves
+and launches the Godot editor with the right `GODOT_MCP_*` connection environment variables, runs MCP and
+system tools over the server's HTTP API, probes server health, writes AI-agent MCP-client config, and
+enables/disables the `godot_mcp` addon in a project.
+
+> **Licensed under Apache-2.0.**
+
+## Install
+
+```bash
+npm install -g godot-mcp-cli
+# or run ad-hoc:
+npx godot-mcp-cli <command>
+```
+
+Requires Node `^20.19.0 || >=22.12.0`.
+
+## Commands
+
+| Command | What it does |
+| --- | --- |
+| `open [path]` | Resolve the Godot editor binary and launch `--editor --path <project>` with `GODOT_MCP_*` connection env vars. |
+| `run-tool <tool> [path]` | POST to `<url>/api/tools/<tool>` with JSON input. |
+| `run-system-tool <tool> [path]` | POST to `<url>/api/system-tools/<tool>` (tools not exposed to MCP clients). |
+| `status [path]` | Detect a running Godot editor for the project and probe MCP-server health. |
+| `wait-for-ready [path]` | Poll the MCP server until it answers `ping`. |
+| `setup-mcp <agent> [path]` | Write the agent's MCP-client config pointing at the Godot server's `<host>/mcp` URL. |
+| `configure [path]` | List / enable / disable tools, prompts, and resources in the project-local `.godot-mcp/features.json`. |
+| `close [path]` | Gracefully stop the Godot editor running for a project (`--force` to hard-kill). |
+| `install-plugin [path]` | Enable the `godot_mcp` addon in `project.godot` `[editor_plugins]`. |
+| `remove-plugin [path]` | Disable the `godot_mcp` addon in `project.godot` `[editor_plugins]`. |
+| `update` | Check npm for a newer `godot-mcp-cli` and install it. |
+
+### Editor resolution (`open`)
+
+`open` locates the Godot editor binary in this order:
+
+1. `--editor-path <path>` (explicit).
+2. `GODOT_BIN` / `GODOT4_BIN` environment variables.
+3. The first matching Godot binary on `PATH` (the mono build is preferred on Windows).
+4. Per-OS common install directories — Windows prefers the mono build; macOS resolves the
+   `.app/Contents/MacOS/Godot` binary; Linux scans common extracted-binary locations.
+
+### Connection env vars
+
+`open` forwards these to the editor process (names match the addon's `GodotMcpConfig`):
+
+| Flag | Env var |
+| --- | --- |
+| `--url <host>` | `GODOT_MCP_HOST` |
+| `--cloud-url <url>` | `GODOT_MCP_CLOUD_URL` |
+| `--token <token>` | `GODOT_MCP_TOKEN` |
+| `--auth None\|Required` | `GODOT_MCP_AUTH_OPTION` |
+| `--mode Cloud\|Custom` | `GODOT_MCP_CONNECTION_MODE` |
+| `--log-level <level>` | `GODOT_MCP_LOG_LEVEL` |
+
+### Server URL resolution (`run-tool` / `status` / `wait-for-ready`)
+
+Unlike Unity, the Godot plugin is a **server-less client** whose persisted config lives in `user://`
+(outside the project tree), so there is no deterministic project-path → port hash. The server base URL is
+resolved as:
+
+1. `--url <url>` (explicit override).
+2. `GODOT_MCP_HOST` env (Custom-mode host).
+3. `GODOT_MCP_CLOUD_URL` env / Cloud mode → cloud base (`https://ai-game.dev`).
+4. Default custom host (`http://localhost:8080`).
+
+Pass `--url http://localhost:<port>` to target a local/self-hosted server.
+
+## `setup-skills` is not in v1
+
+Unlike the Unity CLI, there is **no `setup-skills` command**. Godot skills are generated **addon-side** by
+the McpPlugin engine on plugin boot (`GodotMcpConnection.Start` → `GenerateSkillFilesIfNeeded`, driven by
+the `GodotMcpConfig.GenerateSkillFiles` toggle, with a manual "Generate" button in the dock's Skills card).
+The Godot MCP server exposes **no** `skill-generate` HTTP endpoint for the CLI to call, so porting
+`setup-skills` would have nothing to invoke. It is intentionally out of scope for v1.
+
+## Library API
+
+The package also exports a side-effect-free library (the `.` entry):
+
+```ts
+import { openProject, runTool, setupMcp, installPlugin } from 'godot-mcp-cli';
+```
+
+Every function returns a discriminated union (`{ kind: 'success', ... }` / `{ kind: 'failure', error }`)
+and never throws past the public boundary.
+
+## Development
+
+```bash
+npm install
+npm run build   # tsc → dist/ (ESM)
+npm test        # vitest
+```

--- a/cli/bin/godot-mcp-cli.js
+++ b/cli/bin/godot-mcp-cli.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../dist/index.js';

--- a/cli/docs/README.md
+++ b/cli/docs/README.md
@@ -1,0 +1,7 @@
+# godot-mcp-cli — docs
+
+Additional documentation for `godot-mcp-cli`. See the package [`README.md`](../README.md) for the full
+command reference and library API.
+
+Localized READMEs (e.g. `README.es.md`, `README.ja.md`, `README.zh-CN.md`) may be added here over time,
+mirroring the Unity-MCP CLI's translation set.

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,0 +1,1717 @@
+{
+  "name": "godot-mcp-cli",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "godot-mcp-cli",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.6.2",
+        "commander": "^13.1.0",
+        "yocto-spinner": "^1.1.0"
+      },
+      "bin": {
+        "godot-mcp-cli": "bin/godot-mcp-cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.15.0",
+        "typescript": "^5.8.0",
+        "vitest": "^3.1.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+      "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+      "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+      "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.61.1",
+        "@rollup/rollup-android-arm64": "4.61.1",
+        "@rollup/rollup-darwin-arm64": "4.61.1",
+        "@rollup/rollup-darwin-x64": "4.61.1",
+        "@rollup/rollup-freebsd-arm64": "4.61.1",
+        "@rollup/rollup-freebsd-x64": "4.61.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+        "@rollup/rollup-linux-arm64-musl": "4.61.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+        "@rollup/rollup-linux-loong64-musl": "4.61.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-musl": "4.61.1",
+        "@rollup/rollup-openbsd-x64": "4.61.1",
+        "@rollup/rollup-openharmony-arm64": "4.61.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+        "@rollup/rollup-win32-x64-gnu": "4.61.1",
+        "@rollup/rollup-win32-x64-msvc": "4.61.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-spinner": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-1.2.0.tgz",
+      "integrity": "sha512-Yw0hUB6UA3o4YUgKy3oSe9a4cxoaZ9sBfYDw+JSxo6Id0KoJGoxzPA24qqUXYKBWABs/zDSGTz9kww7t3F0XGw==",
+      "license": "MIT",
+      "dependencies": {
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.19"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "godot-mcp-cli",
+  "version": "0.1.0",
+  "description": "Cross-platform CLI tool for Godot-MCP (Skills & MCP). Resolves and launches the Godot editor with MCP connection env vars, runs MCP/system tools over HTTP, probes server health, configures AI agents (Claude Code, Cursor, VS Code, …), and enables/disables the godot_mcp addon. Works with Claude Code, Cursor, Copilot, and any MCP client.",
+  "type": "module",
+  "main": "dist/lib.js",
+  "types": "dist/lib.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/lib.d.ts",
+      "import": "./dist/lib.js"
+    },
+    "./cli": {
+      "types": "./dist/cli.d.ts",
+      "import": "./dist/cli.js"
+    }
+  },
+  "bin": {
+    "godot-mcp-cli": "bin/godot-mcp-cli.js"
+  },
+  "files": [
+    "dist",
+    "bin",
+    "README.md",
+    "CHANGELOG.md",
+    "docs"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "pretest": "npm run build",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "prepublishOnly": "npm run build",
+    "prepack": "npm run build"
+  },
+  "keywords": [
+    "cli",
+    "godot",
+    "godot ai",
+    "godot skills",
+    "godot mcp",
+    "ai skills",
+    "ai mcp",
+    "ai",
+    "mcp",
+    "model-context-protocol",
+    "gamedev",
+    "game-dev"
+  ],
+  "author": {
+    "name": "Ivan Murzak",
+    "url": "https://github.com/IvanMurzak"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/IvanMurzak/Godot-MCP.git",
+    "directory": "cli"
+  },
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  },
+  "dependencies": {
+    "chalk": "^5.6.2",
+    "commander": "^13.1.0",
+    "yocto-spinner": "^1.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.0",
+    "typescript": "^5.8.0",
+    "vitest": "^3.1.0"
+  }
+}

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -1,0 +1,17 @@
+// CLI entry-point re-exports (`godot-mcp-cli/cli`).
+//
+// Exposes the commander Command instances so a consumer can compose them into
+// their own program. The runnable program lives in `index.ts` (imported by
+// `bin/godot-mcp-cli.js`).
+
+export { openCommand } from './commands/open.js';
+export { runToolCommand } from './commands/run-tool.js';
+export { runSystemToolCommand } from './commands/run-system-tool.js';
+export { statusCommand } from './commands/status.js';
+export { waitForReadyCommand } from './commands/wait-for-ready.js';
+export { setupMcpCommand } from './commands/setup-mcp.js';
+export { configureCommand } from './commands/configure.js';
+export { closeCommand } from './commands/close.js';
+export { createUpdateCommand } from './commands/update.js';
+export { installPluginCommand } from './commands/install-plugin.js';
+export { removePluginCommand } from './commands/remove-plugin.js';

--- a/cli/src/commands/close.ts
+++ b/cli/src/commands/close.ts
@@ -1,0 +1,140 @@
+import { Command } from 'commander';
+import * as fs from 'fs';
+import * as path from 'path';
+import { platform as nodePlatform } from 'os';
+import * as ui from '../utils/ui.js';
+import { verbose } from '../utils/ui.js';
+import { findGodotProcess } from '../utils/godot-process.js';
+import {
+  isProcessAlive,
+  sendGracefulShutdown,
+  sendForceKill,
+  waitForExit,
+  type SupportedPlatform,
+} from '../utils/godot-shutdown.js';
+
+export interface CloseOptions {
+  timeout?: string;
+  force?: boolean;
+}
+
+const DEFAULT_TIMEOUT_SECONDS = 30;
+
+/** Resolve the project path argument to an absolute, canonical path. */
+export function resolveCloseProjectPath(positionalPath: string | undefined, cwd: string): string {
+  const explicit = positionalPath ?? cwd;
+  let resolved = path.resolve(explicit);
+  try {
+    resolved = fs.realpathSync(resolved);
+  } catch {
+    // Path may not exist — let the caller decide what to do.
+  }
+  return resolved;
+}
+
+/** True when `<projectPath>/project.godot` exists. */
+export function isGodotProjectRoot(projectPath: string): boolean {
+  return fs.existsSync(path.join(projectPath, 'project.godot'));
+}
+
+/**
+ * Parse a positive-integer `--timeout` value (seconds). Returns the parsed
+ * value, or `null` when the input is not a valid positive integer. Exported for
+ * unit tests.
+ */
+export function parseTimeoutSeconds(raw: string | undefined): number | null {
+  if (raw === undefined) return DEFAULT_TIMEOUT_SECONDS;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+/** Resolve the editor PID for a given project path, or null when not running. */
+export function resolveEditorPid(projectPath: string): number | null {
+  const proc = findGodotProcess(projectPath);
+  if (proc) {
+    verbose(`Godot editor PID ${proc.pid} matched for project`);
+    return proc.pid;
+  }
+  return null;
+}
+
+export const closeCommand = new Command('close')
+  .description('Gracefully terminate the Godot editor instance running for a given project path')
+  .argument('[path]', 'Path to the Godot project (defaults to current directory)')
+  .option('--timeout <seconds>', `Polite-quit timeout in seconds (default: ${DEFAULT_TIMEOUT_SECONDS})`, String(DEFAULT_TIMEOUT_SECONDS))
+  .option('--force', 'Hard-kill the editor if it does not exit within --timeout')
+  .action(async (positionalPath: string | undefined, options: CloseOptions) => {
+    const projectPath = resolveCloseProjectPath(positionalPath, process.cwd());
+    verbose(`close invoked for project: ${projectPath}`);
+
+    if (!fs.existsSync(projectPath)) {
+      ui.error(`Project path does not exist: ${projectPath}`);
+      process.exit(1);
+    }
+
+    if (!isGodotProjectRoot(projectPath)) {
+      ui.error(`Not a Godot project root: ${projectPath}`);
+      process.exit(1);
+    }
+
+    const timeoutSeconds = parseTimeoutSeconds(options.timeout);
+    if (timeoutSeconds === null) {
+      ui.error(`Invalid --timeout value: "${options.timeout}". Must be a positive integer (seconds).`);
+      process.exit(1);
+    }
+
+    const platform = nodePlatform() as SupportedPlatform;
+    const pid = resolveEditorPid(projectPath);
+
+    if (pid === null) {
+      ui.success(`no running editor for project at ${projectPath}`);
+      process.exit(0);
+    }
+
+    ui.heading('Closing Godot Editor');
+    ui.label('Project', projectPath);
+    ui.label('PID', String(pid));
+    ui.label('Timeout', `${timeoutSeconds}s`);
+    ui.label('Force', options.force ? 'yes' : 'no');
+    ui.divider();
+
+    const spinner = ui.startSpinner(`Sending polite-quit to PID ${pid}...`);
+    const sent = sendGracefulShutdown(pid, platform);
+    if (!sent) {
+      spinner.error(`Failed to deliver polite-quit signal to PID ${pid}`);
+      process.exit(1);
+    }
+
+    spinner.text = `Waiting up to ${timeoutSeconds}s for PID ${pid} to exit...`;
+    const exited = await waitForExit(pid, timeoutSeconds * 1000, platform);
+
+    if (exited) {
+      spinner.success(`Godot editor (PID ${pid}) exited cleanly`);
+      process.exit(0);
+    }
+
+    if (!options.force) {
+      spinner.error(
+        `Godot editor (PID ${pid}) did not exit within ${timeoutSeconds}s. ` +
+          `Re-run with --force to hard-kill, or close it manually.`,
+      );
+      process.exit(1);
+    }
+
+    spinner.text = `Force-killing PID ${pid}...`;
+    const killed = sendForceKill(pid, platform);
+    if (!killed) {
+      spinner.error(`Failed to force-kill PID ${pid}`);
+      process.exit(1);
+    }
+
+    const reaped = await waitForExit(pid, 5000, platform);
+    if (reaped || !isProcessAlive(pid, platform)) {
+      spinner.success(`Godot editor (PID ${pid}) force-killed`);
+      process.exit(0);
+    }
+
+    spinner.error(`Godot editor (PID ${pid}) is still alive after force-kill`);
+    process.exit(1);
+  });

--- a/cli/src/commands/configure.ts
+++ b/cli/src/commands/configure.ts
@@ -1,0 +1,148 @@
+import { Command } from 'commander';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as ui from '../utils/ui.js';
+import { verbose } from '../utils/ui.js';
+import {
+  getOrCreateConfig,
+  writeConfig,
+  updateFeatures,
+  type McpFeature,
+  type GodotMcpFeaturesConfig,
+} from '../utils/config.js';
+
+function parseCommaSeparated(value: string): string[] {
+  return value.split(',').map((s) => s.trim()).filter(Boolean);
+}
+
+interface FeatureAction {
+  enableNames?: string[];
+  disableNames?: string[];
+  enableAll?: boolean;
+  disableAll?: boolean;
+}
+
+function buildAction(
+  enable: string[] | undefined,
+  disable: string[] | undefined,
+  enableAll: boolean | undefined,
+  disableAll: boolean | undefined,
+): FeatureAction | undefined {
+  if (!enable && !disable && !enableAll && !disableAll) return undefined;
+  return { enableNames: enable, disableNames: disable, enableAll, disableAll };
+}
+
+function snapshotFeatures(config: GodotMcpFeaturesConfig, key: 'tools' | 'prompts' | 'resources'): McpFeature[] {
+  const raw = config[key];
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter(
+      (f): f is McpFeature =>
+        typeof f === 'object' && f !== null && typeof f.name === 'string' && typeof f.enabled === 'boolean',
+    )
+    .map((f) => ({ name: f.name, enabled: f.enabled }));
+}
+
+export const configureCommand = new Command('configure')
+  .description('List / enable / disable MCP tools, prompts, and resources in the project-local .godot-mcp/features.json')
+  .argument('[path]', 'Path to the Godot project')
+  .option('--path <path>', 'Path to the Godot project')
+  .option('--enable-tools <names>', 'Enable specific tools (comma-separated)', parseCommaSeparated)
+  .option('--disable-tools <names>', 'Disable specific tools (comma-separated)', parseCommaSeparated)
+  .option('--enable-all-tools', 'Enable all tools')
+  .option('--disable-all-tools', 'Disable all tools')
+  .option('--enable-prompts <names>', 'Enable specific prompts (comma-separated)', parseCommaSeparated)
+  .option('--disable-prompts <names>', 'Disable specific prompts (comma-separated)', parseCommaSeparated)
+  .option('--enable-all-prompts', 'Enable all prompts')
+  .option('--disable-all-prompts', 'Disable all prompts')
+  .option('--enable-resources <names>', 'Enable specific resources (comma-separated)', parseCommaSeparated)
+  .option('--disable-resources <names>', 'Disable specific resources (comma-separated)', parseCommaSeparated)
+  .option('--enable-all-resources', 'Enable all resources')
+  .option('--disable-all-resources', 'Disable all resources')
+  .option('--list', 'List current configuration')
+  .action(
+    async (
+      positionalPath: string | undefined,
+      options: {
+        path?: string;
+        enableTools?: string[];
+        disableTools?: string[];
+        enableAllTools?: boolean;
+        disableAllTools?: boolean;
+        enablePrompts?: string[];
+        disablePrompts?: string[];
+        enableAllPrompts?: boolean;
+        disableAllPrompts?: boolean;
+        enableResources?: string[];
+        disableResources?: string[];
+        enableAllResources?: boolean;
+        disableAllResources?: boolean;
+        list?: boolean;
+      },
+    ) => {
+      const resolvedPath = positionalPath ?? options.path;
+      if (!resolvedPath) {
+        ui.error('Path is required. Usage: godot-mcp-cli configure <path> or --path <path>');
+        process.exit(1);
+      }
+
+      const projectPath = path.resolve(resolvedPath);
+      if (!fs.existsSync(projectPath)) {
+        ui.error(`Project path does not exist: ${projectPath}`);
+        process.exit(1);
+      }
+
+      verbose(`Loading config for project: ${projectPath}`);
+
+      const toolsAction = options.list
+        ? undefined
+        : buildAction(options.enableTools, options.disableTools, options.enableAllTools, options.disableAllTools);
+      const promptsAction = options.list
+        ? undefined
+        : buildAction(options.enablePrompts, options.disablePrompts, options.enableAllPrompts, options.disableAllPrompts);
+      const resourcesAction = options.list
+        ? undefined
+        : buildAction(
+            options.enableResources,
+            options.disableResources,
+            options.enableAllResources,
+            options.disableAllResources,
+          );
+
+      const config = getOrCreateConfig(projectPath);
+
+      const hasAny = (a: FeatureAction | undefined): boolean =>
+        !!a && (!!a.enableNames?.length || !!a.disableNames?.length || a.enableAll === true || a.disableAll === true);
+
+      if (hasAny(toolsAction)) updateFeatures(config, 'tools', toolsAction!);
+      if (hasAny(promptsAction)) updateFeatures(config, 'prompts', promptsAction!);
+      if (hasAny(resourcesAction)) updateFeatures(config, 'resources', resourcesAction!);
+
+      if (hasAny(toolsAction) || hasAny(promptsAction) || hasAny(resourcesAction)) {
+        writeConfig(projectPath, config);
+      }
+
+      if (options.list) {
+        ui.heading('Current configuration');
+
+        const printFeatures = (featureLabel: string, features: McpFeature[]) => {
+          ui.heading(featureLabel);
+          if (features.length === 0) {
+            ui.info('(none configured - all enabled by default)');
+            return;
+          }
+          for (const f of features) {
+            ui.featureRow(f.name, f.enabled);
+          }
+        };
+
+        printFeatures('Tools', snapshotFeatures(config, 'tools'));
+        printFeatures('Prompts', snapshotFeatures(config, 'prompts'));
+        printFeatures('Resources', snapshotFeatures(config, 'resources'));
+        return;
+      }
+
+      verbose('Writing updated configuration');
+      ui.success('Configuration updated successfully.');
+    },
+  );

--- a/cli/src/commands/install-plugin.ts
+++ b/cli/src/commands/install-plugin.ts
@@ -1,0 +1,44 @@
+import { Command } from 'commander';
+import * as path from 'path';
+import * as ui from '../utils/ui.js';
+import { verbose } from '../utils/ui.js';
+import { installPlugin } from '../lib/install-plugin.js';
+
+interface InstallPluginCliOptions {
+  path?: string;
+}
+
+export const installPluginCommand = new Command('install-plugin')
+  .description('Enable the godot_mcp addon in a project (adds res://addons/godot_mcp/plugin.cfg to project.godot [editor_plugins])')
+  .argument('[path]', 'Path to the Godot project')
+  .option('--path <path>', 'Path to the Godot project')
+  .action(async (positionalPath: string | undefined, options: InstallPluginCliOptions) => {
+    const resolvedPath = positionalPath ?? options.path ?? process.cwd();
+    const projectPath = path.resolve(resolvedPath);
+
+    ui.heading('Enabling godot_mcp addon');
+    verbose(`Project path: ${projectPath}`);
+
+    const spinner = ui.startSpinner('Updating project.godot...');
+    const result = await installPlugin({ godotProjectPath: projectPath });
+
+    if (result.kind === 'failure') {
+      spinner.error('Failed to enable plugin');
+      ui.error(result.error.message);
+      process.exit(1);
+    }
+
+    if (result.changed) {
+      spinner.success('godot_mcp addon enabled');
+    } else {
+      spinner.success('godot_mcp addon was already enabled');
+    }
+
+    ui.label('project.godot', result.projectGodotPath);
+    ui.label('Enabled plugins', result.enabledPlugins.join(', ') || '(none)');
+
+    for (const warning of result.warnings) {
+      console.log('');
+      ui.warn(warning);
+    }
+  });

--- a/cli/src/commands/open.ts
+++ b/cli/src/commands/open.ts
@@ -1,0 +1,170 @@
+import { Command } from 'commander';
+import * as path from 'path';
+import * as ui from '../utils/ui.js';
+import { verbose } from '../utils/ui.js';
+import {
+  openProject,
+  resolveProjectPath as libResolveProjectPath,
+  isGodotProjectDir as libIsGodotProjectDir,
+} from '../lib/open.js';
+import type { OpenProjectAuthOption, OpenProjectConnectionMode } from '../lib/types.js';
+
+export interface ResolveProjectPathResult {
+  /** Absolute, resolved path to the project directory. */
+  projectPath: string;
+  /** True if no path was supplied and we fell back to `process.cwd()`. */
+  usedCwdFallback: boolean;
+}
+
+/**
+ * Resolve the project path from the positional argument, `--path` option, or
+ * the current working directory when neither is provided. Re-exported for tests.
+ */
+export function resolveOpenProjectPath(
+  positionalPath: string | undefined,
+  optionPath: string | undefined,
+  cwd: string,
+): ResolveProjectPathResult {
+  const explicit = positionalPath ?? optionPath;
+  return libResolveProjectPath(explicit, cwd);
+}
+
+/** Re-export for backward compatibility with tests. */
+export const isGodotProjectDir = libIsGodotProjectDir;
+
+export const openCommand = new Command('open')
+  .description(
+    'Open a Godot project in the Godot editor, optionally passing GODOT_MCP_* connection env vars when connection options (--url, --token, etc.) are provided. Use --no-connect to suppress all MCP env vars.',
+  )
+  .argument('[path]', 'Path to the Godot project (defaults to current directory)')
+  .option('--path <path>', 'Path to the Godot project (defaults to current directory)')
+  .option('--editor-path <path>', 'Explicit path to the Godot editor executable (skips discovery)')
+  .option('--no-connect', 'Open without MCP connection environment variables')
+  .option('--url <url>', 'MCP server host to connect to (sets GODOT_MCP_HOST)')
+  .option('--cloud-url <url>', 'Cloud base URL override (sets GODOT_MCP_CLOUD_URL)')
+  .option('--token <token>', 'Auth token (sets GODOT_MCP_TOKEN)')
+  .option('--auth <option>', 'Auth option: None or Required (sets GODOT_MCP_AUTH_OPTION)')
+  .option('--mode <mode>', 'Connection mode: Cloud or Custom (sets GODOT_MCP_CONNECTION_MODE)')
+  .option('--log-level <level>', 'Log level: Trace/Debug/Info/Warning/Error/None (sets GODOT_MCP_LOG_LEVEL)')
+  .action(
+    async (
+      positionalPath: string | undefined,
+      options: {
+        path?: string;
+        editorPath?: string;
+        connect?: boolean;
+        url?: string;
+        cloudUrl?: string;
+        token?: string;
+        auth?: string;
+        mode?: string;
+        logLevel?: string;
+      },
+    ) => {
+      const { projectPath, usedCwdFallback } = resolveOpenProjectPath(
+        positionalPath,
+        options.path,
+        process.cwd(),
+      );
+
+      const fs = await import('fs');
+      if (!fs.existsSync(projectPath)) {
+        ui.error(`Project path does not exist: ${projectPath}`);
+        process.exit(1);
+      }
+
+      if (!libIsGodotProjectDir(projectPath)) {
+        if (usedCwdFallback) {
+          ui.error(`Current directory is not a Godot project: ${projectPath}`);
+          ui.info('Run this command from a Godot project folder, or pass a path: godot-mcp-cli open <path>');
+        } else {
+          ui.error(`Not a Godot project (missing project.godot): ${projectPath}`);
+        }
+        process.exit(1);
+      }
+
+      if (usedCwdFallback) {
+        verbose(`No path provided — using current directory: ${projectPath}`);
+      }
+      verbose(`open invoked for project: ${projectPath}`);
+      verbose(`--no-connect: ${options.connect === false}`);
+
+      // Validate auth/mode here so the CLI emits a clear error + exit code.
+      if (options.auth !== undefined && options.auth !== 'None' && options.auth !== 'Required') {
+        ui.error('--auth must be "None" or "Required"');
+        process.exit(1);
+      }
+      if (options.mode !== undefined && options.mode !== 'Cloud' && options.mode !== 'Custom') {
+        ui.error('--mode must be "Cloud" or "Custom"');
+        process.exit(1);
+      }
+
+      const spinner = ui.startSpinner('Locating Godot editor...');
+
+      const result = await openProject({
+        projectPath,
+        editorPath: options.editorPath,
+        noConnect: options.connect === false,
+        url: options.url,
+        cloudUrl: options.cloudUrl,
+        token: options.token,
+        auth: options.auth as OpenProjectAuthOption | undefined,
+        mode: options.mode as OpenProjectConnectionMode | undefined,
+        logLevel: options.logLevel,
+        onProgress: (event) => {
+          switch (event.phase) {
+            case 'editor-resolved': {
+              spinner.success('Godot editor located');
+              verbose(`Editor path: ${event.editorPath}`);
+              break;
+            }
+            case 'connection-details': {
+              const envVars = event.envVars;
+              if (Object.keys(envVars).length > 0) {
+                ui.heading('Connection Details');
+                ui.label('Project', event.projectPath);
+                ui.label('Editor', event.editorPath);
+                ui.heading('Environment Variables');
+                for (const [key, value] of Object.entries(envVars)) {
+                  const display = key === 'GODOT_MCP_TOKEN' ? '***' : value;
+                  ui.label(key, display);
+                }
+                ui.divider();
+              } else {
+                verbose('MCP connection disabled via --no-connect or no options');
+              }
+              break;
+            }
+            case 'launching-editor': {
+              ui.label('Project', event.projectPath);
+              ui.label('Editor', event.editorPath);
+              break;
+            }
+            case 'editor-launched': {
+              ui.success(`Launched Godot editor (PID: ${event.pid ?? 'unknown'})`);
+              break;
+            }
+            default:
+              break;
+          }
+        },
+      });
+
+      if (result.kind === 'failure') {
+        // The spinner.success() on editor-resolved only fires on the happy
+        // path; on failure stop it so the error renders cleanly.
+        spinner.stop();
+        ui.error(result.errorMessage);
+        process.exit(1);
+      }
+
+      if (result.alreadyRunning) {
+        spinner.stop();
+        ui.success(`Godot is already running with this project (PID: ${result.editorPid ?? 'unknown'})`);
+        ui.info('Skipping launch. Use the running instance or close it first.');
+        process.exit(0);
+      }
+
+      verbose(`Resolved project path: ${path.resolve(result.projectPath)}`);
+    },
+  );

--- a/cli/src/commands/remove-plugin.ts
+++ b/cli/src/commands/remove-plugin.ts
@@ -1,0 +1,39 @@
+import { Command } from 'commander';
+import * as path from 'path';
+import * as ui from '../utils/ui.js';
+import { verbose } from '../utils/ui.js';
+import { removePlugin } from '../lib/install-plugin.js';
+
+interface RemovePluginCliOptions {
+  path?: string;
+}
+
+export const removePluginCommand = new Command('remove-plugin')
+  .description('Disable the godot_mcp addon in a project (removes res://addons/godot_mcp/plugin.cfg from project.godot [editor_plugins])')
+  .argument('[path]', 'Path to the Godot project')
+  .option('--path <path>', 'Path to the Godot project')
+  .action(async (positionalPath: string | undefined, options: RemovePluginCliOptions) => {
+    const resolvedPath = positionalPath ?? options.path ?? process.cwd();
+    const projectPath = path.resolve(resolvedPath);
+
+    ui.heading('Disabling godot_mcp addon');
+    verbose(`Project path: ${projectPath}`);
+
+    const spinner = ui.startSpinner('Updating project.godot...');
+    const result = await removePlugin({ godotProjectPath: projectPath });
+
+    if (result.kind === 'failure') {
+      spinner.error('Failed to disable plugin');
+      ui.error(result.error.message);
+      process.exit(1);
+    }
+
+    if (result.changed) {
+      spinner.success('godot_mcp addon disabled');
+    } else {
+      spinner.success('godot_mcp addon was not enabled');
+    }
+
+    ui.label('project.godot', result.projectGodotPath);
+    ui.label('Enabled plugins', result.enabledPlugins.join(', ') || '(none)');
+  });

--- a/cli/src/commands/run-system-tool.ts
+++ b/cli/src/commands/run-system-tool.ts
@@ -1,0 +1,13 @@
+import { runSystemTool } from '../lib/run-tool.js';
+import { buildRunToolCommand } from './run-tool-builder.js';
+
+export const runSystemToolCommand = buildRunToolCommand({
+  name: 'run-system-tool',
+  description: 'Execute a system tool via the HTTP API (not exposed to MCP clients)',
+  argDescription: 'Name of the system tool to execute',
+  routePrefix: '/api/system-tools',
+  verboseLabel: 'System tool',
+  headingLabel: 'Run System Tool',
+  errorNoun: 'system tool',
+  invoke: runSystemTool,
+});

--- a/cli/src/commands/run-tool-builder.ts
+++ b/cli/src/commands/run-tool-builder.ts
@@ -1,0 +1,168 @@
+import { Command } from 'commander';
+import * as ui from '../utils/ui.js';
+import { verbose } from '../utils/ui.js';
+import { resolveAndValidateProjectPath, resolveConnection } from '../utils/connection.js';
+import { parseInput } from '../utils/input.js';
+import type { RunToolFailure, RunToolOptions, RunToolResult } from '../lib/types.js';
+
+interface BuilderOptions {
+  /** CLI subcommand name, e.g. `'run-tool'`. */
+  name: string;
+  /** `description()` text for the commander command. */
+  description: string;
+  /** Description shown next to the `<tool-name>` argument. */
+  argDescription: string;
+  /** URL path prefix the lib function targets, e.g. `'/api/tools'`. */
+  routePrefix: string;
+  /** Verbose-log label, e.g. `'Tool'` or `'System tool'`. */
+  verboseLabel: string;
+  /** Heading printed by `ui.heading`, e.g. `'Run Tool'`. */
+  headingLabel: string;
+  /**
+   * Lower-case noun used in user-facing failure copy:
+   * `Failed to call <noun>:` and `<Capitalized> call timed out…`.
+   */
+  errorNoun: string;
+  /** Library function — `runTool` or `runSystemTool`. */
+  invoke: (opts: RunToolOptions) => Promise<RunToolResult>;
+}
+
+interface CliOptions {
+  path?: string;
+  url?: string;
+  token?: string;
+  input?: string;
+  inputFile?: string;
+  raw?: boolean;
+  timeout?: string;
+}
+
+interface FailureContext {
+  toolName: string;
+  endpoint: string;
+  raw: boolean | undefined;
+  timeoutMs: number;
+  errorNoun: string;
+}
+
+export function buildRunToolCommand(cfg: BuilderOptions): Command {
+  return new Command(cfg.name)
+    .description(cfg.description)
+    .argument('<tool-name>', cfg.argDescription)
+    .argument('[path]', 'Godot project path (used to validate project.godot when --url is omitted)')
+    .option('--path <path>', 'Godot project path')
+    .option('--url <url>', 'MCP server base URL (defaults to GODOT_MCP_HOST/cloud)')
+    .option('--token <token>', 'Bearer token override (defaults to GODOT_MCP_TOKEN)')
+    .option('--input <json>', 'JSON string of tool arguments')
+    .option('--input-file <file>', 'Read JSON arguments from file')
+    .option('--raw', 'Output raw JSON (no formatting)')
+    .option('--timeout <ms>', 'Request timeout in milliseconds (default: 60000)', '60000')
+    .action(async (toolName: string, positionalPath: string | undefined, options: CliOptions) => {
+      // Validate --timeout first so a bad value short-circuits before we read
+      // --input-file or hit the network.
+      const timeoutMs = parseInt(options.timeout!, 10);
+      if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+        ui.error(`Invalid --timeout value: "${options.timeout}". Must be a positive integer (milliseconds).`);
+        process.exit(1);
+      }
+
+      // Resolve path + connection up front so the heading and verbose output
+      // reflect the final endpoint before the HTTP call fires.
+      const projectPath = resolveAndValidateProjectPath(positionalPath, options);
+      const { url: baseUrl, token } = resolveConnection(projectPath, options);
+      const body = parseInput(options);
+      const endpoint = `${baseUrl}${cfg.routePrefix}/${encodeURIComponent(toolName)}`;
+      const authSource = options.token ? '--token flag' : 'config/env';
+
+      verbose(`${cfg.verboseLabel}: ${toolName}`);
+      verbose(`Endpoint: ${endpoint}`);
+      verbose(`Body: ${body}`);
+      if (token) verbose(`Authorization header set (source: ${authSource})`);
+
+      if (!options.raw) {
+        ui.heading(cfg.headingLabel);
+        ui.label('Tool', toolName);
+        ui.label('URL', endpoint);
+        if (token) ui.label('Auth', `from ${authSource}`);
+        ui.divider();
+      }
+
+      const spinner = options.raw ? null : ui.startSpinner(`Calling ${toolName}...`);
+
+      const result = await cfg.invoke({
+        toolName,
+        url: baseUrl,
+        ...(token ? { token } : {}),
+        input: body,
+        timeoutMs,
+      });
+
+      if (result.kind === 'success') {
+        spinner?.success(`${toolName} completed`);
+        if (options.raw) {
+          process.stdout.write(stringifyForRaw(result.data));
+        } else {
+          ui.success('Response:');
+          console.log(
+            typeof result.data === 'string' ? result.data : JSON.stringify(result.data, null, 2),
+          );
+        }
+        return;
+      }
+
+      spinner?.stop();
+      handleFailure(result, {
+        toolName,
+        endpoint,
+        raw: options.raw,
+        timeoutMs,
+        errorNoun: cfg.errorNoun,
+      });
+    });
+}
+
+function stringifyForRaw(data: unknown): string {
+  if (typeof data === 'string') return data;
+  if (data === undefined) return '';
+  return JSON.stringify(data);
+}
+
+function handleFailure(failure: RunToolFailure, ctx: FailureContext): never {
+  if (failure.reason === 'http-error') {
+    if (ctx.raw) {
+      process.stdout.write(stringifyForRaw(failure.data));
+    } else {
+      ui.error(`HTTP ${failure.httpStatus}: ${failure.message}`);
+      if (failure.data !== undefined) {
+        ui.info(
+          typeof failure.data === 'string' ? failure.data : JSON.stringify(failure.data, null, 2),
+        );
+      }
+    }
+    process.exit(1);
+  }
+
+  const message = buildFailureMessage(failure, ctx);
+  if (ctx.raw) process.stderr.write(message + '\n');
+  else ui.error(`Failed to call ${ctx.errorNoun}: ${message}`);
+  process.exit(1);
+}
+
+function buildFailureMessage(failure: RunToolFailure, ctx: FailureContext): string {
+  switch (failure.reason) {
+    case 'timeout':
+      return `${capitalize(ctx.errorNoun)} call timed out after ${ctx.timeoutMs / 1000} seconds: ${ctx.toolName}`;
+    case 'connection-refused':
+      return `Connection refused at ${ctx.endpoint}. Is the MCP server running? Open Godot with the godot_mcp plugin connected first.`;
+    case 'connection-reset':
+      return `Connection was reset by the server at ${ctx.endpoint}. The server may have crashed or restarted.`;
+    case 'network-error':
+      return `Cannot reach ${ctx.endpoint}. Check your network connection and server URL.`;
+    default:
+      return failure.message;
+  }
+}
+
+function capitalize(s: string): string {
+  return s.length === 0 ? s : s.charAt(0).toUpperCase() + s.slice(1);
+}

--- a/cli/src/commands/run-tool.ts
+++ b/cli/src/commands/run-tool.ts
@@ -1,0 +1,13 @@
+import { runTool } from '../lib/run-tool.js';
+import { buildRunToolCommand } from './run-tool-builder.js';
+
+export const runToolCommand = buildRunToolCommand({
+  name: 'run-tool',
+  description: 'Execute an MCP tool via the HTTP API',
+  argDescription: 'Name of the MCP tool to execute',
+  routePrefix: '/api/tools',
+  verboseLabel: 'Tool',
+  headingLabel: 'Run Tool',
+  errorNoun: 'tool',
+  invoke: runTool,
+});

--- a/cli/src/commands/setup-mcp.ts
+++ b/cli/src/commands/setup-mcp.ts
@@ -1,0 +1,80 @@
+import { Command } from 'commander';
+import * as ui from '../utils/ui.js';
+import { verbose } from '../utils/ui.js';
+import { getAgentById, getAgentIds, listAgentTable, MCP_SERVER_NAME } from '../utils/agents.js';
+import { setupMcp } from '../lib/setup-mcp.js';
+
+interface SetupMcpCliOptions {
+  url?: string;
+  token?: string;
+  list?: boolean;
+}
+
+function listAgents(): void {
+  listAgentTable('Available AI Agents', 'Config Path', (a) => a.configPathDisplay);
+}
+
+export const setupMcpCommand = new Command('setup-mcp')
+  .description('Write MCP client config for an AI agent, pointing at the Godot MCP server')
+  .argument('[agent-id]', 'Agent to configure (use --list to see all)')
+  .argument('[path]', 'Godot project path (defaults to cwd)')
+  .option('--url <url>', 'MCP server host override (the <host>/mcp client URL is derived from it)')
+  .option('--token <token>', 'Auth token override (defaults to GODOT_MCP_TOKEN)')
+  .option('--list', 'List all available agent IDs')
+  .action(
+    async (
+      agentId: string | undefined,
+      positionalPath: string | undefined,
+      options: SetupMcpCliOptions,
+    ) => {
+      if (options.list) {
+        listAgents();
+        return;
+      }
+
+      if (!agentId) {
+        ui.error('Missing required argument: agent-id');
+        ui.info(`Available agent IDs: ${getAgentIds().join(', ')}`);
+        process.exit(1);
+      }
+
+      const agent = getAgentById(agentId);
+      if (!agent) {
+        ui.error(`Unknown agent: "${agentId}"`);
+        ui.info(`Available agent IDs: ${getAgentIds().join(', ')}`);
+        process.exit(1);
+      }
+
+      const spinner = ui.startSpinner(`Configuring ${agent.name}...`);
+
+      const result = await setupMcp({
+        agentId,
+        godotProjectPath: positionalPath,
+        url: options.url,
+        token: options.token,
+      });
+
+      if (result.kind === 'failure') {
+        spinner.error('Failed to write config');
+        ui.error(result.error.message);
+        process.exit(1);
+      }
+
+      if (positionalPath) {
+        verbose(`Project path: ${positionalPath}`);
+      }
+      verbose(`Config file: ${result.configPath}`);
+
+      spinner.success(`${agent.name} configured successfully`);
+
+      console.log('');
+      ui.label('Config file', result.configPath);
+      ui.label('Server URL', result.serverUrl);
+      ui.label('Server name', MCP_SERVER_NAME);
+
+      for (const warning of result.warnings) {
+        console.log('');
+        ui.warn(warning);
+      }
+    },
+  );

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -1,0 +1,75 @@
+import { Command } from 'commander';
+import * as ui from '../utils/ui.js';
+import { verbose } from '../utils/ui.js';
+import { resolveAndValidateProjectPath, resolveConnection } from '../utils/connection.js';
+import { findGodotProcess } from '../utils/godot-process.js';
+import { probe } from '../utils/probe.js';
+
+interface StatusOptions {
+  path?: string;
+  url?: string;
+  token?: string;
+  timeout?: string;
+}
+
+export const statusCommand = new Command('status')
+  .description('Check Godot editor and MCP server connection status')
+  .argument('[path]', 'Godot project path (used to detect a running editor and validate project.godot)')
+  .option('--path <path>', 'Godot project path')
+  .option('--url <url>', 'MCP server base URL (defaults to GODOT_MCP_HOST/cloud)')
+  .option('--token <token>', 'Bearer token override (defaults to GODOT_MCP_TOKEN)')
+  .option('--timeout <ms>', 'Probe timeout in milliseconds (default: 5000)', '5000')
+  .action(async (positionalPath: string | undefined, options: StatusOptions) => {
+    const projectPath = resolveAndValidateProjectPath(positionalPath, options);
+    const { url: serverUrl, token } = resolveConnection(projectPath, options);
+
+    const timeoutMs = parseInt(options.timeout ?? '5000', 10);
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      ui.error(`Invalid --timeout value: "${options.timeout}". Must be a positive integer (milliseconds).`);
+      process.exit(1);
+    }
+
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    ui.heading('Godot-MCP Status');
+    ui.label('Project', projectPath);
+    ui.divider();
+
+    // 1. Godot process detection
+    ui.heading('Godot Editor Process');
+    const proc = findGodotProcess(projectPath);
+    if (proc) {
+      ui.success(`Godot is running (PID: ${proc.pid})`);
+    } else {
+      ui.warn('Godot is not running with this project');
+    }
+
+    // 2. MCP server check
+    ui.heading('MCP Server');
+    ui.label('URL', serverUrl);
+
+    const spinner = ui.startSpinner(`Probing ${serverUrl}...`);
+    const result = await probe(serverUrl, headers, timeoutMs);
+    if (result.ok) {
+      spinner.success('Connected');
+      verbose(`Server response: ${JSON.stringify(result.data)}`);
+    } else {
+      spinner.error(`Not available (${result.reason})`);
+    }
+
+    ui.divider();
+
+    if (result.ok) {
+      ui.success('MCP server is reachable — ready for tool calls');
+      process.exit(0);
+    } else if (proc) {
+      ui.warn('Godot is running but MCP server is not responding yet');
+      process.exit(1);
+    } else {
+      ui.error('Godot is not running and MCP server is not reachable');
+      process.exit(1);
+    }
+  });

--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -1,0 +1,86 @@
+import { Command } from 'commander';
+import { spawn } from 'child_process';
+import { platform } from 'os';
+import * as ui from '../utils/ui.js';
+import { fetchLatestVersion, formatUpdateAvailable, isRunningViaNpx } from '../utils/update-check.js';
+import { isNewerVersion } from '../utils/semver.js';
+
+const PACKAGE_NAME = 'godot-mcp-cli';
+
+interface UpdateOptions {
+  check?: boolean;
+}
+
+function npmCommand(): string {
+  return platform() === 'win32' ? 'npm.cmd' : 'npm';
+}
+
+function runNpmInstall(packageSpec: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(npmCommand(), ['install', '-g', packageSpec], { stdio: 'inherit' });
+    child.on('error', reject);
+    child.on('close', (code) => resolve(code ?? 1));
+  });
+}
+
+export function createUpdateCommand(currentVersion: string): Command {
+  return new Command('update')
+    .description('Update godot-mcp-cli to the latest version')
+    .option('--check', 'Only check for updates without installing')
+    .action(async (options: UpdateOptions) => {
+      if (isRunningViaNpx()) {
+        ui.info('Running via npx — it always fetches the latest published version.');
+        ui.info('No update action needed.');
+        process.exit(0);
+      }
+
+      const spinner = ui.startSpinner('Checking for updates...');
+      let latest: string;
+      try {
+        latest = await fetchLatestVersion();
+      } catch (err) {
+        spinner.error('Failed to check for updates');
+        ui.error((err as Error).message || String(err));
+        process.exit(1);
+        return;
+      }
+
+      if (!isNewerVersion(currentVersion, latest)) {
+        spinner.success(`Already up to date (v${currentVersion})`);
+        process.exit(0);
+      }
+
+      spinner.success(formatUpdateAvailable(currentVersion, latest));
+      console.log();
+
+      // --check mode: exit 2 = outdated (distinct from exit 1 = error)
+      if (options.check) {
+        process.exit(2);
+      }
+
+      ui.info(`Installing ${PACKAGE_NAME}@${latest}...`);
+      console.log();
+
+      try {
+        const exitCode = await runNpmInstall(`${PACKAGE_NAME}@${latest}`);
+        if (exitCode !== 0) {
+          console.log();
+          ui.error('Update failed.');
+          if (platform() === 'win32') {
+            ui.info('Try running the terminal as Administrator.');
+          } else {
+            ui.info(`Try: sudo npm install -g ${PACKAGE_NAME}@latest`);
+          }
+          process.exit(1);
+        }
+      } catch (err) {
+        console.log();
+        ui.error(`Could not run npm: ${(err as Error).message}`);
+        ui.info('Make sure npm is installed and in your PATH.');
+        process.exit(1);
+      }
+
+      console.log();
+      ui.success(`Updated to v${latest}`);
+    });
+}

--- a/cli/src/commands/wait-for-ready.ts
+++ b/cli/src/commands/wait-for-ready.ts
@@ -1,0 +1,75 @@
+import { Command } from 'commander';
+import * as ui from '../utils/ui.js';
+import { verbose } from '../utils/ui.js';
+import { resolveAndValidateProjectPath, resolveConnection } from '../utils/connection.js';
+import { probe } from '../utils/probe.js';
+
+const MAX_PROBE_TIMEOUT_MS = 10_000;
+
+interface WaitForReadyOptions {
+  path?: string;
+  url?: string;
+  token?: string;
+  timeout?: string;
+  interval?: string;
+}
+
+export const waitForReadyCommand = new Command('wait-for-ready')
+  .description('Wait until the Godot editor and MCP server are ready to accept tool calls')
+  .argument('[path]', 'Godot project path (validated when --url is omitted)')
+  .option('--path <path>', 'Godot project path')
+  .option('--url <url>', 'MCP server base URL (defaults to GODOT_MCP_HOST/cloud)')
+  .option('--token <token>', 'Bearer token override (defaults to GODOT_MCP_TOKEN)')
+  .option('--timeout <ms>', 'Maximum time to wait in milliseconds (default: 120000)', '120000')
+  .option('--interval <ms>', 'Polling interval in milliseconds (default: 3000)', '3000')
+  .action(async (positionalPath: string | undefined, options: WaitForReadyOptions) => {
+    const projectPath = resolveAndValidateProjectPath(positionalPath, options);
+    const { url: serverUrl, token } = resolveConnection(projectPath, options);
+
+    const timeoutMs = parseInt(options.timeout ?? '120000', 10);
+    const intervalMs = parseInt(options.interval ?? '3000', 10);
+
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      ui.error(`Invalid --timeout value: "${options.timeout}". Must be a positive integer (milliseconds).`);
+      process.exit(1);
+    }
+    if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+      ui.error(`Invalid --interval value: "${options.interval}". Must be a positive integer (milliseconds).`);
+      process.exit(1);
+    }
+
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    verbose(`Probe target: ${serverUrl}`);
+    verbose(`Timeout: ${timeoutMs}ms, Interval: ${intervalMs}ms`);
+
+    const spinner = ui.startSpinner('Waiting for Godot editor and MCP server...');
+    const startTime = Date.now();
+
+    while (true) {
+      const elapsed = Date.now() - startTime;
+      if (elapsed >= timeoutMs) {
+        spinner.error(`Timed out after ${(timeoutMs / 1000).toFixed(1)}s waiting for MCP server`);
+        process.exit(1);
+      }
+
+      const remaining = Math.ceil((timeoutMs - elapsed) / 1000);
+      spinner.text = `Waiting for Godot editor and MCP server... (${remaining}s remaining)`;
+
+      const probeTimeout = Math.min(intervalMs, MAX_PROBE_TIMEOUT_MS);
+      const result = await probe(serverUrl, headers, probeTimeout);
+
+      if (result.ok) {
+        const totalSeconds = ((Date.now() - startTime) / 1000).toFixed(1);
+        spinner.success(`MCP server is ready at ${result.baseUrl} (connected in ${totalSeconds}s)`);
+        process.exit(0);
+      }
+
+      const remainingMs = timeoutMs - (Date.now() - startTime);
+      if (remainingMs <= 0) continue;
+      await new Promise((resolve) => setTimeout(resolve, Math.min(intervalMs, remainingMs)));
+    }
+  });

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,0 +1,78 @@
+import { Command } from 'commander';
+import { createRequire } from 'module';
+import { openCommand } from './commands/open.js';
+import { runToolCommand } from './commands/run-tool.js';
+import { runSystemToolCommand } from './commands/run-system-tool.js';
+import { statusCommand } from './commands/status.js';
+import { waitForReadyCommand } from './commands/wait-for-ready.js';
+import { setupMcpCommand } from './commands/setup-mcp.js';
+import { configureCommand } from './commands/configure.js';
+import { closeCommand } from './commands/close.js';
+import { createUpdateCommand } from './commands/update.js';
+import { installPluginCommand } from './commands/install-plugin.js';
+import { removePluginCommand } from './commands/remove-plugin.js';
+import { configureStyledHelp, error as uiError, setVerbose } from './utils/ui.js';
+import { checkForUpdate, isRunningViaNpx, printUpdateNotification } from './utils/update-check.js';
+
+const require = createRequire(import.meta.url);
+const pkg = require('../package.json') as { version: string };
+
+const program = new Command();
+
+program
+  .name('godot-mcp-cli')
+  .description('Cross-platform CLI tool for Godot-MCP operations')
+  .version(pkg.version)
+  .option('-v, --verbose', 'Enable verbose diagnostic output');
+
+// Register all subcommands
+const subcommands = [
+  closeCommand,
+  configureCommand,
+  installPluginCommand,
+  openCommand,
+  removePluginCommand,
+  runToolCommand,
+  runSystemToolCommand,
+  setupMcpCommand,
+  statusCommand,
+  createUpdateCommand(pkg.version),
+  waitForReadyCommand,
+];
+
+for (const cmd of subcommands) {
+  cmd.option('-v, --verbose', 'Enable verbose diagnostic output');
+  configureStyledHelp(cmd);
+  program.addCommand(cmd);
+}
+
+// Apply styled help to root (after subcommands so banner knows about them)
+configureStyledHelp(program, pkg.version);
+
+// Wire verbose flag before any command executes
+program.hook('preAction', (_thisCommand, actionCommand) => {
+  const opts = actionCommand.optsWithGlobals() as { verbose?: boolean };
+  if (opts.verbose) {
+    setVerbose(true);
+  }
+});
+
+// Show help when no command provided
+program.action(() => {
+  program.outputHelp();
+});
+
+// Start update check in background (non-blocking, parallel with command execution)
+const updateCheckPromise = isRunningViaNpx() ? Promise.resolve(null) : checkForUpdate(pkg.version);
+
+program.parseAsync()
+  .then(async () => {
+    const update = await updateCheckPromise;
+    if (update) {
+      printUpdateNotification(update.current, update.latest);
+    }
+  })
+  .catch((err) => {
+    uiError((err as Error).message || String(err));
+    process.exit(1);
+  });

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -1,0 +1,57 @@
+// Library entry point for `godot-mcp-cli`.
+//
+// Constraints:
+// - NO top-level side effects. Importing this file must not open sockets, spin
+//   up spinners, write to stdout/stderr, or parse argv.
+// - NO `commander` import reachable from this file.
+// - Every result is a discriminated union keyed on `kind`. Successes are
+//   `{ kind: 'success', success: true, ... }`; failures are
+//   `{ kind: 'failure', success: false, error }`. Errors are never thrown past
+//   the public boundary. Narrow on `kind` for type-safe access.
+// - Progress is surfaced via an optional `onProgress` callback, not globals.
+//
+// Consumers: `import { openProject } from 'godot-mcp-cli'` (maps to this file
+// via the `exports` field in package.json).
+
+export { openProject } from './lib/open.js';
+export { runTool, runSystemTool } from './lib/run-tool.js';
+export { setupMcp, listAgentIds } from './lib/setup-mcp.js';
+export { installPlugin, removePlugin } from './lib/install-plugin.js';
+
+export type {
+  // Shared
+  ProgressEvent,
+  ProgressCallback,
+  ResultKind,
+  // open-project
+  OpenProjectOptions,
+  OpenProjectResult,
+  OpenProjectSuccess,
+  OpenProjectFailure,
+  OpenProjectAuthOption,
+  OpenProjectConnectionMode,
+  // run-tool / run-system-tool
+  RunToolOptions,
+  RunToolResult,
+  RunToolSuccess,
+  RunToolFailure,
+  RunToolFailureReason,
+  RunSystemToolOptions,
+  RunSystemToolResult,
+  RunSystemToolSuccess,
+  RunSystemToolFailure,
+  // setup-mcp
+  SetupMcpOptions,
+  SetupMcpResult,
+  SetupMcpSuccess,
+  SetupMcpFailure,
+  // install-plugin / remove-plugin
+  InstallPluginOptions,
+  InstallPluginResult,
+  InstallPluginSuccess,
+  InstallPluginFailure,
+  RemovePluginOptions,
+  RemovePluginResult,
+  RemovePluginSuccess,
+  RemovePluginFailure,
+} from './lib/types.js';

--- a/cli/src/lib/install-plugin.ts
+++ b/cli/src/lib/install-plugin.ts
@@ -1,0 +1,143 @@
+import * as fs from 'fs';
+import {
+  GODOT_MCP_PLUGIN_PATH,
+  projectGodotPath as resolveProjectGodotPath,
+  togglePluginInText,
+} from '../utils/project-godot.js';
+import { emitProgress } from './progress.js';
+import { requireGodotProject } from './validation.js';
+import type {
+  InstallPluginOptions,
+  InstallPluginResult,
+  RemovePluginOptions,
+  RemovePluginResult,
+} from './types.js';
+
+/**
+ * Enable the `godot_mcp` addon in a project's `project.godot` `[editor_plugins]`
+ * `enabled` array. Library-safe: no stdout noise, no process.exit, no throws
+ * past the public boundary.
+ *
+ * v1 is intentionally minimal — it only flips the project.godot plugin-enable
+ * state. It does NOT copy addon files or patch the consumer `.csproj` with the
+ * NuGet PackageReferences the addon needs (that is the consumer's responsibility
+ * per the addon's install docs); a warning surfaces that requirement.
+ *
+ * Idempotent: enabling an already-enabled plugin returns `changed: false`.
+ */
+export async function installPlugin(opts: InstallPluginOptions): Promise<InstallPluginResult> {
+  const warnings: string[] = [];
+
+  try {
+    const validated = requireGodotProject(opts?.godotProjectPath);
+    if (!validated.ok) {
+      return {
+        kind: 'failure',
+        success: false,
+        projectGodotPath: validated.projectGodotPath,
+        warnings,
+        error: validated.error,
+      };
+    }
+    const { projectPath, projectGodotPath } = validated;
+
+    emitProgress(opts.onProgress, {
+      phase: 'start',
+      message: `Enabling godot_mcp addon for ${projectPath}`,
+    });
+
+    const text = fs.readFileSync(projectGodotPath, 'utf-8');
+    const result = togglePluginInText(text, true, GODOT_MCP_PLUGIN_PATH);
+
+    if (result.kind === 'changed') {
+      fs.writeFileSync(projectGodotPath, result.text);
+      emitProgress(opts.onProgress, {
+        phase: 'manifest-patched',
+        message: `Wrote ${projectGodotPath}`,
+        manifestPath: projectGodotPath,
+      });
+    }
+
+    warnings.push(
+      'Ensure the project .csproj declares the com.IvanMurzak.ReflectorNet and com.IvanMurzak.McpPlugin PackageReferences the addon needs (see the addon README).',
+    );
+
+    emitProgress(opts.onProgress, { phase: 'done', message: 'godot_mcp addon enabled.' });
+
+    return {
+      kind: 'success',
+      success: true,
+      changed: result.kind === 'changed',
+      projectGodotPath,
+      enabledPlugins: result.enabled,
+      warnings,
+    };
+  } catch (err: unknown) {
+    return {
+      kind: 'failure',
+      success: false,
+      warnings,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}
+
+/**
+ * Disable the `godot_mcp` addon in a project's `project.godot`
+ * `[editor_plugins]` `enabled` array. Idempotent: disabling an already-absent
+ * plugin returns `changed: false`. Does NOT delete addon files.
+ */
+export async function removePlugin(opts: RemovePluginOptions): Promise<RemovePluginResult> {
+  const warnings: string[] = [];
+
+  try {
+    const validated = requireGodotProject(opts?.godotProjectPath);
+    if (!validated.ok) {
+      return {
+        kind: 'failure',
+        success: false,
+        projectGodotPath: validated.projectGodotPath,
+        warnings,
+        error: validated.error,
+      };
+    }
+    const { projectPath, projectGodotPath } = validated;
+
+    emitProgress(opts.onProgress, {
+      phase: 'start',
+      message: `Disabling godot_mcp addon for ${projectPath}`,
+    });
+
+    const text = fs.readFileSync(projectGodotPath, 'utf-8');
+    const result = togglePluginInText(text, false, GODOT_MCP_PLUGIN_PATH);
+
+    if (result.kind === 'changed') {
+      fs.writeFileSync(projectGodotPath, result.text);
+      emitProgress(opts.onProgress, {
+        phase: 'manifest-patched',
+        message: `Wrote ${projectGodotPath}`,
+        manifestPath: projectGodotPath,
+      });
+    }
+
+    emitProgress(opts.onProgress, { phase: 'done', message: 'godot_mcp addon disabled.' });
+
+    return {
+      kind: 'success',
+      success: true,
+      changed: result.kind === 'changed',
+      projectGodotPath,
+      enabledPlugins: result.enabled,
+      warnings,
+    };
+  } catch (err: unknown) {
+    return {
+      kind: 'failure',
+      success: false,
+      warnings,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}
+
+export { resolveProjectGodotPath };

--- a/cli/src/lib/open.ts
+++ b/cli/src/lib/open.ts
@@ -1,0 +1,240 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { findGodotBinary, launchEditor } from '../utils/godot-editor.js';
+import { findGodotProcess } from '../utils/godot-process.js';
+import {
+  ENV_AUTH_OPTION,
+  ENV_CLOUD_URL,
+  ENV_CONNECTION_MODE,
+  ENV_HOST,
+  ENV_LOG_LEVEL,
+  ENV_TOKEN,
+} from '../utils/connection.js';
+import { emitProgress } from './progress.js';
+import type {
+  OpenEnvInputs,
+  OpenProjectAuthOption,
+  OpenProjectConnectionMode,
+  OpenProjectOptions,
+  OpenProjectResult,
+} from './types.js';
+
+/**
+ * Resolve the project path from an explicit option or fall back to the supplied
+ * cwd. Returns an absolute path plus a flag indicating whether the cwd fallback
+ * was used. Pure / no I/O.
+ */
+export function resolveProjectPath(
+  optionPath: string | undefined,
+  cwd: string,
+): { projectPath: string; usedCwdFallback: boolean } {
+  const explicit = optionPath;
+  const resolvedPath = explicit ?? cwd;
+  return {
+    projectPath: path.resolve(resolvedPath),
+    usedCwdFallback: explicit === undefined,
+  };
+}
+
+/**
+ * Returns true if `projectPath` looks like a Godot project — i.e. it contains a
+ * `project.godot` file. Pure / no I/O beyond `fs.existsSync`.
+ */
+export function isGodotProjectDir(projectPath: string): boolean {
+  return fs.existsSync(path.join(projectPath, 'project.godot'));
+}
+
+function isValidAuth(v: unknown): v is OpenProjectAuthOption {
+  return v === 'None' || v === 'Required';
+}
+
+function isValidMode(v: unknown): v is OpenProjectConnectionMode {
+  return v === 'Cloud' || v === 'Custom';
+}
+
+/**
+ * Build the `GODOT_MCP_*` env-var map propagated to the editor process when
+ * `noConnect !== true`. Pure (returns a fresh object); validates `auth` /
+ * `mode` enums and throws on bad input — the `openProject` boundary catches the
+ * throw and returns it as a `{ kind: 'failure' }` result.
+ *
+ * Exported for tests so the env-var assembly can be exercised without a real
+ * editor launch.
+ */
+export function buildOpenEnv(options: OpenEnvInputs): Record<string, string> | undefined {
+  if (options.noConnect === true) return undefined;
+
+  const env: Record<string, string> = {};
+
+  if (options.url !== undefined) env[ENV_HOST] = options.url;
+  if (options.cloudUrl !== undefined) env[ENV_CLOUD_URL] = options.cloudUrl;
+  if (options.token !== undefined) env[ENV_TOKEN] = options.token;
+  if (options.logLevel !== undefined) env[ENV_LOG_LEVEL] = options.logLevel;
+
+  if (options.auth !== undefined) {
+    if (!isValidAuth(options.auth)) {
+      throw new Error('auth must be "None" or "Required"');
+    }
+    env[ENV_AUTH_OPTION] = options.auth;
+  }
+
+  if (options.mode !== undefined) {
+    if (!isValidMode(options.mode)) {
+      throw new Error('mode must be "Cloud" or "Custom"');
+    }
+    env[ENV_CONNECTION_MODE] = options.mode;
+  }
+
+  return Object.keys(env).length > 0 ? env : undefined;
+}
+
+/**
+ * Open a Godot project in the Godot editor — the library-callable equivalent of
+ * the `open` CLI command. Library-safe: never calls `process.exit`, never
+ * prints to stdout/stderr, never throws past the public boundary.
+ *
+ * Launches `<godot> --editor --path <project>` with the `GODOT_MCP_*` connection
+ * env vars wired on.
+ */
+export async function openProject(options: OpenProjectOptions): Promise<OpenProjectResult> {
+  const warnings: string[] = [];
+  let resolvedProjectPath: string | undefined;
+  let resolvedEditorPath: string | undefined;
+
+  try {
+    const { projectPath } = resolveProjectPath(options.projectPath, process.cwd());
+    resolvedProjectPath = projectPath;
+
+    if (!fs.existsSync(projectPath)) {
+      throw new Error(`Project path does not exist: ${projectPath}`);
+    }
+
+    if (!isGodotProjectDir(projectPath)) {
+      throw new Error(`Not a Godot project (missing project.godot): ${projectPath}`);
+    }
+
+    emitProgress(options.onProgress, {
+      phase: 'start',
+      message: `Opening Godot project at ${projectPath}`,
+    });
+
+    // Validate auth/mode BEFORE editor resolution so a typo fails fast.
+    const env = buildOpenEnv(options);
+
+    // Already-running short-circuit.
+    const existingProcess = findGodotProcess(projectPath);
+    if (existingProcess) {
+      warnings.push(
+        `Godot is already running with this project (PID: ${existingProcess.pid}). Skipping launch.`,
+      );
+      emitProgress(options.onProgress, {
+        phase: 'done',
+        message: 'Godot is already running for this project — launch skipped.',
+      });
+      return {
+        kind: 'success',
+        success: true,
+        editorPath: existingProcess.commandLine.split(/\s+/)[0] ?? '',
+        editorPid: existingProcess.pid,
+        projectPath,
+        warnings,
+        alreadyRunning: true,
+      };
+    }
+
+    // Locate the Godot binary.
+    const editorPath = findGodotBinary(options.editorPath);
+    if (!editorPath) {
+      throw new Error(
+        'No Godot editor binary found. Set GODOT_BIN (or GODOT4_BIN), add godot to PATH, or pass --editor-path.',
+      );
+    }
+    resolvedEditorPath = editorPath;
+
+    emitProgress(options.onProgress, {
+      phase: 'editor-resolved',
+      message: `Resolved Godot editor at ${editorPath}`,
+      editorPath,
+    });
+
+    emitProgress(options.onProgress, {
+      phase: 'connection-details',
+      message: env
+        ? 'MCP connection environment variables prepared'
+        : 'No MCP connection environment variables (--no-connect or no options provided)',
+      projectPath,
+      editorPath,
+      envVars: env ?? {},
+    });
+
+    emitProgress(options.onProgress, {
+      phase: 'launching-editor',
+      message: 'Launching Godot editor',
+      editorPath,
+      projectPath,
+    });
+
+    const child = launchEditor(editorPath, projectPath, env, {
+      onSpawn: (pid) => {
+        emitProgress(options.onProgress, {
+          phase: 'editor-launched',
+          message: `Launched Godot editor (PID: ${pid ?? 'unknown'})`,
+          pid,
+        });
+      },
+      onError: (err) => {
+        warnings.push(`Editor spawn reported error: ${err.message}`);
+      },
+    });
+
+    const pid = await waitForSpawn(child);
+
+    emitProgress(options.onProgress, { phase: 'done', message: 'Editor launched.' });
+
+    return {
+      kind: 'success',
+      success: true,
+      editorPath,
+      editorPid: pid,
+      projectPath,
+      warnings,
+    };
+  } catch (err: unknown) {
+    const errorObj = err instanceof Error ? err : new Error(String(err));
+    return {
+      kind: 'failure',
+      success: false,
+      projectPath: resolvedProjectPath,
+      editorPath: resolvedEditorPath,
+      warnings,
+      errorMessage: errorObj.message,
+      error: errorObj,
+    };
+  }
+}
+
+/**
+ * Resolve to the spawned PID once the child process emits its `spawn` event, or
+ * to `undefined` if a short timeout elapses or the process emits `error` first.
+ * Library-safe: never throws, never blocks process exit (the caller detached).
+ */
+function waitForSpawn(
+  child: import('child_process').ChildProcess,
+  timeoutMs = 2000,
+): Promise<number | undefined> {
+  return new Promise((resolve) => {
+    if (child.pid !== undefined && child.pid !== null) {
+      resolve(child.pid);
+      return;
+    }
+    let settled = false;
+    const finish = (pid: number | undefined): void => {
+      if (settled) return;
+      settled = true;
+      resolve(pid);
+    };
+    child.once('spawn', () => finish(child.pid ?? undefined));
+    child.once('error', () => finish(undefined));
+    setTimeout(() => finish(child.pid ?? undefined), timeoutMs).unref();
+  });
+}

--- a/cli/src/lib/progress.ts
+++ b/cli/src/lib/progress.ts
@@ -1,0 +1,15 @@
+import type { ProgressCallback, ProgressEvent } from './types.js';
+
+/**
+ * Forward a single progress event to the caller's optional callback,
+ * swallowing any exception the callback throws. A broken onProgress handler
+ * must never abort the underlying library operation.
+ */
+export function emitProgress(onProgress: ProgressCallback | undefined, event: ProgressEvent): void {
+  if (!onProgress) return;
+  try {
+    onProgress(event);
+  } catch {
+    // Intentionally ignored — see doc comment.
+  }
+}

--- a/cli/src/lib/run-tool.ts
+++ b/cli/src/lib/run-tool.ts
@@ -1,0 +1,217 @@
+// Library-safe `runTool` / `runSystemTool` implementations.
+//
+// Constraints (same contract as the rest of `lib/*.ts`):
+// - No commander, no spinners, no process.exit, no console output.
+// - Errors are returned in `{ kind: 'failure', success: false, ... }`,
+//   never thrown past the public boundary.
+
+import type {
+  RunToolFailure,
+  RunToolFailureReason,
+  RunToolOptions,
+  RunToolResult,
+  RunToolSuccess,
+} from './types.js';
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+interface ErrorCause {
+  code?: string;
+  message?: string;
+}
+
+/**
+ * Invoke a regular MCP tool over the Godot plugin's HTTP API.
+ * POSTs to `<url>/api/tools/{name}`. No console output, no `process.exit`;
+ * errors are returned in the `kind: 'failure'` variant.
+ */
+export async function runTool(opts: RunToolOptions): Promise<RunToolResult> {
+  return invokeTool('/api/tools', opts);
+}
+
+/**
+ * Invoke a system tool (not exposed to MCP clients) over the Godot plugin's
+ * HTTP API. POSTs to `<url>/api/system-tools/{name}`.
+ */
+export async function runSystemTool(opts: RunToolOptions): Promise<RunToolResult> {
+  return invokeTool('/api/system-tools', opts);
+}
+
+async function invokeTool(routePrefix: string, opts: RunToolOptions): Promise<RunToolResult> {
+  const validationFailure = validateOptions(opts);
+  if (validationFailure) return validationFailure;
+
+  const url = opts.url!.replace(/\/$/, '');
+  const token = opts.token;
+
+  const body = serializeInput(opts.input);
+  if ('error' in body) {
+    return makeFailure({
+      endpoint: '',
+      reason: 'invalid-input',
+      message: body.error.message,
+      error: body.error,
+    });
+  }
+
+  const endpoint = `${url}${routePrefix}/${encodeURIComponent(opts.toolName)}`;
+
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  const timeoutMs =
+    typeof opts.timeoutMs === 'number' && opts.timeoutMs > 0 ? opts.timeoutMs : DEFAULT_TIMEOUT_MS;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const externalAbort = (): void => controller.abort();
+  if (opts.signal) {
+    if (opts.signal.aborted) controller.abort();
+    else opts.signal.addEventListener('abort', externalAbort, { once: true });
+  }
+
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+
+  try {
+    const response = await fetchImpl(endpoint, {
+      method: 'POST',
+      headers,
+      body: body.json,
+      signal: controller.signal,
+    });
+
+    const text = await safeReadText(response);
+    const data = parseJsonOrText(text);
+
+    if (!response.ok) {
+      return makeFailure({
+        endpoint,
+        reason: 'http-error',
+        httpStatus: response.status,
+        data,
+        message: response.statusText || `HTTP ${response.status}`,
+      });
+    }
+
+    const success: RunToolSuccess = {
+      kind: 'success',
+      success: true,
+      endpoint,
+      httpStatus: response.status,
+      data,
+    };
+    return success;
+  } catch (err) {
+    return classifyFetchError(err, endpoint, timeoutMs);
+  } finally {
+    clearTimeout(timer);
+    opts.signal?.removeEventListener('abort', externalAbort);
+  }
+}
+
+function validateOptions(opts: RunToolOptions): RunToolFailure | null {
+  if (!opts || typeof opts !== 'object') {
+    return makeFailure({
+      endpoint: '',
+      reason: 'invalid-input',
+      message: 'options object is required.',
+    });
+  }
+  if (typeof opts.toolName !== 'string' || opts.toolName.trim().length === 0) {
+    return makeFailure({
+      endpoint: '',
+      reason: 'invalid-input',
+      message: 'toolName is required and must be a non-empty string.',
+    });
+  }
+  const hasUrl = typeof opts.url === 'string' && opts.url.length > 0;
+  if (!hasUrl) {
+    return makeFailure({
+      endpoint: '',
+      reason: 'invalid-input',
+      message: 'url is required (the Godot-MCP server base URL).',
+    });
+  }
+  return null;
+}
+
+function serializeInput(input: unknown): { json: string } | { error: Error } {
+  if (input === undefined || input === null) return { json: '{}' };
+  if (typeof input === 'string') {
+    try {
+      JSON.parse(input);
+      return { json: input };
+    } catch (err) {
+      return {
+        error: new Error(
+          `input string is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+        ),
+      };
+    }
+  }
+  if (typeof input !== 'object') {
+    return {
+      error: new Error('input must be a plain object, JSON string, undefined, or null.'),
+    };
+  }
+  try {
+    return { json: JSON.stringify(input) };
+  } catch (err) {
+    return {
+      error: new Error(
+        `input could not be serialized to JSON: ${err instanceof Error ? err.message : String(err)}`,
+      ),
+    };
+  }
+}
+
+async function safeReadText(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return '';
+  }
+}
+
+function parseJsonOrText(text: string): unknown {
+  if (text.length === 0) return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function getCause(err: unknown): ErrorCause | undefined {
+  if (!(err instanceof Error) || !('cause' in err)) return undefined;
+  return err.cause as ErrorCause | undefined;
+}
+
+function classifyFetchError(err: unknown, endpoint: string, timeoutMs: number): RunToolFailure {
+  if (err instanceof Error && err.name === 'AbortError') {
+    return makeFailure({
+      endpoint,
+      reason: 'timeout',
+      message: `Tool call timed out after ${timeoutMs}ms.`,
+      error: err,
+    });
+  }
+
+  const error = err instanceof Error ? err : new Error(String(err));
+  const causeCode = getCause(err)?.code;
+
+  let reason: RunToolFailureReason = 'unknown';
+  if (causeCode === 'ECONNREFUSED') reason = 'connection-refused';
+  else if (causeCode === 'ECONNRESET') reason = 'connection-reset';
+  else if (causeCode === 'ENOTFOUND' || causeCode === 'EAI_AGAIN') reason = 'network-error';
+
+  return makeFailure({
+    endpoint,
+    reason,
+    message: error.message,
+    error,
+  });
+}
+
+function makeFailure(fields: Omit<RunToolFailure, 'kind' | 'success'>): RunToolFailure {
+  return { kind: 'failure', success: false, ...fields };
+}

--- a/cli/src/lib/setup-mcp.ts
+++ b/cli/src/lib/setup-mcp.ts
@@ -1,0 +1,141 @@
+import * as path from 'path';
+import {
+  CLOUD_MCP_URL,
+  DEFAULT_CUSTOM_HOST,
+  ENV_HOST,
+  ENV_TOKEN,
+  MCP_HUB_PATH,
+} from '../utils/connection.js';
+import {
+  getAgentById,
+  getAgentIds,
+  writeJsonAgentConfig,
+  MCP_SERVER_NAME,
+} from '../utils/agents.js';
+import { emitProgress } from './progress.js';
+import { requireExistingPath } from './validation.js';
+import type { SetupMcpOptions, SetupMcpResult } from './types.js';
+
+/**
+ * Normalize an env-supplied value (trim + strip a single wrapping double-quote
+ * pair), mirroring the addon's `GodotMcpConfig.NormalizeEnv`.
+ */
+function normalizeEnv(raw: string | undefined): string | undefined {
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  return trimmed.replace(/^"(.*)"$/, '$1');
+}
+
+/**
+ * Resolve the MCP-client URL an external AI agent should connect to. This is
+ * the `<host>/mcp` streamable-HTTP endpoint (NOT the plugin's
+ * `<host>/hub/mcp-server` SignalR endpoint), matching the addon's
+ * `GodotMcpConfig.ResolveMcpClientUrl`:
+ *   1. explicit `--url` override (host) → `<host>/mcp`
+ *   2. GODOT_MCP_HOST env (Custom host) → `<host>/mcp`
+ *   3. default cloud MCP URL (https://ai-game.dev/mcp)
+ */
+function resolveMcpClientUrl(optUrl: string | undefined): string {
+  const host = optUrl ?? normalizeEnv(process.env[ENV_HOST]);
+  if (!host) return CLOUD_MCP_URL;
+
+  const trimmed = host.replace(/\/$/, '');
+  if (trimmed.toLowerCase().endsWith(MCP_HUB_PATH)) return trimmed;
+  return trimmed + MCP_HUB_PATH;
+}
+
+/**
+ * Write MCP configuration for the given AI agent so it can talk to a Godot-MCP
+ * server. Library-safe: no stdout noise, no process.exit, no throws past the
+ * public boundary.
+ *
+ * Writes an HTTP server entry pointing at the resolved MCP-client URL. The
+ * Godot config body shape mirrors the addon's `AgentConfigJson` / `AgentConfigPaths`
+ * conventions (`.mcp.json` under `mcpServers` for Claude Code, `.vscode/mcp.json`
+ * under `servers` for VS Code, etc.).
+ */
+export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
+  const warnings: string[] = [];
+
+  try {
+    if (!opts || typeof opts.agentId !== 'string' || opts.agentId.length === 0) {
+      return {
+        kind: 'failure',
+        success: false,
+        warnings,
+        error: new Error(`agentId is required. Available agent IDs: ${getAgentIds().join(', ')}`),
+      };
+    }
+
+    const agent = getAgentById(opts.agentId);
+    if (!agent) {
+      return {
+        kind: 'failure',
+        success: false,
+        warnings,
+        error: new Error(
+          `Unknown agent: "${opts.agentId}". Available agent IDs: ${getAgentIds().join(', ')}`,
+        ),
+      };
+    }
+
+    // Resolve project path. If supplied it must exist; otherwise fall back to cwd.
+    let projectPath: string;
+    if (opts.godotProjectPath) {
+      const validated = requireExistingPath(opts.godotProjectPath);
+      if (!validated.ok) {
+        return { kind: 'failure', success: false, warnings, error: validated.error };
+      }
+      projectPath = validated.projectPath;
+    } else {
+      projectPath = path.resolve(process.cwd());
+    }
+
+    emitProgress(opts.onProgress, {
+      phase: 'start',
+      message: `Configuring ${agent.name} for ${projectPath}`,
+    });
+
+    const serverUrl = resolveMcpClientUrl(opts.url);
+    const token = opts.token ?? normalizeEnv(process.env[ENV_TOKEN]) ?? '';
+    const authRequired = token.length > 0;
+
+    const configPath = agent.getConfigPath(projectPath);
+    const props = agent.getHttpProps(serverUrl, token, authRequired);
+
+    writeJsonAgentConfig(configPath, agent.bodyPath, MCP_SERVER_NAME, props, agent.httpRemoveKeys);
+
+    emitProgress(opts.onProgress, {
+      phase: 'manifest-patched',
+      message: `Wrote ${configPath}`,
+      manifestPath: configPath,
+    });
+
+    emitProgress(opts.onProgress, { phase: 'done', message: `${agent.name} configured successfully.` });
+
+    return {
+      kind: 'success',
+      success: true,
+      agentId: agent.id,
+      configPath,
+      serverUrl,
+      warnings,
+    };
+  } catch (err: unknown) {
+    return {
+      kind: 'failure',
+      success: false,
+      warnings,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}
+
+/** List every agent id known to `setupMcp`. */
+export function listAgentIds(): string[] {
+  return getAgentIds();
+}
+
+// Re-export the constants so the CLI command can surface the default URL in help.
+export { CLOUD_MCP_URL, DEFAULT_CUSTOM_HOST };

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -1,0 +1,260 @@
+// Shared public types for the godot-mcp-cli library API.
+//
+// This file is re-exported from `lib.ts` — consumers should import
+// from `godot-mcp-cli` (the package root), NOT from deep paths.
+//
+// No top-level side effects, no runtime deps beyond TypeScript types.
+
+// ---------------------------------------------------------------------------
+// Progress events
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminated union describing every progress event the library can emit to
+ * the optional `onProgress` callback. Consumers narrow on `event.phase`.
+ */
+export type ProgressEvent =
+  | { phase: 'start'; message: string }
+  | { phase: 'manifest-patched'; message: string; manifestPath: string }
+  // openProject phases
+  | { phase: 'editor-resolved'; message: string; editorPath: string }
+  | {
+      phase: 'connection-details';
+      message: string;
+      projectPath: string;
+      editorPath: string;
+      envVars: Record<string, string>;
+    }
+  | { phase: 'launching-editor'; message: string; editorPath: string; projectPath: string }
+  | { phase: 'editor-launched'; message: string; pid?: number }
+  | { phase: 'done'; message: string };
+
+export type ProgressCallback = (event: ProgressEvent) => void;
+
+// ---------------------------------------------------------------------------
+// Result discriminator
+// ---------------------------------------------------------------------------
+
+export type ResultKind = 'success' | 'failure';
+
+// ---------------------------------------------------------------------------
+// setup-mcp
+// ---------------------------------------------------------------------------
+
+export interface SetupMcpOptions {
+  /** Agent to configure. Use `listAgentIds()` to discover valid values. */
+  agentId: string;
+  /** Optional Godot project path. Defaults to `process.cwd()` if omitted. */
+  godotProjectPath?: string;
+  /** Explicit MCP server URL override (the `<host>/mcp` client endpoint). */
+  url?: string;
+  /** Auth token override. */
+  token?: string;
+  onProgress?: ProgressCallback;
+}
+
+export interface SetupMcpSuccess {
+  kind: 'success';
+  success: true;
+  agentId: string;
+  configPath: string;
+  serverUrl: string;
+  warnings: string[];
+}
+
+export interface SetupMcpFailure {
+  kind: 'failure';
+  success: false;
+  warnings: string[];
+  error: Error;
+}
+
+export type SetupMcpResult = SetupMcpSuccess | SetupMcpFailure;
+
+// ---------------------------------------------------------------------------
+// open-project
+// ---------------------------------------------------------------------------
+
+/** Auth option propagated to the editor as `GODOT_MCP_AUTH_OPTION`. */
+export type OpenProjectAuthOption = 'None' | 'Required';
+
+/** Connection mode propagated to the editor as `GODOT_MCP_CONNECTION_MODE`. */
+export type OpenProjectConnectionMode = 'Cloud' | 'Custom';
+
+export interface OpenProjectOptions {
+  /** Path to the Godot project to open. Defaults to `process.cwd()`. */
+  projectPath?: string;
+  /** Explicit Godot editor executable path (skips resolution). */
+  editorPath?: string;
+  /** If `true`, skip wiring the GODOT_MCP_* env vars onto the editor process. */
+  noConnect?: boolean;
+  /** MCP server host — sets `GODOT_MCP_HOST`. */
+  url?: string;
+  /** Cloud base URL override — sets `GODOT_MCP_CLOUD_URL`. */
+  cloudUrl?: string;
+  /** Auth token — sets `GODOT_MCP_TOKEN`. */
+  token?: string;
+  /** Auth option — sets `GODOT_MCP_AUTH_OPTION`. */
+  auth?: OpenProjectAuthOption;
+  /** Connection mode — sets `GODOT_MCP_CONNECTION_MODE`. */
+  mode?: OpenProjectConnectionMode;
+  /** Log level — sets `GODOT_MCP_LOG_LEVEL`. */
+  logLevel?: string;
+  onProgress?: ProgressCallback;
+}
+
+export interface OpenProjectSuccess {
+  kind: 'success';
+  success: true;
+  editorPath: string;
+  editorPid?: number;
+  projectPath: string;
+  warnings: string[];
+  /** True when an editor was already running for this project; launch skipped. */
+  alreadyRunning?: boolean;
+}
+
+export interface OpenProjectFailure {
+  kind: 'failure';
+  success: false;
+  projectPath?: string;
+  editorPath?: string;
+  warnings: string[];
+  errorMessage: string;
+  error: Error;
+}
+
+export type OpenProjectResult = OpenProjectSuccess | OpenProjectFailure;
+
+/**
+ * Subset of `OpenProjectOptions` consumed by `buildOpenEnv` — every field here
+ * maps to a `GODOT_MCP_*` environment variable.
+ */
+export interface OpenEnvInputs {
+  noConnect?: OpenProjectOptions['noConnect'];
+  url?: OpenProjectOptions['url'];
+  cloudUrl?: OpenProjectOptions['cloudUrl'];
+  token?: OpenProjectOptions['token'];
+  auth?: OpenProjectOptions['auth'];
+  mode?: OpenProjectOptions['mode'];
+  logLevel?: OpenProjectOptions['logLevel'];
+}
+
+// ---------------------------------------------------------------------------
+// run-tool / run-system-tool
+// ---------------------------------------------------------------------------
+
+export type RunToolFailureReason =
+  | 'invalid-input'
+  | 'connection-refused'
+  | 'connection-reset'
+  | 'network-error'
+  | 'timeout'
+  | 'http-error'
+  | 'unknown';
+
+/**
+ * Options accepted by both {@link runTool} and {@link runSystemTool}.
+ *
+ * `url` (the MCP server base URL) MUST be provided — unlike the Unity CLI there
+ * is no deterministic project-path→port fallback, because the Godot plugin is a
+ * server-less client whose persisted config lives in `user://` (outside the
+ * project tree).
+ */
+export interface RunToolOptions {
+  /** Tool name to invoke. URL-encoded into the `{name}` route segment. */
+  toolName: string;
+  /** MCP server base URL (no trailing slash required). REQUIRED. */
+  url?: string;
+  /** Bearer token override. */
+  token?: string;
+  /** Tool arguments serialized as the JSON request body. Defaults to `{}`. */
+  input?: unknown;
+  /** Per-request timeout in milliseconds. Defaults to `60000`. */
+  timeoutMs?: number;
+  /** Optional abort signal. */
+  signal?: AbortSignal;
+  /** Optional fetch injection point for tests. */
+  fetchImpl?: typeof fetch;
+}
+
+export interface RunToolSuccess {
+  kind: 'success';
+  success: true;
+  endpoint: string;
+  httpStatus: number;
+  data: unknown;
+}
+
+export interface RunToolFailure {
+  kind: 'failure';
+  success: false;
+  endpoint: string;
+  reason: RunToolFailureReason;
+  httpStatus?: number;
+  data?: unknown;
+  message: string;
+  error?: Error;
+}
+
+export type RunToolResult = RunToolSuccess | RunToolFailure;
+
+export type RunSystemToolOptions = RunToolOptions;
+export type RunSystemToolResult = RunToolResult;
+export type RunSystemToolSuccess = RunToolSuccess;
+export type RunSystemToolFailure = RunToolFailure;
+
+// ---------------------------------------------------------------------------
+// install-plugin / remove-plugin
+// ---------------------------------------------------------------------------
+
+export interface InstallPluginOptions {
+  /** Absolute or relative path to the Godot project root. */
+  godotProjectPath: string;
+  onProgress?: ProgressCallback;
+}
+
+export interface InstallPluginSuccess {
+  kind: 'success';
+  success: true;
+  /** True when the plugin was newly enabled; false when it was already enabled. */
+  changed: boolean;
+  projectGodotPath: string;
+  enabledPlugins: string[];
+  warnings: string[];
+}
+
+export interface InstallPluginFailure {
+  kind: 'failure';
+  success: false;
+  projectGodotPath?: string;
+  warnings: string[];
+  error: Error;
+}
+
+export type InstallPluginResult = InstallPluginSuccess | InstallPluginFailure;
+
+export interface RemovePluginOptions {
+  godotProjectPath: string;
+  onProgress?: ProgressCallback;
+}
+
+export interface RemovePluginSuccess {
+  kind: 'success';
+  success: true;
+  /** True when the plugin was disabled; false when it was already absent. */
+  changed: boolean;
+  projectGodotPath: string;
+  enabledPlugins: string[];
+  warnings: string[];
+}
+
+export interface RemovePluginFailure {
+  kind: 'failure';
+  success: false;
+  projectGodotPath?: string;
+  warnings: string[];
+  error: Error;
+}
+
+export type RemovePluginResult = RemovePluginSuccess | RemovePluginFailure;

--- a/cli/src/lib/validation.ts
+++ b/cli/src/lib/validation.ts
@@ -1,0 +1,58 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Small, side-effect-free input-validation helpers shared by the
+ * library-facing API functions. Each helper returns a discriminated union so
+ * call sites can pattern-match without throwing across the public boundary.
+ */
+
+export type ValidatedPath =
+  | { ok: true; projectPath: string }
+  | { ok: false; error: Error };
+
+export type ValidatedGodotProject =
+  | { ok: true; projectPath: string; projectGodotPath: string }
+  | { ok: false; projectGodotPath?: string; error: Error };
+
+/** Require a non-empty string and resolve it to an absolute path. */
+export function requireProjectPath(raw: unknown): ValidatedPath {
+  if (typeof raw !== 'string' || raw.length === 0) {
+    return {
+      ok: false,
+      error: new Error('godotProjectPath is required and must be a non-empty string.'),
+    };
+  }
+  return { ok: true, projectPath: path.resolve(raw) };
+}
+
+/**
+ * Require a non-empty path AND that the path hosts a Godot project (identified
+ * by the presence of `project.godot`).
+ */
+export function requireGodotProject(raw: unknown): ValidatedGodotProject {
+  const outer = requireProjectPath(raw);
+  if (!outer.ok) return outer;
+  const projectGodotPath = path.join(outer.projectPath, 'project.godot');
+  if (!fs.existsSync(projectGodotPath)) {
+    return {
+      ok: false,
+      projectGodotPath,
+      error: new Error(`Not a valid Godot project (missing project.godot): ${outer.projectPath}`),
+    };
+  }
+  return { ok: true, projectPath: outer.projectPath, projectGodotPath };
+}
+
+/** Require that the given path exists on disk (need not host a project.godot). */
+export function requireExistingPath(raw: unknown): ValidatedPath {
+  const outer = requireProjectPath(raw);
+  if (!outer.ok) return outer;
+  if (!fs.existsSync(outer.projectPath)) {
+    return {
+      ok: false,
+      error: new Error(`Project path does not exist: ${outer.projectPath}`),
+    };
+  }
+  return outer;
+}

--- a/cli/src/utils/agents.ts
+++ b/cli/src/utils/agents.ts
@@ -1,0 +1,264 @@
+import chalk from 'chalk';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// ---------------------------------------------------------------------------
+// Agent Definition
+// ---------------------------------------------------------------------------
+
+/**
+ * An AI-agent MCP-client configurator. Mirrors the Godot addon's
+ * `GodotAgentConfigurator` registry (`addons/godot_mcp/UI/Agents/`), adapted
+ * to the CLI's file-writing surface. Each agent knows where its MCP-client
+ * config lives and what HTTP-transport server entry to write.
+ *
+ * Godot is a server-less client: the plugin connects out to a server, and an
+ * external AI client connects to the same server's `<host>/mcp` streamable-HTTP
+ * endpoint. So every configurator here writes an HTTP server entry pointing at
+ * the resolved MCP-client URL (NOT the plugin's `<host>/hub/mcp-server` SignalR
+ * endpoint).
+ */
+export interface AgentDefinition {
+  id: string;
+  name: string;
+  configPathDisplay: string;
+  bodyPath: string;
+  /** Resolve the absolute config-file path for a given project root. */
+  getConfigPath(projectPath: string): string;
+  /** Build the HTTP server entry written under `bodyPath[MCP_SERVER_NAME]`. */
+  getHttpProps(url: string, token: string, authRequired: boolean): Record<string, unknown>;
+  /** Keys to delete from a pre-existing entry before merging new props. */
+  httpRemoveKeys: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Platform helpers
+// ---------------------------------------------------------------------------
+
+function appData(): string {
+  return process.env['APPDATA'] ?? path.join(os.homedir(), 'AppData', 'Roaming');
+}
+
+function home(): string {
+  return os.homedir();
+}
+
+function isWindows(): boolean {
+  return process.platform === 'win32';
+}
+
+function isMac(): boolean {
+  return process.platform === 'darwin';
+}
+
+function authHeaders(token: string, authRequired: boolean): Record<string, string> | undefined {
+  if (authRequired && token) {
+    return { Authorization: `Bearer ${token}` };
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Agent Registry
+// ---------------------------------------------------------------------------
+
+const MCP_SERVER_NAME = 'ai-game-developer';
+
+export const agentRegistry: readonly AgentDefinition[] = [
+  // ── Claude Code ──────────────────────────────────────────────
+  {
+    id: 'claude-code',
+    name: 'Claude Code',
+    configPathDisplay: '.mcp.json',
+    bodyPath: 'mcpServers',
+    getConfigPath: (p) => path.join(p, '.mcp.json'),
+    getHttpProps: (url, token, authRequired) => ({
+      type: 'http',
+      url,
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    httpRemoveKeys: ['command', 'args'],
+  },
+
+  // ── Claude Desktop ───────────────────────────────────────────
+  {
+    id: 'claude-desktop',
+    name: 'Claude Desktop',
+    configPathDisplay: '~/Claude/claude_desktop_config.json',
+    bodyPath: 'mcpServers',
+    getConfigPath: () => {
+      if (isWindows()) {
+        return path.join(appData(), 'Claude', 'claude_desktop_config.json');
+      }
+      if (isMac()) {
+        return path.join(home(), 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json');
+      }
+      return path.join(home(), '.config', 'Claude', 'claude_desktop_config.json');
+    },
+    getHttpProps: (url, token, authRequired) => ({
+      type: 'http',
+      url,
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    httpRemoveKeys: ['command', 'args'],
+  },
+
+  // ── Cursor ───────────────────────────────────────────────────
+  {
+    id: 'cursor',
+    name: 'Cursor',
+    configPathDisplay: '.cursor/mcp.json',
+    bodyPath: 'mcpServers',
+    getConfigPath: (p) => path.join(p, '.cursor', 'mcp.json'),
+    getHttpProps: (url, token, authRequired) => ({
+      type: 'http',
+      url,
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    httpRemoveKeys: ['command', 'args'],
+  },
+
+  // ── VS Code (Copilot) ────────────────────────────────────────
+  {
+    id: 'vscode',
+    name: 'Visual Studio Code (Copilot)',
+    configPathDisplay: '.vscode/mcp.json',
+    bodyPath: 'servers',
+    getConfigPath: (p) => path.join(p, '.vscode', 'mcp.json'),
+    getHttpProps: (url, token, authRequired) => ({
+      type: 'http',
+      url,
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    httpRemoveKeys: ['command', 'args'],
+  },
+
+  // ── Custom (generic mcpServers entry written to a caller path) ─
+  {
+    id: 'custom',
+    name: 'Custom (generic MCP client)',
+    configPathDisplay: 'mcp.json',
+    bodyPath: 'mcpServers',
+    getConfigPath: (p) => path.join(p, 'mcp.json'),
+    getHttpProps: (url, token, authRequired) => ({
+      type: 'http',
+      url,
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    httpRemoveKeys: ['command', 'args'],
+  },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Lookup helpers
+// ---------------------------------------------------------------------------
+
+export function getAgentById(id: string): AgentDefinition | undefined {
+  return agentRegistry.find((a) => a.id === id);
+}
+
+export function getAgentIds(): string[] {
+  return agentRegistry.map((a) => a.id);
+}
+
+export function listAgentTable(
+  heading: string,
+  locationLabel: string,
+  locationFn: (agent: AgentDefinition) => string,
+): void {
+  const sorted = [...agentRegistry].sort((a, b) => a.id.localeCompare(b.id));
+
+  const colId = 'ID';
+  const colLoc = locationLabel;
+
+  const wId = Math.max(colId.length, ...sorted.map((a) => a.id.length));
+  const wLoc = Math.max(colLoc.length, ...sorted.map((a) => locationFn(a).length));
+
+  const sep = chalk.dim;
+  const hBar = (w: number) => '─'.repeat(w);
+
+  console.log(`\n${chalk.bold.cyan(heading)}\n`);
+
+  // Header
+  console.log(sep('  ┌─') + sep(hBar(wId)) + sep('─┬─') + sep(hBar(wLoc)) + sep('─┐'));
+  console.log(
+    sep('  │ ') + chalk.bold.white(colId.padEnd(wId)) + sep(' │ ') + chalk.bold.white(colLoc.padEnd(wLoc)) + sep(' │'),
+  );
+  console.log(sep('  ├─') + sep(hBar(wId)) + sep('─┼─') + sep(hBar(wLoc)) + sep('─┤'));
+
+  // Rows
+  for (const agent of sorted) {
+    const loc = locationFn(agent);
+    console.log(
+      sep('  │ ') + chalk.yellow(agent.id.padEnd(wId)) + sep(' │ ') + chalk.green(loc.padEnd(wLoc)) + sep(' │'),
+    );
+  }
+
+  // Footer
+  console.log(sep('  └─') + sep(hBar(wId)) + sep('─┴─') + sep(hBar(wLoc)) + sep('─┘'));
+  console.log('');
+}
+
+// ---------------------------------------------------------------------------
+// Config file writing — JSON
+// ---------------------------------------------------------------------------
+
+export function writeJsonAgentConfig(
+  configPath: string,
+  bodyPath: string,
+  serverName: string,
+  props: Record<string, unknown>,
+  removeKeys: string[],
+): void {
+  const dir = path.dirname(configPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  let root: Record<string, unknown> = {};
+  if (fs.existsSync(configPath)) {
+    try {
+      root = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+    } catch {
+      // If the file is malformed, start fresh
+      root = {};
+    }
+    if (!root || typeof root !== 'object' || Array.isArray(root)) {
+      root = {};
+    }
+  }
+
+  // Navigate/create bodyPath
+  let body = root[bodyPath] as Record<string, unknown> | undefined;
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    body = {};
+    root[bodyPath] = body;
+  }
+
+  // Remove deprecated "Godot-MCP" entries
+  delete body['Godot-MCP'];
+
+  // Get or create the server entry
+  let entry = body[serverName] as Record<string, unknown> | undefined;
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+    entry = {};
+  }
+
+  // Remove stale keys
+  for (const key of removeKeys) {
+    delete entry[key];
+  }
+
+  // Merge new properties
+  for (const [key, value] of Object.entries(props)) {
+    entry[key] = value;
+  }
+
+  body[serverName] = entry;
+  root[bodyPath] = body;
+
+  fs.writeFileSync(configPath, JSON.stringify(root, null, 2) + '\n');
+}
+
+export { MCP_SERVER_NAME };

--- a/cli/src/utils/config.ts
+++ b/cli/src/utils/config.ts
@@ -1,0 +1,125 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Project-local feature-override config the CLI manages. Godot's plugin
+ * persists its live config in `user://godot-mcp-config.json` (outside the
+ * project tree), which the CLI cannot reliably reach. This file is the CLI's
+ * own in-project surface for declaring which tools/prompts/resources should be
+ * enabled/disabled — a small, explicit, version-controllable override list a
+ * user can commit alongside the project.
+ */
+export const CONFIG_RELATIVE_PATH = '.godot-mcp/features.json';
+
+export interface McpFeature {
+  name: string;
+  enabled: boolean;
+}
+
+export interface GodotMcpFeaturesConfig {
+  tools?: McpFeature[];
+  prompts?: McpFeature[];
+  resources?: McpFeature[];
+  [key: string]: unknown;
+}
+
+export function getConfigPath(projectPath: string): string {
+  return path.join(projectPath, CONFIG_RELATIVE_PATH);
+}
+
+/** Create a default (empty) features config. */
+export function createDefaultConfig(): GodotMcpFeaturesConfig {
+  return { tools: [], prompts: [], resources: [] };
+}
+
+/** Read the features config from a project. Returns null when absent. */
+export function readConfig(projectPath: string): GodotMcpFeaturesConfig | null {
+  const configPath = getConfigPath(projectPath);
+  if (!fs.existsSync(configPath)) {
+    return null;
+  }
+  const json = fs.readFileSync(configPath, 'utf-8');
+  try {
+    return JSON.parse(json) as GodotMcpFeaturesConfig;
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      throw new SyntaxError(`Malformed JSON in config file: ${configPath}\n${err.message}`);
+    }
+    throw err;
+  }
+}
+
+/** Write the features config, creating the parent directory if needed. */
+export function writeConfig(projectPath: string, config: GodotMcpFeaturesConfig): void {
+  const configPath = getConfigPath(projectPath);
+  const dir = path.dirname(configPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+}
+
+/** Read the config, creating it with defaults if it does not exist. */
+export function getOrCreateConfig(projectPath: string): GodotMcpFeaturesConfig {
+  if (fs.existsSync(getConfigPath(projectPath))) {
+    return readConfig(projectPath) as GodotMcpFeaturesConfig;
+  }
+  const config = createDefaultConfig();
+  writeConfig(projectPath, config);
+  return config;
+}
+
+/**
+ * Update a feature group (tools / prompts / resources) in the config.
+ *   - enableNames: set these to enabled=true
+ *   - disableNames: set these to enabled=false
+ *   - enableAll / disableAll: override every feature already present
+ */
+export function updateFeatures(
+  config: GodotMcpFeaturesConfig,
+  featureType: 'tools' | 'prompts' | 'resources',
+  options: {
+    enableNames?: string[];
+    disableNames?: string[];
+    enableAll?: boolean;
+    disableAll?: boolean;
+  },
+): void {
+  const rawFeatures = config[featureType];
+  const features: McpFeature[] = Array.isArray(rawFeatures)
+    ? rawFeatures.filter(
+        (f): f is McpFeature =>
+          typeof f === 'object' && f !== null && typeof f.name === 'string' && typeof f.enabled === 'boolean',
+      )
+    : [];
+
+  if (options.enableAll) {
+    for (const f of features) f.enabled = true;
+    config[featureType] = features;
+    return;
+  }
+
+  if (options.disableAll) {
+    for (const f of features) f.enabled = false;
+    config[featureType] = features;
+    return;
+  }
+
+  if (options.enableNames) {
+    for (const name of options.enableNames) {
+      const existing = features.find((f) => f.name === name);
+      if (existing) existing.enabled = true;
+      else features.push({ name, enabled: true });
+    }
+  }
+
+  if (options.disableNames) {
+    for (const name of options.disableNames) {
+      const existing = features.find((f) => f.name === name);
+      if (existing) existing.enabled = false;
+      else features.push({ name, enabled: false });
+    }
+  }
+
+  config[featureType] = features;
+}

--- a/cli/src/utils/connection.ts
+++ b/cli/src/utils/connection.ts
@@ -1,0 +1,148 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { verbose } from './ui.js';
+import * as ui from './ui.js';
+
+// --- Godot MCP connection constants (mirror addons/godot_mcp GodotMcpConfig). ---
+
+/** Default hosted cloud base URL (GodotMcpConfig.DefaultCloudBaseUrl). */
+export const DEFAULT_CLOUD_BASE_URL = 'https://ai-game.dev';
+
+/** The MCP hub path appended to a base host (GodotMcpConfig.CloudHubPath). */
+export const MCP_HUB_PATH = '/mcp';
+
+/** Resolved cloud MCP-client URL (base + /mcp). */
+export const CLOUD_MCP_URL = `${DEFAULT_CLOUD_BASE_URL}${MCP_HUB_PATH}`;
+
+/** Default custom-mode host (GodotMcpConfig.DefaultCustomHost). */
+export const DEFAULT_CUSTOM_HOST = 'http://localhost:8080';
+
+// --- Environment-variable names the addon reads (GodotMcpConfig EnvX consts). ---
+
+export const ENV_CLOUD_URL = 'GODOT_MCP_CLOUD_URL';
+export const ENV_HOST = 'GODOT_MCP_HOST';
+export const ENV_TOKEN = 'GODOT_MCP_TOKEN';
+export const ENV_CONNECTION_MODE = 'GODOT_MCP_CONNECTION_MODE';
+export const ENV_AUTH_OPTION = 'GODOT_MCP_AUTH_OPTION';
+export const ENV_LOG_LEVEL = 'GODOT_MCP_LOG_LEVEL';
+
+export interface ConnectionOptions {
+  path?: string;
+  url?: string;
+  token?: string;
+}
+
+/**
+ * Returns true if the given directory looks like a Godot project — i.e.
+ * it contains a `project.godot` file. Pure / no I/O beyond `fs.existsSync`.
+ */
+export function isGodotProject(dir: string): boolean {
+  return fs.existsSync(path.join(dir, 'project.godot'));
+}
+
+/**
+ * Resolve the project path from positional arg, --path option, or cwd.
+ */
+export function resolveProjectPath(positionalPath: string | undefined, options: ConnectionOptions): string {
+  const resolved = path.resolve(positionalPath ?? options.path ?? process.cwd());
+  if ((positionalPath !== undefined || options.path !== undefined) && !fs.existsSync(resolved)) {
+    ui.error(`Project path does not exist: ${resolved}`);
+    process.exit(1);
+  }
+  return resolved;
+}
+
+/**
+ * Resolve the project path and validate it is a Godot project.
+ * Skips validation when --url is provided (explicit server override).
+ */
+export function resolveAndValidateProjectPath(positionalPath: string | undefined, options: ConnectionOptions): string {
+  const resolved = resolveProjectPath(positionalPath, options);
+
+  // Skip Godot project validation when --url is explicitly provided
+  if (options.url) {
+    return resolved;
+  }
+
+  if (!isGodotProject(resolved)) {
+    ui.error(`Not a Godot project (missing project.godot): ${resolved}`);
+    ui.info('Provide a Godot project path as an argument, or use --url to connect to a server directly.');
+    process.exit(1);
+  }
+
+  return resolved;
+}
+
+/**
+ * Strip a single pair of wrapping double-quotes and surrounding whitespace
+ * from an environment value, mirroring the addon's `GodotMcpConfig.NormalizeEnv`
+ * so `GODOT_MCP_TOKEN="abc"` yields `abc`.
+ */
+function normalizeEnv(raw: string | undefined): string | undefined {
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  return trimmed.replace(/^"(.*)"$/, '$1');
+}
+
+/** True when the configured/env mode is Cloud (case-insensitive, name only). */
+function isCloudMode(): boolean {
+  const mode = normalizeEnv(process.env[ENV_CONNECTION_MODE]);
+  return mode !== undefined && mode.toLowerCase() === 'cloud';
+}
+
+/**
+ * Resolve the MCP server base URL + auth token for direct-tool-call requests
+ * (the `<base>/api/tools/<name>` HTTP API exposed by a Godot-MCP server).
+ *
+ * URL priority:
+ *   1. --url flag (explicit override)
+ *   2. GODOT_MCP_HOST env (Custom-mode host)
+ *   3. GODOT_MCP_CLOUD_URL env / Cloud mode → cloud base (https://ai-game.dev)
+ *   4. default custom host (http://localhost:8080)
+ *
+ * Token priority:
+ *   1. --token flag (explicit override)
+ *   2. GODOT_MCP_TOKEN env
+ *
+ * Unlike the Unity CLI, there is NO deterministic project-path→port hash:
+ * the Godot plugin is a server-less client whose persisted config lives in
+ * `user://` (outside the project tree), so the CLI cannot read a project-local
+ * config file. Resolution is therefore env-var + cloud-default based, and
+ * `--url` is the authoritative override for a local/self-hosted server.
+ */
+export function resolveConnection(
+  _projectPath: string,
+  options: ConnectionOptions,
+): { url: string; token: string | undefined } {
+  let url: string;
+  if (options.url) {
+    url = options.url.replace(/\/$/, '');
+    verbose(`Using explicit --url: ${url}`);
+  } else {
+    const envHost = normalizeEnv(process.env[ENV_HOST]);
+    const envCloud = normalizeEnv(process.env[ENV_CLOUD_URL]);
+    if (envHost) {
+      url = envHost.replace(/\/$/, '');
+      verbose(`Using ${ENV_HOST}: ${url}`);
+    } else if (envCloud) {
+      url = envCloud.replace(new RegExp(`${MCP_HUB_PATH}$`), '').replace(/\/$/, '');
+      verbose(`Using ${ENV_CLOUD_URL} base: ${url}`);
+    } else if (isCloudMode()) {
+      url = DEFAULT_CLOUD_BASE_URL;
+      verbose(`Using default cloud base URL: ${url}`);
+    } else {
+      url = DEFAULT_CUSTOM_HOST;
+      verbose(`Using default custom host: ${url}`);
+    }
+  }
+
+  const token = options.token ?? normalizeEnv(process.env[ENV_TOKEN]);
+  if (options.token) {
+    verbose('Using explicit --token');
+  } else if (token) {
+    verbose(`Using ${ENV_TOKEN}`);
+  }
+
+  return { url, token };
+}

--- a/cli/src/utils/godot-editor.ts
+++ b/cli/src/utils/godot-editor.ts
@@ -1,0 +1,212 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawn } from 'child_process';
+import { homedir, platform } from 'os';
+
+/**
+ * Environment variables that, when set, point directly at a Godot editor
+ * binary. Checked before PATH and common install dirs. `GODOT_BIN` is the
+ * conventional name; `GODOT4_BIN` is honored for setups that pin a Godot 4
+ * binary alongside a legacy Godot 3 one.
+ */
+export const GODOT_BIN_ENV_VARS = ['GODOT_BIN', 'GODOT4_BIN'] as const;
+
+/**
+ * Candidate executable base-names searched on `PATH`. The Windows mono build
+ * uses a `_console.exe` companion that surfaces stdout; the mono editor binary
+ * itself ships under several historical names, so we probe a small set.
+ */
+function pathCandidateNames(os: NodeJS.Platform): string[] {
+  if (os === 'win32') {
+    // Prefer the mono build; the `_console` variant surfaces GD.Print/stdout.
+    return [
+      'godot_mono.exe',
+      'godot.exe',
+      'Godot_mono.exe',
+      'Godot.exe',
+    ];
+  }
+  if (os === 'darwin') {
+    return ['godot', 'godot_mono', 'Godot'];
+  }
+  return ['godot', 'godot_mono', 'Godot'];
+}
+
+/**
+ * Per-OS common install directories to scan for a Godot editor binary when
+ * neither an env override nor a PATH hit resolves one.
+ *   - Windows: prefer the mono build under Program Files / common download dirs.
+ *   - macOS: the `.app` bundle's inner `Contents/MacOS/Godot` binary.
+ *   - Linux: extracted binaries under common app dirs.
+ */
+function commonInstallCandidates(os: NodeJS.Platform): string[] {
+  const home = homedir();
+  const candidates: string[] = [];
+
+  if (os === 'win32') {
+    const programFiles = process.env['PROGRAMFILES'] ?? 'C:\\Program Files';
+    const localAppData = process.env['LOCALAPPDATA'] ?? path.join(home, 'AppData', 'Local');
+    for (const root of [
+      path.join(programFiles, 'Godot'),
+      path.join(localAppData, 'Programs', 'Godot'),
+      path.join(home, 'Downloads'),
+    ]) {
+      // Prefer the mono console build (surfaces stdout), then the plain mono build.
+      candidates.push(path.join(root, 'Godot_mono.exe'));
+      candidates.push(path.join(root, 'Godot.exe'));
+    }
+    return candidates;
+  }
+
+  if (os === 'darwin') {
+    for (const app of [
+      '/Applications/Godot_mono.app',
+      '/Applications/Godot.app',
+      path.join(home, 'Applications', 'Godot_mono.app'),
+      path.join(home, 'Applications', 'Godot.app'),
+    ]) {
+      candidates.push(path.join(app, 'Contents', 'MacOS', 'Godot'));
+    }
+    return candidates;
+  }
+
+  // linux + others
+  for (const dir of [
+    '/usr/local/bin',
+    '/usr/bin',
+    path.join(home, '.local', 'bin'),
+    path.join(home, 'Applications'),
+    path.join(home, 'bin'),
+  ]) {
+    candidates.push(path.join(dir, 'godot'));
+    candidates.push(path.join(dir, 'godot_mono'));
+    candidates.push(path.join(dir, 'Godot'));
+  }
+  return candidates;
+}
+
+/**
+ * Search the directories on `PATH` for the first matching Godot binary name.
+ * Pure filesystem lookup — never spawns anything.
+ */
+function findOnPath(os: NodeJS.Platform): string | null {
+  const pathEnv = process.env['PATH'] ?? '';
+  if (!pathEnv) return null;
+  const sep = os === 'win32' ? ';' : ':';
+  const dirs = pathEnv.split(sep).filter((d) => d.length > 0);
+  const names = pathCandidateNames(os);
+  for (const dir of dirs) {
+    for (const name of names) {
+      const candidate = path.join(dir, name);
+      if (existsAsFile(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return null;
+}
+
+function existsAsFile(p: string): boolean {
+  try {
+    return fs.statSync(p).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the Godot editor binary path.
+ *
+ * Resolution order (first hit wins):
+ *   1. An explicit `editorPath` argument (validated to be an existing file).
+ *   2. `GODOT_BIN` / `GODOT4_BIN` environment variables.
+ *   3. The first matching Godot binary on `PATH`.
+ *   4. Per-OS common install directories (Windows prefers the mono build;
+ *      macOS resolves the `.app/Contents/MacOS` binary; Linux scans common
+ *      extracted-binary locations).
+ *
+ * Returns the absolute path, or `null` when no Godot binary can be located.
+ * Pure / no spawn — exported for unit tests (the `os`/env are injectable via
+ * the running process; tests stub `fs` + env).
+ */
+export function findGodotBinary(
+  editorPath?: string,
+  os: NodeJS.Platform = platform(),
+): string | null {
+  // 1. Explicit path
+  if (editorPath !== undefined) {
+    const trimmed = editorPath.trim();
+    if (trimmed.length === 0) return null;
+    const resolved = path.resolve(trimmed);
+    return existsAsFile(resolved) ? resolved : null;
+  }
+
+  // 2. Env overrides
+  for (const envVar of GODOT_BIN_ENV_VARS) {
+    const raw = process.env[envVar];
+    if (raw && raw.trim().length > 0) {
+      const resolved = path.resolve(raw.trim());
+      if (existsAsFile(resolved)) {
+        return resolved;
+      }
+    }
+  }
+
+  // 3. PATH
+  const onPath = findOnPath(os);
+  if (onPath) return onPath;
+
+  // 4. Common install dirs
+  for (const candidate of commonInstallCandidates(os)) {
+    if (existsAsFile(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+export interface LaunchEditorCallbacks {
+  /** Fired once the OS reports the child process has spawned. */
+  onSpawn?: (pid: number | undefined) => void;
+  /** Fired if the spawn itself fails (binary missing, permission denied, …). */
+  onError?: (err: Error) => void;
+}
+
+/**
+ * Spawn the Godot editor binary opening the given project, optionally with
+ * `GODOT_MCP_*` connection environment variables. Mirrors the Unity CLI's
+ * `launchEditor`: spawns detached, with `stdio: 'ignore'`, and `unref()`s so
+ * the parent process can exit without waiting on the editor.
+ *
+ * Godot's editor-open invocation is `--editor --path <project>` (the
+ * `--editor` flag forces the project to open in the editor rather than run).
+ *
+ * Library-safe (no process.exit, no stdout/stderr writes — observability is
+ * the caller's responsibility via the optional callbacks).
+ */
+export function launchEditor(
+  editorPath: string,
+  projectPath: string,
+  env?: Record<string, string>,
+  callbacks?: LaunchEditorCallbacks,
+): import('child_process').ChildProcess {
+  const args = ['--editor', '--path', path.resolve(projectPath)];
+
+  const child = spawn(editorPath, args, {
+    detached: true,
+    stdio: 'ignore',
+    env: { ...process.env, ...env },
+  });
+
+  child.on('spawn', () => {
+    callbacks?.onSpawn?.(child.pid);
+  });
+
+  child.on('error', (err) => {
+    callbacks?.onError?.(err);
+  });
+
+  child.unref();
+  return child;
+}

--- a/cli/src/utils/godot-process.ts
+++ b/cli/src/utils/godot-process.ts
@@ -1,0 +1,110 @@
+import { execFileSync, execSync } from 'child_process';
+import { platform } from 'os';
+import * as path from 'path';
+import { verbose } from './ui.js';
+
+export interface GodotProcess {
+  pid: number;
+  projectPath: string;
+  commandLine: string;
+}
+
+/**
+ * Extract the `--path <project>` value from a Godot editor command line.
+ * Quote-aware: a double-quoted path (Windows CIM `CommandLine` shape for paths
+ * with spaces) is consumed whole, otherwise the first whitespace-delimited
+ * token is used. Returns the resolved absolute path, or null when absent.
+ */
+function extractProjectPath(commandLine: string): string | null {
+  const quoted = commandLine.match(/--path\s+"([^"]+)"/i);
+  if (quoted) return path.resolve(quoted[1].trim());
+  const unquoted = commandLine.match(/--path\s+(\S+)/i);
+  if (unquoted) return path.resolve(unquoted[1].trim());
+  return null;
+}
+
+/**
+ * Check if a Godot editor process is running with the given project path.
+ * Returns process info if found, null otherwise.
+ */
+export function findGodotProcess(projectPath: string): GodotProcess | null {
+  const isWindows = platform() === 'win32';
+  const resolvedTarget = path.resolve(projectPath);
+  const normalizedTarget = isWindows ? resolvedTarget.toLowerCase() : resolvedTarget;
+  const processes = listGodotProcesses();
+
+  for (const proc of processes) {
+    const normalizedProc = isWindows ? proc.projectPath.toLowerCase() : proc.projectPath;
+    if (normalizedProc === normalizedTarget) {
+      verbose(`Found Godot process PID ${proc.pid} with project: ${proc.projectPath}`);
+      return proc;
+    }
+  }
+
+  verbose(`No Godot process found for project: ${projectPath}`);
+  return null;
+}
+
+/**
+ * List all running Godot editor processes with their project paths. Matches
+ * any process whose name contains "godot" (covers `Godot.exe`, `Godot_mono.exe`,
+ * `godot_mono_console.exe`, the macOS `Godot` binary, and Linux extracted
+ * binaries) and that carries a `--path` argument.
+ */
+function listGodotProcesses(): GodotProcess[] {
+  const os = platform();
+  const results: GodotProcess[] = [];
+
+  try {
+    if (os === 'win32') {
+      const psCommand =
+        "Get-CimInstance Win32_Process -Filter \"Name LIKE '%godot%'\" | Select-Object ProcessId,CommandLine | ForEach-Object { $_.ProcessId.ToString() + '|||' + $_.CommandLine }";
+      const output = execFileSync(
+        'powershell.exe',
+        ['-NoProfile', '-Command', psCommand],
+        { encoding: 'utf-8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] },
+      );
+      const lines = output.split('\n').filter((l) => l.trim().length > 0);
+
+      for (const line of lines) {
+        const sepIdx = line.indexOf('|||');
+        if (sepIdx === -1) continue;
+
+        const pid = parseInt(line.substring(0, sepIdx).trim(), 10);
+        const commandLine = line.substring(sepIdx + 3).trim();
+        if (!Number.isFinite(pid) || pid === 0) continue;
+        if (!/--path/i.test(commandLine)) continue;
+
+        const projectPath = extractProjectPath(commandLine);
+        if (projectPath) {
+          results.push({ pid, projectPath, commandLine });
+        }
+      }
+    } else {
+      const output = execSync(
+        "ps -eo pid,args | grep -i '[g]odot' || true",
+        { encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] },
+      );
+      const lines = output.split('\n').filter((l) => l.trim().length > 0);
+
+      for (const line of lines) {
+        const match = line.trim().match(/^(\d+)\s+(.*)$/);
+        if (!match) continue;
+
+        const pid = parseInt(match[1], 10);
+        const commandLine = match[2];
+        if (!/--path/i.test(commandLine)) continue;
+
+        const projectPath = extractProjectPath(commandLine);
+        if (projectPath) {
+          results.push({ pid, projectPath, commandLine });
+        }
+      }
+    }
+  } catch (err) {
+    verbose(`Failed to list Godot processes: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  verbose(`Found ${results.length} Godot process(es)`);
+  return results;
+}

--- a/cli/src/utils/godot-shutdown.ts
+++ b/cli/src/utils/godot-shutdown.ts
@@ -1,0 +1,78 @@
+import { execFileSync } from 'child_process';
+import { platform } from 'os';
+
+export type SupportedPlatform = 'win32' | 'darwin' | 'linux';
+
+/** True when the process with the given PID is currently alive. */
+export function isProcessAlive(pid: number, os: SupportedPlatform = platform() as SupportedPlatform): boolean {
+  try {
+    if (os === 'win32') {
+      const out = execFileSync('tasklist', ['/FI', `PID eq ${pid}`, '/NH'], {
+        encoding: 'utf-8',
+        timeout: 5000,
+      });
+      return out.includes(String(pid));
+    }
+    // POSIX: signal 0 probes existence without delivering a signal.
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Send a graceful-shutdown request. On POSIX this is SIGTERM; on Windows we use
+ * `taskkill` WITHOUT `/F` (a polite close request the OS routes to the process).
+ * Returns true when the signal was delivered without error.
+ */
+export function sendGracefulShutdown(
+  pid: number,
+  os: SupportedPlatform = platform() as SupportedPlatform,
+): boolean {
+  try {
+    if (os === 'win32') {
+      execFileSync('taskkill', ['/PID', String(pid)], { encoding: 'utf-8', timeout: 5000, stdio: 'pipe' });
+      return true;
+    }
+    process.kill(pid, 'SIGTERM');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Hard-kill the process. SIGKILL on POSIX; `taskkill /F` on Windows. */
+export function sendForceKill(
+  pid: number,
+  os: SupportedPlatform = platform() as SupportedPlatform,
+): boolean {
+  try {
+    if (os === 'win32') {
+      execFileSync('taskkill', ['/PID', String(pid), '/F'], { encoding: 'utf-8', timeout: 5000, stdio: 'pipe' });
+      return true;
+    }
+    process.kill(pid, 'SIGKILL');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Poll for the process to exit, up to `timeoutMs`. Resolves true when the
+ * process is gone, false on timeout.
+ */
+export async function waitForExit(
+  pid: number,
+  timeoutMs: number,
+  os: SupportedPlatform = platform() as SupportedPlatform,
+): Promise<boolean> {
+  const start = Date.now();
+  const interval = 250;
+  while (Date.now() - start < timeoutMs) {
+    if (!isProcessAlive(pid, os)) return true;
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+  return !isProcessAlive(pid, os);
+}

--- a/cli/src/utils/input.ts
+++ b/cli/src/utils/input.ts
@@ -1,0 +1,76 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as ui from './ui.js';
+import { verbose } from './ui.js';
+import { parseJsonStrict, JsonParseError } from './json-parse.js';
+
+export interface InputOptions {
+  input?: string;
+  inputFile?: string;
+}
+
+/**
+ * Parse tool input from --input, --input-file, or stdin.
+ *
+ * - `--input-file -` or `--input-file /dev/stdin` reads from stdin (cross-platform).
+ * - `--input-file <path>` reads from a file.
+ * - `--input <json>` parses inline JSON.
+ * - Falls back to `{}` if nothing provided.
+ */
+export function parseInput(options: InputOptions): string {
+  if (options.inputFile) {
+    const isStdin = options.inputFile === '-' || options.inputFile === '/dev/stdin';
+    let content: string;
+
+    if (isStdin) {
+      verbose('Reading input from stdin...');
+      try {
+        content = fs.readFileSync(0, 'utf-8');
+      } catch {
+        ui.error('Failed to read from stdin.');
+        process.exit(1);
+      }
+      if (!content.trim()) {
+        ui.error('No input received from stdin.');
+        process.exit(1);
+      }
+    } else {
+      const filePath = path.resolve(options.inputFile);
+      if (!fs.existsSync(filePath)) {
+        ui.error(`Input file does not exist: ${filePath}`);
+        process.exit(1);
+      }
+      content = fs.readFileSync(filePath, 'utf-8');
+    }
+
+    try {
+      parseJsonStrict(content);
+    } catch (err) {
+      const source = isStdin ? 'stdin' : options.inputFile;
+      if (err instanceof JsonParseError) {
+        ui.error(`--input-file content from '${source}' must be valid JSON\n${err.message}`);
+      } else {
+        ui.error(`--input-file content from '${source}' must be valid JSON`);
+      }
+      process.exit(1);
+    }
+
+    return content;
+  }
+
+  if (options.input) {
+    try {
+      const result = parseJsonStrict(options.input);
+      return result.raw;
+    } catch (err) {
+      if (err instanceof JsonParseError) {
+        ui.error(`--input must be valid JSON\n${err.message}`);
+      } else {
+        ui.error('--input must be valid JSON');
+      }
+      process.exit(1);
+    }
+  }
+
+  return '{}';
+}

--- a/cli/src/utils/json-parse.ts
+++ b/cli/src/utils/json-parse.ts
@@ -1,0 +1,111 @@
+/**
+ * Robust JSON parsing with detailed error reporting.
+ *
+ * 1. Try to parse the raw string as JSON.
+ * 2. If invalid, report the exact position where parsing fails.
+ */
+export interface JsonParseResult {
+  readonly value: unknown;
+  readonly raw: string;
+  readonly wasStringified: boolean;
+}
+
+export class JsonParseError extends Error {
+  readonly position: number;
+  readonly snippet: string;
+
+  constructor(message: string, position: number, snippet: string) {
+    super(message);
+    this.name = 'JsonParseError';
+    this.position = position;
+    this.snippet = snippet;
+  }
+}
+
+/**
+ * Extract the error position from a JSON.parse SyntaxError message.
+ * Common formats:
+ *   - "... at position 42"           (V8 / Node)
+ *   - "... at line 3 column 5"       (some engines)
+ *   - "Unexpected token X in JSON at position 42"
+ */
+function extractErrorPosition(error: SyntaxError, input: string): number {
+  const msg = error.message;
+
+  const posMatch = msg.match(/position\s+(\d+)/i);
+  if (posMatch) {
+    return parseInt(posMatch[1], 10);
+  }
+
+  const lineColMatch = msg.match(/line\s+(\d+)\s+column\s+(\d+)/i);
+  if (lineColMatch) {
+    const targetLine = parseInt(lineColMatch[1], 10);
+    const targetCol = parseInt(lineColMatch[2], 10);
+    const lines = input.split('\n');
+    let offset = 0;
+    for (let i = 0; i < targetLine - 1 && i < lines.length; i++) {
+      offset += lines[i].length + 1; // +1 for newline
+    }
+    return offset + targetCol - 1;
+  }
+
+  return -1;
+}
+
+/**
+ * Build a human-readable snippet around the error position.
+ */
+function buildSnippet(input: string, position: number): string {
+  if (position < 0 || position > input.length) {
+    return input.length <= 80 ? input : input.slice(0, 80) + '...';
+  }
+
+  const contextBefore = 20;
+  const contextAfter = 20;
+
+  const start = Math.max(0, position - contextBefore);
+  const end = Math.min(input.length, position + contextAfter);
+
+  const before = (start > 0 ? '...' : '') + input.slice(start, position);
+  const errorChar = position < input.length ? input[position] : '<end>';
+  const after = input.slice(position + 1, end) + (end < input.length ? '...' : '');
+
+  const pointer = ' '.repeat(before.length) + '^';
+
+  return `${before}${errorChar}${after}\n${pointer}`;
+}
+
+/**
+ * Build a detailed error message for a JSON parse failure.
+ */
+function buildDetailedError(input: string, error: SyntaxError): JsonParseError {
+  const position = extractErrorPosition(error, input);
+  const snippet = buildSnippet(input, position);
+
+  const posInfo = position >= 0 ? ` at position ${position}` : '';
+  const message =
+    `Invalid JSON${posInfo}: ${error.message}\n\n` +
+    `  ${snippet.split('\n').join('\n  ')}\n`;
+
+  return new JsonParseError(message, position, snippet);
+}
+
+/**
+ * Parse a string as strict JSON. Throws {@link JsonParseError} with
+ * position and snippet on failure.
+ *
+ * @param input  The raw string to parse as JSON.
+ * @returns      A result containing the parsed value.
+ * @throws       {@link JsonParseError} with position and snippet on failure.
+ */
+export function parseJsonStrict(input: string): JsonParseResult {
+  try {
+    const value = JSON.parse(input);
+    return { value, raw: input, wasStringified: false };
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw buildDetailedError(input, error);
+    }
+    throw error;
+  }
+}

--- a/cli/src/utils/probe.ts
+++ b/cli/src/utils/probe.ts
@@ -1,0 +1,73 @@
+import { verbose } from './ui.js';
+
+export const PING_ENDPOINT = '/api/tools/ping';
+
+export interface ProbeSuccess {
+  ok: true;
+  baseUrl: string;
+  data: unknown;
+}
+
+export interface ProbeFailure {
+  ok: false;
+  reason: string;
+}
+
+export type ProbeResult = ProbeSuccess | ProbeFailure;
+
+/**
+ * Probe a Godot-MCP server's ping endpoint (`<base>/api/tools/ping`).
+ * Returns a structured result. The `ping` tool is registered by the
+ * `Tool_Ping` family (pure-managed, no editor required), so a connected
+ * plugin responds `{ "structured": { "result": "pong" } }`.
+ */
+export async function probe(
+  baseUrl: string,
+  headers: Record<string, string>,
+  timeoutMs: number,
+): Promise<ProbeResult> {
+  const endpoint = `${baseUrl}${PING_ENDPOINT}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers,
+      body: '{}',
+      signal: controller.signal,
+    });
+
+    const text = await response.text();
+    if (response.ok) {
+      let data: unknown;
+      try { data = JSON.parse(text); } catch { data = text; }
+      return { ok: true, baseUrl, data };
+    }
+
+    verbose(`[${baseUrl}] HTTP ${response.status} — not ready yet`);
+    return { ok: false, reason: `HTTP ${response.status}` };
+  } catch (err) {
+    const cause = err instanceof Error && 'cause' in err ? (err.cause as Error & { code?: string }) : null;
+    const code = cause?.code ?? '';
+    const isAbort = err instanceof Error && err.name === 'AbortError';
+
+    let reason: string;
+    if (isAbort) {
+      reason = 'timed out';
+      verbose(`[${baseUrl}] probe timed out`);
+    } else if (code === 'ECONNREFUSED') {
+      reason = 'connection refused';
+      verbose(`[${baseUrl}] connection refused`);
+    } else if (code === 'ECONNRESET') {
+      reason = 'connection reset';
+      verbose(`[${baseUrl}] connection reset`);
+    } else {
+      reason = err instanceof Error ? err.message : String(err);
+      verbose(`[${baseUrl}] probe failed: ${reason}`);
+    }
+    return { ok: false, reason };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/cli/src/utils/project-godot.ts
+++ b/cli/src/utils/project-godot.ts
@@ -1,0 +1,149 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * The plugin.cfg resource path Godot uses to identify the godot_mcp addon in
+ * the `[editor_plugins]` `enabled` array.
+ */
+export const GODOT_MCP_PLUGIN_PATH = 'res://addons/godot_mcp/plugin.cfg';
+
+/** Absolute path to a project's `project.godot` manifest. */
+export function projectGodotPath(projectRoot: string): string {
+  return path.join(projectRoot, 'project.godot');
+}
+
+/** True when `<projectRoot>/project.godot` exists. */
+export function isGodotProjectRoot(projectRoot: string): boolean {
+  return fs.existsSync(projectGodotPath(projectRoot));
+}
+
+/**
+ * Parse the `enabled=PackedStringArray("a", "b")` entry inside the
+ * `[editor_plugins]` section of a `project.godot` file body, returning the
+ * ordered list of enabled plugin.cfg paths. Returns an empty array when the
+ * section or the `enabled` key is absent.
+ *
+ * Pure — operates on the file text only. Exported for unit tests.
+ */
+export function parseEnabledPlugins(projectGodotText: string): string[] {
+  const section = extractEditorPluginsSection(projectGodotText);
+  if (section === null) return [];
+
+  const match = section.match(/enabled\s*=\s*PackedStringArray\(([^)]*)\)/);
+  if (!match) return [];
+
+  const inner = match[1];
+  const paths: string[] = [];
+  // Match each double-quoted string literal in the array.
+  const re = /"([^"]*)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(inner)) !== null) {
+    paths.push(m[1]);
+  }
+  return paths;
+}
+
+/**
+ * Extract the raw text of the `[editor_plugins]` section (everything between
+ * its header and the next `[section]` header or EOF). Returns null when the
+ * section is absent.
+ */
+function extractEditorPluginsSection(text: string): string | null {
+  const lines = text.split('\n');
+  const headerIdx = lines.findIndex((l) => l.trim() === '[editor_plugins]');
+  if (headerIdx === -1) return null;
+
+  let endIdx = headerIdx + 1;
+  while (endIdx < lines.length && !lines[endIdx].trim().startsWith('[')) {
+    endIdx++;
+  }
+  return lines.slice(headerIdx + 1, endIdx).join('\n');
+}
+
+/**
+ * Render a PackedStringArray literal from a list of plugin paths.
+ */
+function renderEnabledLine(paths: string[]): string {
+  const quoted = paths.map((p) => `"${p}"`).join(', ');
+  return `enabled=PackedStringArray(${quoted})`;
+}
+
+export type PluginToggleResult =
+  | { kind: 'changed'; enabled: string[] }
+  | { kind: 'unchanged'; enabled: string[] };
+
+/**
+ * Return a new `project.godot` body with the godot_mcp plugin path added to
+ * (enable) or removed from (disable) the `[editor_plugins]` `enabled` array.
+ *
+ * - Creates the `[editor_plugins]` section / `enabled` line when enabling and
+ *   they are absent.
+ * - Idempotent: enabling an already-enabled plugin (or disabling an
+ *   already-disabled one) returns `{ kind: 'unchanged' }` with the original
+ *   text untouched.
+ *
+ * Pure — returns the new text; never touches the filesystem. Exported for
+ * unit tests.
+ */
+export function togglePluginInText(
+  projectGodotText: string,
+  enable: boolean,
+  pluginPath: string = GODOT_MCP_PLUGIN_PATH,
+): { text: string } & PluginToggleResult {
+  const current = parseEnabledPlugins(projectGodotText);
+  const has = current.includes(pluginPath);
+
+  if (enable && has) {
+    return { text: projectGodotText, kind: 'unchanged', enabled: current };
+  }
+  if (!enable && !has) {
+    return { text: projectGodotText, kind: 'unchanged', enabled: current };
+  }
+
+  const next = enable
+    ? [...current, pluginPath]
+    : current.filter((p) => p !== pluginPath);
+
+  const newText = writeEnabledArray(projectGodotText, next);
+  return { text: newText, kind: 'changed', enabled: next };
+}
+
+/**
+ * Write the `enabled=PackedStringArray(...)` line into the `[editor_plugins]`
+ * section, creating the section/line if needed. The Godot `[editor_plugins]`
+ * section is conventionally written with a blank line between the header and
+ * the `enabled` line; this preserves that shape on creation.
+ */
+function writeEnabledArray(text: string, paths: string[]): string {
+  const lines = text.split('\n');
+  const headerIdx = lines.findIndex((l) => l.trim() === '[editor_plugins]');
+  const enabledLine = renderEnabledLine(paths);
+
+  if (headerIdx === -1) {
+    // Append a fresh [editor_plugins] section.
+    const prefix = text.length > 0 && !text.endsWith('\n') ? '\n' : '';
+    const sep = text.trim().length > 0 ? '\n' : '';
+    return `${text}${prefix}${sep}[editor_plugins]\n\n${enabledLine}\n`;
+  }
+
+  // Find an existing `enabled` line within the section.
+  let endIdx = headerIdx + 1;
+  while (endIdx < lines.length && !lines[endIdx].trim().startsWith('[')) {
+    endIdx++;
+  }
+  const enabledIdx = lines.findIndex(
+    (l, i) => i > headerIdx && i < endIdx && /^\s*enabled\s*=/.test(l),
+  );
+
+  if (enabledIdx >= 0) {
+    lines[enabledIdx] = enabledLine;
+  } else {
+    // Insert after the header (and a following blank line if present).
+    const insertAt = headerIdx + 1 < lines.length && lines[headerIdx + 1].trim() === ''
+      ? headerIdx + 2
+      : headerIdx + 1;
+    lines.splice(insertAt, 0, enabledLine);
+  }
+
+  return lines.join('\n');
+}

--- a/cli/src/utils/semver.ts
+++ b/cli/src/utils/semver.ts
@@ -1,0 +1,26 @@
+const SEMVER_NUMERIC = /^\d+(\.\d+)*$/;
+
+/** Returns true if the string is a valid numeric semver (e.g. "1.2.3"). */
+export function isValidVersion(version: string): boolean {
+  return SEMVER_NUMERIC.test(version);
+}
+
+/** Returns -1 if a < b, 0 if equal, 1 if a > b. */
+function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  const len = Math.max(pa.length, pb.length);
+
+  for (let i = 0; i < len; i++) {
+    const na = pa[i] ?? 0;
+    const nb = pb[i] ?? 0;
+    if (na < nb) return -1;
+    if (na > nb) return 1;
+  }
+  return 0;
+}
+
+/** Returns true if `latest` is strictly greater than `current`. */
+export function isNewerVersion(current: string, latest: string): boolean {
+  return compareVersions(current, latest) < 0;
+}

--- a/cli/src/utils/ui.ts
+++ b/cli/src/utils/ui.ts
@@ -1,0 +1,269 @@
+import chalk from 'chalk';
+import yoctoSpinner, { type Spinner } from 'yocto-spinner';
+import type { Command, Help } from 'commander';
+
+// --- Verbose mode ---
+let verboseEnabled = false;
+
+export function setVerbose(enabled: boolean): void {
+  verboseEnabled = enabled;
+}
+
+export function verbose(msg: string): void {
+  if (verboseEnabled) {
+    if (isTTY()) {
+      console.log(chalk.dim(`[verbose] ${msg}`));
+    } else {
+      console.log(`[verbose] ${msg}`);
+    }
+  }
+}
+
+// --- TTY detection ---
+function isTTY(): boolean {
+  return !!process.stdout.isTTY;
+}
+
+/**
+ * Draw a Unicode rounded box around text with cyan borders.
+ */
+function drawBox(text: string): string {
+  const lines = text.split('\n');
+  const padding = 2;
+  const maxLen = Math.max(...lines.map(l => stripAnsi(l).length));
+  const innerWidth = maxLen + padding * 2;
+  const pad = ' '.repeat(padding);
+
+  const top = chalk.cyan('╭' + '─'.repeat(innerWidth) + '╮');
+  const bottom = chalk.cyan('╰' + '─'.repeat(innerWidth) + '╯');
+  const middle = lines.map(l => {
+    const visible = stripAnsi(l).length;
+    const right = ' '.repeat(maxLen - visible);
+    return chalk.cyan('│') + pad + l + right + pad + chalk.cyan('│');
+  });
+
+  return [top, ...middle, bottom].join('\n');
+}
+
+/**
+ * Strip ANSI escape codes from a string.
+ */
+function stripAnsi(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1B\[[0-9;]*m/g, '');
+}
+
+/**
+ * Apply styled help formatting to a Commander command.
+ * Call this on every Command instance (root and subcommands)
+ * so that --help / -h always renders the fancy UI.
+ *
+ * @param appVersion - The CLI version string, shown in the root banner.
+ */
+export function configureStyledHelp(cmd: Command, appVersion?: string): Command {
+  cmd.configureHelp({
+    formatHelp(target: Command, helper: Help): string {
+      const isRoot = !target.parent;
+      const lines: string[] = [];
+
+      // Banner for root, styled title for subcommands
+      if (isRoot && appVersion) {
+        lines.push(
+          drawBox(
+            `${chalk.bold.cyan('Godot-MCP CLI')}  ${chalk.dim(`v${appVersion}`)}\n${chalk.dim('Bridge LLMs with Godot via Model Context Protocol')}`
+          )
+        );
+      } else {
+        lines.push(
+          drawBox(
+            `${chalk.bold.cyan(target.name())} ${chalk.dim('—')} ${target.description()}`
+          )
+        );
+      }
+      lines.push('');
+
+      // Usage
+      lines.push(`${chalk.bold('Usage:')} ${chalk.yellow(helper.commandUsage(target))}`);
+      lines.push('');
+
+      // Subcommands
+      const subcommands = helper.visibleCommands(target);
+      if (subcommands.length > 0) {
+        lines.push(chalk.bold('Commands:'));
+        for (const sub of subcommands) {
+          lines.push(`  ${chalk.yellow(sub.name().padEnd(20))} ${chalk.dim(sub.description() || '')}`);
+        }
+        lines.push('');
+      }
+
+      // Arguments
+      const args = helper.visibleArguments(target);
+      if (args.length > 0) {
+        lines.push(chalk.bold('Arguments:'));
+        for (const arg of args) {
+          lines.push(`  ${chalk.green(helper.argumentTerm(arg).padEnd(30))} ${chalk.dim(helper.argumentDescription(arg))}`);
+        }
+        lines.push('');
+      }
+
+      // Options
+      const options = helper.visibleOptions(target);
+      if (options.length > 0) {
+        lines.push(chalk.bold('Options:'));
+        for (const opt of options) {
+          lines.push(`  ${chalk.green(helper.optionTerm(opt).padEnd(30))} ${chalk.dim(helper.optionDescription(opt))}`);
+        }
+        lines.push('');
+      }
+
+      // Footer
+      if (isRoot) {
+        lines.push(
+          chalk.dim('Run ') +
+          chalk.yellow('godot-mcp-cli <command> --help') +
+          chalk.dim(' for detailed usage of each command.')
+        );
+        lines.push('');
+      }
+
+      return lines.join('\n');
+    },
+  });
+  return cmd;
+}
+
+/**
+ * Print a success message with a green checkmark.
+ * In non-TTY mode, uses plain text prefix.
+ */
+export function success(msg: string): void {
+  if (isTTY()) {
+    console.log(`${chalk.green('✔')}  ${msg}`);
+  } else {
+    console.log(`SUCCESS: ${msg}`);
+  }
+}
+
+/**
+ * Print an error message with a red cross to stderr.
+ * In non-TTY mode, uses plain text prefix.
+ */
+export function error(msg: string): void {
+  if (isTTY()) {
+    console.error(`${chalk.red('✖')}  ${chalk.red(msg)}`);
+  } else {
+    console.error(`ERROR: ${msg}`);
+  }
+}
+
+/**
+ * Print an info message with a blue info symbol.
+ * In non-TTY mode, uses plain text prefix.
+ */
+export function info(msg: string): void {
+  if (isTTY()) {
+    console.log(`${chalk.blue('ℹ')}  ${msg}`);
+  } else {
+    console.log(`INFO: ${msg}`);
+  }
+}
+
+/**
+ * Print a warning message with a yellow warning symbol.
+ * In non-TTY mode, uses plain text prefix.
+ */
+export function warn(msg: string): void {
+  if (isTTY()) {
+    console.log(`${chalk.yellow('⚠')}  ${chalk.yellow(msg)}`);
+  } else {
+    console.log(`WARN: ${msg}`);
+  }
+}
+
+/**
+ * Print a bold cyan section heading.
+ */
+export function heading(msg: string): void {
+  console.log(`\n${chalk.bold.cyan(msg)}`);
+}
+
+/**
+ * Print a formatted key-value label.
+ */
+export function label(key: string, value: string): void {
+  console.log(`  ${chalk.bold(key + ':')} ${value}`);
+}
+
+/**
+ * Create a no-op spinner for non-TTY environments.
+ * Methods are safe to call but produce no ANSI output.
+ */
+function createNoOpSpinner(text: string): Spinner {
+  console.log(text);
+  const self: Spinner = {
+    start: () => self,
+    stop: () => self,
+    success: (msg?: string) => { if (msg) console.log(`SUCCESS: ${msg}`); return self; },
+    error: (msg?: string) => { if (msg) console.error(`ERROR: ${msg}`); return self; },
+    warning: (msg?: string) => { if (msg) console.log(`WARN: ${msg}`); return self; },
+    info: (msg?: string) => { if (msg) console.log(`INFO: ${msg}`); return self; },
+    clear: () => self,
+    get text() { return text; },
+    set text(value: string) { text = value; },
+    get isSpinning() { return false; },
+    get color() { return 'cyan' as const; },
+    set color(_: string) { /* no-op */ },
+  } as unknown as Spinner;
+  return self;
+}
+
+/**
+ * Start a spinner with the given text. Returns a wrapped spinner instance
+ * whose success/error/warning/info methods add an extra space after the symbol
+ * for consistent formatting.
+ *
+ * In non-TTY environments (CI pipelines, piped output), returns a no-op
+ * spinner that outputs plain text without ANSI escape codes.
+ */
+export function startSpinner(text: string): Spinner {
+  if (!isTTY()) {
+    return createNoOpSpinner(text);
+  }
+
+  const spinner = yoctoSpinner({ text, color: 'cyan' }).start();
+
+  const origSuccess = spinner.success.bind(spinner);
+  const origError = spinner.error.bind(spinner);
+  const origWarning = spinner.warning.bind(spinner);
+  const origInfo = spinner.info.bind(spinner);
+
+  spinner.success = (msg?: string) => origSuccess(msg ? ` ${msg}` : undefined);
+  spinner.error = (msg?: string) => origError(msg ? ` ${msg}` : undefined);
+  spinner.warning = (msg?: string) => origWarning(msg ? ` ${msg}` : undefined);
+  spinner.info = (msg?: string) => origInfo(msg ? ` ${msg}` : undefined);
+
+  return spinner;
+}
+
+/**
+ * Format a status badge (enabled/disabled).
+ */
+export function badge(enabled: boolean): string {
+  return enabled
+    ? chalk.bgGreen.black('[enabled]')
+    : chalk.bgRed.white('[disabled]');
+}
+
+/**
+ * Print a feature row with a styled badge and name.
+ */
+export function featureRow(name: string, enabled: boolean): void {
+  console.log(`    ${badge(enabled)} ${name}`);
+}
+
+/**
+ * Print a divider line.
+ */
+export function divider(): void {
+  console.log(chalk.dim('─'.repeat(50)));
+}

--- a/cli/src/utils/update-check.ts
+++ b/cli/src/utils/update-check.ts
@@ -1,0 +1,110 @@
+import { homedir } from 'os';
+import { join } from 'path';
+import { readFileSync, writeFileSync } from 'fs';
+import chalk from 'chalk';
+import { isNewerVersion, isValidVersion } from './semver.js';
+
+const PACKAGE_NAME = 'godot-mcp-cli';
+const NPM_REGISTRY_URL = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;
+const CACHE_FILE = join(homedir(), '.godot-mcp-cli-update.json');
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const FETCH_TIMEOUT_MS = 3000;
+
+interface UpdateCache {
+  latestVersion: string;
+  lastChecked: number;
+}
+
+interface UpdateInfo {
+  current: string;
+  latest: string;
+}
+
+/** Fetch the latest version string from the npm registry. */
+export async function fetchLatestVersion(): Promise<string> {
+  const response = await fetch(NPM_REGISTRY_URL, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    headers: { 'Accept': 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`npm registry returned ${response.status}`);
+  }
+
+  const data = (await response.json()) as { version?: string };
+  if (!data.version) {
+    throw new Error('No version field in registry response');
+  }
+  return data.version;
+}
+
+function readCache(): UpdateCache | null {
+  try {
+    const raw = readFileSync(CACHE_FILE, 'utf-8');
+    const parsed = JSON.parse(raw) as UpdateCache;
+    if (parsed.latestVersion && typeof parsed.lastChecked === 'number' && isValidVersion(parsed.latestVersion)) {
+      return parsed;
+    }
+  } catch {
+    // Cache missing or corrupt — ignore
+  }
+  return null;
+}
+
+function writeCache(latestVersion: string): void {
+  try {
+    const data: UpdateCache = { latestVersion, lastChecked: Date.now() };
+    writeFileSync(CACHE_FILE, JSON.stringify(data), 'utf-8');
+  } catch {
+    // Non-critical — ignore write failures
+  }
+}
+
+/**
+ * Check if a newer version is available on npm.
+ * Returns update info if available, null otherwise.
+ * Never throws — all errors are silently caught.
+ */
+export async function checkForUpdate(currentVersion: string): Promise<UpdateInfo | null> {
+  try {
+    // Check cache first
+    const cache = readCache();
+    if (cache && Date.now() - cache.lastChecked < CACHE_TTL_MS) {
+      if (isNewerVersion(currentVersion, cache.latestVersion)) {
+        return { current: currentVersion, latest: cache.latestVersion };
+      }
+      return null;
+    }
+
+    // Fetch fresh
+    const latest = await fetchLatestVersion();
+    writeCache(latest);
+
+    if (isNewerVersion(currentVersion, latest)) {
+      return { current: currentVersion, latest };
+    }
+  } catch {
+    // Best-effort — never disrupt CLI usage
+  }
+  return null;
+}
+
+/** Format the "update available" message with chalk styling. */
+export function formatUpdateAvailable(current: string, latest: string): string {
+  return `Update available: ${chalk.dim(current)} → ${chalk.green(latest)}`;
+}
+
+/** Print a styled update notification to stderr (does not interfere with stdout piping). */
+export function printUpdateNotification(current: string, latest: string): void {
+  console.error();
+  console.error(chalk.yellow(`  ${formatUpdateAvailable(current, latest)}`));
+  console.error(chalk.dim(`  Run ${chalk.cyan(`npm i -g ${PACKAGE_NAME}`)} to update`));
+  console.error();
+}
+
+/** Returns true if the CLI was likely invoked via npx. */
+export function isRunningViaNpx(): boolean {
+  const execPath = process.env['npm_execpath'] ?? '';
+  const npmCommand = process.env['npm_command'] ?? '';
+  return execPath.includes('npx') || npmCommand === 'exec';
+}

--- a/cli/tests/cli.test.ts
+++ b/cli/tests/cli.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI_PATH = path.resolve(__dirname, '..', 'bin', 'godot-mcp-cli.js');
+
+function runCli(args: string[], options?: { cwd?: string }): { stdout: string; exitCode: number } {
+  try {
+    const stdout = execFileSync('node', [CLI_PATH, ...args], {
+      encoding: 'utf-8',
+      timeout: 15000,
+      cwd: options?.cwd,
+    });
+    return { stdout, exitCode: 0 };
+  } catch (err: unknown) {
+    const error = err as { stdout?: string; stderr?: string; status?: number };
+    return {
+      stdout: (error.stdout ?? '') + (error.stderr ?? ''),
+      exitCode: error.status ?? 1,
+    };
+  }
+}
+
+describe('CLI integration', () => {
+  describe('global options', () => {
+    it('shows help with --help', () => {
+      const { stdout, exitCode } = runCli(['--help']);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('godot-mcp-cli');
+      expect(stdout).toContain('open');
+      expect(stdout).toContain('run-tool');
+      expect(stdout).toContain('run-system-tool');
+      expect(stdout).toContain('status');
+      expect(stdout).toContain('wait-for-ready');
+      expect(stdout).toContain('setup-mcp');
+      expect(stdout).toContain('configure');
+      expect(stdout).toContain('close');
+      expect(stdout).toContain('install-plugin');
+      expect(stdout).toContain('remove-plugin');
+      expect(stdout).toContain('update');
+    });
+
+    it('does NOT register a setup-skills command (scoped out of v1)', () => {
+      const { stdout, exitCode } = runCli(['--help']);
+      expect(exitCode).toBe(0);
+      // The word "skills" may appear in prose, but there is no `setup-skills`
+      // command listed in the Commands section.
+      expect(stdout).not.toMatch(/^\s*setup-skills\b/m);
+    });
+
+    it('shows version with --version', () => {
+      const { stdout, exitCode } = runCli(['--version']);
+      expect(exitCode).toBe(0);
+      expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+    });
+  });
+
+  describe('open', () => {
+    it('shows help with --help including connection options', () => {
+      const { stdout, exitCode } = runCli(['open', '--help']);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('--path');
+      expect(stdout).toContain('--editor-path');
+      expect(stdout).toContain('--no-connect');
+      expect(stdout).toContain('--url');
+      expect(stdout).toContain('--token');
+      expect(stdout).toContain('--auth');
+      expect(stdout).toContain('--mode');
+    });
+
+    it('falls back to cwd and fails when cwd is not a Godot project', () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-mcp-cli-open-'));
+      try {
+        const { exitCode, stdout } = runCli(['open'], { cwd: tmp });
+        expect(exitCode).toBe(1);
+        expect(stdout).toContain('Current directory is not a Godot project');
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('run-tool', () => {
+    it('shows help with --help', () => {
+      const { stdout, exitCode } = runCli(['run-tool', '--help']);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('--url');
+      expect(stdout).toContain('--input');
+      expect(stdout).toContain('--timeout');
+    });
+  });
+
+  describe('configure', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-mcp-cli-cfg-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('shows help with --help', () => {
+      const { stdout, exitCode } = runCli(['configure', '--help']);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('--enable-tools');
+      expect(stdout).toContain('--disable-tools');
+      expect(stdout).toContain('--list');
+    });
+
+    it('creates default config and lists it', () => {
+      const { stdout, exitCode } = runCli(['configure', '--path', tmpDir, '--list']);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('Current configuration');
+      // A fresh config writes the project-local features file.
+      expect(fs.existsSync(path.join(tmpDir, '.godot-mcp', 'features.json'))).toBe(true);
+    });
+
+    it('enables and disables tools', () => {
+      runCli(['configure', '--path', tmpDir, '--enable-tools', 'tool-a,tool-b']);
+
+      const { stdout } = runCli(['configure', '--path', tmpDir, '--list']);
+      expect(stdout).toContain('[enabled] tool-a');
+      expect(stdout).toContain('[enabled] tool-b');
+
+      runCli(['configure', '--path', tmpDir, '--disable-tools', 'tool-a']);
+      const { stdout: stdout2 } = runCli(['configure', '--path', tmpDir, '--list']);
+      expect(stdout2).toContain('[disabled] tool-a');
+      expect(stdout2).toContain('[enabled] tool-b');
+    });
+
+    it('fails when project path does not exist', () => {
+      const { exitCode, stdout } = runCli([
+        'configure',
+        '--path',
+        path.join(tmpDir, 'does-not-exist-12345'),
+        '--list',
+      ]);
+      expect(exitCode).toBe(1);
+      expect(stdout).toContain('does not exist');
+    });
+  });
+
+  describe('install-plugin / remove-plugin', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-mcp-cli-plugin-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('install-plugin shows help', () => {
+      const { stdout, exitCode } = runCli(['install-plugin', '--help']);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('--path');
+    });
+
+    it('fails when project.godot is missing', () => {
+      const { exitCode, stdout } = runCli(['install-plugin', '--path', tmpDir]);
+      expect(exitCode).toBe(1);
+      expect(stdout).toContain('Not a valid Godot project');
+    });
+
+    it('enables then disables the addon in project.godot', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'project.godot'),
+        '; Engine configuration file.\nconfig_version=5\n\n[application]\n\nconfig/name="Test"\n',
+      );
+
+      const install = runCli(['install-plugin', '--path', tmpDir]);
+      expect(install.exitCode).toBe(0);
+      let text = fs.readFileSync(path.join(tmpDir, 'project.godot'), 'utf-8');
+      expect(text).toContain('[editor_plugins]');
+      expect(text).toContain('res://addons/godot_mcp/plugin.cfg');
+
+      const remove = runCli(['remove-plugin', '--path', tmpDir]);
+      expect(remove.exitCode).toBe(0);
+      text = fs.readFileSync(path.join(tmpDir, 'project.godot'), 'utf-8');
+      expect(text).not.toContain('res://addons/godot_mcp/plugin.cfg');
+    });
+  });
+});

--- a/cli/tests/config.test.ts
+++ b/cli/tests/config.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  getConfigPath,
+  getOrCreateConfig,
+  readConfig,
+  updateFeatures,
+  writeConfig,
+  type GodotMcpFeaturesConfig,
+} from '../src/utils/config.js';
+
+describe('features config', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cfg-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('config path is project-local .godot-mcp/features.json', () => {
+    expect(getConfigPath(tmpDir)).toBe(path.join(tmpDir, '.godot-mcp', 'features.json'));
+  });
+
+  it('returns null when no config exists', () => {
+    expect(readConfig(tmpDir)).toBeNull();
+  });
+
+  it('getOrCreateConfig writes a default empty config', () => {
+    const cfg = getOrCreateConfig(tmpDir);
+    expect(cfg).toEqual({ tools: [], prompts: [], resources: [] });
+    expect(fs.existsSync(getConfigPath(tmpDir))).toBe(true);
+  });
+
+  it('updateFeatures enables and disables named features', () => {
+    const cfg: GodotMcpFeaturesConfig = { tools: [], prompts: [], resources: [] };
+    updateFeatures(cfg, 'tools', { enableNames: ['a', 'b'] });
+    expect(cfg.tools).toEqual([
+      { name: 'a', enabled: true },
+      { name: 'b', enabled: true },
+    ]);
+    updateFeatures(cfg, 'tools', { disableNames: ['a'] });
+    expect(cfg.tools).toContainEqual({ name: 'a', enabled: false });
+    expect(cfg.tools).toContainEqual({ name: 'b', enabled: true });
+  });
+
+  it('updateFeatures enableAll / disableAll flips every present feature', () => {
+    const cfg: GodotMcpFeaturesConfig = {
+      tools: [
+        { name: 'a', enabled: false },
+        { name: 'b', enabled: false },
+      ],
+    };
+    updateFeatures(cfg, 'tools', { enableAll: true });
+    expect(cfg.tools?.every((f) => f.enabled)).toBe(true);
+    updateFeatures(cfg, 'tools', { disableAll: true });
+    expect(cfg.tools?.every((f) => !f.enabled)).toBe(true);
+  });
+
+  it('round-trips through write/read', () => {
+    const cfg = getOrCreateConfig(tmpDir);
+    updateFeatures(cfg, 'resources', { enableNames: ['res-a'] });
+    writeConfig(tmpDir, cfg);
+    const reread = readConfig(tmpDir);
+    expect(reread?.resources).toContainEqual({ name: 'res-a', enabled: true });
+  });
+});

--- a/cli/tests/connection.test.ts
+++ b/cli/tests/connection.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  resolveConnection,
+  CLOUD_MCP_URL,
+  DEFAULT_CLOUD_BASE_URL,
+  DEFAULT_CUSTOM_HOST,
+  ENV_HOST,
+  ENV_CLOUD_URL,
+  ENV_TOKEN,
+  ENV_CONNECTION_MODE,
+} from '../src/utils/connection.js';
+
+describe('resolveConnection', () => {
+  const saved: Record<string, string | undefined> = {};
+  const ENV_KEYS = [ENV_HOST, ENV_CLOUD_URL, ENV_TOKEN, ENV_CONNECTION_MODE];
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('uses an explicit --url (trailing slash stripped) over everything', () => {
+    process.env[ENV_HOST] = 'http://env-host:1111';
+    const { url } = resolveConnection('/proj', { url: 'http://explicit:9000/' });
+    expect(url).toBe('http://explicit:9000');
+  });
+
+  it('uses GODOT_MCP_HOST when no --url is given', () => {
+    process.env[ENV_HOST] = 'http://localhost:5544/';
+    const { url } = resolveConnection('/proj', {});
+    expect(url).toBe('http://localhost:5544');
+  });
+
+  it('strips a trailing /mcp from GODOT_MCP_CLOUD_URL to get the base', () => {
+    process.env[ENV_CLOUD_URL] = 'https://example.test/mcp';
+    const { url } = resolveConnection('/proj', {});
+    expect(url).toBe('https://example.test');
+  });
+
+  it('falls back to the cloud base when mode is Cloud', () => {
+    process.env[ENV_CONNECTION_MODE] = 'Cloud';
+    const { url } = resolveConnection('/proj', {});
+    expect(url).toBe(DEFAULT_CLOUD_BASE_URL);
+  });
+
+  it('falls back to the default custom host otherwise', () => {
+    const { url } = resolveConnection('/proj', {});
+    expect(url).toBe(DEFAULT_CUSTOM_HOST);
+  });
+
+  it('resolves the token from --token, then GODOT_MCP_TOKEN', () => {
+    process.env[ENV_TOKEN] = '"env-tok"';
+    expect(resolveConnection('/proj', { token: 'flag-tok' }).token).toBe('flag-tok');
+    // env value is normalized (wrapping quotes stripped)
+    expect(resolveConnection('/proj', {}).token).toBe('env-tok');
+  });
+
+  it('exposes the cloud MCP-client URL constant as <base>/mcp', () => {
+    expect(CLOUD_MCP_URL).toBe(`${DEFAULT_CLOUD_BASE_URL}/mcp`);
+  });
+});

--- a/cli/tests/godot-editor.test.ts
+++ b/cli/tests/godot-editor.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { spawn } from 'child_process';
+import { findGodotBinary, launchEditor, GODOT_BIN_ENV_VARS } from '../src/utils/godot-editor.js';
+
+// ESM module namespaces are non-configurable, so spying on a named export is
+// not possible; mock the module instead and assert against the mocked spawn.
+vi.mock('child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+const spawnMock = vi.mocked(spawn);
+
+describe('findGodotBinary', () => {
+  let tmpDir: string;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-bin-'));
+    for (const v of GODOT_BIN_ENV_VARS) {
+      savedEnv[v] = process.env[v];
+      delete process.env[v];
+    }
+    savedEnv['PATH'] = process.env['PATH'];
+  });
+
+  afterEach(() => {
+    for (const v of [...GODOT_BIN_ENV_VARS, 'PATH']) {
+      if (savedEnv[v] === undefined) delete process.env[v];
+      else process.env[v] = savedEnv[v];
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns an explicit editorPath when it exists', () => {
+    const bin = path.join(tmpDir, 'godot-bin');
+    fs.writeFileSync(bin, '');
+    expect(findGodotBinary(bin)).toBe(path.resolve(bin));
+  });
+
+  it('returns null for an explicit editorPath that does not exist', () => {
+    expect(findGodotBinary(path.join(tmpDir, 'nope'))).toBeNull();
+  });
+
+  it('returns null for an empty/whitespace explicit editorPath', () => {
+    expect(findGodotBinary('   ')).toBeNull();
+  });
+
+  it('resolves GODOT_BIN before PATH and common dirs', () => {
+    const bin = path.join(tmpDir, 'godot_mono.exe');
+    fs.writeFileSync(bin, '');
+    process.env['GODOT_BIN'] = bin;
+    expect(findGodotBinary(undefined, 'win32')).toBe(path.resolve(bin));
+  });
+
+  it('honors GODOT4_BIN as a fallback env var', () => {
+    const bin = path.join(tmpDir, 'godot');
+    fs.writeFileSync(bin, '');
+    process.env['GODOT4_BIN'] = bin;
+    expect(findGodotBinary(undefined, 'linux')).toBe(path.resolve(bin));
+  });
+
+  it('finds a binary on PATH when no env override is set', () => {
+    // Use the host platform so the PATH separator matches the tmpDir's path
+    // shape (a Windows absolute path contains ':' which the linux ':' splitter
+    // would otherwise break apart). On Windows the PATH candidate name is
+    // `godot.exe`; elsewhere `godot`.
+    const hostOs = process.platform;
+    const binName = hostOs === 'win32' ? 'godot.exe' : 'godot';
+    const bin = path.join(tmpDir, binName);
+    fs.writeFileSync(bin, '');
+    process.env['PATH'] = tmpDir;
+    expect(findGodotBinary(undefined, hostOs)).toBe(path.join(tmpDir, binName));
+  });
+
+  it('returns null when nothing resolves', () => {
+    process.env['PATH'] = path.join(tmpDir, 'empty');
+    // Pass an OS whose common dirs are unlikely to exist in the test sandbox.
+    const result = findGodotBinary(undefined, 'linux');
+    // Either null, or a real system godot if the runner has one — accept both,
+    // but assert it never resolves a phantom path inside our empty PATH dir.
+    if (result !== null) {
+      expect(result).not.toContain(path.join(tmpDir, 'empty'));
+    }
+  });
+});
+
+describe('launchEditor', () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  it('spawns the editor detached with --editor --path and merged env, then unrefs', () => {
+    const unref = vi.fn();
+    const on = vi.fn();
+    const fakeChild = { on, unref, pid: 4321 } as unknown as ReturnType<typeof spawn>;
+    spawnMock.mockReturnValue(fakeChild);
+
+    const child = launchEditor('/path/to/godot', '/my/project', { GODOT_MCP_HOST: 'http://localhost:9000' });
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [bin, args, opts] = spawnMock.mock.calls[0];
+    expect(bin).toBe('/path/to/godot');
+    expect(args).toEqual(['--editor', '--path', path.resolve('/my/project')]);
+    expect(opts).toMatchObject({ detached: true, stdio: 'ignore' });
+    expect((opts as { env: Record<string, string> }).env['GODOT_MCP_HOST']).toBe('http://localhost:9000');
+    expect(unref).toHaveBeenCalledTimes(1);
+    expect(child).toBe(fakeChild);
+  });
+});

--- a/cli/tests/helpers/cli.ts
+++ b/cli/tests/helpers/cli.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import * as path from 'path';
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const CLI_PATH = path.resolve(__dirname, '..', '..', 'bin', 'godot-mcp-cli.js');
+
+/** Run the CLI as a child process with timeout and error handling. */
+export function runCliAsync(args: string[], cwd?: string): Promise<{ stdout: string; exitCode: number }> {
+  return new Promise((resolve) => {
+    const child = spawn('node', [CLI_PATH, ...args], { stdio: 'pipe', cwd });
+    let stdout = '';
+    let settled = false;
+    const timeoutMs = 30000;
+
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try { child.kill(); } catch { /* noop */ }
+      stdout += '\n[runCliAsync] Process timed out.\n';
+      resolve({ stdout, exitCode: 1 });
+    }, timeoutMs);
+
+    const finish = (exitCode: number) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve({ stdout, exitCode });
+    };
+
+    child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
+    child.stderr?.on('data', (d: Buffer) => { stdout += d.toString(); });
+    child.on('close', (code) => { finish(code ?? 0); });
+    child.on('error', (err) => {
+      stdout += `\n[runCliAsync] Error: ${String(err)}\n`;
+      finish(1);
+    });
+  });
+}

--- a/cli/tests/open.test.ts
+++ b/cli/tests/open.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { spawn } from 'child_process';
+import { buildOpenEnv, isGodotProjectDir, openProject } from '../src/lib/open.js';
+
+// ESM module namespaces are non-configurable; mock child_process so we can
+// observe spawn and stub the process-enumeration calls (execFileSync/execSync)
+// used by the already-running check. The stubs return empty so no editor is
+// detected as already running.
+vi.mock('child_process', () => ({
+  spawn: vi.fn(),
+  execFileSync: vi.fn(() => ''),
+  execSync: vi.fn(() => ''),
+}));
+
+const spawnMock = vi.mocked(spawn);
+
+describe('buildOpenEnv', () => {
+  it('returns undefined when noConnect is true', () => {
+    expect(buildOpenEnv({ noConnect: true, url: 'http://localhost:8080' })).toBeUndefined();
+  });
+
+  it('returns undefined when no connection inputs are provided', () => {
+    expect(buildOpenEnv({})).toBeUndefined();
+  });
+
+  it('maps each input to the matching GODOT_MCP_* env var', () => {
+    const env = buildOpenEnv({
+      url: 'http://localhost:8080',
+      cloudUrl: 'https://ai-game.dev',
+      token: 'abc',
+      auth: 'Required',
+      mode: 'Custom',
+      logLevel: 'Trace',
+    });
+    expect(env).toEqual({
+      GODOT_MCP_HOST: 'http://localhost:8080',
+      GODOT_MCP_CLOUD_URL: 'https://ai-game.dev',
+      GODOT_MCP_TOKEN: 'abc',
+      GODOT_MCP_AUTH_OPTION: 'Required',
+      GODOT_MCP_CONNECTION_MODE: 'Custom',
+      GODOT_MCP_LOG_LEVEL: 'Trace',
+    });
+  });
+
+  it('throws on an invalid auth value', () => {
+    expect(() => buildOpenEnv({ auth: 'bogus' as never })).toThrow(/auth must be/);
+  });
+
+  it('throws on an invalid mode value', () => {
+    expect(() => buildOpenEnv({ mode: 'bogus' as never })).toThrow(/mode must be/);
+  });
+});
+
+describe('isGodotProjectDir', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-open-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('is true when project.godot exists', () => {
+    fs.writeFileSync(path.join(tmpDir, 'project.godot'), 'config_version=5\n');
+    expect(isGodotProjectDir(tmpDir)).toBe(true);
+  });
+
+  it('is false when project.godot is absent', () => {
+    expect(isGodotProjectDir(tmpDir)).toBe(false);
+  });
+});
+
+describe('openProject', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-open-proj-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('fails for a non-Godot directory', async () => {
+    const result = await openProject({ projectPath: tmpDir, editorPath: 'x', noConnect: true });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') {
+      expect(result.errorMessage).toContain('Not a Godot project');
+    }
+  });
+
+  it('fails when no editor can be resolved', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'project.godot'), 'config_version=5\n');
+    const result = await openProject({
+      projectPath: tmpDir,
+      editorPath: path.join(tmpDir, 'does-not-exist'),
+      noConnect: true,
+    });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') {
+      expect(result.errorMessage).toContain('No Godot editor binary found');
+    }
+  });
+
+  it('launches the resolved editor with --editor --path + GODOT_MCP_* env', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'project.godot'), 'config_version=5\n');
+    const fakeBin = path.join(tmpDir, 'godot-bin');
+    fs.writeFileSync(fakeBin, '');
+
+    const on = vi.fn();
+    const unref = vi.fn();
+    const fakeChild = { on, unref, pid: 9999, once: vi.fn() } as unknown as ReturnType<typeof spawn>;
+    spawnMock.mockReset();
+    spawnMock.mockReturnValue(fakeChild);
+
+    const result = await openProject({
+      projectPath: tmpDir,
+      editorPath: fakeBin,
+      url: 'http://localhost:8080',
+      token: 'secret',
+    });
+
+    expect(result.kind).toBe('success');
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [bin, args, opts] = spawnMock.mock.calls[0];
+    expect(bin).toBe(path.resolve(fakeBin));
+    expect(args).toEqual(['--editor', '--path', path.resolve(tmpDir)]);
+    const env = (opts as { env: Record<string, string> }).env;
+    expect(env['GODOT_MCP_HOST']).toBe('http://localhost:8080');
+    expect(env['GODOT_MCP_TOKEN']).toBe('secret');
+  });
+});

--- a/cli/tests/project-godot.test.ts
+++ b/cli/tests/project-godot.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseEnabledPlugins,
+  togglePluginInText,
+  GODOT_MCP_PLUGIN_PATH,
+} from '../src/utils/project-godot.js';
+
+const BASE = `; Engine configuration file.
+config_version=5
+
+[application]
+
+config/name="Test"
+`;
+
+describe('parseEnabledPlugins', () => {
+  it('returns [] when there is no [editor_plugins] section', () => {
+    expect(parseEnabledPlugins(BASE)).toEqual([]);
+  });
+
+  it('parses a single enabled plugin', () => {
+    const text = `${BASE}
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/godot_mcp/plugin.cfg")
+`;
+    expect(parseEnabledPlugins(text)).toEqual(['res://addons/godot_mcp/plugin.cfg']);
+  });
+
+  it('parses multiple enabled plugins', () => {
+    const text = `${BASE}
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/other/plugin.cfg", "res://addons/godot_mcp/plugin.cfg")
+`;
+    expect(parseEnabledPlugins(text)).toEqual([
+      'res://addons/other/plugin.cfg',
+      'res://addons/godot_mcp/plugin.cfg',
+    ]);
+  });
+});
+
+describe('togglePluginInText — enable', () => {
+  it('creates the [editor_plugins] section when absent', () => {
+    const r = togglePluginInText(BASE, true);
+    expect(r.kind).toBe('changed');
+    expect(r.text).toContain('[editor_plugins]');
+    expect(r.text).toContain('enabled=PackedStringArray("res://addons/godot_mcp/plugin.cfg")');
+    expect(parseEnabledPlugins(r.text)).toEqual([GODOT_MCP_PLUGIN_PATH]);
+  });
+
+  it('appends to an existing enabled array, preserving siblings', () => {
+    const text = `${BASE}
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/other/plugin.cfg")
+`;
+    const r = togglePluginInText(text, true);
+    expect(r.kind).toBe('changed');
+    expect(parseEnabledPlugins(r.text)).toEqual([
+      'res://addons/other/plugin.cfg',
+      GODOT_MCP_PLUGIN_PATH,
+    ]);
+  });
+
+  it('is idempotent when already enabled', () => {
+    const text = `${BASE}
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/godot_mcp/plugin.cfg")
+`;
+    const r = togglePluginInText(text, true);
+    expect(r.kind).toBe('unchanged');
+    expect(r.text).toBe(text);
+  });
+});
+
+describe('togglePluginInText — disable', () => {
+  it('removes the plugin, preserving siblings', () => {
+    const text = `${BASE}
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/other/plugin.cfg", "res://addons/godot_mcp/plugin.cfg")
+`;
+    const r = togglePluginInText(text, false);
+    expect(r.kind).toBe('changed');
+    expect(parseEnabledPlugins(r.text)).toEqual(['res://addons/other/plugin.cfg']);
+  });
+
+  it('is idempotent when already absent', () => {
+    const r = togglePluginInText(BASE, false);
+    expect(r.kind).toBe('unchanged');
+    expect(r.text).toBe(BASE);
+  });
+});

--- a/cli/tests/run-tool.test.ts
+++ b/cli/tests/run-tool.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runTool, runSystemTool } from '../src/lib/run-tool.js';
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('runTool', () => {
+  it('fails with invalid-input when toolName is missing', async () => {
+    const result = await runTool({ toolName: '', url: 'http://localhost:8080' });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') {
+      expect(result.reason).toBe('invalid-input');
+      expect(result.message).toContain('toolName is required');
+    }
+  });
+
+  it('fails with invalid-input when url is missing (no port-hash fallback)', async () => {
+    const result = await runTool({ toolName: 'ping' });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') {
+      expect(result.reason).toBe('invalid-input');
+      expect(result.message).toContain('url is required');
+    }
+  });
+
+  it('POSTs to /api/tools/<name> and returns parsed data on success', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(200, { structured: { result: 'pong' } }));
+    const result = await runTool({
+      toolName: 'ping',
+      url: 'http://localhost:8080/',
+      input: { message: 'hi' },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [endpoint, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(endpoint).toBe('http://localhost:8080/api/tools/ping');
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe(JSON.stringify({ message: 'hi' }));
+
+    expect(result.kind).toBe('success');
+    if (result.kind === 'success') {
+      expect(result.httpStatus).toBe(200);
+      expect(result.data).toEqual({ structured: { result: 'pong' } });
+    }
+  });
+
+  it('attaches a Bearer header when a token is provided', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(200, {}));
+    await runTool({
+      toolName: 'ping',
+      url: 'http://localhost:8080',
+      token: 'tok',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer tok');
+  });
+
+  it('returns http-error on a non-OK response', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(404, { error: 'not found' }));
+    const result = await runTool({
+      toolName: 'missing',
+      url: 'http://localhost:8080',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') {
+      expect(result.reason).toBe('http-error');
+      expect(result.httpStatus).toBe(404);
+    }
+  });
+
+  it('rejects malformed JSON input strings', async () => {
+    const result = await runTool({
+      toolName: 'ping',
+      url: 'http://localhost:8080',
+      input: '{not json',
+    });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') {
+      expect(result.reason).toBe('invalid-input');
+    }
+  });
+});
+
+describe('runSystemTool', () => {
+  it('POSTs to /api/system-tools/<name>', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(200, {}));
+    await runSystemTool({
+      toolName: 'reload',
+      url: 'http://localhost:8080',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const [endpoint] = fetchImpl.mock.calls[0] as [string];
+    expect(endpoint).toBe('http://localhost:8080/api/system-tools/reload');
+  });
+});

--- a/cli/tests/setup-mcp.test.ts
+++ b/cli/tests/setup-mcp.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { setupMcp, listAgentIds } from '../src/lib/setup-mcp.js';
+import { ENV_HOST, ENV_TOKEN } from '../src/utils/connection.js';
+
+describe('setupMcp', () => {
+  let tmpDir: string;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-setup-mcp-'));
+    for (const k of [ENV_HOST, ENV_TOKEN]) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of [ENV_HOST, ENV_TOKEN]) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('lists the known agent ids', () => {
+    const ids = listAgentIds();
+    expect(ids).toContain('claude-code');
+    expect(ids).toContain('cursor');
+    expect(ids).toContain('vscode');
+    expect(ids).toContain('custom');
+  });
+
+  it('fails for an unknown agent', async () => {
+    const result = await setupMcp({ agentId: 'nope', godotProjectPath: tmpDir });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') {
+      expect(result.error.message).toContain('Unknown agent');
+    }
+  });
+
+  it('writes a claude-code .mcp.json under mcpServers with the cloud /mcp URL by default', async () => {
+    const result = await setupMcp({ agentId: 'claude-code', godotProjectPath: tmpDir });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+
+    expect(result.serverUrl).toBe('https://ai-game.dev/mcp');
+    const json = JSON.parse(fs.readFileSync(path.join(tmpDir, '.mcp.json'), 'utf-8'));
+    expect(json.mcpServers['ai-game-developer']).toMatchObject({
+      type: 'http',
+      url: 'https://ai-game.dev/mcp',
+    });
+  });
+
+  it('derives the <host>/mcp client URL from --url', async () => {
+    const result = await setupMcp({
+      agentId: 'cursor',
+      godotProjectPath: tmpDir,
+      url: 'http://localhost:8080',
+    });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+    expect(result.serverUrl).toBe('http://localhost:8080/mcp');
+    const json = JSON.parse(fs.readFileSync(path.join(tmpDir, '.cursor', 'mcp.json'), 'utf-8'));
+    expect(json.mcpServers['ai-game-developer'].url).toBe('http://localhost:8080/mcp');
+  });
+
+  it('writes a VS Code config under the "servers" body path', async () => {
+    const result = await setupMcp({ agentId: 'vscode', godotProjectPath: tmpDir, url: 'http://localhost:8080' });
+    expect(result.kind).toBe('success');
+    const json = JSON.parse(fs.readFileSync(path.join(tmpDir, '.vscode', 'mcp.json'), 'utf-8'));
+    expect(json.servers['ai-game-developer'].url).toBe('http://localhost:8080/mcp');
+  });
+
+  it('adds an Authorization header when a token is provided', async () => {
+    const result = await setupMcp({
+      agentId: 'claude-code',
+      godotProjectPath: tmpDir,
+      url: 'http://localhost:8080',
+      token: 'secret',
+    });
+    expect(result.kind).toBe('success');
+    const json = JSON.parse(fs.readFileSync(path.join(tmpDir, '.mcp.json'), 'utf-8'));
+    expect(json.mcpServers['ai-game-developer'].headers).toEqual({ Authorization: 'Bearer secret' });
+  });
+});

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- New TypeScript npm package `godot-mcp-cli` under `cli/`, mirroring the feature set + structure of `unity-mcp-cli` (`Unity-MCP/cli/`), adapted for Godot.
- Commands: `open` (editor resolution `GODOT_BIN`/`GODOT4_BIN` → PATH → per-OS common dirs; launch `--editor --path` with `GODOT_MCP_*` env vars), `run-tool` / `run-system-tool` (HTTP POST to `/api/tools` and `/api/system-tools`), `status`, `wait-for-ready`, `setup-mcp` (claude-code/claude-desktop/cursor/vscode/custom → `<host>/mcp`), `configure` (project-local `.godot-mcp/features.json`), `close`, `install-plugin` / `remove-plugin` (toggle `res://addons/godot_mcp/plugin.cfg` in `project.godot` `[editor_plugins]`), `update`.
- New reusable workflow `.github/workflows/test_cli.yml` (`workflow_call`, node 20 & 22 matrix: `npm ci` → `npm run build` → `npm test` in `./cli`). Wiring it into PR CI is a follow-up.

## Scope decisions

- **`setup-skills` intentionally out of v1.** Godot skills are generated **addon-side** by the McpPlugin engine (`GodotMcpConnection.Start` → `GenerateSkillFilesIfNeeded`, the dock's Skills card). The Godot MCP server exposes **no** skill-generate HTTP endpoint for the CLI to call, so there is nothing to invoke.
- **No deterministic project-path→port hash.** Unlike Unity, the Godot plugin is a server-less client whose persisted config lives in `user://` (outside the project tree). Server-URL resolution is therefore `--url` → `GODOT_MCP_HOST`/`GODOT_MCP_CLOUD_URL` env → cloud default (`https://ai-game.dev`) → default custom host (`http://localhost:8080`).
- **Not published here** (a separate release task). `cli/` is **not** added to `Godot-MCP.sln`, so the `dotnet build (.NET 8)` CI gate is unaffected; the C# addon and its frozen NuGet pins are untouched.

## Test plan

- [x] `cd cli && npm install && npm run build` — 0 tsc errors.
- [x] `npm test` — 65 vitest tests pass (cli help/version, open editor-resolution + launch with mocked spawn, run-tool, connection/config/project-godot, setup-mcp).
- [x] `dotnet build Godot-MCP.sln --configuration Debug` — 0 errors (proves `cli/` did not leak into the .NET build).
- [x] `dotnet test Godot-MCP.Tests` — 614 xUnit tests pass (no addon regression).

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)