### PR TITLE
ci(release): version-gated release.yml + OIDC npm publish of godot-mcp-cli (Unity-MCP parity)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,87 @@
+# ┌──────────────────────────────────────────────────────────────────┐
+# │  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+# │  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+# │  Copyright (c) 2026 Ivan Murzak                                  │
+# │  Licensed under the Apache License, Version 2.0.                 │
+# │  See the LICENSE file in the project root for more information.  │
+# └──────────────────────────────────────────────────────────────────┘
+#
+# Deploy: publish the godot-mcp-cli npm package (cli/) to the public npm
+# registry via OIDC Trusted Publishing with build provenance. Mirrors
+# Unity-MCP/.github/workflows/deploy.yml's `deploy-cli-to-npm` job 1:1.
+#
+# Called by release.yml ONLY after the GitHub Release has been created on a
+# real version bump (the release pipeline is version-tag-gated, so a no-bump
+# merge to main never reaches this workflow). Can also be dispatched manually
+# with an explicit version for re-publish.
+#
+# IMPORTANT — first publish prerequisite (owner action, separate from this PR):
+#   npm OIDC Trusted Publishing requires the `godot-mcp-cli` package to have a
+#   Trusted Publisher configured on npmjs.com that authorizes THIS repository +
+#   workflow. Until the owner sets that up, the `npm publish` step will fail
+#   auth. There is NO NPM_TOKEN secret — auth is exchanged at runtime via the
+#   `id-token: write` OIDC token. See:
+#   https://docs.npmjs.com/trusted-publishers
+
+name: deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "npm package version to publish (e.g. 0.1.0)."
+        required: true
+        type: string
+
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+
+jobs:
+  deploy-cli-to-npm:
+    name: publish godot-mcp-cli to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC Trusted Publishing — no NPM_TOKEN needed.
+    defaults:
+      run:
+        working-directory: ./cli
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Resolve version
+        id: version
+        run: |
+          version="${{ inputs.version }}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Publishing godot-mcp-cli version: ${version}"
+
+      # Align the cli package.json version to the release version so the
+      # published artifact matches the GitHub Release tag. plugin.cfg is the
+      # single source of truth for the release version (see docs/RELEASING.md);
+      # this writes that value into the cli at publish time. --allow-same-version
+      # makes it a no-op when cli/package.json already matches.
+      - name: Set package version
+        run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      - name: Publish to npm with provenance
+        run: npm publish --access public --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,37 +6,165 @@
 # │  See the LICENSE file in the project root for more information.  │
 # └──────────────────────────────────────────────────────────────────┘
 #
-# Tag-triggered release: builds + tests the solution for sanity, packages the
-# addons/godot_mcp/ folder into a versioned zip, and publishes a GitHub Release
-# with that zip attached + auto-generated notes.
+# Release pipeline (Unity-MCP parity: release.yml -> deploy.yml).
 #
