### PR TITLE
feat(server): add Godot-MCP-Server cross-platform binaries project

### DIFF
--- a/Godot-MCP-Server/.dockerignore
+++ b/Godot-MCP-Server/.dockerignore
@@ -1,0 +1,31 @@
+# configurations
+.vscode
+.claude
+
+# dotnet build
+bin
+obj
+
+# dotnet publish
+publish
+nupkg
+
+# runtime logs
+logs
+
+# documentation
+*.md
+
+# scripts
+*.ps1
+*.sh
+
+# project files
+*.sln
+
+# MCP Publisher
+.mcpregistry_github_token
+.mcpregistry_registry_token
+
+# other
+server.json

--- a/Godot-MCP-Server/.gitignore
+++ b/Godot-MCP-Server/.gitignore
@@ -1,0 +1,44 @@
+## Ignore Visual Studio files
+.vs/
+*.user
+*.suo
+*.userosscache
+*.sln.docstates
+
+## Build results
+bin/
+obj/
+
+## OS-generated files
+.DS_Store
+Thumbs.db
+
+## Rider (JetBrains)
+.idea/
+*.sln.iml
+
+## Dotnet specific
+project.lock.json
+project.fragment.lock.json
+artifacts/
+
+## NuGet
+*.nupkg
+*.snupkg
+*.psmdcp
+.nuget/
+
+# Published pre-compiled server
+publish/
+packages/
+nupkg/
+
+# Runtime logs (NLog.config writes here)
+logs/
+
+# Claude Code settings
+.claude/
+
+# MCP Publisher
+.mcpregistry_github_token
+.mcpregistry_registry_token

--- a/Godot-MCP-Server/Dockerfile
+++ b/Godot-MCP-Server/Dockerfile
@@ -1,0 +1,32 @@
+# See https://docs.microsoft.com/aspnet/core/host-and-deploy/docker/building-net-docker-images
+# for more information about using .NET with Docker.
+
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+# Copy main project file
+COPY ["com.IvanMurzak.Godot.MCP.Server.csproj", "."]
+
+# Restore dependencies
+RUN dotnet restore "com.IvanMurzak.Godot.MCP.Server.csproj"
+
+# Copy the rest of the source code
+COPY . .
+
+# Publish
+RUN dotnet publish "com.IvanMurzak.Godot.MCP.Server.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+
+# MCP server metadata
+LABEL io.modelcontextprotocol.server.name="io.github.IvanMurzak/Godot-MCP"
+
+# Expose the default plugin port and the HTTP client port so external scanners
+# (like Smithery) and platform port mappings can reach the server.
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "godot-mcp-server.dll"]

--- a/Godot-MCP-Server/Godot-MCP-Server.sln
+++ b/Godot-MCP-Server/Godot-MCP-Server.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "com.IvanMurzak.Godot.MCP.Server", "com.IvanMurzak.Godot.MCP.Server.csproj", "{004B0787-9F60-4750-BBBF-16DF9CBF0803}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{004B0787-9F60-4750-BBBF-16DF9CBF0803}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{004B0787-9F60-4750-BBBF-16DF9CBF0803}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{004B0787-9F60-4750-BBBF-16DF9CBF0803}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{004B0787-9F60-4750-BBBF-16DF9CBF0803}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0FDBDD92-FBE2-40F4-8229-8B6528311F70}
+	EndGlobalSection
+EndGlobal

