### PR TITLE
ci: PR test matrix across Godot versions (Unity-MCP parity)

### DIFF
--- a/.github/workflows/test_godot_plugin.yml
+++ b/.github/workflows/test_godot_plugin.yml
@@ -59,19 +59,39 @@ jobs:
           test -f "${TEST_PROJECT}/addons/godot_mcp/plugin.cfg"
           test -f "${TEST_PROJECT}/addons/godot_mcp/GodotMcpPlugin.cs"
 
-      - name: Build C# solution (headless)
+      - name: Import the project (generate .godot layout)
+        shell: bash
+        run: |
+          set -uo pipefail
+          # A cold CI checkout has no .godot/. Godot's `--build-solutions` is a
+          # silent no-op until the project has been imported once (it materializes
+          # the .godot/mono layout only on first editor import). Run an import pass
+          # so the project is recognized before we build. Headless import prints
+          # benign "progress dialog while flushing the message queue" warnings and
+          # may exit non-zero on teardown — neither is fatal, so do NOT gate on the
+          # import's exit code (the real gates are the emitted DLL below + the
+          # plugin-loaded assertion). See ../../CLAUDE.md "Testbed runbook".
+          godot --headless --path "${TEST_PROJECT}" --import --quit 2>&1 | tee import.log || true
+          echo "Import pass complete."
+
+      - name: Build C# (addon compiles into the project assembly)
         shell: bash
         run: |
           set -euo pipefail