-# Triggers:
-#   - push of a tag matching `v*` (e.g. `v0.1.0`)  -> builds, zips, AND publishes
-#     the GitHub Release.
-#   - workflow_dispatch (manual)                   -> DRY RUN: builds + zips and
-#     uploads the zip only as a workflow ARTIFACT. The publish step is guarded by
-#     `if: startsWith(github.ref, 'refs/tags/')`, so a dispatch run NEVER creates a
-#     Release. There is intentionally NO `push: branches` trigger — a merge to main
-#     must not cut a release. A `v*` tag push is the one and only publish path.
+# Trigger: push to `main`. A `check-version-tag` job reads the release version
+# from addons/godot_mcp/plugin.cfg (the SINGLE source of truth for the release
+# version — see docs/RELEASING.md) and decides whether THIS push should cut a
+# release. The gate (`should_release`) is the conjunction of two conditions:
+#
+#   1. tag_exists == 'false'      — no `v<version>` tag exists yet for the
+#                                   version currently in plugin.cfg, AND
+#   2. version_changed == 'true'  — this push actually modified plugin.cfg's
+#                                   `version=` line (a deliberate bump).
+#
+# EVERY downstream release/publish job is gated on
+# `needs.check-version-tag.outputs.should_release == 'true'`, so:
+#
+#   * A plain merge to main that does NOT touch plugin.cfg's version is a
+#     guaranteed no-op (version_changed == 'false') — NO release, NO npm
+#     publish — even on a virgin repo that has no tags yet. THIS is what makes
+#     merging a workflow-only / feature PR inert.
+#   * A merge that DOES bump plugin.cfg to a new (untagged) version satisfies
+#     both conditions -> the gate opens, tests run, the GitHub Release (addon
+#     zip) is cut on the new `v<version>` tag, and the cli is published to npm.
+#   * Re-running on an already-released version is also a no-op (tag_exists
+#     short-circuits even if plugin.cfg appears in the diff).
+#
+# The `version_changed` condition is deliberately STRICTER than Unity-MCP's
+# tag-only gate: Godot-MCP's current 0.1.0 has no tag yet, so a tag-only gate
+# would (wrongly) fire a v0.1.0 release on the very next merge. Requiring an
+# actual version-line bump prevents that and matches the safety contract that
+# the first real publish must be a deliberate maintainer action.
+#
+# The release is gated on the full test set as `needs:` — the .NET build+test,
+# the godot-mcp-cli node tests (test_cli.yml), and the Godot engine smoke matrix
+# (test_godot_plugin.yml for 4.3/4.4/4.5). The release proceeds only if all pass.
+#
+# Manual dispatch (workflow_dispatch) bypasses the version_changed check (there
+# is no push diff to inspect) but STILL honors tag_exists — a dispatch cuts a
+# release only when the current plugin.cfg version has no tag yet. This is the
+# escape hatch for re-running a release when a bump already landed on main.
+#
+# SAFETY: the npm publish (deploy.yml) runs ONLY on a real version bump AND
+# requires the owner to have configured an npm Trusted Publisher for the
+# godot-mcp-cli package (no NPM_TOKEN secret exists; auth is OIDC at runtime).
+# Until both are true, no publish happens.
 
 name: release
 
 on:
   push:
-    tags:
-      - "v*"
-  workflow_dispatch: # manual dry-run: build + zip + upload artifact, no Release
+    branches:
+      - main
+  workflow_dispatch:
 
-# Least-privilege: only the release job needs to write the GitHub Release.
+# Least-privilege defaults; the publish job in deploy.yml elevates id-token for OIDC.
 permissions:
   contents: write
 
 jobs:
-  release:
-    name: build, zip addon, publish release
+  # Read the release version from plugin.cfg and decide whether THIS push
+  # should cut a release: only when no `v<version>` tag exists yet AND this
+  # push actually bumped plugin.cfg's version line (see should_release).
+  check-version-tag:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+      tag: ${{ steps.get_version.outputs.tag }}
+      tag_exists: ${{ steps.tag_exists.outputs.exists }}
+      version_changed: ${{ steps.version_changed.outputs.changed }}
+      should_release: ${{ steps.gate.outputs.should_release }}
     steps:
-      - name: Checkout
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      # plugin.cfg is an INI file, so read its `version="x.y.z"` line directly
+      # rather than with npm-get-version-action (which expects a package.json).
+      - name: Get version from plugin.cfg
+        id: get_version
+        run: |
+          set -euo pipefail
+          version="$(grep -E '^version=' addons/godot_mcp/plugin.cfg | head -n1 | sed -E 's/^version="?([^"]*)"?.*/\1/')"
+          if [ -z "${version}" ]; then
+            echo "::error::Could not read version= from addons/godot_mcp/plugin.cfg"
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${version}" >> "$GITHUB_OUTPUT"
+          echo "Release version: ${version} (tag v${version})"
+
+      - name: Check if tag exists
+        id: tag_exists
+        uses: mukunku/tag-exists-action@v1.7.0
+        with:
+          tag: ${{ steps.get_version.outputs.tag }}
+
+      # Did THIS push bump the version line in plugin.cfg? On a push event we
+      # diff the pushed range (before..after) and look for a change to the
+      # `version=` line of addons/godot_mcp/plugin.cfg. A plain feature/workflow
+      # merge that does not touch that line yields changed=false, which keeps
+      # the whole release inert. On workflow_dispatch (no push diff) we cannot
+      # inspect a range, so we report changed=true and rely on tag_exists to
+      # keep dispatch a no-op for an already-released version.
+      - name: Detect version-line bump
+        id: version_changed
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ "${EVENT_NAME}" != "push" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Non-push event (${EVENT_NAME}): version-bump check skipped (relying on tag_exists gate)."
+            exit 0
+          fi
+          # A brand-new branch push reports an all-zero before SHA; treat as changed
+          # so a first push that already contains a bump is not silently ignored.
+          if [ -z "${BEFORE_SHA}" ] || [ "${BEFORE_SHA}" = "0000000000000000000000000000000000000000" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "No usable 'before' SHA — treating as changed."
+            exit 0
+          fi
+          if git diff "${BEFORE_SHA}" "${AFTER_SHA}" -- addons/godot_mcp/plugin.cfg \
+               | grep -qE '^\+version='; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "plugin.cfg version line changed in ${BEFORE_SHA}..${AFTER_SHA}."
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "plugin.cfg version line unchanged in ${BEFORE_SHA}..${AFTER_SHA} — release is a no-op."
+          fi
+
+      # The release gate: cut a release only when no tag exists yet for the
+      # current version AND this push actually bumped the version line.
+      - name: Compute release gate
+        id: gate
+        env:
+          TAG_EXISTS: ${{ steps.tag_exists.outputs.exists }}
+          VERSION_CHANGED: ${{ steps.version_changed.outputs.changed }}
+        run: |
+          set -euo pipefail
+          if [ "${TAG_EXISTS}" = "false" ] && [ "${VERSION_CHANGED}" = "true" ]; then
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            echo "Gate OPEN: tag does not exist and version was bumped -> release."
+          else
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "Gate CLOSED: tag_exists=${TAG_EXISTS}, version_changed=${VERSION_CHANGED} -> no release."
+          fi
+
+  # --- TEST GATE (only runs when the version tag does not yet exist) ---
+
+  # .NET build + xUnit (mirrors ci.yml). Required before a release is cut.
+  dotnet-build-test:
+    runs-on: ubuntu-latest
+    needs: [check-version-tag]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    steps:
+      - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Setup .NET 8
@@ -44,9 +172,6 @@ jobs:
         with:
           dotnet-version: "8.0.x"
 
-      # Sanity build + test. Mirrors ci.yml so a tag on a red commit fails loudly
-      # before any zip/Release is produced. Godot.NET.Sdk is a NuGet SDK, so no
-      # Godot binary is needed here.
       - name: Restore
         run: dotnet restore Godot-MCP.sln
 
@@ -56,22 +181,73 @@ jobs:
       - name: Test
         run: dotnet test Godot-MCP.Tests/Godot-MCP.Tests.csproj --configuration Debug --no-build --verbosity normal
 
-      # Resolve the release version. On a tag push this is the tag name with any
-      # leading `v` stripped (v0.1.0 -> 0.1.0). On a manual dispatch (no tag)
-      # fall back to the plugin.cfg version + a `-dryrun` suffix so the artifact
-      # name is unambiguous and never collides with a real release asset.
-      - name: Resolve version
-        id: version
-        run: |
-          set -euo pipefail
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            version="${GITHUB_REF_NAME#v}"
-          else
-            cfg_version="$(grep -E '^version=' addons/godot_mcp/plugin.cfg | head -n1 | sed -E 's/^version="?([^"]*)"?.*/\1/')"
-            version="${cfg_version}-dryrun"
-          fi
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "Resolved release version: ${version}"
+  # godot-mcp-cli node tests (Node 20 & 22). Required before a release is cut.
+  test-cli:
+    needs: [check-version-tag]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    uses: ./.github/workflows/test_cli.yml
+
+  # godot_mcp addon-load smoke across the Godot engine matrix (mono).
+  test-godot-4-3:
+    needs: [check-version-tag]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    uses: ./.github/workflows/test_godot_plugin.yml
+    with:
+      godotVersion: "4.3.0"
+
+  test-godot-4-4:
+    needs: [check-version-tag]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    uses: ./.github/workflows/test_godot_plugin.yml
+    with:
+      godotVersion: "4.4.0"
+
+  test-godot-4-5:
+    needs: [check-version-tag]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    uses: ./.github/workflows/test_godot_plugin.yml
+    with:
+      godotVersion: "4.5.1"
+
+  # --- PUBLISH (gated on tag-not-existing AND every test passing) ---
+
+  # Build + package the addon zip and cut the GitHub Release on the new
+  # `v<version>` tag. Identical packaging to the previous tag-triggered flow,
+  # now gated on the version check + tests instead of a tag push.
+  release-addon:
+    runs-on: ubuntu-latest
+    needs:
+      [
+        check-version-tag,
+        dotnet-build-test,
+        test-cli,
+        test-godot-4-3,
+        test-godot-4-4,
+        test-godot-4-5,
+      ]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    outputs:
+      version: ${{ needs.check-version-tag.outputs.version }}
+      published: ${{ steps.mark.outputs.published }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      # Sanity build + test before producing the zip, so a release is never cut
+      # on a red commit. Godot.NET.Sdk is a NuGet SDK -> no Godot binary needed.
+      - name: Restore
+        run: dotnet restore Godot-MCP.sln
+
+      - name: Build
+        run: dotnet build Godot-MCP.sln --configuration Debug --no-restore
+
+      - name: Test
+        run: dotnet test Godot-MCP.Tests/Godot-MCP.Tests.csproj --configuration Debug --no-build --verbosity normal
 
       # Package only the addon SOURCE folder (the deliverable — Godot has no
       # compiled artifact to ship). Exclude dev cruft so the zip is install-clean.
@@ -79,7 +255,7 @@ jobs:
         id: package
         run: |
           set -euo pipefail
-          version="${{ steps.version.outputs.version }}"
+          version="${{ needs.check-version-tag.outputs.version }}"
           zip_name="godot-mcp-addon-${version}.zip"
           # Zip the addons/ tree so the archive expands to addons/godot_mcp/...,
           # which drops straight into a consumer project's res:// root.
@@ -93,24 +269,30 @@ jobs:
           echo "Created ${zip_name}:"
           unzip -l "${zip_name}"
 
-      # DRY-RUN path (workflow_dispatch, no tag): upload the zip as an artifact so
-      # the packaging can be inspected without publishing. Never runs on a tag.
-      - name: Upload addon zip as artifact (dry run)
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.package.outputs.zip_name }}
-          path: ${{ steps.package.outputs.zip_name }}
-
-      # PUBLISH path (tag push only): create the GitHub Release with the zip
-      # attached and auto-generated notes. Guarded so the dispatch dry-run never
-      # reaches it.
+      # Create the GitHub Release + tag with the zip attached and auto-generated
+      # notes. tag_name is the `v<version>` computed from plugin.cfg.
       - name: Create GitHub Release
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: softprops/action-gh-release@v2
         with:
-          name: ${{ github.ref_name }}
-          tag_name: ${{ github.ref_name }}
+          name: ${{ needs.check-version-tag.outputs.tag }}
+          tag_name: ${{ needs.check-version-tag.outputs.tag }}
           generate_release_notes: true
           fail_on_unmatched_files: true
           files: ${{ steps.package.outputs.zip_name }}
+
+      - name: Mark publish success
+        id: mark
+        run: echo "published=true" >> "$GITHUB_OUTPUT"
+
+  # Publish godot-mcp-cli to npm (OIDC Trusted Publishing). Gated on the GitHub
+  # Release having been created. The cli version is set to the release version
+  # at publish time inside deploy.yml.
+  deploy:
+    needs: [check-version-tag, release-addon]
+    if: needs.release-addon.outputs.published == 'true'
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/deploy.yml
+    with:
+      version: ${{ needs.check-version-tag.outputs.version }}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,57 +1,81 @@
 # Releasing Godot-MCP
 
-How a new version of the **Godot-MCP** addon is built, published, and distributed.
+How a new version of **Godot-MCP** is built, published, and distributed.
 
-The single distribution channel is the **addon source folder** (`addons/godot_mcp/`), shipped
-two ways from the same artifact:
+There are two distribution artifacts, both cut from the **same release version**:
 
-1. a **GitHub Release** with a versioned `godot-mcp-addon-<version>.zip` attached, and
-2. a **Godot Asset Library** entry that points at that repository/version.
+1. the **addon source folder** (`addons/godot_mcp/`), shipped as
+   - a **GitHub Release** with a versioned `godot-mcp-addon-<version>.zip` attached, and
+   - a **Godot Asset Library** entry that points at that repository/version; and
+2. the **`godot-mcp-cli`** npm package (`cli/`), published to the public npm registry.
 
 Godot-MCP does **not** publish any NuGet package of its own — see [NuGet](#nuget-decision) below.
+
+## Version source of truth (addon ⇄ cli reconciliation)
+
+The release version has a **single source of truth: the `version` field in
+[`addons/godot_mcp/plugin.cfg`](../addons/godot_mcp/plugin.cfg)**. That value:
+
+- names the GitHub Release tag (`v<version>`) and the addon zip (`godot-mcp-addon-<version>.zip`);
+- is written into `cli/package.json` **at publish time** by the deploy workflow via
+  `npm version <version> --no-git-tag-version --allow-same-version`, so the published npm package
+  always matches the addon release. The `cli/package.json` `version` committed in the repo is
+  therefore advisory — the release pipeline overwrites it to match `plugin.cfg` before `npm publish`.
+
+To bump the release version, edit `plugin.cfg`'s `version` only. Keeping `cli/package.json` in sync
+manually is optional (the pipeline forces it), but recommended so local `cli/` runs report the right
+number.
 
 ---
 
 ## How to cut a release
 
-The release is fully automated by [`.github/workflows/release.yml`](../.github/workflows/release.yml),
-which fires **only on a `v*` tag push**. Merging to `main` does NOT cut a release.
+The release is fully automated by [`.github/workflows/release.yml`](../.github/workflows/release.yml)
+(which calls [`deploy.yml`](../.github/workflows/deploy.yml) for the npm publish). The pipeline runs
+on **every push to `main`** but is **version-tag-gated**: it cuts a release only when
+`plugin.cfg`'s version does not yet have a matching `v<version>` tag. A plain merge that does not
+bump the version is therefore a **no-op** — nothing is released and nothing is published.
 
-1. **Bump the addon version.** Edit the `version` field in
+1. **Bump the version.** Edit the `version` field in
    [`addons/godot_mcp/plugin.cfg`](../addons/godot_mcp/plugin.cfg) to the new semver
-   (e.g. `version="0.2.0"`). This is the canonical version source for the addon. Commit it to `main`
-   through the normal PR flow.
-2. **Tag the release commit.** Once the version bump is on `main`, create and push a matching tag
-   prefixed with `v`:
+   (e.g. `version="0.2.0"`). This is the single canonical version source (see
+   [Version source of truth](#version-source-of-truth-addon--cli-reconciliation)). Land it on `main`
+   through the normal PR flow. No manual tag push is required — the pipeline derives the tag from
+   `plugin.cfg`.
 
-   ```bash
-   git tag v0.2.0
-   git push origin v0.2.0
-   ```
+2. **The pipeline runs on the merge to `main`.** `release.yml`:
+   - `check-version-tag` reads `version` from `plugin.cfg`, computes `v<version>`, and checks whether
+     that tag already exists. If it does (no bump), **every** downstream job is skipped — the run is a
+     no-op. If it does not (a real bump), the gate opens;
+   - the test gate runs as `needs:` — the .NET build+test, the `godot-mcp-cli` node tests
+     (`test_cli.yml`, Node 20/22), and the Godot engine smoke matrix (`test_godot_plugin.yml` for
+     4.3/4.4/4.5). The release proceeds only if all pass;
+   - `release-addon` zips `addons/godot_mcp/` into `godot-mcp-addon-<version>.zip` (excluding
+     `*.uid`, `*.import`, `bin/`, `obj/`, `.godot/`) and creates the **GitHub Release** + `v<version>`
+     tag with the zip attached and auto-generated notes (`generate_release_notes: true`);
+   - `deploy` (deploy.yml) sets `cli/package.json` to the release version, runs `npm ci && npm run
+     build && npm test`, then **publishes `godot-mcp-cli` to npm** with `npm publish --access public
+     --provenance` via **OIDC Trusted Publishing** (no `NPM_TOKEN` — see
+     [npm Trusted Publisher prerequisite](#npm-trusted-publisher-prerequisite-first-publish-only)).
 
-   > The tag name (`v0.2.0`) is what names the GitHub Release; the workflow strips the leading `v`
-   > for the zip filename (`godot-mcp-addon-0.2.0.zip`). Keep the tag's semver in lockstep with the
-   > `plugin.cfg` `version` you bumped in step 1.
+3. **Verify.** Check the new Release at
+   `https://github.com/IvanMurzak/Godot-MCP/releases/tag/v0.2.0` (zip attached, notes right) and the
+   npm package at `https://www.npmjs.com/package/godot-mcp-cli`.
 
-3. **The workflow runs.** On the tag push, `release.yml`:
-   - restores + builds + tests `Godot-MCP.sln` (sanity gate — a tag on a red commit fails here
-     before anything is published);
-   - zips `addons/godot_mcp/` into `godot-mcp-addon-<version>.zip`, excluding dev cruft
-     (`*.uid`, `*.import`, `bin/`, `obj/`, `.godot/`);
-   - creates the **GitHub Release** named after the tag, with the zip attached and
-     auto-generated release notes (`generate_release_notes: true`).
+### npm Trusted Publisher prerequisite (first publish only)
 
-4. **Verify.** Check the new Release at
-   `https://github.com/IvanMurzak/Godot-MCP/releases/tag/v0.2.0` and confirm the zip asset is
-   attached and the notes look right.
+The npm publish uses **OIDC Trusted Publishing** — there is intentionally **no `NPM_TOKEN` secret**.
+Before the **first** real publish can succeed, the maintainer must configure a **Trusted Publisher**
+for the `godot-mcp-cli` package on npmjs.com, authorizing this repository and the `deploy.yml`
+workflow. See <https://docs.npmjs.com/trusted-publishers>. Until that is configured, the `npm
+publish` step fails authentication; the addon GitHub Release still succeeds (it does not depend on
+npm). This is a deliberate maintainer gate (see [GATES](#gates--what-requires-the-maintainer-ivan)).
 
-### Dry run (no publish)
+### Manual re-run
 
-To exercise the build + zip without publishing a Release, trigger the workflow manually
-(`workflow_dispatch`, e.g. via *Actions → release → Run workflow*). The manual path builds and zips
-exactly as the tag path does, but uploads the zip as a **workflow artifact** only — the
-Release-publish step is guarded by `if: startsWith(github.ref, 'refs/tags/')`, so a dispatch run
-**never** creates a Release. Download the artifact from the run summary to inspect the package.
+`release.yml` also accepts a `workflow_dispatch`. Dispatch is useful if `main` already carries a
+bumped-but-unreleased version (e.g. a previous run failed after the bump landed). The same
+version-gate applies: if the tag already exists, the dispatch run is a no-op.
 
 ---
 
@@ -95,11 +119,12 @@ in this repo):
 | `com.IvanMurzak.McpPlugin` | `6.5.5` | MCP plugin client (transitively pulls `McpPlugin.Common` + `ReflectorNet`) |
 
 The addon **source folder** — distributed via the GitHub Release zip and the Godot Asset Library
-entry — is the **sole** distribution channel for Godot-MCP. There is no new package ID to claim and
-no NuGet publish secret to configure; `release.yml` contains **no** `dotnet pack` / `dotnet nuget
-push` step, by design. (This is the deliberate difference from the sibling `ReflectorNet` /
-`MCP-Plugin-dotnet` repos, whose `deploy.yml` workflows DO push NuGet packages — those repos ARE the
-upstream publishers; Godot-MCP is only a consumer.)
+entry — plus the **`godot-mcp-cli` npm package** are the distribution channels for Godot-MCP. There
+is no new NuGet package ID to claim and no NuGet publish secret to configure; `release.yml` /
+`deploy.yml` contain **no** `dotnet pack` / `dotnet nuget push` step, by design. (This is the
+deliberate difference from the sibling `ReflectorNet` / `MCP-Plugin-dotnet` repos, whose `deploy.yml`
+workflows DO push NuGet packages — those repos ARE the upstream publishers; Godot-MCP only *consumes*
+NuGet packages, and publishes its **cli to npm** rather than to NuGet.)
 
 ---
 
@@ -108,14 +133,17 @@ upstream publishers; Godot-MCP is only a consumer.)
 Every action below is intentionally **out of scope for automation / agents** and must be performed
 by the maintainer:
 
-- **The first `v*` tag / first Release.** No agent cuts a tag or runs `gh release create`. The
-  maintainer pushes the `v<semver>` tag; `release.yml` then runs on its own.
-- **Each subsequent release tag.** Same — bumping `plugin.cfg` lands via PR, but the tag that
-  actually publishes is pushed by the maintainer.
+- **The version bump that triggers a release.** Releasing is gated on `plugin.cfg`'s version: only a
+  maintainer-approved version bump landing on `main` opens the release gate. A no-bump merge is a
+  no-op. No agent bumps the version to force a release.
+- **Configuring the npm Trusted Publisher** for `godot-mcp-cli` (one-time, before the first publish).
+  A manual step on npmjs.com authorizing this repo + `deploy.yml` to publish via OIDC. Until it is
+  done, the `npm publish` step fails auth (the GitHub Release still succeeds). See
+  [npm Trusted Publisher prerequisite](#npm-trusted-publisher-prerequisite-first-publish-only).
 - **Godot Asset Library submission (and version edits).** A manual web-form step at
   <https://godotengine.org/asset-library/>, never automated.
 - **Adding the addon icon** required by the Asset Library form (none ships today).
 - **Any future NuGet publishing** — new package IDs, `dotnet nuget push` steps, or NuGet
   publish secrets / trusted-publishing config. None exist today and none should be added without an
-  explicit maintainer decision (the current model is consume-only; see
+  explicit maintainer decision (the NuGet model is consume-only; see
   [NuGet decision](#nuget-decision)).


### PR DESCRIPTION
## Summary

- Restructures `release.yml` to mirror Unity-MCP's `release.yml` → `deploy.yml`: triggers on push to `main` (+ `workflow_dispatch`), runs the full test gate, cuts the addon GitHub Release, and publishes `godot-mcp-cli` to npm via OIDC Trusted Publishing with provenance.
- **Version-gated for safety**: a `check-version-tag` job reads the version from `addons/godot_mcp/plugin.cfg` (single source of truth). Every release/publish job is gated on `should_release == 'true'` = (`tag_exists == 'false'` AND `version_changed == 'true'`). A no-bump merge — like this PR — is a **guaranteed no-op**: no release, no npm publish.
- New `deploy.yml` `deploy-cli-to-npm`: `id-token: write` (OIDC, **no `NPM_TOKEN`**), node + `registry-url: npmjs`, sets the cli version to the release version, `npm ci && npm run build && npm test`, then `npm publish --access public --provenance` from `./cli`.
- `docs/RELEASING.md` updated for the new flow, the addon ⇄ cli version reconciliation, and the npm Trusted Publisher prerequisite.

## Safety / inertness

This PR does **not** bump `plugin.cfg`'s version, so on merge `version_changed == 'false'` → `should_release == 'false'` → **all** release/publish jobs are skipped. The first real publish requires (a) a deliberate version bump on `main` and (b) the owner configuring an npm Trusted Publisher for `godot-mcp-cli`. Neither happens here.

## Scope

CI/workflow only. `ci.yml` + `test_pull_request.yml` untouched; the required `dotnet build (.NET 8)` check name is unchanged. No addon source, cli source, csproj, or frozen NuGet pins changed.

## Test plan

- [x] `python -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"` — all 6 workflows parse.
- [x] `dotnet build Godot-MCP.sln --configuration Debug` — 0 errors / 0 warnings.
- [x] Reasoned through the gate: no-bump merge is inert (see Safety above).

Closes #72