--- a/Godot-MCP-Server/LICENSE
+++ b/Godot-MCP-Server/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Godot-MCP-Server/NLog.config
+++ b/Godot-MCP-Server/NLog.config
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <targets>
+    <!-- Write logs to a file -->
+    <target
+      xsi:type="File"
+      name="logFile"
+      fileName="logs/server-log.txt"
+      archiveAboveSize="10485760"
+      archiveNumbering="Rolling"
+      maxArchiveFiles="5"
+      layout="${longdate} | ${level:uppercase=true:padding=-5} | ${logger} | ${message} ${exception:format=toString}" />
+    <target
+      xsi:type="File"
+      name="errorLogFile"
+      fileName="logs/server-log-error.txt"
+      archiveAboveSize="10485760"
+      archiveNumbering="Rolling"
+      maxArchiveFiles="5"
+      layout="${longdate} | ${level:uppercase=true:padding=-5} | ${callsite:className=true:includeNamespace=false} | ${message} ${exception:format=toString}" />
+    <!-- Write logs to console with Microsoft-style colors -->
+    <target
+      xsi:type="ColoredConsole"
+      name="console"
+      layout="[${time:HH:mm:ss:fff}] ${when:when=level==LogLevel.Trace:inner=trce}${when:when=level==LogLevel.Debug:inner=dbug}${when:when=level==LogLevel.Info:inner=info}${when:when=level==LogLevel.Warn:inner=warn}${when:when=level==LogLevel.Error:inner=fail}${when:when=level==LogLevel.Fatal:inner=crit}: ${logger}[${event-properties:item=EventId_Id:whenEmpty=0}]${newline}      ${message} ${exception:format=toString}">
+      <highlight-row condition="level == LogLevel.Fatal" foregroundColor="White" backgroundColor="Red" />
+      <highlight-row condition="level == LogLevel.Error" foregroundColor="Red" />
+      <highlight-row condition="level == LogLevel.Warn" foregroundColor="Yellow" />
+      <highlight-row condition="level == LogLevel.Info" foregroundColor="White" />
+      <highlight-row condition="level == LogLevel.Debug" foregroundColor="Gray" />
+      <highlight-row condition="level == LogLevel.Trace" foregroundColor="Gray" />
+      <highlight-word text="trce:" foregroundColor="Gray" />
+      <highlight-word text="dbug:" foregroundColor="Gray" />
+      <highlight-word text="info:" foregroundColor="DarkGreen" />
+      <highlight-word text="warn:" foregroundColor="Yellow" />
+      <highlight-word text="fail:" foregroundColor="Red" />
+      <highlight-word text="crit:" foregroundColor="White" backgroundColor="Red" />
+    </target>
+  </targets>
+
+  <rules>
+    <logger name="Microsoft.*"  maxlevel="Warn"   final="true" />
+    <logger name="*"            minlevel="Trace"  maxlevel="Warn" writeTo="logFile,console" />
+    <logger name="*"            minlevel="Error"  writeTo="logFile,console,errorLogFile" />
+  </rules>
+
+  <extensions>
+    <add assembly="NLog.Web.AspNetCore"/>
+  </extensions>
+</nlog>

--- a/Godot-MCP-Server/README.md
+++ b/Godot-MCP-Server/README.md
@@ -1,0 +1,59 @@
+# Godot-MCP-Server
+
+A thin [ASP.NET Core](https://learn.microsoft.com/aspnet/core/) host around the
+[Model Context Protocol](https://modelcontextprotocol.io/) server core
+(`com.IvanMurzak.McpPlugin.Server`). It bridges MCP clients (Claude, Cursor,
+Copilot, etc.) and the Godot Editor / Godot games via the
+[`addons/godot_mcp`](../addons/godot_mcp) plugin over SignalR.
+
+This is the Godot analog of `Unity-MCP-Server`. The server logic lives entirely
+in the `McpPlugin.Server` NuGet package — there is no Godot-specific server code
+here. `Program.cs` simply wires Kestrel / SignalR / NLog and delegates to the
+`McpPlugin.Server` extension methods.
+
+## Build / run
+
+```bash
+# Build
+dotnet build com.IvanMurzak.Godot.MCP.Server.csproj
+
+# Run (HTTP transport on port 8080)
+dotnet run --project com.IvanMurzak.Godot.MCP.Server.csproj -- --client-transport streamableHttp --port 8080
+
+# Run (STDIO transport — for local MCP clients)
+dotnet run --project com.IvanMurzak.Godot.MCP.Server.csproj -- --client-transport stdio
+```
+
+## Configuration
+
+CLI args / environment variables are parsed by the shared
+`com.IvanMurzak.McpPlugin.Common` `DataArguments`:
+
+| Argument                | Env var                       | Default          | Description                                              |
+| ----------------------- | ----------------------------- | ---------------- | ------------------------------------------------------- |
+| `--port`                | `MCP_PLUGIN_PORT`             | `8080`           | Client → Server ← Plugin connection port.               |
+| `--plugin-timeout`      | `MCP_PLUGIN_CLIENT_TIMEOUT`   | `10000`          | Plugin → Server connection timeout (ms).                |
+| `--idle-timeout-seconds`| —                             | `600`            | Evict an idle plugin connection after this many seconds.|
+| `--client-transport`    | `MCP_PLUGIN_CLIENT_TRANSPORT` | `stdio`          | `stdio` or `streamableHttp`.                            |
+| `--token`               | —                             | —                | Bearer token (when authorization is `required`).        |
+| `--authorization`       | —                             | `none`           | `none` or `required`.                                   |
+
+## Cross-platform binaries
+
+`build-all.sh` / `build-all.ps1` produce self-contained single-file binaries for
+`win-x64`, `win-x86`, `win-arm64`, `linux-x64`, `linux-arm64`, `osx-x64`, and
+`osx-arm64`, zipped as `godot-mcp-server-<rid>.zip` under `./publish/`.
+
+```bash
+./build-all.sh            # all runtimes
+./build-all.sh win-x64    # a single runtime
+```
+
+```powershell
+./build-all.ps1                       # all runtimes
+./build-all.ps1 -Platforms win-x64    # a single runtime
+```
+
+## License
+
+Licensed under the [Apache License, Version 2.0](./LICENSE).

--- a/Godot-MCP-Server/appsettings.json
+++ b/Godot-MCP-Server/appsettings.json
@@ -1,0 +1,9 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Trace",
+            "Microsoft": "Information",
+            "Microsoft.Hosting.Lifetime": "Information"
+        }
+    }
+}