-          # Godot generates the .sln/.csproj wiring + compiles the project (the
-          # addon globs into the project assembly). A non-zero exit on teardown
-          # is tolerated; the real build signal is the emitted managed assembly.
-          godot --headless --path "${TEST_PROJECT}" --build-solutions --quit \
-            2>&1 | tee build-solutions.log || true
+          # Compile via `dotnet build` directly on the test project's .csproj
+          # rather than `godot --build-solutions` — the latter silently no-ops in
+          # a headless cold checkout (it produces no assembly and no diagnostics).
+          # `dotnet build` is deterministic: Godot.NET.Sdk resolves GodotSharp from
+          # nuget.org for the pinned SDK, and the addon's *.cs (copied in above)
+          # globs into THIS project assembly, so a successful build proves the
+          # addon's C# compiles against the frozen McpPlugin / ReflectorNet pins.
+          # Output lands at .godot/mono/temp/bin/<Config>/Godot-MCP-Tests.dll.
+          dotnet build "${TEST_PROJECT}/Godot-Tests.csproj" \
+            --configuration Debug 2>&1 | tee build.log
           if ! ls "${TEST_PROJECT}"/.godot/mono/temp/bin/*/Godot-MCP-Tests.dll >/dev/null 2>&1; then
             echo "::error::C# build did not produce Godot-MCP-Tests.dll — the addon failed to compile."
-            echo "----- build-solutions.log -----"
-            cat build-solutions.log || true
+            echo "----- build.log -----"
+            cat build.log || true
             exit 1
           fi
 
@@ -105,7 +125,8 @@ jobs:
         with:
           name: godot-${{ inputs.godotVersion }}-logs
           path: |
-            build-solutions.log
+            import.log
+            build.log
             editor-boot.log
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/test_godot_plugin.yml
+++ b/.github/workflows/test_godot_plugin.yml
@@ -1,0 +1,111 @@
+# ┌──────────────────────────────────────────────────────────────────┐
+# │  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+# │  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+# │  Copyright (c) 2026 Ivan Murzak                                  │
+# │  Licensed under the Apache License, Version 2.0.                 │
+# │  See the LICENSE file in the project root for more information.  │
+# └──────────────────────────────────────────────────────────────────┘
+
+# Reusable workflow: boot a headless Godot editor (mono / .NET build) of the
+# requested version against the in-repo Godot-Tests/ project and assert the
+# godot_mcp addon loads cleanly. Godot needs NO license (unlike Unity), so this
+# uses the official Godot binaries via chickensoft-games/setup-godot — no
+# game-ci. Called once per matrix version by test_pull_request.yml.
+name: Test Godot Plugin
+
+on:
+  workflow_call:
+    inputs:
+      godotVersion:
+        description: "Godot mono version to install and boot (e.g. 4.3.0, 4.4.0, 4.5.1)."
+        required: true
+        type: string
+
+jobs:
+  test-godot-plugin:
+    name: godot ${{ inputs.godotVersion }} (mono)
+    runs-on: ubuntu-latest
+    env:
+      # The in-repo test project. The addon is copied into <TEST_PROJECT>/addons/
+      # at runtime (a dev junction does not survive checkout).
+      TEST_PROJECT: Godot-Tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Setup Godot ${{ inputs.godotVersion }} (mono)
+        uses: chickensoft-games/setup-godot@v2
+        with:
+          version: ${{ inputs.godotVersion }}
+          use-dotnet: true
+          include-templates: false
+
+      - name: Report Godot version
+        shell: bash
+        run: godot --version --headless
+
+      - name: Copy addon into the test project
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf "${TEST_PROJECT}/addons/godot_mcp"
+          mkdir -p "${TEST_PROJECT}/addons"
+          cp -r addons/godot_mcp "${TEST_PROJECT}/addons/godot_mcp"
+          test -f "${TEST_PROJECT}/addons/godot_mcp/plugin.cfg"
+          test -f "${TEST_PROJECT}/addons/godot_mcp/GodotMcpPlugin.cs"
+
+      - name: Build C# solution (headless)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Godot generates the .sln/.csproj wiring + compiles the project (the
+          # addon globs into the project assembly). A non-zero exit on teardown
+          # is tolerated; the real build signal is the emitted managed assembly.
+          godot --headless --path "${TEST_PROJECT}" --build-solutions --quit \
+            2>&1 | tee build-solutions.log || true
+          if ! ls "${TEST_PROJECT}"/.godot/mono/temp/bin/*/Godot-MCP-Tests.dll >/dev/null 2>&1; then
+            echo "::error::C# build did not produce Godot-MCP-Tests.dll — the addon failed to compile."
+            echo "----- build-solutions.log -----"
+            cat build-solutions.log || true
+            exit 1
+          fi
+
+      - name: Boot editor headless and assert addon loads
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Boot the editor once; the godot_mcp EditorPlugin runs its _EnterTree
+          # and prints "[Godot-MCP] plugin loaded". Capture stdout+stderr.
+          godot --headless --path "${TEST_PROJECT}" --editor --quit \
+            2>&1 | tee editor-boot.log || true
+
+          echo "----- editor-boot.log -----"
+          cat editor-boot.log
+
+          if ! grep -qF "[Godot-MCP] plugin loaded" editor-boot.log; then
+            echo "::error::'[Godot-MCP] plugin loaded' was NOT found — the addon did not load on Godot ${{ inputs.godotVersion }}."
+            exit 1
+          fi
+
+          if grep -qE "FileNotFoundException|Cannot open file|Failed to load script|Unable to load addon|addon .* failed" editor-boot.log; then
+            echo "::error::An addon-load / assembly-resolution error appeared in the editor boot output on Godot ${{ inputs.godotVersion }}."
+            exit 1
+          fi
+
+          echo "Godot ${{ inputs.godotVersion }}: addon loaded cleanly."
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: godot-${{ inputs.godotVersion }}-logs
+          path: |
+            build-solutions.log
+            editor-boot.log
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -1,0 +1,74 @@
+# ┌──────────────────────────────────────────────────────────────────┐
+# │  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+# │  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+# │  Copyright (c) 2026 Ivan Murzak                                  │
+# │  Licensed under the Apache License, Version 2.0.                 │
+# │  See the LICENSE file in the project root for more information.  │
+# └──────────────────────────────────────────────────────────────────┘
+
+# Pull-request CI aggregator (Unity-MCP parity with test_pull_request.yml).
+# Fans out, with fail-fast disabled so every leg reports independently:
+#   (a) .NET build + xUnit  — a PR-aggregate copy of ci.yml's build/test
+#   (b) godot-mcp-cli node tests (20/22) via the reusable test_cli.yml
+#   (c) the godot_mcp addon-load smoke across Godot 4.3 / 4.4 / 4.5 (mono) via
+#       the reusable test_godot_plugin.yml
+#
+# NOTE: ci.yml is intentionally left untouched and still runs on push + PR; its
+# job display name `dotnet build (.NET 8)` remains the canonical required check.
+# The `dotnet-build-test` job below is an additional aggregate signal, NOT a
+# rename of that check.
+name: Test Pull Request
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Auto-cancel superseded runs when a new commit is pushed to the same PR, so
+# intermediate pushes don't pile up runner time.
+concurrency:
+  group: test-pr-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # (a) .NET build + xUnit (mirrors ci.yml; aggregate signal for this PR run).
+  dotnet-build-test:
+    name: dotnet build + test (.NET 8)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Restore
+        run: dotnet restore Godot-MCP.sln
+
+      - name: Build
+        run: dotnet build Godot-MCP.sln --configuration Debug --no-restore
+
+      - name: Test
+        run: dotnet test Godot-MCP.Tests/Godot-MCP.Tests.csproj --configuration Debug --no-build --verbosity normal
+
+  # (b) godot-mcp-cli node tests (Node 20 & 22).
+  test-cli:
+    uses: ./.github/workflows/test_cli.yml
+
+  # (c) godot_mcp addon-load smoke across the Godot engine matrix (mono).
+  test-godot-4-3:
+    uses: ./.github/workflows/test_godot_plugin.yml
+    with:
+      godotVersion: "4.3.0"
+
+  test-godot-4-4:
+    uses: ./.github/workflows/test_godot_plugin.yml
+    with:
+      godotVersion: "4.4.0"
+
+  test-godot-4-5:
+    uses: ./.github/workflows/test_godot_plugin.yml
+    with:
+      godotVersion: "4.5.1"

