### PR TITLE
ci(release): build & attach Godot-MCP-Server binaries to the GitHub release

### DIFF
--- a/.github/workflows/deploy_server_executables.yml
+++ b/.github/workflows/deploy_server_executables.yml
@@ -1,0 +1,58 @@
+# ┌──────────────────────────────────────────────────────────────────┐
+# │  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+# │  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+# │  Copyright (c) 2026 Ivan Murzak                                  │
+# │  Licensed under the Apache License, Version 2.0.                 │
+# │  See the LICENSE file in the project root for more information.  │
+# └──────────────────────────────────────────────────────────────────┘
+
+# Fallback: build the Godot-MCP-Server self-contained executables for all 7 RIDs
+# and (re-)attach the `godot-mcp-server-<rid>.zip` assets to an already-published
+# release (Unity-MCP parity: deploy_server_executables.yml).
+#
+# Trigger: a release being PUBLISHED. The primary path attaches these zips inside
+# release.yml's `release-addon` job at release-creation time; this workflow is the
+# safety net for cases where a release was published without them (e.g. a release
+# created/edited by hand, or a re-run after the primary upload failed). Uploads are
+# idempotent — softprops/action-gh-release replaces same-named assets on the tag.
+#
+# This is NOT part of the version-gated push pipeline: it fires only on the
+# `release: published` event (which the gated release-addon job itself emits when
+# it cuts the `v<version>` release on a real version bump), never on a plain merge.
+
+name: deploy-server-executables
+
+on:
+  release:
+    types: [published]
+
+# Least-privilege: the release-asset upload needs contents:write.
+permissions:
+  contents: write
+
+jobs:
+  build-and-zip:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Make build script executable
+        run: chmod +x ./Godot-MCP-Server/build-all.sh
+
+      - name: Build self-contained server executables for all RIDs
+        shell: bash
+        run: cd Godot-MCP-Server && ./build-all.sh Release
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ./Godot-MCP-Server/publish/*.zip
+          tag_name: ${{ github.event.release.tag_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,11 +209,52 @@ jobs:
     with:
       godotVersion: "4.5.1"
 
+  # Cross-compile the Godot-MCP-Server self-contained binaries for all 7 RIDs
+  # and zip each into `godot-mcp-server-<rid>.zip` (Unity-MCP parity:
+  # build-and-zip-mcp-server). Gated on `should_release` like every other job
+  # here, so a no-bump merge of a workflow/feature PR builds NOTHING.
+  #
+  # Runner choice: ubuntu-latest. build-all.sh cross-compiles ALL runtimes from
+  # a single host via `dotnet publish -r <rid> --self-contained` (PublishSingleFile),
+  # which needs only a .NET 8 SDK and works identically on any OS — there is no
+  # per-RID native toolchain requirement. ubuntu-latest is the cheapest GitHub
+  # runner and matches this repo's other .NET jobs (dotnet-build-test runs on
+  # ubuntu-latest), so we pick it over Unity's macos-latest for cost/consistency.
+  # The 7 emitted zips (win-x64/-x86/-arm64, linux-x64/-arm64, osx-x64/-arm64)
+  # are identical regardless of build host.
+  build-and-zip-godot-server:
+    runs-on: ubuntu-latest
+    needs: [check-version-tag]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Make build script executable
+        run: chmod +x ./Godot-MCP-Server/build-all.sh
+
+      - name: Build self-contained server executables for all RIDs
+        shell: bash
+        run: cd Godot-MCP-Server && ./build-all.sh Release
+
+      - name: Upload server zips as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: godot-mcp-server-zips
+          path: ./Godot-MCP-Server/publish/*.zip
+          if-no-files-found: error
+
   # --- PUBLISH (gated on tag-not-existing AND every test passing) ---
 
   # Build + package the addon zip and cut the GitHub Release on the new
   # `v<version>` tag. Identical packaging to the previous tag-triggered flow,
-  # now gated on the version check + tests instead of a tag push.
+  # now gated on the version check + tests instead of a tag push. Also attaches
+  # the cross-platform Godot-MCP-Server zips built by build-and-zip-godot-server.
   release-addon:
     runs-on: ubuntu-latest
     needs:
@@ -224,6 +265,7 @@ jobs:
         test-godot-4-3,
         test-godot-4-4,
         test-godot-4-5,
+        build-and-zip-godot-server,
       ]
     if: needs.check-version-tag.outputs.should_release == 'true'
     outputs:
@@ -269,8 +311,27 @@ jobs:
           echo "Created ${zip_name}:"
           unzip -l "${zip_name}"
 
-      # Create the GitHub Release + tag with the zip attached and auto-generated
-      # notes. tag_name is the `v<version>` computed from plugin.cfg.
+      # Pull in the 7 cross-platform server zips built by build-and-zip-godot-server
+      # so they ride the same GitHub Release as the addon zip. They land in
+      # ./server-zips/godot-mcp-server-<rid>.zip and are added to the files: list
+      # below. SV3's downloader resolves them at
+      # releases/download/<version>/godot-mcp-server-<os>-<arch>.zip.
+      - name: Download server zips artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: godot-mcp-server-zips
+          path: ./server-zips
+
+      - name: List assembled release assets
+        run: |
+          set -euo pipefail
+          echo "Addon zip: ${{ steps.package.outputs.zip_name }}"
+          echo "Server zips:"
+          ls -la ./server-zips
+
+      # Create the GitHub Release + tag with the addon zip + the 7 server zips
+      # attached and auto-generated notes. tag_name is the `v<version>` computed
+      # from plugin.cfg.
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -278,7 +339,9 @@ jobs:
           tag_name: ${{ needs.check-version-tag.outputs.tag }}
           generate_release_notes: true
           fail_on_unmatched_files: true
-          files: ${{ steps.package.outputs.zip_name }}
+          files: |
+            ${{ steps.package.outputs.zip_name }}
+            ./server-zips/*.zip
 
       - name: Mark publish success
         id: mark


### PR DESCRIPTION
## Summary
- Add `build-and-zip-godot-server` job to `release.yml` (gated on `should_release`) that cross-compiles the 7 self-contained server RIDs via `Godot-MCP-Server/build-all.sh Release` and uploads `godot-mcp-server-<rid>.zip` as an artifact.
- `release-addon` now `needs:` that job, downloads the artifact, and adds `./server-zips/*.zip` to the `softprops/action-gh-release` `files:` list so all 7 server zips land on the `v<version>` release beside the addon zip.
- New `deploy_server_executables.yml` (on `release: published`) re-builds + re-attaches the zips as a fallback (Unity-MCP parity).

## Version-gating safety
Every new piece is gated on `needs.check-version-tag.outputs.should_release == 'true'`. `should_release` is `tag_exists=='false' && version_changed=='true'`. **Merging this PR does NOT bump `plugin.cfg`'s version**, so `version_changed=='false'` → gate CLOSED → the server-build job is skipped and **nothing is built or attached**. The actual binary build + release-attach runs only on a real future release after a deliberate version bump.

## Asset naming (for SV3 downloader)
`build-all.sh` emits `godot-mcp-server-<rid>.zip` for the 7 RIDs `win-x64`, `win-x86`, `win-arm64`, `linux-x64`, `linux-arm64`, `osx-x64`, `osx-arm64` — i.e. `godot-mcp-server-<os>-<arch>.zip`, resolvable at `releases/download/<version>/godot-mcp-server-<os>-<arch>.zip`.

## Runner choice
`ubuntu-latest` (cheapest, matches `dotnet-build-test`). `build-all.sh` cross-compiles all RIDs from one host via `dotnet publish -r <rid> --self-contained`, so no per-RID native toolchain is needed; the zips are host-independent.

## Test plan
- [x] YAML lint: all 7 `.github/workflows/*.yml` parse via `yaml.safe_load`.
- [x] `dotnet build Godot-MCP.sln --configuration Debug` → 0 errors, 0 warnings (workflow-only change, solution unaffected).
- [x] Scope: only `.github/workflows/release.yml` + new `deploy_server_executables.yml`; no addon/cli/server-csproj/NuGet-pin changes; no version bump.

Closes #76