--- a/Godot-MCP-Server/build-all.ps1
+++ b/Godot-MCP-Server/build-all.ps1
@@ -1,0 +1,159 @@
+#!/usr/bin/env pwsh
+# Universal PowerShell script to build self-contained executables for all platforms
+# Works on Windows, macOS, and Linux with PowerShell Core
+
+param(
+    [string]$Configuration = "Release",
+    [string]$ProjectFile = "com.IvanMurzak.Godot.MCP.Server.csproj",
+    [string[]]$Platforms = @()
+)
+
+Write-Host "Building self-contained executables..." -ForegroundColor Green
+
+# Root output directory (relative to this script location)
+$PublishRoot = Join-Path $PSScriptRoot "publish"
+if (Test-Path $PublishRoot) {
+    Write-Host "Cleaning existing publish folder..." -ForegroundColor Cyan
+    try {
+        Remove-Item $PublishRoot -Recurse -Force -ErrorAction Stop
+    }
+    catch {
+        Write-Host "Failed to clean publish folder: $($_.Exception.Message)" -ForegroundColor Red
+        exit 1
+    }
+}
+New-Item -ItemType Directory -Path $PublishRoot | Out-Null
+
+$allRuntimes = @(
+    "win-x64",
+    "win-x86",
+    "win-arm64",
+    "linux-x64",
+    "linux-arm64",
+    "osx-x64",
+    "osx-arm64"
+)
+
+$runtimes = if ($Platforms.Count -gt 0) {
+    $allRuntimes | Where-Object { $_ -in $Platforms }
+} else {
+    $allRuntimes
+}
+
+if ($runtimes.Count -eq 0 -and $Platforms.Count -gt 0) {
+    Write-Host "No valid runtimes found matching: $($Platforms -join ', ')" -ForegroundColor Red
+    Write-Host "Available runtimes: $($allRuntimes -join ', ')" -ForegroundColor Cyan
+    exit 1
+}
+
+Write-Host "Target runtimes: $($runtimes -join ', ')" -ForegroundColor Cyan
+
+$success = 0
+$failed = 0
+
+foreach ($runtime in $runtimes) {
+    Write-Host "Building for $runtime..." -ForegroundColor Yellow
+
+    $outputPath = Join-Path $PublishRoot $runtime
+    if (-not (Test-Path $outputPath)) { New-Item -ItemType Directory -Path $outputPath | Out-Null }
+
+    $publishArgs = @(
+        "publish",
+        $ProjectFile,
+        "-c", $Configuration,
+        "-r", $runtime,
+        "--self-contained", "true",
+        "-p:PublishSingleFile=true",
+        "-o", $outputPath
+    )
+
+    Write-Host "Executing: dotnet $($publishArgs -join ' ')" -ForegroundColor DarkGray
+
+    try {
+        dotnet @publishArgs
+        $exitCode = $LASTEXITCODE
+    }
+    catch {
+        Write-Host "Error executing dotnet publish: $($_.Exception.Message)" -ForegroundColor Red
+        $exitCode = 1
+    }
+
+    if ($exitCode -eq 0) {
+        Write-Host "Successfully built $runtime" -ForegroundColor Green
+        $success++
+    }
+    else {
+        Write-Host "Failed to build $runtime (exit code: $exitCode)" -ForegroundColor Red
+        $failed++
+    }
+}
+
+Write-Host "`nBuild Summary:" -ForegroundColor Cyan
+Write-Host "Success: $success" -ForegroundColor Green
+Write-Host "Failed: $failed" -ForegroundColor Red
+
+if ($failed -gt 0) {
+    Write-Host "`nSome builds failed. Check the output above." -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host "`nAll builds completed successfully!" -ForegroundColor Green
+Write-Host "Executables are located in: $PublishRoot" -ForegroundColor Yellow
+Write-Host "Per-platform folders: ./publish/{runtime}/" -ForegroundColor Yellow
+
+Write-Host "`nCreating zip archives for each runtime..." -ForegroundColor Cyan
+
+$zipSuccess = 0
+$zipFailed = 0
+
+foreach ($runtime in $runtimes) {
+    $runtimePath = Join-Path $PublishRoot $runtime
+
+    if (Test-Path $runtimePath) {
+        Write-Host "Creating zip for $runtime..." -ForegroundColor Yellow
+
+        $zipName = "godot-mcp-server-$runtime.zip"
+        $zipPath = Join-Path $PublishRoot $zipName
+
+        try {
+            if (Test-Path $zipPath) {
+                Remove-Item $zipPath -Force
+            }
+
+            Add-Type -AssemblyName System.IO.Compression.FileSystem
+            [System.IO.Compression.ZipFile]::CreateFromDirectory($runtimePath, $zipPath)
+
+            Write-Host "Successfully created $zipName" -ForegroundColor Green
+            $zipSuccess++
+        }
+        catch {
+            Write-Host "Failed to create $zipName : $($_.Exception.Message)" -ForegroundColor Red
+            $zipFailed++
+        }
+    }
+    else {
+        Write-Host "Skipping $runtime - directory not found" -ForegroundColor Yellow
+        $zipFailed++
+    }
+}
+
+Write-Host "`nZip Creation Summary:" -ForegroundColor Cyan
+Write-Host "Success: $zipSuccess" -ForegroundColor Green
+Write-Host "Failed: $zipFailed" -ForegroundColor Red
+
+if ($zipFailed -eq 0) {
+    Write-Host "`nAll zip archives created successfully!" -ForegroundColor Green
+    Write-Host "Zip files are located in: $PublishRoot" -ForegroundColor Yellow
+    Write-Host "Created files:" -ForegroundColor Cyan
+
+    $zipFiles = Get-ChildItem -Path $PublishRoot -Filter "*.zip" -ErrorAction SilentlyContinue
+    if ($zipFiles) {
+        foreach ($zipFile in $zipFiles) {
+            $sizeKB = [math]::Round($zipFile.Length / 1KB, 2)
+            Write-Host "  $($zipFile.Name) ($sizeKB KB)" -ForegroundColor White
+        }
+    }
+} else {
+    Write-Host "`n$zipFailed zip archive(s) failed to create. See errors above." -ForegroundColor Red
+    exit 1
+}

--- a/Godot-MCP-Server/build-all.sh
+++ b/Godot-MCP-Server/build-all.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+# Universal bash script to build self-contained executables for all platforms
+# Works on macOS and Linux
+
+set -uo pipefail
+
+CONFIGURATION="Release"
+PROJECT_FILE="com.IvanMurzak.Godot.MCP.Server.csproj"
+SPECIFIED_PLATFORMS=()
+
+all_runtimes=(
+    "win-x64"
+    "win-x86"
+    "win-arm64"
+    "linux-x64"
+    "linux-arm64"
+    "osx-x64"
+    "osx-arm64"
+)
+
+# Argument parsing
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -c|--configuration)
+            CONFIGURATION="$2"
+            shift 2
+            ;;
+        Debug|Release)
+            CONFIGURATION="$1"
+            shift
+            ;;
+        *.csproj)
+            PROJECT_FILE="$1"
+            shift
+            ;;
+        *)
+            # Check if it's a known runtime
+            is_runtime=false
+            for runtime in "${all_runtimes[@]}"; do
+                if [ "$1" == "$runtime" ]; then
+                    SPECIFIED_PLATFORMS+=("$1")
+                    is_runtime=true
+                    break
+                fi
+            done
+            if [ "$is_runtime" = false ]; then
+                echo "Unknown argument: $1"
+                echo "Usage: $0 [Debug|Release] [-c|--configuration <config>] [*.csproj] [runtime...]"
+                echo "Known runtimes: ${all_runtimes[*]}"
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+PUBLISH_ROOT="${SCRIPT_DIR}/publish"
+
+echo "Building self-contained executables..."
+
+# Clean publish root
+if [ -d "${PUBLISH_ROOT}" ]; then
+    echo "Cleaning existing publish folder..."
+    rm -rf "${PUBLISH_ROOT}" || { echo "Failed to remove publish folder"; exit 1; }
+fi
+mkdir -p "${PUBLISH_ROOT}" || { echo "Failed to create publish folder"; exit 1; }
+
+# Filter runtimes if platforms are specified
+runtimes=()
+if [ ${#SPECIFIED_PLATFORMS[@]} -gt 0 ]; then
+    runtimes=("${SPECIFIED_PLATFORMS[@]}")
+else
+    runtimes=("${all_runtimes[@]}")
+fi
+
+echo "Configuration: ${CONFIGURATION}"
+echo "Project File: ${PROJECT_FILE}"
+echo "Target runtimes: ${runtimes[*]}"
+echo ""
+
+success=0
+failed=0
+
+for runtime in "${runtimes[@]}"; do
+    echo "Building for ${runtime}..."
+
+    OUTPUT_PATH="${PUBLISH_ROOT}/${runtime}"
+    mkdir -p "${OUTPUT_PATH}"
+
+    echo "Running: dotnet publish ${PROJECT_FILE} -c ${CONFIGURATION} -r ${runtime} --self-contained true -p:PublishSingleFile=true -o ${OUTPUT_PATH}"
+    if dotnet publish "${PROJECT_FILE}" \
+        -c "${CONFIGURATION}" \
+        -r "${runtime}" \
+        --self-contained true \
+        -p:PublishSingleFile=true \
+        -o "${OUTPUT_PATH}" 2>&1; then
+        echo "Successfully built ${runtime} -> ${OUTPUT_PATH}"
+        ((success++))
+    else
+        echo "Failed to build ${runtime}"
+        ((failed++))
+    fi
+    echo ""
+done
+
+echo "Build Summary:"
+echo "Success: $success"
+echo "Failed: $failed"
+
+if [ $failed -eq 0 ]; then
+    echo ""
+    echo "All builds completed successfully!"
+    echo "Executables are located in: ${PUBLISH_ROOT}/{runtime}/"
+
+    echo ""
+    echo "Creating zip archives for each runtime..."
+
+    # Change to publish directory
+    cd "${PUBLISH_ROOT}"
+
+    zip_success=0
+    zip_failed=0
+
+    for runtime in "${runtimes[@]}"; do
+        if [ -d "${runtime}" ]; then
+            echo "Creating zip for ${runtime}..."
+
+            ZIP_NAME="godot-mcp-server-${runtime}.zip"
+
+            if zip -r "${ZIP_NAME}" "${runtime}/" > /dev/null 2>&1; then
+                echo "Successfully created ${ZIP_NAME}"
+                ((zip_success++))
+            else
+                echo "Failed to create ${ZIP_NAME}"
+                ((zip_failed++))
+            fi
+        else
+            echo "Skipping ${runtime} - directory not found"
+            ((zip_failed++))
+        fi
+    done
+
+    echo ""
+    echo "Zip Creation Summary:"
+    echo "Success: $zip_success"
+    echo "Failed: $zip_failed"
+
+    if [ $zip_failed -eq 0 ]; then
+        echo ""
+        echo "All zip archives created successfully!"
+        echo "Zip files are located in: ${PUBLISH_ROOT}/"
+        echo "Created files:"
+        ls -la *.zip 2>/dev/null || echo "No zip files found"
+    else
+        echo ""
+        echo "Some zip creations failed. Check the output above."
+    fi
+else
+    echo ""
+    echo "Some builds failed. Check the output above. Partial outputs: ${PUBLISH_ROOT}"
+    exit 1
+fi

--- a/Godot-MCP-Server/com.IvanMurzak.Godot.MCP.Server.csproj
+++ b/Godot-MCP-Server/com.IvanMurzak.Godot.MCP.Server.csproj
@@ -1,0 +1,70 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>com.IvanMurzak.Godot.MCP.Server</RootNamespace>
+    <AssemblyName>godot-mcp-server</AssemblyName>
+
+    <!-- NuGet Package Properties -->
+    <IsPackable>true</IsPackable>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>godot-mcp-server</ToolCommandName>
+    <PackageId>com.IvanMurzak.Godot.MCP.Server</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Ivan Murzak</Authors>
+    <Company>Ivan Murzak</Company>
+    <Copyright>Copyright © 2026 Ivan Murzak</Copyright>
+    <Description>Godot MCP Server - A Model Context Protocol server that enables AI assistants to interact with the Godot Editor and games through the Godot-MCP addon</Description>
+    <PackageTags>godot;mcp;model-context-protocol;ai;assistant;signalr;dotnet-tool</PackageTags>
+    <RepositoryUrl>https://github.com/IvanMurzak/Godot-MCP</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/IvanMurzak/Godot-MCP</PackageProjectUrl>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReleaseNotes>Initial release of Godot MCP Server as a global dotnet tool</PackageReleaseNotes>
+  </PropertyGroup>
+
+  <!-- Disable static web assets manifests & strip debug symbols for lean Release output -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <GenerateStaticWebAssetsManifest>false</GenerateStaticWebAssetsManifest>
+    <GenerateStaticWebAssetsEndpointsManifest>false</GenerateStaticWebAssetsEndpointsManifest>
+    <DebugType>none</DebugType>
+    <DebugSymbols>false</DebugSymbols>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
+
+  <!--
+    Frozen reused NuGet pins. These are kept in lockstep with the Godot-MCP addon
+    (Godot-MCP.csproj): McpPlugin.Server 6.7.0 + ReflectorNet 5.3.1. The server core
+    lives entirely in the McpPlugin.Server package; there is no Godot-specific server
+    code. Do NOT bump these here — version changes run through the upstream release
+    pipelines (see the Godot-MCP target profile PIPELINE.md invariant).
+  -->
+  <ItemGroup>
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.1" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin.Server" Version="6.7.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.2" />
+    <PackageReference Include="R3" Version="1.3.0" />
+  </ItemGroup>
+
+  <!-- Include package files -->
+  <ItemGroup>
+    <None Include="LICENSE" Pack="true" PackagePath="" />
+    <None Include="README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <!-- Exclude the local publish output folder so successive publishes don't recursively include previous outputs -->
+  <ItemGroup>
+    <None Remove="publish/**" />
+    <Content Remove="publish/**" />
+    <EmbeddedResource Remove="publish/**" />
+  </ItemGroup>
+
+</Project>

--- a/Godot-MCP-Server/server.json
+++ b/Godot-MCP-Server/server.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.IvanMurzak/Godot-MCP",
+  "description": "Make games in Godot Engine with AI. MCP Server + addon for the Godot Editor and Godot games.",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/IvanMurzak/Godot-MCP",
+    "source": "github",
+    "subfolder": "Godot-MCP-Server"
+  },
+  "version": "0.1.0",
+  "packages": [
+    {
+      "registry_type": "oci",
+      "registry_base_url": "https://docker.io",
+      "identifier": "ivanmurzakdev/godot-mcp-server",
+      "version": "0.1.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environment_variables": [
+        {
+          "name": "MCP_PLUGIN_PORT",
+          "description": "Client -> Server <- Plugin connection port (default: 8080)",
+          "format": "number",
+          "is_required": false,
+          "is_secret": false
+        },
+        {
+          "name": "MCP_PLUGIN_CLIENT_TIMEOUT",
+          "description": "Plugin -> Server connection timeout (ms) (default: 10000)",
+          "format": "number",
+          "is_required": false,
+          "is_secret": false
+        },
+        {
+          "name": "MCP_PLUGIN_CLIENT_TRANSPORT",
+          "description": "Client -> Server transport type: stdio or streamableHttp (default: stdio)",
+          "format": "string",
+          "default": "stdio",
+          "enum": [
+            "streamableHttp",
+            "stdio"
+          ],
+          "is_required": false,
+          "is_secret": false
+        }
+      ]
+    }
+  ]
+}