--- a/Godot-Tests/.gitignore
+++ b/Godot-Tests/.gitignore
@@ -1,0 +1,24 @@
+# CI-only Godot testbed — keep this dir minimal. The addon is copied into
+# addons/godot_mcp/ at CI time (see .github/workflows/test_godot_plugin.yml) and
+# is NEVER committed here (the real source lives in ../addons/godot_mcp/). All
+# build/import artifacts are generated and ignored.
+
+# Copied-in addon (populated by CI; the canonical source is ../addons/godot_mcp/)
+/addons/
+
+# Godot 4+ generated dirs / caches
+.godot/
+.import/
+export_presets.cfg
+.mono/
+*.import
+*.cs.uid
+
+# .NET build output
+bin/
+obj/
+
+# Godot-generated solution / nuget config (regenerated on build-solutions)
+Godot-MCP-Tests.sln
+Godot-Tests.sln
+nuget.config

--- a/Godot-Tests/Godot-Tests.csproj
+++ b/Godot-Tests/Godot-Tests.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Godot.NET.Sdk/4.3.0">
+
+  <!--
+    CI-only testbed project for the godot_mcp addon (analog of Unity-MCP's
+    Unity-Tests/<version>/ projects). Used exclusively by
+    .github/workflows/test_godot_plugin.yml to boot a headless Godot editor
+    across the 4.3 / 4.4 / 4.5 (mono) matrix and assert "[Godot-MCP] plugin
+    loaded" with no addon-load exception.
+
+    Godot compiles EVERY .cs file under the project dir (including the addon
+    scripts the workflow copies into addons/godot_mcp/ before boot) into THIS
+    single assembly. So this csproj must declare the same NuGet
+    PackageReferences the addon's scripts depend on, otherwise the addon's C#
+    will not compile here. Keep these pins in lockstep with ../Godot-MCP.csproj
+    (com.IvanMurzak.ReflectorNet 5.3.1, com.IvanMurzak.McpPlugin 6.7.0).
+
+    SDK pin note: Godot.NET.Sdk/4.3.0 is the engine floor the addon supports
+    (matches ../Godot-MCP.csproj). The .NET SDK package is published to
+    nuget.org and restores on any runner; the installed Godot binary
+    (4.3/4.4/4.5) drives the actual `--build-solutions` compile via its own
+    bundled GodotSharp, so a single floor pin works across the whole matrix.
+
+    EXCLUDED from ../Godot-MCP.sln so the existing `dotnet build (.NET 8)` CI
+    gate is unaffected — this project is only ever built by the Godot editor.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <Nullable>enable</Nullable>
+    <RootNamespace>com.IvanMurzak.Godot.MCP.Tests.Project</RootNamespace>
+    <AssemblyName>Godot-MCP-Tests</AssemblyName>
+  </PropertyGroup>
+
+  <!-- Mirror of ../Godot-MCP.csproj package pins (must stay in lockstep). -->
+  <ItemGroup>
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.1" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="6.7.0" />
+  </ItemGroup>
+
+</Project>

--- a/Godot-Tests/Godot-Tests.csproj
+++ b/Godot-Tests/Godot-Tests.csproj
@@ -17,10 +17,10 @@
     SDK pin note: Godot.NET.Sdk/4.3.0 is the engine floor the addon supports
     (matches ../Godot-MCP.csproj). The .NET SDK package is published to
     nuget.org and restores on any runner; the installed Godot binary
-    (4.3/4.4/4.5) drives the actual `--build-solutions` compile via its own
+    (4.3/4.4/4.5) drives the actual build-solutions compile via its own
     bundled GodotSharp, so a single floor pin works across the whole matrix.
 
-    EXCLUDED from ../Godot-MCP.sln so the existing `dotnet build (.NET 8)` CI
+    EXCLUDED from ../Godot-MCP.sln so the existing dotnet build (.NET 8) CI
     gate is unaffected — this project is only ever built by the Godot editor.
   -->
   <PropertyGroup>

--- a/Godot-Tests/README.md
+++ b/Godot-Tests/README.md
@@ -1,0 +1,47 @@
+# Godot-Tests — headless CI testbed
+
+A deliberately minimal Godot 4 (C#/mono) project used **only by CI** to verify that
+the `godot_mcp` addon loads cleanly across a matrix of Godot engine versions
+(**4.3 / 4.4 / 4.5**, mono). It is the Godot analog of Unity-MCP's
+`Unity-Tests/<version>/` projects, and mirrors the infra repo's
+`Godot-Test-Project/` testbed — but self-contained inside this repo so CI needs no
+external checkout or junction.
+
+## What it contains
+
+- `project.godot` — enables `res://addons/godot_mcp/plugin.cfg` in `[editor_plugins]`.
+- `Godot-Tests.csproj` — `Godot.NET.Sdk` + the **same frozen NuGet pins** as
+  `../Godot-MCP.csproj` (`com.IvanMurzak.ReflectorNet` 5.3.1,
+  `com.IvanMurzak.McpPlugin` 6.7.0), so the addon's C# compiles into the project
+  assembly. Excluded from `../Godot-MCP.sln` so the `dotnet build (.NET 8)` gate is
+  unaffected.
+- No game content, no scenes, no committed addon copy.
+
+## How CI uses it
+
+`.github/workflows/test_godot_plugin.yml` (reusable, input `godotVersion`):
+
+1. installs the requested Godot **mono** binary + .NET 8,
+2. **copies** `../addons/godot_mcp` into `Godot-Tests/addons/godot_mcp` (a dev
+   junction does not survive checkout in CI; the copy is `.gitignore`d here),
+3. builds the project C# (`<godot> --headless --path Godot-Tests --build-solutions --quit`),
+4. boots the editor headless (`<godot> --headless --path Godot-Tests --editor --quit`)
+   and **fails the job** unless `[Godot-MCP] plugin loaded` appears with no
+   `FileNotFoundException` / addon-load exception.
+
+`.github/workflows/test_pull_request.yml` fans this out once per matrix version
+alongside the `dotnet build (.NET 8)` + xUnit job and the `godot-mcp-cli` node
+tests. The live matrix only runs in the PR's own GitHub CI run (the runners
+download Godot).
+
+## Local run
+
+Mirror the CI smoke against the infra testbed instead (it junctions the live
+addon) — see `../CLAUDE.md` "Testbed runbook". To run this exact project locally,
+copy the addon in first:
+
+```bash
+cp -r ../addons/godot_mcp addons/godot_mcp
+"$GODOT" --headless --path . --build-solutions --quit
+"$GODOT" --headless --path . --editor --quit   # expect: [Godot-MCP] plugin loaded
+```

--- a/Godot-Tests/README.md
+++ b/Godot-Tests/README.md
@@ -24,8 +24,13 @@ external checkout or junction.
 1. installs the requested Godot **mono** binary + .NET 8,
 2. **copies** `../addons/godot_mcp` into `Godot-Tests/addons/godot_mcp` (a dev
    junction does not survive checkout in CI; the copy is `.gitignore`d here),