--- a/Godot-MCP-Server/src/Program.cs
+++ b/Godot-MCP-Server/src/Program.cs
@@ -1,0 +1,148 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using com.IvanMurzak.McpPlugin.Server;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NLog;
+using NLog.Extensions.Logging;
+
+namespace com.IvanMurzak.Godot.MCP.Server
+{
+    public class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            // Configure NLog
+            LogManager.Setup().LoadConfigurationFromFile("NLog.config");
+
+            var dataArguments = new DataArguments(args);
+
+            // In STDIO mode, redirect console logs to stderr to avoid polluting stdout with non-JSON content
+            if (dataArguments.ClientTransport == Consts.MCP.Server.TransportMethod.stdio)
+            {
+                var consoleTarget = LogManager.Configuration?.FindTargetByName("console") as NLog.Targets.ColoredConsoleTarget;
+                if (consoleTarget != null)
+                {
+                    consoleTarget.StdErr = true;
+                }
+                LogManager.ReconfigExistingLoggers();
+            }
+
+            var logger = LogManager.GetCurrentClassLogger();
+            try
+            {
+                var consoleWriteLine = dataArguments.ClientTransport switch
+                {
+                    Consts.MCP.Server.TransportMethod.stdio => (Action<string>)(message => { /* ignore console output */ }),
+                    Consts.MCP.Server.TransportMethod.streamableHttp => (Action<string>)(message => Console.WriteLine(message)),
+                    _ => throw new ArgumentException($"Unsupported transport method: {dataArguments.ClientTransport}. " +
+                        $"Supported methods are: {Consts.MCP.Server.TransportMethod.stdio}, {Consts.MCP.Server.TransportMethod.streamableHttp}")
+                };
+
+                consoleWriteLine("Location: " + Environment.CurrentDirectory);
+                consoleWriteLine($"Launch arguments: {string.Join(" ", args)}");
+                consoleWriteLine($"Parsed arguments: {JsonSerializer.Serialize(dataArguments, JsonOptions.Pretty)}");
+
+                var builder = WebApplication.CreateBuilder(args);
+
+                // Replace default logging with NLog
+                builder.Logging.ClearProviders();
+                builder.Logging.AddNLog();
+
+                // Setup MCP Plugin ---------------------------------------------------------------
+
+                builder.Services
+                    .WithMcpServer(dataArguments, logger)
+                    .WithMcpPluginServer(dataArguments);
+
+                // builder.WebHost.UseUrls(Consts.Hub.DefaultEndpoint);
+
+                logger.Info($"Start listening on port: {dataArguments.Port}");
+
+                // Bind IPv4 and IPv6 separately to avoid dual-stack socket issues on macOS.
+                builder.WebHost.UseKestrelForMcpPlugin(dataArguments.Port);
+
+                var app = builder.Build();
+
+                // Middleware ----------------------------------------------------------------
+                // ---------------------------------------------------------------------------
+
+                // Setup SignalR ----------------------------------------------------
+                app.UseMcpPluginServer(dataArguments);
+
+                // Setup MCP client -------------------------------------------------
+                if (dataArguments.ClientTransport == Consts.MCP.Server.TransportMethod.streamableHttp)
+                {
+                    // Add a GET /help endpoint for informational message
+                    app.MapGet("/help", () =>
+                    {
+                        var header =
+                            "Author: Ivan Murzak (https://github.com/IvanMurzak)\n" +
+                            "Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)\n" +
+                            "Copyright (c) 2026 Ivan Murzak\n" +
+                            "Licensed under the Apache License, Version 2.0.\n" +
+                            "See the LICENSE file in the project root for more information.\n" +
+                            "\n" +
+                            "Use \"/\" endpoint to get connected to MCP server\n";
+                        return Results.Text(header, Consts.MimeType.TextPlain);
+                    });
+                }
+
+                #region Print Logs
+                if (logger.IsEnabled(NLog.LogLevel.Debug))
+                {
+                    var endpointDataSource = app.Services.GetRequiredService<Microsoft.AspNetCore.Routing.EndpointDataSource>();
+                    foreach (var endpoint in endpointDataSource.Endpoints)
+                        logger.Debug($"Configured endpoint: {endpoint.DisplayName}");
+
+                    app.Use(async (context, next) =>
+                    {
+                        logger.Debug($"Request: {context.Request.Method} {context.Request.Path}");
+                        try
+                        {
+                            await next.Invoke();
+                            logger.Debug($"Response: {context.Response.StatusCode} ({context.Request.Method} {context.Request.Path})");
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            // Optionally log as debug or ignore
+                        }
+                        catch (Exception ex)
+                        {
+                            logger.Error(ex, $"Error occurred while processing request: {context.Request.Method} {context.Request.Path}");
+                            return;
+                        }
+                    });
+                }
+                #endregion
+
+                await app.RunAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.Error(ex, "Application stopped due to an exception.");
+                throw;
+            }
+            finally
+            {
+                LogManager.Shutdown();
+            }
+        }
+    }
+}

--- a/Godot-MCP.csproj
+++ b/Godot-MCP.csproj
@@ -21,12 +21,16 @@
   </ItemGroup>
 
   <!--
-    The Godot.NET.Sdk auto-globs every *.cs under the project dir into THIS game assembly. The xUnit
-    test project (Godot-MCP.Tests/) lives in a subfolder and has its own .csproj, so exclude it here —
-    otherwise its test files (which reference xUnit) get compiled into the game assembly and fail.
+    The Godot.NET.Sdk auto-globs every *.cs under the project dir into THIS game assembly. Sibling
+    projects that live in subfolders and own their own .csproj must be excluded here, otherwise their
+    sources (which reference packages this game assembly does not, e.g. xUnit or ASP.NET Core) get
+    compiled into the game assembly and break the build:
+      - Godot-MCP.Tests/   — the xUnit unit-test project.
+      - Godot-MCP-Server/   — the standalone ASP.NET Core MCP server (its own .sln; NOT part of this one).
   -->
   <ItemGroup>
     <Compile Remove="Godot-MCP.Tests/**/*.cs" />
+    <Compile Remove="Godot-MCP-Server/**/*.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Add a standalone **`Godot-MCP-Server/`** project: a thin ASP.NET Core host around the frozen `com.IvanMurzak.McpPlugin.Server` 6.7.0 NuGet (the same MCP server core Unity-MCP-Server uses), adapted from Unity-MCP-Server. The server logic lives entirely in the NuGet — `Program.cs` only wires Kestrel/SignalR/NLog and delegates to the `McpPlugin.Server` extension methods. Namespace `com.IvanMurzak.Godot.MCP.Server`, assembly `godot-mcp-server`.
- Frozen NuGet pins kept in lockstep with the addon: `McpPlugin.Server` 6.7.0 + `ReflectorNet` 5.3.1.
- `build-all.sh` / `build-all.ps1` produce self-contained single-file binaries for the 7 RIDs (win-x64/x86/arm64, linux-x64/arm64, osx-x64/arm64), zipped as `godot-mcp-server-<rid>.zip` under `./publish/`.
- Own solution (`Godot-MCP-Server.sln`); **NOT** referenced by `Godot-MCP.sln`. Also excludes `Godot-MCP-Server/**/*.cs` from the addon game project's auto-glob (same discipline as `Godot-MCP.Tests/**`) so the server does not leak into the addon assembly and the `dotnet build (.NET 8)` CI gate stays green.
- No publish/release performed in this task.

## Test plan

- [x] `dotnet build` of the new server project — 0 errors.
- [x] `dotnet build Godot-MCP.sln --configuration Debug` — 0 errors; addon unit suite 614/614 pass (server did not leak into the addon solution).
- [x] `dotnet publish -c Release -r win-x64 --self-contained -p:PublishSingleFile=true` produces `godot-mcp-server.exe` (output not committed).
- [x] Published binary boots over `streamableHttp` and serves the branded `/help` endpoint.
- [ ] Live tool round-trip (`ping`) — operator-only; requires a connected Godot plugin (Suite 3).

Closes #74