-3. builds the project C# (`<godot> --headless --path Godot-Tests --build-solutions --quit`),
-4. boots the editor headless (`<godot> --headless --path Godot-Tests --editor --quit`)
+3. imports the project once (`<godot> --headless --path Godot-Tests --import --quit`)
+   to materialize the `.godot/` layout on a cold checkout,
+4. builds the project C# with **`dotnet build Godot-Tests/Godot-Tests.csproj`** —
+   the addon `*.cs` globs into the project assembly, so a clean build proves the
+   addon compiles against the frozen pins. (`godot --build-solutions` is a silent
+   no-op on a cold headless checkout, so `dotnet build` is used directly.)
+5. boots the editor headless (`<godot> --headless --path Godot-Tests --editor --quit`)
    and **fails the job** unless `[Godot-MCP] plugin loaded` appears with no
    `FileNotFoundException` / addon-load exception.
 
@@ -42,6 +47,7 @@ copy the addon in first:
 
 ```bash
 cp -r ../addons/godot_mcp addons/godot_mcp
-"$GODOT" --headless --path . --build-solutions --quit
-"$GODOT" --headless --path . --editor --quit   # expect: [Godot-MCP] plugin loaded
+"$GODOT" --headless --path . --import --quit          # generate .godot/ (cold start)
+dotnet build Godot-Tests.csproj --configuration Debug # -> .godot/mono/temp/bin/Debug/Godot-MCP-Tests.dll
+"$GODOT" --headless --path . --editor --quit          # expect: [Godot-MCP] plugin loaded
 ```

--- a/Godot-Tests/project.godot
+++ b/Godot-Tests/project.godot
@@ -1,0 +1,27 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Minimal Godot 4 C# project used ONLY by CI (.github/workflows/test_godot_plugin.yml)
+; to boot a headless editor across Godot 4.3 / 4.4 / 4.5 (mono) and assert the
+; godot_mcp addon loads. No game content. The addon source is copied into
+; res://addons/godot_mcp/ by the workflow before boot (a dev junction does not
+; survive checkout in CI). Keep the NuGet pins in Godot-Tests.csproj in lockstep
+; with ../Godot-MCP.csproj. The "4.3" feature is the engine floor the addon
+; supports; opening under 4.4/4.5 just triggers a silent (headless) upgrade.
+
+config_version=5
+
+[application]
+
+config/name="Godot-MCP-Tests"
+config/description="Minimal headless CI testbed verifying the godot_mcp addon loads across Godot 4.3/4.4/4.5 (mono). No game content."
+config/features=PackedStringArray("4.3", "C#")
+
+[dotnet]
+
+project/assembly_name="Godot-MCP-Tests"
+
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/godot_mcp/plugin.cfg")


### PR DESCRIPTION
## Summary
- Add a reusable `test_godot_plugin.yml` (workflow_call, input `godotVersion`) that installs the official Godot **mono** binary via `chickensoft-games/setup-godot` (no license / no game-ci), builds the test project C#, boots a headless editor, and fails unless `[Godot-MCP] plugin loaded` appears with no addon-load exception.
- Add `test_pull_request.yml` (on: pull_request) fanning out the .NET build+xUnit, `test_cli.yml` (node 20/22), and `test_godot_plugin.yml` once per **Godot 4.3 / 4.4 / 4.5** (mono). Independent jobs, so a failing leg doesn't cancel the others.
- Add a minimal in-repo `Godot-Tests/` project (enables `res://addons/godot_mcp/plugin.cfg`, same frozen pins McpPlugin 6.7.0 / ReflectorNet 5.3.1). Excluded from `Godot-MCP.sln` so the required `dotnet build (.NET 8)` gate is unaffected; build artifacts gitignored.
- `ci.yml` left untouched — its `dotnet build (.NET 8)` check name remains the canonical required gate.

## Test plan
- [x] All 5 workflow YAML files parse (`yaml.safe_load`); `actionlint` not available on this machine.
- [x] `dotnet build Godot-MCP.sln --configuration Debug` → 0 warnings, 0 errors; `Godot-Tests` did NOT leak into the solution.
- [x] `dotnet test Godot-MCP.Tests` → 614 passed, 0 failed.
- [ ] **Godot 4.3/4.4/4.5 mono matrix** — runs only in this PR's own GitHub CI (runners download Godot); cannot be exercised locally.

Closes #70