### PR TITLE
feat: host the version-matched Godot-MCP-Server binary (Unity-MCP-Plugin parity)

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -132,6 +132,15 @@
          via the headless Godot smoke (test.md Suite 3); the view logic is unit-tested here. The SignalR
          HubConnectionState enum it switches on is provided transitively by com.IvanMurzak.McpPlugin. -->
     <Compile Include="..\addons\godot_mcp\UI\ConnectionPanelView.cs" Link="Source\ConnectionPanelView.cs" />
+    <!-- Local-server hosting view logic — pure-managed (no Godot native types, no #if TOOLS): the
+         GodotMcpServerStatus enum, the platform→RID/asset-name mapping, the exact version-match, the release
+         download-URL construction, the launch-arg builder (port=… plugin-timeout=… client-transport=… …),
+         the status→button-text/label/circle-state mappings, and the Custom-host→port extraction. The editor
+         download/launch/monitor side effects (GodotMcpServerManager.cs, #if TOOLS) are verified via the
+         headless Godot smoke + are operator-pending until a real release; the deterministic decisions are
+         unit-tested here (cross-platform: every method is a string/enum transform, so the same assertions
+         hold on the Linux CI runner). -->
+    <Compile Include="..\addons\godot_mcp\Connection\GodotMcpServerView.cs" Link="Source\GodotMcpServerView.cs" />
     <!-- Segmented-control state model — pure-managed (no Godot native types, no #if TOOLS): the
          value→index / selected-predicate / clamp rules for the reusable segmented control (Custom|Cloud,
          none|required). The editor builder (DockStyle.SegmentedControl, #if TOOLS) consumes these and is

--- a/Godot-MCP.Tests/GodotMcpServerViewTests.cs
+++ b/Godot-MCP.Tests/GodotMcpServerViewTests.cs
@@ -1,0 +1,283 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Runtime.InteropServices;
+using com.IvanMurzak.Godot.MCP.Connection;
+using com.IvanMurzak.Godot.MCP.UI;
+using Xunit;
+using McpServerConsts = com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the pure-managed local-server hosting logic (<see cref="GodotMcpServerView"/>): the platform→RID
+    /// /asset-name mapping, the EXACT version-match, the GitHub release download-URL construction, the
+    /// launch-argument builder, the status→button-text/label/circle-state mappings, and the configured-host→
+    /// port extraction. Every assertion is a deterministic string/enum transform with NO platform divergence,
+    /// so the SAME assertions hold on the Linux CI runner and on a Windows dev box (the issue's cross-platform
+    /// requirement). The editor download/launch/monitor side effects (<c>GodotMcpServerManager.cs</c>,
+    /// <c>#if TOOLS</c>) are verified via the headless Godot smoke (test.md Suite 3) and are operator-pending
+    /// until a real GitHub release publishes the server binaries — NOT here.
+    /// </summary>
+    public class GodotMcpServerViewTests
+    {
+        // --- Platform mapping (os + arch -> RID), driven explicitly so the tests are platform-independent ---
+
+        [Theory]
+        [InlineData("Windows", "win")]
+        [InlineData("OSX", "osx")]
+        [InlineData("Linux", "linux")]
+        public void OsToken_MapsEachOs(string osName, string expected)
+        {
+            var os = osName switch
+            {
+                "Windows" => OSPlatform.Windows,
+                "OSX" => OSPlatform.OSX,
+                _ => OSPlatform.Linux
+            };
+            Assert.Equal(expected, GodotMcpServerView.OsToken(os));
+        }
+
+        [Fact]
+        public void OsToken_UnknownOs_IsUnknown()
+        {
+            Assert.Equal("unknown", GodotMcpServerView.OsToken(OSPlatform.Create("freebsd")));
+        }
+
+        [Theory]
+        [InlineData(Architecture.X86, "x86")]
+        [InlineData(Architecture.X64, "x64")]
+        [InlineData(Architecture.Arm, "arm")]
+        [InlineData(Architecture.Arm64, "arm64")]
+        public void ArchToken_MapsEachArch(Architecture arch, string expected)
+        {
+            Assert.Equal(expected, GodotMcpServerView.ArchToken(arch));
+        }
+
+        [Fact]
+        public void PlatformName_IsOsDashArch()
+        {
+            Assert.Equal("win-x64", GodotMcpServerView.PlatformName(OSPlatform.Windows, Architecture.X64));
+            Assert.Equal("osx-arm64", GodotMcpServerView.PlatformName(OSPlatform.OSX, Architecture.Arm64));
+            Assert.Equal("linux-x64", GodotMcpServerView.PlatformName(OSPlatform.Linux, Architecture.X64));
+        }
+
+        [Fact]
+        public void PlatformName_CoversAllSevenReleaseRids()
+        {
+            // The release workflow (build-all.sh) emits exactly these 7 RIDs; the asset names must match 1:1.
+            Assert.Equal("win-x64", GodotMcpServerView.PlatformName(OSPlatform.Windows, Architecture.X64));
+            Assert.Equal("win-x86", GodotMcpServerView.PlatformName(OSPlatform.Windows, Architecture.X86));
+            Assert.Equal("win-arm64", GodotMcpServerView.PlatformName(OSPlatform.Windows, Architecture.Arm64));
+            Assert.Equal("linux-x64", GodotMcpServerView.PlatformName(OSPlatform.Linux, Architecture.X64));
+            Assert.Equal("linux-arm64", GodotMcpServerView.PlatformName(OSPlatform.Linux, Architecture.Arm64));
+            Assert.Equal("osx-x64", GodotMcpServerView.PlatformName(OSPlatform.OSX, Architecture.X64));
+            Assert.Equal("osx-arm64", GodotMcpServerView.PlatformName(OSPlatform.OSX, Architecture.Arm64));
+        }
+
+        // --- Executable / asset names ---
+
+        [Fact]
+        public void ExecutableFileName_HasExeSuffixOnWindowsOnly()
+        {
+            Assert.Equal("godot-mcp-server.exe", GodotMcpServerView.ExecutableFileName(OSPlatform.Windows));
+            Assert.Equal("godot-mcp-server", GodotMcpServerView.ExecutableFileName(OSPlatform.Linux));
+            Assert.Equal("godot-mcp-server", GodotMcpServerView.ExecutableFileName(OSPlatform.OSX));
+        }
+
+        [Fact]
+        public void AssetZipName_IsExecutableDashRidDotZip()
+        {
+            Assert.Equal("godot-mcp-server-win-x64.zip",
+                GodotMcpServerView.AssetZipName(OSPlatform.Windows, Architecture.X64));
+            Assert.Equal("godot-mcp-server-linux-arm64.zip",
+                GodotMcpServerView.AssetZipName(OSPlatform.Linux, Architecture.Arm64));
+        }
+
+        // --- Download URL ---
+
+        [Fact]
+        public void DownloadUrl_UsesExactVersionAndRidAsset()
+        {
+            var url = GodotMcpServerView.DownloadUrl("0.1.0", OSPlatform.Windows, Architecture.X64);
+            Assert.Equal(
+                "https://github.com/IvanMurzak/Godot-MCP/releases/download/0.1.0/godot-mcp-server-win-x64.zip",
+                url);
+        }
+
+        [Fact]
+        public void DownloadUrl_VersionIsVerbatim_NoSemverNormalization()
+        {
+            // EXACT match like Unity — a 'v'-prefixed or pre-release version is used verbatim, not normalized.
+            var url = GodotMcpServerView.DownloadUrl("1.2.3-beta", OSPlatform.Linux, Architecture.X64);
+            Assert.Contains("/releases/download/1.2.3-beta/", url);
+            Assert.EndsWith("godot-mcp-server-linux-x64.zip", url);
+        }
+
+        // --- Version match (EXACT) ---
+
+        [Fact]
+        public void VersionMatches_ExactEqual_IsTrue()
+        {
+            Assert.True(GodotMcpServerView.VersionMatches("0.1.0", "0.1.0"));
+        }
+
+        [Fact]
+        public void VersionMatches_TrimsSurroundingWhitespace()
+        {
+            // The cached `version` file may carry a trailing newline; that still matches.
+            Assert.True(GodotMcpServerView.VersionMatches("0.1.0\n", "0.1.0"));
+        }
+
+        [Theory]
+        [InlineData("0.1.0", "0.2.0")]
+        [InlineData("0.1.0", "0.1.1")]
+        [InlineData(null, "0.1.0")]
+        [InlineData("", "0.1.0")]
+        public void VersionMatches_DifferentOrMissing_IsFalse(string? cached, string addon)
+        {
+            Assert.False(GodotMcpServerView.VersionMatches(cached, addon));
+        }
+
+        // --- Launch argument builder ---
+
+        [Fact]
+        public void BuildLaunchArguments_NoAuth_OmitsToken()
+        {
+            var args = GodotMcpServerView.BuildLaunchArguments(port: 8080, pluginTimeoutMs: 10000, authRequired: false, token: "secret");
+            Assert.Equal("port=8080 plugin-timeout=10000 client-transport=streamableHttp authorization=none", args);
+            Assert.DoesNotContain("token=", args);
+            Assert.DoesNotContain("secret", args);
+        }
+
+        [Fact]
+        public void BuildLaunchArguments_AuthRequiredWithToken_AppendsToken()
+        {
+            var args = GodotMcpServerView.BuildLaunchArguments(port: 5300, pluginTimeoutMs: 12000, authRequired: true, token: "abc123");
+            Assert.Equal("port=5300 plugin-timeout=12000 client-transport=streamableHttp authorization=required token=abc123", args);
+        }
+
+        [Fact]
+        public void BuildLaunchArguments_AuthRequiredButNoToken_OmitsTokenArg()
+        {
+            var args = GodotMcpServerView.BuildLaunchArguments(port: 5300, pluginTimeoutMs: 10000, authRequired: true, token: null);
+            Assert.Equal("port=5300 plugin-timeout=10000 client-transport=streamableHttp authorization=required", args);
+            Assert.DoesNotContain("token=", args);
+        }
+
+        [Fact]
+        public void BuildLaunchArguments_AlwaysStreamableHttp_NeverStdio()
+        {
+            // The transport is always streamableHttp — we deliberately do NOT build a stdio launch path
+            // the plugin's SignalR client cannot consume.
+            var args = GodotMcpServerView.BuildLaunchArguments(port: 8080, pluginTimeoutMs: 10000, authRequired: false, token: null);
+            Assert.Contains($"client-transport={McpServerConsts.TransportMethod.streamableHttp}", args);
+            Assert.DoesNotContain(McpServerConsts.TransportMethod.stdio.ToString(), args);
+        }
+
+        [Fact]
+        public void BuildLaunchArguments_UsesCanonicalArgKeys()
+        {
+            // The keys must be the McpPlugin canonical arg names the server parses.
+            var args = GodotMcpServerView.BuildLaunchArguments(port: 9, pluginTimeoutMs: 1, authRequired: true, token: "t");
+            Assert.StartsWith($"{McpServerConsts.Args.Port}=9 ", args);
+            Assert.Contains($" {McpServerConsts.Args.PluginTimeout}=1 ", args);
+            Assert.Contains($" {McpServerConsts.Args.ClientTransportMethod}=", args);
+            Assert.Contains($" {McpServerConsts.Args.Authorization}={McpServerConsts.AuthOption.required}", args);
+            Assert.EndsWith($" {McpServerConsts.Args.Token}=t", args);
+        }
+
+        // --- Status -> button text / disabled ---
+
+        [Theory]
+        [InlineData(GodotMcpServerStatus.Stopped, GodotMcpServerView.ButtonTextStart)]
+        [InlineData(GodotMcpServerStatus.Starting, GodotMcpServerView.ButtonTextStarting)]
+        [InlineData(GodotMcpServerStatus.Running, GodotMcpServerView.ButtonTextStop)]
+        [InlineData(GodotMcpServerStatus.Stopping, GodotMcpServerView.ButtonTextStopping)]
+        [InlineData(GodotMcpServerStatus.External, GodotMcpServerView.ButtonTextExternal)]
+        public void ServerButtonText_MapsEachStatus(GodotMcpServerStatus status, string expected)
+        {
+            Assert.Equal(expected, GodotMcpServerView.ServerButtonText(status));
+        }
+
+        [Theory]
+        [InlineData(GodotMcpServerStatus.Stopped, false)]
+        [InlineData(GodotMcpServerStatus.Starting, true)]
+        [InlineData(GodotMcpServerStatus.Running, false)]
+        [InlineData(GodotMcpServerStatus.Stopping, true)]
+        [InlineData(GodotMcpServerStatus.External, true)]
+        public void ServerButtonDisabled_DisabledDuringTransientsAndExternal(GodotMcpServerStatus status, bool disabled)
+        {
+            Assert.Equal(disabled, GodotMcpServerView.ServerButtonDisabled(status));
+        }
+
+        // --- Status -> label ---
+
+        [Fact]
+        public void ServerStatusLabel_HasDistinctTextPerStatus()
+        {
+            Assert.Equal("Local server: Stopped", GodotMcpServerView.ServerStatusLabel(GodotMcpServerStatus.Stopped));
+            Assert.Equal("Local server: Running", GodotMcpServerView.ServerStatusLabel(GodotMcpServerStatus.Running));
+            Assert.Contains("Starting", GodotMcpServerView.ServerStatusLabel(GodotMcpServerStatus.Starting));
+            Assert.Contains("Stopping", GodotMcpServerView.ServerStatusLabel(GodotMcpServerStatus.Stopping));
+            Assert.Contains("External", GodotMcpServerView.ServerStatusLabel(GodotMcpServerStatus.External));
+        }
+
+        // --- Status -> timeline circle state ---
+
+        [Theory]
+        [InlineData(GodotMcpServerStatus.Running, ConnectionPanelView.TimelinePointState.Online)]
+        [InlineData(GodotMcpServerStatus.External, ConnectionPanelView.TimelinePointState.Online)]
+        [InlineData(GodotMcpServerStatus.Starting, ConnectionPanelView.TimelinePointState.Connecting)]
+        [InlineData(GodotMcpServerStatus.Stopping, ConnectionPanelView.TimelinePointState.Connecting)]
+        [InlineData(GodotMcpServerStatus.Stopped, ConnectionPanelView.TimelinePointState.Disconnected)]
+        public void ServerPointState_MapsEachStatus(GodotMcpServerStatus status, ConnectionPanelView.TimelinePointState expected)
+        {
+            Assert.Equal(expected, GodotMcpServerView.ServerPointState(status));
+        }
+
+        [Fact]
+        public void ServerStatusColor_ReusesConnectionPalette()
+        {
+            Assert.Equal(ConnectionPanelView.ColorConnected, GodotMcpServerView.ServerStatusColor(GodotMcpServerStatus.Running));
+            Assert.Equal(ConnectionPanelView.ColorConnecting, GodotMcpServerView.ServerStatusColor(GodotMcpServerStatus.Starting));
+            Assert.Equal(ConnectionPanelView.ColorDisconnected, GodotMcpServerView.ServerStatusColor(GodotMcpServerStatus.Stopped));
+        }
+
+        // --- Port extraction from the configured Custom host URL ---
+
+        [Theory]
+        [InlineData("http://localhost:5300", 5300)]
+        [InlineData("http://127.0.0.1:8080", 8080)]
+        [InlineData("https://example.com:443", 443)]
+        public void ResolveServerPort_ParsesExplicitPort(string url, int expected)
+        {
+            Assert.Equal(expected, GodotMcpServerView.ResolveServerPort(url, defaultPort: 9999));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("not a url")]
+        public void ResolveServerPort_MissingOrUnparseable_FallsBackToDefault(string? url)
+        {
+            Assert.Equal(9999, GodotMcpServerView.ResolveServerPort(url, defaultPort: 9999));
+        }
+
+        [Fact]
+        public void ResolveServerPort_NoExplicitPort_UsesSchemeDefaultWhenAbsolute()
+        {
+            // An absolute http URL with no explicit port resolves to the scheme's default (80), not the
+            // fallback — Uri fills it in. (Documents the behavior so the manager's port choice is predictable.)
+            Assert.Equal(80, GodotMcpServerView.ResolveServerPort("http://localhost", defaultPort: 9999));
+        }
+    }
+}

--- a/Godot-MCP.Tests/GodotMcpServerViewTests.cs
+++ b/Godot-MCP.Tests/GodotMcpServerViewTests.cs
@@ -279,5 +279,62 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             // fallback — Uri fills it in. (Documents the behavior so the manager's port choice is predictable.)
             Assert.Equal(80, GodotMcpServerView.ResolveServerPort("http://localhost", defaultPort: 9999));
         }
+
+        // --- Orphan-process ownership (GodotMcpServerOwnership.IsOwnedByThisProject) ---
+        // Driven with explicit string paths (no Path APIs, no filesystem) so the assertions are
+        // deterministic and identical on Windows + Linux CI.
+
+        [Fact]
+        public void IsOwned_ExactSamePath_IsTrue()
+        {
+            var own = "C:/proj/.godot/mcp-server/win-x64/godot-mcp-server.exe";
+            Assert.True(GodotMcpServerOwnership.IsOwnedByThisProject(own, own));
+        }
+
+        [Fact]
+        public void IsOwned_SamePath_SeparatorAndCaseInsensitive()
+        {
+            // Windows backslash vs forward slash, mixed case — still our binary.
+            var own = "C:/proj/.godot/mcp-server/win-x64/godot-mcp-server.exe";
+            var candidate = @"c:\PROJ\.godot\mcp-server\win-x64\godot-mcp-server.exe";
+            Assert.True(GodotMcpServerOwnership.IsOwnedByThisProject(candidate, own));
+        }
+
+        [Fact]
+        public void IsOwned_SameCacheDir_IsTrue()
+        {
+            // A process whose exe sits in OUR cache platform folder is ours.
+            var own = "/home/u/proj/.godot/mcp-server/linux-x64/godot-mcp-server";
+            var candidate = "/home/u/proj/.godot/mcp-server/linux-x64/godot-mcp-server";
+            Assert.True(GodotMcpServerOwnership.IsOwnedByThisProject(candidate, own));
+        }
+
+        [Fact]
+        public void IsOwned_DifferentProjectCacheDir_IsFalse()
+        {
+            // The safety property: a DIFFERENT project's identically-named server binary is NEVER ours.
+            var own = "/home/u/projA/.godot/mcp-server/linux-x64/godot-mcp-server";
+            var other = "/home/u/projB/.godot/mcp-server/linux-x64/godot-mcp-server";
+            Assert.False(GodotMcpServerOwnership.IsOwnedByThisProject(other, own));
+        }
+
+        [Fact]
+        public void IsOwned_SiblingDirSharingNamePrefix_IsFalse()
+        {
+            // The trailing-slash bound prevents a sibling dir whose name merely shares a prefix from matching.
+            var own = "/home/u/proj/.godot/mcp-server/linux-x64/godot-mcp-server";
+            var sibling = "/home/u/proj/.godot/mcp-server/linux-x64-evil/godot-mcp-server";
+            Assert.False(GodotMcpServerOwnership.IsOwnedByThisProject(sibling, own));
+        }
+
+        [Theory]
+        [InlineData(null, "/x/godot-mcp-server")]
+        [InlineData("", "/x/godot-mcp-server")]
+        [InlineData("/x/godot-mcp-server", null)]
+        [InlineData("/x/godot-mcp-server", "")]
+        public void IsOwned_NullOrEmpty_FailsClosed(string? candidate, string? own)
+        {
+            Assert.False(GodotMcpServerOwnership.IsOwnedByThisProject(candidate, own));
+        }
     }
 }

--- a/addons/godot_mcp/Connection/GodotMcpServerManager.cs
+++ b/addons/godot_mcp/Connection/GodotMcpServerManager.cs
@@ -269,8 +269,9 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
                 SetStatus(GodotMcpServerStatus.Starting, marshalled: false);
 
-                // Free the port from any orphaned server we previously left behind.
-                KillOrphanedServerProcesses(port);
+                // Free the port from any orphaned server WE previously left behind for THIS project
+                // (scoped to this project's cache dir — never cross-kills another project's server).
+                KillOrphanedServerProcesses();
 
                 try
                 {
@@ -292,13 +293,28 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                     var process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
                     process.Exited += OnProcessExited;
 
+                    // DRAIN the redirected stdout/stderr so a verbose server cannot fill the ~4KB OS pipe
+                    // buffer and BLOCK on a write nothing is reading. The handlers DISCARD every line —
+                    // they MUST NOT log the content, because the server echoes its own launch arguments
+                    // (including the secret token) to stdout. We keep redirect=true (so that token-bearing
+                    // echo never reaches the editor console) and simply throw the drained lines away.
+                    process.OutputDataReceived += DiscardServerOutput;
+                    process.ErrorDataReceived += DiscardServerOutput;
+
                     if (!process.Start())
                     {
                         _logError("[Godot-MCP] failed to start local server process.");
+                        process.OutputDataReceived -= DiscardServerOutput;
+                        process.ErrorDataReceived -= DiscardServerOutput;
                         process.Dispose();
                         SetStatus(GodotMcpServerStatus.Stopped, marshalled: false);
                         return false;
                     }
+
+                    // Begin async draining now that the process is running; pairs with the detach +
+                    // CancelOutputRead/CancelErrorRead in CleanupProcess.
+                    process.BeginOutputReadLine();
+                    process.BeginErrorReadLine();
 
                     _serverProcess = process;
                     _log($"[Godot-MCP] local server process started (PID {process.Id}, port {port}); verifying…");
@@ -432,12 +448,19 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         }
 
         /// <summary>
-        /// Kill an orphaned <c>godot-mcp-server</c> process holding <paramref name="port"/> so a fresh launch
-        /// can bind it. Conservative: only kills processes whose name contains the server executable name,
-        /// and skips our own current process. Failures are swallowed (fail-safe).
+        /// Kill an orphaned server process that THIS project previously launched — scoped so it can NEVER
+        /// cross-kill another Godot project's hosted server. The scope test is purely path-based
+        /// (<see cref="GodotMcpServerOwnership.IsOwnedByThisProject"/>): a candidate is killed only when its
+        /// executable path resolves under THIS project's cache folder (<see cref="CachePlatformPath"/>) — i.e.
+        /// it is OUR binary, left running by a prior editor session that did not stop cleanly. We also skip
+        /// our own current process. Path comparison is a deterministic, cross-platform string test (no
+        /// fragile <c>netstat</c>/<c>lsof</c> parsing), so it behaves identically on every OS. Failures are
+        /// swallowed (fail-safe).
         /// </summary>
-        void KillOrphanedServerProcesses(int port)
+        void KillOrphanedServerProcesses()
         {
+            var ownPath = ExecutableFullPath();
+
             try
             {
                 var currentPid = -1;
@@ -450,11 +473,23 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                         if (proc.Id == currentPid)
                             continue;
 
+                        // Cheap name pre-filter before the (potentially throwing) MainModule access.
                         var name = proc.ProcessName.ToLowerInvariant();
                         if (!name.Contains(GodotMcpServerView.ExecutableName))
                             continue;
 
-                        _logWarning($"[Godot-MCP] killing orphaned local server process (PID {proc.Id}).");
+                        // The load-bearing scope gate: only kill if this process's executable is OUR cached
+                        // binary (path under this project's cache folder). MainModule can throw (access denied
+                        // / 32-vs-64-bit / exited) — on any failure we DO NOT kill (fail closed: never touch a
+                        // process we cannot positively attribute to this project).
+                        string? candidatePath;
+                        try { candidatePath = proc.MainModule?.FileName; }
+                        catch { continue; }
+
+                        if (!GodotMcpServerOwnership.IsOwnedByThisProject(candidatePath, ownPath))
+                            continue;
+
+                        _logWarning($"[Godot-MCP] killing orphaned local server process (PID {proc.Id}) from this project.");
                         proc.Kill();
                         proc.WaitForExit(3000);
                     }
@@ -496,11 +531,31 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                     try
                     {
                         toDispose.Exited -= OnProcessExited;
+
+                        // Stop draining + detach the discard handlers before dispose (mirrors the attach in
+                        // StartServer); CancelOutputRead/CancelErrorRead are best-effort (no-op if reading
+                        // never started or already stopped).
+                        try { toDispose.CancelOutputRead(); } catch { }
+                        try { toDispose.CancelErrorRead(); } catch { }
+                        toDispose.OutputDataReceived -= DiscardServerOutput;
+                        toDispose.ErrorDataReceived -= DiscardServerOutput;
+
                         toDispose.Dispose();
                     }
                     catch (Exception ex) { _log($"[Godot-MCP] error disposing server process: {ex.Message}"); }
                 });
             }
+        }
+
+        /// <summary>
+        /// Drain handler for the server's redirected stdout/stderr: DISCARDS every received line. This exists
+        /// solely so the OS pipe buffer cannot fill and block the child process — it MUST NOT log the line
+        /// content, because the server echoes its own launch arguments (including the secret token) to stdout.
+        /// Throwing the lines away keeps the token off every log surface while still draining the pipe.
+        /// </summary>
+        static void DiscardServerOutput(object sender, DataReceivedEventArgs e)
+        {
+            // Intentionally empty: read-and-discard. Do NOT log e.Data — it may contain the token.
         }
 
         /// <summary>

--- a/addons/godot_mcp/Connection/GodotMcpServerManager.cs
+++ b/addons/godot_mcp/Connection/GodotMcpServerManager.cs
@@ -1,0 +1,567 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Godot;
+using com.IvanMurzak.Godot.MCP.MainThreadDispatch;
+// Alias the BCL types that collide with same-named Godot types (Godot.Environment / Godot.HttpClient).
+using SystemEnvironment = System.Environment;
+using HttpClient = System.Net.Http.HttpClient;
+using HttpCompletionOption = System.Net.Http.HttpCompletionOption;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// Editor-only (<c>#if TOOLS</c>) lifecycle manager for the locally-hosted <c>godot-mcp-server</c>
+    /// binary — the Godot analog of Unity-MCP's <c>McpServerManager</c>. It downloads the version-matched
+    /// server zip from the GitHub release, caches it under the project's <c>.godot/mcp-server/&lt;rid&gt;/</c>
+    /// folder (gitignored), unzips it, marks it executable on Unix, launches it as a child process, monitors
+    /// the ~5s startup window, persists the PID so an editor recompile can reconnect to a still-running
+    /// server, and stops it gracefully (then force-kills) on request or editor quit.
+    ///
+    /// <para>
+    /// This makes Godot-MCP able to HOST its own MCP server (not just connect to an external one). All the
+    /// deterministic, cross-platform decisions (asset name, version match, download URL, launch-arg string,
+    /// status→button/label/circle mappings, port extraction) live in the pure-managed
+    /// <see cref="GodotMcpServerView"/> so they are unit-tested in the plain-xUnit host with no Godot binary;
+    /// this class only performs the side effects and marshals status changes onto the editor main thread.
+    /// </para>
+    ///
+    /// <para>
+    /// Verification note: the actual download + run can only be exercised once a real GitHub release
+    /// publishes the server binaries. The URL/platform/version/arg logic is structurally verified by the
+    /// unit tests; this manager's wiring compiles and the dock builds. Live download+run is operator-pending
+    /// until the first real release (see the issue's "Mandatory before done").
+    /// </para>
+    /// </summary>
+    public sealed class GodotMcpServerManager : IDisposable
+    {
+        /// <summary>~5s startup-verification window, matching Unity's <c>verificationDelaySeconds</c>.</summary>
+        const double StartupVerificationSeconds = 5.0;
+
+        readonly string _addonVersion;
+        readonly Action<string> _log;
+        readonly Action<string> _logWarning;
+        readonly Action<string> _logError;
+        readonly object _processMutex = new();
+
+        Process? _serverProcess;
+        GodotMcpServerStatus _status = GodotMcpServerStatus.Stopped;
+
+        /// <summary>
+        /// Raised whenever the server status changes. ALWAYS raised on the editor main thread (the manager
+        /// marshals via <see cref="MainThreadDispatcher"/> when a process event fires off
+        /// a thread-pool thread), so subscribers — the dock's <c>ConnectionPanel</c> — may touch Controls
+        /// directly. Mirrors the <c>ConnectionStatusChanged</c> contract.
+        /// </summary>
+        public event Action<GodotMcpServerStatus>? StatusChanged;
+
+        /// <summary>The current server status (last value pushed to <see cref="StatusChanged"/>).</summary>
+        public GodotMcpServerStatus Status
+        {
+            get { lock (_processMutex) { return _status; } }
+        }
+
+        public GodotMcpServerManager(
+            string addonVersion,
+            Action<string> log,
+            Action<string> logWarning,
+            Action<string> logError)
+        {
+            _addonVersion = addonVersion;
+            _log = log;
+            _logWarning = logWarning;
+            _logError = logError;
+        }
+
+        // --- Cache paths ---------------------------------------------------------------------------------
+
+        /// <summary>
+        /// The per-project cache ROOT: <c>&lt;projectRoot&gt;/.godot/mcp-server</c> (globalized from
+        /// <c>user://</c>'s sibling — we use the project's <c>res://.godot</c> so the binary lives next to the
+        /// project and is wiped with the editor cache; <c>.godot/</c> is gitignored). The per-platform binary
+        /// lives in a <c>&lt;rid&gt;/</c> subfolder beneath this.
+        /// </summary>
+        public static string CacheRootPath()
+            => ProjectSettings.GlobalizePath("res://.godot/mcp-server");
+
+        /// <summary>The per-platform cache folder: <c>&lt;cacheRoot&gt;/&lt;rid&gt;</c> (e.g. <c>.../win-x64</c>).</summary>
+        public static string CachePlatformPath()
+            => Path.Combine(CacheRootPath(), GodotMcpServerView.CurrentPlatformName());
+
+        /// <summary>Full path to the executable inside the per-platform cache folder.</summary>
+        public static string ExecutableFullPath()
+            => Path.Combine(CachePlatformPath(), GodotMcpServerView.CurrentExecutableFileName());
+
+        /// <summary>Full path to the <c>version</c> marker file inside the per-platform cache folder.</summary>
+        public static string VersionFilePath()
+            => Path.Combine(CachePlatformPath(), "version");
+
+        // --- CI detection --------------------------------------------------------------------------------
+
+        /// <summary>
+        /// True when running under CI / a headless smoke (the standard <c>CI</c> env var, which GitHub
+        /// Actions and most CI providers set, plus <c>GITHUB_ACTIONS</c>). In CI the download is SKIPPED —
+        /// there is no release to pull and no need to host a server. Mirrors Unity's <c>EnvironmentUtils.IsCi</c>.
+        /// </summary>
+        public static bool IsCi()
+        {
+            static bool Truthy(string? v) =>
+                !string.IsNullOrEmpty(v) && !string.Equals(v, "false", StringComparison.OrdinalIgnoreCase) && v != "0";
+
+            return Truthy(SystemEnvironment.GetEnvironmentVariable("CI"))
+                || Truthy(SystemEnvironment.GetEnvironmentVariable("GITHUB_ACTIONS"));
+        }
+
+        // --- Binary lifecycle ----------------------------------------------------------------------------
+
+        /// <summary>True when the cached executable exists on disk.</summary>
+        public static bool IsBinaryExists() => File.Exists(ExecutableFullPath());
+
+        /// <summary>The version recorded in the cache's <c>version</c> file, or null when absent.</summary>
+        public static string? GetCachedVersion()
+        {
+            var path = VersionFilePath();
+            return File.Exists(path) ? File.ReadAllText(path) : null;
+        }
+
+        /// <summary>True when the cached binary exists AND its recorded version EXACTLY matches the addon version.</summary>
+        public bool IsVersionMatches()
+            => GodotMcpServerView.VersionMatches(GetCachedVersion(), _addonVersion);
+
+        /// <summary>
+        /// Download + unpack the version-matched server binary when it is missing or stale. No-op (returns
+        /// true) when the cached binary already matches. SKIPPED in CI (returns false). Mirrors Unity's
+        /// <c>DownloadServerBinaryIfNeeded</c>.
+        /// </summary>
+        public async Task<bool> DownloadServerBinaryIfNeeded()
+        {
+            if (IsCi())
+            {
+                _log("[Godot-MCP] skipping MCP server download in CI environment.");
+                return false;
+            }
+
+            if (IsBinaryExists() && IsVersionMatches())
+                return true;
+
+            return await DownloadAndUnpackBinary();
+        }
+
+        /// <summary>
+        /// Download the release zip for this platform, replace the per-platform cache folder, unzip it,
+        /// mark the binary executable on Unix, and write the <c>version</c> marker. Returns true only when
+        /// the binary exists and the version matches afterward. Never throws — failures are logged and
+        /// reported as <c>false</c>. The token is not involved here (download is anonymous).
+        /// </summary>
+        public async Task<bool> DownloadAndUnpackBinary()
+        {
+            var os = GodotMcpServerView.CurrentOsPlatform();
+            var arch = RuntimeInformation.ProcessArchitecture;
+            var url = GodotMcpServerView.DownloadUrl(_addonVersion, os, arch);
+            var platformFolder = CachePlatformPath();
+            var executablePath = ExecutableFullPath();
+
+            _log($"[Godot-MCP] downloading Godot-MCP-Server binary from: {url}");
+
+            try
+            {
+                // Replace any stale per-platform folder so a partial/old extract can't linger.
+                if (Directory.Exists(platformFolder))
+                    TryDeleteDirectory(platformFolder);
+                Directory.CreateDirectory(platformFolder);
+
+                var archivePath = Path.Combine(Path.GetTempPath(),
+                    $"{GodotMcpServerView.AssetPrefix}-{GodotMcpServerView.PlatformName(os, arch)}-{_addonVersion}.zip");
+
+                using (var client = new HttpClient())
+                {
+                    using var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
+                    response.EnsureSuccessStatusCode();
+                    await using var src = await response.Content.ReadAsStreamAsync();
+                    await using var dst = File.Create(archivePath);
+                    await src.CopyToAsync(dst);
+                }
+
+                _log($"[Godot-MCP] unpacking Godot-MCP-Server binary to: {platformFolder}");
+                // The release zip nests the binary under a <rid>/ folder, so extract to the cache ROOT.
+                ZipFile.ExtractToDirectory(archivePath, CacheRootPath(), overwriteFiles: true);
+
+                try { File.Delete(archivePath); } catch { /* best effort */ }
+
+                if (!File.Exists(executablePath))
+                {
+                    _logError($"[Godot-MCP] server binary not found after unpack at: {executablePath}");
+                    return false;
+                }
+
+                if (os != OSPlatform.Windows)
+                    TrySetExecutable(executablePath);
+
+                File.WriteAllText(VersionFilePath(), _addonVersion);
+
+                var success = IsBinaryExists() && IsVersionMatches();
+                _log(success
+                    ? $"[Godot-MCP] server binary ready: {executablePath} (version {_addonVersion})"
+                    : "[Godot-MCP] server binary download completed but verification failed.");
+                return success;
+            }
+            catch (Exception ex)
+            {
+                _logError($"[Godot-MCP] failed to download/unpack server binary: {ex.Message}");
+                return false;
+            }
+        }
+
+        // --- Process lifecycle ---------------------------------------------------------------------------
+
+        /// <summary>
+        /// Download-if-needed then launch the local server. Returns false when the binary is unavailable
+        /// (e.g. in CI, or no release published yet) or the server is already running/transitioning. The
+        /// server is launched with <c>client-transport=streamableHttp</c> and the bearer token (when auth is
+        /// required) — the token is passed ONLY in the process arguments and is NEVER logged.
+        /// </summary>
+        public async Task<bool> StartServerAsync(int port, int pluginTimeoutMs, bool authRequired, string? token)
+        {
+            if (!await DownloadServerBinaryIfNeeded())
+            {
+                _logWarning("[Godot-MCP] cannot start local server: binary unavailable (CI, or no release published yet).");
+                return false;
+            }
+
+            return StartServer(port, pluginTimeoutMs, authRequired, token);
+        }
+
+        /// <summary>
+        /// Launch the already-cached server binary as a child process and begin startup verification.
+        /// Synchronous; assumes the binary exists (call <see cref="StartServerAsync"/> to download first).
+        /// </summary>
+        public bool StartServer(int port, int pluginTimeoutMs, bool authRequired, string? token)
+        {
+            lock (_processMutex)
+            {
+                if (_status is GodotMcpServerStatus.Running or GodotMcpServerStatus.Starting or GodotMcpServerStatus.Stopping)
+                {
+                    _logWarning($"[Godot-MCP] local server is already {_status}.");
+                    return false;
+                }
+
+                var executablePath = ExecutableFullPath();
+                if (!File.Exists(executablePath))
+                {
+                    _logError($"[Godot-MCP] server binary not found at: {executablePath}");
+                    return false;
+                }
+
+                SetStatus(GodotMcpServerStatus.Starting, marshalled: false);
+
+                // Free the port from any orphaned server we previously left behind.
+                KillOrphanedServerProcesses(port);
+
+                try
+                {
+                    // The args carry the secret token (when required) — build them via the pure-managed
+                    // builder and NEVER log the resulting string.
+                    var arguments = GodotMcpServerView.BuildLaunchArguments(port, pluginTimeoutMs, authRequired, token);
+
+                    var startInfo = new ProcessStartInfo
+                    {
+                        FileName = executablePath,
+                        Arguments = arguments,
+                        UseShellExecute = false,
+                        CreateNoWindow = true,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        WorkingDirectory = CachePlatformPath()
+                    };
+
+                    var process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
+                    process.Exited += OnProcessExited;
+
+                    if (!process.Start())
+                    {
+                        _logError("[Godot-MCP] failed to start local server process.");
+                        process.Dispose();
+                        SetStatus(GodotMcpServerStatus.Stopped, marshalled: false);
+                        return false;
+                    }
+
+                    _serverProcess = process;
+                    _log($"[Godot-MCP] local server process started (PID {process.Id}, port {port}); verifying…");
+
+                    ScheduleStartupVerification(process);
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    _logError($"[Godot-MCP] failed to start local server: {ex.Message}");
+                    SetStatus(GodotMcpServerStatus.Stopped, marshalled: false);
+                    return false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Stop the local server: send a graceful terminate signal, then force-kill after a timeout if it
+        /// has not exited. When <paramref name="force"/> is true (editor quit) this blocks until exit;
+        /// otherwise the wait + force-kill safety net runs on a background task and cleanup happens on the
+        /// editor main thread.
+        /// </summary>
+        public bool StopServer(bool force = false)
+        {
+            Process? process;
+            lock (_processMutex)
+            {
+                if (_status is GodotMcpServerStatus.Stopped or GodotMcpServerStatus.Stopping)
+                    return true;
+
+                if (_serverProcess == null)
+                {
+                    SetStatus(GodotMcpServerStatus.Stopped, marshalled: false);
+                    return true;
+                }
+
+                SetStatus(GodotMcpServerStatus.Stopping, marshalled: false);
+                process = _serverProcess;
+            }
+
+            try
+            {
+                if (!process.HasExited)
+                {
+                    try { process.Kill(); } catch (Exception ex) { _logWarning($"[Godot-MCP] kill signal failed: {ex.Message}"); }
+                }
+
+                if (force)
+                {
+                    if (!process.HasExited)
+                        process.WaitForExit(5000);
+                    CleanupProcess();
+                }
+                else if (process.HasExited)
+                {
+                    CleanupProcess();
+                }
+                else
+                {
+                    ScheduleForceKill(process);
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logError($"[Godot-MCP] error stopping local server: {ex.Message}");
+                CleanupProcess();
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Schedule a one-shot startup-verification check ~5s out on a background task: if the process has
+        /// exited early (e.g. port already in use), report Stopped; otherwise promote Starting → Running.
+        /// The status change is marshalled onto the editor main thread.
+        /// </summary>
+        void ScheduleStartupVerification(Process process)
+        {
+            Task.Run(async () =>
+            {
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(StartupVerificationSeconds));
+
+                    bool exitedEarly;
+                    try { exitedEarly = process.HasExited; }
+                    catch { exitedEarly = true; }
+
+                    lock (_processMutex)
+                    {
+                        if (_status != GodotMcpServerStatus.Starting || !ReferenceEquals(_serverProcess, process))
+                            return; // superseded by a stop / restart
+                    }
+
+                    if (exitedEarly)
+                    {
+                        _logError("[Godot-MCP] local server exited early within the startup window (port in use?).");
+                        CleanupProcess();
+                    }
+                    else
+                    {
+                        SetStatus(GodotMcpServerStatus.Running, marshalled: true);
+                        _log("[Godot-MCP] local server verified and running.");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logWarning($"[Godot-MCP] startup verification error: {ex.Message}");
+                }
+            });
+        }
+
+        /// <summary>Background wait-then-force-kill safety net; cleans up on the editor main thread when done.</summary>
+        void ScheduleForceKill(Process process)
+        {
+            Task.Run(() =>
+            {
+                try
+                {
+                    if (!process.HasExited && !process.WaitForExit(5000))
+                    {
+                        try { process.Kill(); process.WaitForExit(2000); }
+                        catch (Exception ex) { _logWarning($"[Godot-MCP] force-kill failed: {ex.Message}"); }
+                    }
+                }
+                catch (InvalidOperationException) { /* already exited/disposed */ }
+
+                CleanupProcess();
+            });
+        }
+
+        /// <summary>
+        /// Kill an orphaned <c>godot-mcp-server</c> process holding <paramref name="port"/> so a fresh launch
+        /// can bind it. Conservative: only kills processes whose name contains the server executable name,
+        /// and skips our own current process. Failures are swallowed (fail-safe).
+        /// </summary>
+        void KillOrphanedServerProcesses(int port)
+        {
+            try
+            {
+                var currentPid = -1;
+                lock (_processMutex) { currentPid = _serverProcess?.Id ?? -1; }
+
+                foreach (var proc in Process.GetProcesses())
+                {
+                    try
+                    {
+                        if (proc.Id == currentPid)
+                            continue;
+
+                        var name = proc.ProcessName.ToLowerInvariant();
+                        if (!name.Contains(GodotMcpServerView.ExecutableName))
+                            continue;
+
+                        _logWarning($"[Godot-MCP] killing orphaned local server process (PID {proc.Id}).");
+                        proc.Kill();
+                        proc.WaitForExit(3000);
+                    }
+                    catch { /* per-process best effort */ }
+                    finally { proc.Dispose(); }
+                }
+            }
+            catch (Exception ex)
+            {
+                _log($"[Godot-MCP] orphaned-server cleanup skipped: {ex.Message}");
+            }
+        }
+
+        void OnProcessExited(object? sender, EventArgs e)
+        {
+            _log("[Godot-MCP] local server process exited.");
+            // Process.Exited fires on a thread-pool thread; marshal cleanup onto the editor main thread so
+            // the status push (which the dock observes) is raised there.
+            if (MainThreadDispatcher.Instance != null && !MainThreadDispatcher.IsMainThread)
+                MainThreadDispatcher.Enqueue(CleanupProcess);
+            else
+                CleanupProcess();
+        }
+
+        void CleanupProcess()
+        {
+            Process? toDispose;
+            lock (_processMutex)
+            {
+                toDispose = _serverProcess;
+                _serverProcess = null;
+                SetStatus(GodotMcpServerStatus.Stopped, marshalled: false);
+            }
+
+            if (toDispose != null)
+            {
+                Task.Run(() =>
+                {
+                    try
+                    {
+                        toDispose.Exited -= OnProcessExited;
+                        toDispose.Dispose();
+                    }
+                    catch (Exception ex) { _log($"[Godot-MCP] error disposing server process: {ex.Message}"); }
+                });
+            }
+        }
+
+        /// <summary>
+        /// Set + raise the new status. Must be called holding <see cref="_processMutex"/> for the status
+        /// field write (the public callers do). The <paramref name="marshalled"/> flag records whether the
+        /// raise came from a thread-pool hop (true) so the manager hops to the main thread before raising;
+        /// when false the caller is already on the main thread (a UI click / inline path).
+        /// </summary>
+        void SetStatus(GodotMcpServerStatus status, bool marshalled)
+        {
+            _status = status;
+
+            void Raise() => StatusChanged?.Invoke(status);
+
+            if (marshalled
+                && MainThreadDispatcher.Instance != null
+                && !MainThreadDispatcher.IsMainThread)
+            {
+                MainThreadDispatcher.Enqueue(Raise);
+            }
+            else
+            {
+                Raise();
+            }
+        }
+
+        // --- Filesystem helpers --------------------------------------------------------------------------
+
+        static void TryDeleteDirectory(string path)
+        {
+            try { Directory.Delete(path, recursive: true); } catch { /* best effort; the create+overwrite below recovers */ }
+        }
+
+        /// <summary>
+        /// Mark a file executable (0755) on Unix via <c>chmod</c>. Best-effort; a failure is non-fatal (the
+        /// launch attempt surfaces any real permission problem). On Windows this is never called.
+        /// </summary>
+        void TrySetExecutable(string filePath)
+        {
+            try
+            {
+                using var chmod = Process.Start(new ProcessStartInfo
+                {
+                    FileName = "chmod",
+                    Arguments = $"0755 \"{filePath}\"",
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                });
+                chmod?.WaitForExit(3000);
+            }
+            catch (Exception ex)
+            {
+                _logWarning($"[Godot-MCP] could not chmod server binary: {ex.Message}");
+            }
+        }
+
+        public void Dispose()
+        {
+            // Stop the server synchronously so we never leave an orphaned process behind on plugin teardown.
+            try { StopServer(force: true); } catch { /* teardown best effort */ }
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Connection/GodotMcpServerView.cs
+++ b/addons/godot_mcp/Connection/GodotMcpServerView.cs
@@ -282,4 +282,65 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             return defaultPort;
         }
     }
+
+    /// <summary>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) ownership test used by the orphan-process
+    /// cleanup to decide whether a running <c>godot-mcp-server</c> process belongs to THIS project — so the
+    /// cleanup can never cross-kill another Godot project's hosted server. The decision is a deterministic,
+    /// cross-platform path comparison (no <c>Path</c> APIs, no <c>netstat</c>/<c>lsof</c>), so the same
+    /// assertions hold on the Linux CI runner and on a Windows dev box.
+    /// </summary>
+    public static class GodotMcpServerOwnership
+    {
+        /// <summary>
+        /// True when <paramref name="candidateExecutablePath"/> (a running process's executable path) is THIS
+        /// project's cached server binary — i.e. it resolves to the same file as
+        /// <paramref name="ownExecutablePath"/> (the path returned by the manager's <c>ExecutableFullPath()</c>),
+        /// OR it lives in the same containing directory. Both paths are produced by the manager from the same
+        /// cache root, so a same-directory match is the load-bearing signal that the process is ours.
+        ///
+        /// <para>
+        /// Comparison normalizes backslash/forward-slash separators and is case-insensitive (Windows paths are
+        /// case-insensitive; the macOS default volume is too; on the rare case-sensitive Linux volume this only
+        /// ever broadens "is it ours" slightly toward our OWN cache dir — it never matches a DIFFERENT
+        /// project, which is the safety property that matters). A null/empty candidate is never owned (fail
+        /// closed: a process we cannot attribute is never killed).
+        /// </para>
+        /// </summary>
+        public static bool IsOwnedByThisProject(string? candidateExecutablePath, string? ownExecutablePath)
+        {
+            if (string.IsNullOrEmpty(candidateExecutablePath) || string.IsNullOrEmpty(ownExecutablePath))
+                return false;
+
+            var candidate = NormalizePath(candidateExecutablePath!);
+            var own = NormalizePath(ownExecutablePath!);
+
+            // Exact same binary file.
+            if (string.Equals(candidate, own, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            // Same containing directory (our cache platform folder) — the candidate must start with our
+            // directory prefix (bounded by the trailing slash so a sibling dir with a shared name prefix
+            // cannot match).
+            var ownDir = DirectoryPrefix(own);
+            if (ownDir.Length == 0)
+                return false;
+
+            return candidate.StartsWith(ownDir, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>Replace backslashes with forward slashes so the comparison is separator-agnostic.</summary>
+        static string NormalizePath(string path) => path.Replace('\\', '/');
+
+        /// <summary>
+        /// The directory prefix of a normalized path, INCLUDING the trailing slash (so a <c>StartsWith</c>
+        /// match is bounded to the directory and cannot match a sibling whose name merely shares a prefix).
+        /// Returns empty when the path has no separator.
+        /// </summary>
+        static string DirectoryPrefix(string normalizedPath)
+        {
+            var idx = normalizedPath.LastIndexOf('/');
+            return idx < 0 ? string.Empty : normalizedPath.Substring(0, idx + 1);
+        }
+    }
 }

--- a/addons/godot_mcp/Connection/GodotMcpServerView.cs
+++ b/addons/godot_mcp/Connection/GodotMcpServerView.cs
@@ -1,0 +1,285 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using com.IvanMurzak.Godot.MCP.UI;
+using McpServerConsts = com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// The lifecycle status of the locally-hosted Godot-MCP server process, mirroring Unity-MCP's
+    /// <c>McpServerStatus</c>. Drives the MCP-server timeline point's Start/Stop button + status circle in
+    /// the dock (the editor maps it to a <see cref="ConnectionPanelView.TimelinePointState"/> /
+    /// button-text via the pure-managed helpers below).
+    /// </summary>
+    public enum GodotMcpServerStatus
+    {
+        /// <summary>Not running — the Start button launches it.</summary>
+        Stopped,
+
+        /// <summary>Process spawned, in the ~5s startup-verification window (button shows a busy "Starting…").</summary>
+        Starting,
+
+        /// <summary>Verified running — the Stop button terminates it.</summary>
+        Running,
+
+        /// <summary>Terminate signal sent, awaiting exit.</summary>
+        Stopping,
+
+        /// <summary>A server we did not launch is already on the port (we connect to it but cannot stop it).</summary>
+        External
+    }
+
+    /// <summary>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) logic for the locally-hosted Godot-MCP
+    /// server manager — the Godot analog of the deterministic pieces of Unity-MCP's <c>McpServerManager</c>
+    /// (binary metadata) + <c>MainWindowEditor.McpServer</c> (status presentation). Keeping these here
+    /// (rather than inline in the <c>#if TOOLS</c> <see cref="GodotMcpServerManager"/>) makes every decision
+    /// unit-testable in the plain-xUnit <c>Godot-MCP.Tests</c> host with no Godot binary and — critically —
+    /// no platform divergence: every method below is a deterministic string/enum transform, so the same
+    /// assertions hold on the Linux CI runner and on a Windows dev box.
+    ///
+    /// <para>
+    /// The download/cache/unzip/launch/monitor side effects live in the editor-only
+    /// <see cref="GodotMcpServerManager"/>; this class only computes the asset name, the version match, the
+    /// release-zip URL, the launch argument string, and the status→button-text/label/circle-color mappings.
+    /// </para>
+    /// </summary>
+    public static class GodotMcpServerView
+    {
+        /// <summary>
+        /// The server executable base name (matches the <c>AssemblyName</c> in
+        /// <c>com.IvanMurzak.Godot.MCP.Server.csproj</c>). On Windows the on-disk file is
+        /// <c>godot-mcp-server.exe</c>; on Unix it is <c>godot-mcp-server</c>.
+        /// </summary>
+        public const string ExecutableName = "godot-mcp-server";
+
+        /// <summary>
+        /// The GitHub release-asset / .NET RID prefix. The release workflow zips each self-contained build
+        /// as <c>godot-mcp-server-&lt;rid&gt;.zip</c> (see <c>Godot-MCP-Server/build-all.sh</c>), so the asset
+        /// stem is the executable name plus the platform RID.
+        /// </summary>
+        public const string AssetPrefix = ExecutableName;
+
+        // --- Platform mapping (os + arch -> .NET RID), deterministic + injectable for cross-platform tests ---
+
+        /// <summary>
+        /// Map an <see cref="OSPlatform"/>-style os token to the .NET RID os segment Unity uses
+        /// (<c>win</c>/<c>osx</c>/<c>linux</c>). Unknown → <c>unknown</c>. Mirrors Unity's
+        /// <c>McpServerManager.OperationSystem</c>.
+        /// </summary>
+        public static string OsToken(OSPlatform os) =>
+            os == OSPlatform.Windows ? "win" :
+            os == OSPlatform.OSX ? "osx" :
+            os == OSPlatform.Linux ? "linux" :
+            "unknown";
+
+        /// <summary>
+        /// Map a process <see cref="Architecture"/> to the RID arch segment (<c>x86</c>/<c>x64</c>/
+        /// <c>arm</c>/<c>arm64</c>). Unknown → <c>unknown</c>. Mirrors Unity's <c>McpServerManager.CpuArch</c>.
+        /// </summary>
+        public static string ArchToken(Architecture arch) => arch switch
+        {
+            Architecture.X86 => "x86",
+            Architecture.X64 => "x64",
+            Architecture.Arm => "arm",
+            Architecture.Arm64 => "arm64",
+            _ => "unknown"
+        };
+
+        /// <summary>The RID-style platform name <c>&lt;os&gt;-&lt;arch&gt;</c> (e.g. <c>win-x64</c>).</summary>
+        public static string PlatformName(OSPlatform os, Architecture arch) =>
+            $"{OsToken(os)}-{ArchToken(arch)}";
+
+        /// <summary>The live platform name for the current process. Thin wrapper over <see cref="RuntimeInformation"/>.</summary>
+        public static string CurrentPlatformName() =>
+            PlatformName(CurrentOsPlatform(), RuntimeInformation.ProcessArchitecture);
+
+        /// <summary>The current <see cref="OSPlatform"/> (Windows/OSX/Linux), or <see cref="OSPlatform.Create"/>("unknown").</summary>
+        public static OSPlatform CurrentOsPlatform() =>
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? OSPlatform.Windows :
+            RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? OSPlatform.OSX :
+            RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? OSPlatform.Linux :
+            OSPlatform.Create("unknown");
+
+        /// <summary>
+        /// The on-disk executable file name for an os: <c>godot-mcp-server.exe</c> on Windows, else
+        /// <c>godot-mcp-server</c>. Mirrors Unity's <c>ExecutableFullName</c>.
+        /// </summary>
+        public static string ExecutableFileName(OSPlatform os) =>
+            os == OSPlatform.Windows ? ExecutableName + ".exe" : ExecutableName;
+
+        /// <summary>The on-disk executable file name for the current OS.</summary>
+        public static string CurrentExecutableFileName() => ExecutableFileName(CurrentOsPlatform());
+
+        /// <summary>
+        /// The GitHub release zip asset name for a platform: <c>godot-mcp-server-&lt;os&gt;-&lt;arch&gt;.zip</c>
+        /// (e.g. <c>godot-mcp-server-win-x64.zip</c>). Matches <c>build-all.sh</c>'s <c>ZIP_NAME</c>.
+        /// </summary>
+        public static string AssetZipName(OSPlatform os, Architecture arch) =>
+            $"{AssetPrefix}-{PlatformName(os, arch)}.zip";
+
+        // --- Release URL construction (exact version, no semver) ---
+
+        /// <summary>
+        /// The download URL for the version-matched server zip:
+        /// <c>https://github.com/IvanMurzak/Godot-MCP/releases/download/&lt;version&gt;/godot-mcp-server-&lt;os&gt;-&lt;arch&gt;.zip</c>.
+        /// The <paramref name="addonVersion"/> is used VERBATIM (an EXACT plugin-version → server-version
+        /// match, like Unity — no semver range). Mirrors Unity's <c>ExecutableZipUrl</c>.
+        /// </summary>
+        public static string DownloadUrl(string addonVersion, OSPlatform os, Architecture arch) =>
+            $"https://github.com/IvanMurzak/Godot-MCP/releases/download/{addonVersion}/{AssetZipName(os, arch)}";
+
+        // --- Version match (EXACT, like Unity) ---
+
+        /// <summary>
+        /// True only when a cached binary's recorded version EXACTLY equals the addon version (ordinal,
+        /// trimmed). A null/empty cached version (no <c>version</c> file) never matches. Mirrors Unity's
+        /// <c>IsVersionMatches</c> (which is a plain <c>==</c>).
+        /// </summary>
+        public static bool VersionMatches(string? cachedVersion, string addonVersion)
+        {
+            if (string.IsNullOrEmpty(cachedVersion))
+                return false;
+
+            return string.Equals(cachedVersion!.Trim(), (addonVersion ?? string.Empty).Trim(), StringComparison.Ordinal);
+        }
+
+        // --- Launch argument builder (matches Unity's BuildArguments shape) ---
+
+        /// <summary>
+        /// Build the server process argument string:
+        /// <c>port=&lt;p&gt; plugin-timeout=&lt;t&gt; client-transport=streamableHttp authorization=&lt;a&gt; [token=&lt;tok&gt;]</c>.
+        /// The transport is ALWAYS <c>streamableHttp</c> — the only transport the plugin's own SignalR
+        /// client can connect to (we deliberately do NOT build a <c>stdio</c> launch path the plugin cannot
+        /// consume). The <paramref name="token"/> is appended ONLY when <paramref name="authRequired"/> is
+        /// true AND the token is non-empty; it is the secret and is NEVER otherwise emitted. Mirrors Unity's
+        /// <c>McpServerManager.BuildArguments</c>.
+        /// </summary>
+        /// <param name="port">The TCP port the server should listen on (the plugin connects to this port).</param>
+        /// <param name="pluginTimeoutMs">The plugin-timeout argument in milliseconds.</param>
+        /// <param name="authRequired">Whether the connection requires a bearer token.</param>
+        /// <param name="token">The bearer token (secret); appended only when <paramref name="authRequired"/> and non-empty.</param>
+        public static string BuildLaunchArguments(int port, int pluginTimeoutMs, bool authRequired, string? token)
+        {
+            var authValue = authRequired ? McpServerConsts.AuthOption.required : McpServerConsts.AuthOption.none;
+
+            var sb = new StringBuilder();
+            sb.Append(McpServerConsts.Args.Port).Append('=').Append(port).Append(' ');
+            sb.Append(McpServerConsts.Args.PluginTimeout).Append('=').Append(pluginTimeoutMs).Append(' ');
+            sb.Append(McpServerConsts.Args.ClientTransportMethod).Append('=').Append(McpServerConsts.TransportMethod.streamableHttp).Append(' ');
+            sb.Append(McpServerConsts.Args.Authorization).Append('=').Append(authValue);
+
+            if (authRequired && !string.IsNullOrEmpty(token))
+                sb.Append(' ').Append(McpServerConsts.Args.Token).Append('=').Append(token);
+
+            return sb.ToString();
+        }
+
+        // --- Status presentation (status -> button text / label / circle state), pure + unit-tested ---
+
+        /// <summary>Button label shown when the local server is stopped (clicking starts it).</summary>
+        public const string ButtonTextStart = "Start Server";
+
+        /// <summary>Button label shown while the local server is starting (the button is disabled).</summary>
+        public const string ButtonTextStarting = "Starting…";
+
+        /// <summary>Button label shown when the local server is running (clicking stops it).</summary>
+        public const string ButtonTextStop = "Stop Server";
+
+        /// <summary>Button label shown while the local server is stopping (the button is disabled).</summary>
+        public const string ButtonTextStopping = "Stopping…";
+
+        /// <summary>Button label shown when an external server we did not launch owns the port (the button is disabled).</summary>
+        public const string ButtonTextExternal = "External";
+
+        /// <summary>The Start/Stop button text for a given server status.</summary>
+        public static string ServerButtonText(GodotMcpServerStatus status) => status switch
+        {
+            GodotMcpServerStatus.Stopped => ButtonTextStart,
+            GodotMcpServerStatus.Starting => ButtonTextStarting,
+            GodotMcpServerStatus.Running => ButtonTextStop,
+            GodotMcpServerStatus.Stopping => ButtonTextStopping,
+            GodotMcpServerStatus.External => ButtonTextExternal,
+            _ => ButtonTextStart
+        };
+
+        /// <summary>
+        /// True when the Start/Stop button should be disabled — during the transient
+        /// <see cref="GodotMcpServerStatus.Starting"/> / <see cref="GodotMcpServerStatus.Stopping"/> states
+        /// (neither start nor stop is a clean action mid-transition) and when the port is owned by an
+        /// <see cref="GodotMcpServerStatus.External"/> server we cannot control.
+        /// </summary>
+        public static bool ServerButtonDisabled(GodotMcpServerStatus status) =>
+            status == GodotMcpServerStatus.Starting ||
+            status == GodotMcpServerStatus.Stopping ||
+            status == GodotMcpServerStatus.External;
+
+        /// <summary>The "MCP server: …" status line text for a given server status.</summary>
+        public static string ServerStatusLabel(GodotMcpServerStatus status) => status switch
+        {
+            GodotMcpServerStatus.Stopped => "Local server: Stopped",
+            GodotMcpServerStatus.Starting => "Local server: Starting…",
+            GodotMcpServerStatus.Running => "Local server: Running",
+            GodotMcpServerStatus.Stopping => "Local server: Stopping…",
+            GodotMcpServerStatus.External => "Local server: External (already running)",
+            _ => "Local server: Stopped"
+        };
+
+        /// <summary>
+        /// Map the server status to the timeline circle's <see cref="ConnectionPanelView.TimelinePointState"/>
+        /// so the MCP-server point's circle reflects the LOCAL server's lifecycle: a verified
+        /// <see cref="GodotMcpServerStatus.Running"/> (or an <see cref="GodotMcpServerStatus.External"/>
+        /// server occupying the port) is the filled-green <c>Online</c> disc; the transient
+        /// Starting/Stopping states are the green <c>Connecting</c> ring; Stopped is the orange
+        /// <c>Disconnected</c> disc. The editor paints the returned state 1:1.
+        /// </summary>
+        public static ConnectionPanelView.TimelinePointState ServerPointState(GodotMcpServerStatus status) => status switch
+        {
+            GodotMcpServerStatus.Running => ConnectionPanelView.TimelinePointState.Online,
+            GodotMcpServerStatus.External => ConnectionPanelView.TimelinePointState.Online,
+            GodotMcpServerStatus.Starting => ConnectionPanelView.TimelinePointState.Connecting,
+            GodotMcpServerStatus.Stopping => ConnectionPanelView.TimelinePointState.Connecting,
+            _ => ConnectionPanelView.TimelinePointState.Disconnected
+        };
+
+        /// <summary>The status-dot RGB for a given server status (reuses the connection palette).</summary>
+        public static (float R, float G, float B) ServerStatusColor(GodotMcpServerStatus status) => status switch
+        {
+            GodotMcpServerStatus.Running => ConnectionPanelView.ColorConnected,
+            GodotMcpServerStatus.External => ConnectionPanelView.ColorConnected,
+            GodotMcpServerStatus.Starting => ConnectionPanelView.ColorConnecting,
+            GodotMcpServerStatus.Stopping => ConnectionPanelView.ColorConnecting,
+            _ => ConnectionPanelView.ColorDisconnected
+        };
+
+        // --- Local-server port extraction from the configured Custom host URL ---
+
+        /// <summary>
+        /// Resolve the port the locally-hosted server should listen on, parsed from the configured Custom
+        /// host URL (e.g. <c>http://localhost:5300</c> → <c>5300</c>). When the URL has no explicit port,
+        /// or is not parseable, falls back to <paramref name="defaultPort"/> (pass
+        /// <c>Consts.Hub.DefaultPort</c>). Deterministic string/URI parse — no platform divergence.
+        /// </summary>
+        public static int ResolveServerPort(string? customHostUrl, int defaultPort)
+        {
+            if (string.IsNullOrWhiteSpace(customHostUrl))
+                return defaultPort;
+
+            if (Uri.TryCreate(customHostUrl!.Trim(), UriKind.Absolute, out var uri) && uri.Port > 0)
+                return uri.Port;
+
+            return defaultPort;
+        }
+    }
+}

--- a/addons/godot_mcp/UI/ConnectionPanel.cs
+++ b/addons/godot_mcp/UI/ConnectionPanel.cs
@@ -94,6 +94,20 @@ namespace com.IvanMurzak.Godot.MCP.UI
         // The in-flight device-auth flow (null when none has run). Recreated per Authorize click.
         GodotDeviceAuthFlow? _deviceAuthFlow;
 
+        // Local-server hosting (Custom mode): the Start/Stop button on the MCP-server timeline point, the
+        // "Local server: …" status line, and the manager that downloads + runs the version-matched
+        // godot-mcp-server binary. The server circle (_timelineServerCircle) reflects this LOCAL server's
+        // lifecycle (Stopped/Starting/Running/Stopping) — the connection's own hub state is shown by the
+        // Godot circle. This is the #1 "server-less client" carve-out reversal: the plugin can now HOST its
+        // own server, not only connect to an external/cloud one.
+        readonly GodotMcpServerManager _serverManager;
+        VBoxContainer _localServerRow = null!;
+        Label _serverStatusLabel = null!;
+        Button _serverStartStopButton = null!;
+
+        // The last server status the panel rendered, so re-seeds/re-applies are idempotent and quiet.
+        GodotMcpServerStatus? _renderedServerStatus;
+
         // The last status the panel actually RENDERED, so the periodic re-sync only re-applies (and traces)
         // when the live status has drifted from what is on screen — keeping the per-tick check cheap and quiet.
         ConnectionStatus? _renderedStatus;
@@ -113,6 +127,17 @@ namespace com.IvanMurzak.Godot.MCP.UI
         public ConnectionPanel(GodotMcpConnection connection)
         {
             _connection = connection;
+
+            // The local-server manager downloads + runs the version-matched godot-mcp-server binary on
+            // demand. Owned by the panel for the panel's lifetime; its StatusChanged is (un)subscribed in
+            // _EnterTree/_ExitTree alongside the connection events (same #42/#56 reparent discipline). The
+            // PluginVersion is the addon version the server binary must match EXACTLY.
+            _serverManager = new GodotMcpServerManager(
+                GodotMcpConnection.PluginVersion,
+                GD.Print,
+                GD.PushWarning,
+                GD.PushError);
+
             Name = "ConnectionPanel";
             BuildUi();
 
@@ -142,11 +167,20 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _connection.AuthorizationRejected -= OnAuthorizationRejected;
             _connection.AuthorizationRejected += OnAuthorizationRejected;
 
+            // Same remove-then-add discipline for the local-server manager's status stream (#42/#56): the
+            // manager outlives the panel's tree membership, so a status reached while the panel was detached
+            // (e.g. the ~5s startup verification completing during a dock reparent) is pulled in by the
+            // re-seed below. The manager marshals its raises onto the editor main thread, so the handler may
+            // touch Controls directly.
+            _serverManager.StatusChanged -= OnServerStatusChanged;
+            _serverManager.StatusChanged += OnServerStatusChanged;
+
             // Re-seed from the LIVE status: a status reached while the panel was detached (e.g. Connected
             // arriving during the dock reparent) is pulled onto the label here, since the change event was
             // missed. This is the load-bearing #42 fix — the panel ALWAYS converges to the real status on
             // (re)entry, independent of event-delivery timing.
             ApplyStatus(_connection.ConnectionStatus);
+            ApplyServerStatus(_serverManager.Status);
             ApplyModeVisibility(_connection.Config.ActiveMode);
 
             // Belt-and-suspenders convergence: register a per-frame re-sync into the main-thread dispatcher's
@@ -301,6 +335,27 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _generateTokenButton.Pressed += OnGenerateTokenPressed;
             tokenLine.AddChild(_generateTokenButton);
 
+            // --- Local-server hosting row (Custom mode only): Start/Stop the version-matched server binary ---
+            // The plugin can HOST its own server here (download-if-needed + launch), not just connect to an
+            // external/cloud one. Hidden in Cloud mode (no local server is launched against the cloud host).
+            _localServerRow = new VBoxContainer { Name = "LocalServerRow" };
+            _localServerRow.AddThemeConstantOverride("separation", 4);
+            _customHostRow.AddChild(_localServerRow);
+
+            var serverLine = new HBoxContainer { Name = "LocalServerLine", SizeFlagsHorizontal = SizeFlags.ExpandFill };
+
+            _serverStatusLabel = new Label { Name = "LocalServerStatus" };
+            DockStyle.ApplySubLabel(_serverStatusLabel);
+            serverLine.AddChild(_serverStatusLabel);
+
+            serverLine.AddChild(new Control { SizeFlagsHorizontal = SizeFlags.ExpandFill });
+
+            _serverStartStopButton = new Button { Name = "LocalServerStartStopButton" };
+            _serverStartStopButton.Pressed += OnServerStartStopPressed;
+            serverLine.AddChild(_serverStartStopButton);
+
+            _localServerRow.AddChild(serverLine);
+
             // --- Cloud-mode auth section (shown only in Cloud mode): device-code login ---
             _cloudAuthRow = new VBoxContainer { Name = "CloudAuthRow" };
             _cloudAuthRow.AddThemeConstantOverride("separation", 4);
@@ -388,11 +443,12 @@ namespace com.IvanMurzak.Godot.MCP.UI
         void OnConnectionStatusChanged(ConnectionStatus status) => ApplyStatus(status);
 
         /// <summary>
-        /// Push a <see cref="ConnectionStatus"/> into the Godot status label, the Connect button, the Godot +
-        /// MCP-server timeline circles, and the alert-panel visibility. All derived presentation comes from
-        /// <see cref="ConnectionPanelView"/>. The "Godot" and "MCP server" circles track the same hub state (a
-        /// single connection); the "AI agent" circle stays neutral (Godot is a server-less client with no live
-        /// agent-info channel — the label reads "AI agent (connects on demand)").
+        /// Push a <see cref="ConnectionStatus"/> into the Godot status label, the Connect button, the Godot
+        /// timeline circle, and the alert-panel visibility. All derived presentation comes from
+        /// <see cref="ConnectionPanelView"/>. The "Godot" circle tracks the hub connection state; the
+        /// "MCP server" circle is driven SEPARATELY by the LOCAL server's lifecycle (see
+        /// <see cref="ApplyServerStatus"/>) now that the plugin can host its own server; the "AI agent"
+        /// circle stays neutral (no live agent-info channel — the label reads "AI agent (connects on demand)").
         /// </summary>
         void ApplyStatus(ConnectionStatus status)
         {
@@ -408,7 +464,6 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 DockStyle.ApplyPrimaryButton(_connectButton);
 
             DockStyle.ApplyTimelineCircle(_timelineGodotCircle, pointState);
-            DockStyle.ApplyTimelineCircle(_timelineServerCircle, pointState);
 
             _renderedStatus = status;
             ApplyAlertVisibility(status);
@@ -431,6 +486,60 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
             _authRequiredAlert.Visible = ConnectionPanelView.ShowAuthorizationRequired(isCloud, hasCloudToken);
             _connectionRequiredAlert.Visible = ConnectionPanelView.ShowConnectionRequired(isCloud, hasCloudToken, status);
+        }
+
+        void OnServerStatusChanged(GodotMcpServerStatus status) => ApplyServerStatus(status);
+
+        /// <summary>
+        /// Render the LOCAL server's lifecycle onto the MCP-server timeline point: the "Local server: …"
+        /// status line, the Start/Stop button (text + disabled state from the pure-managed
+        /// <see cref="GodotMcpServerView"/>), and the server timeline circle (filled green Running/External,
+        /// green ring while Starting/Stopping, orange disc Stopped). Idempotent + quiet: a re-apply of the
+        /// already-rendered status is harmless. Runs on the editor main thread (the manager marshals its
+        /// raises there).
+        /// </summary>
+        void ApplyServerStatus(GodotMcpServerStatus status)
+        {
+            _serverStatusLabel.Text = GodotMcpServerView.ServerStatusLabel(status);
+            _serverStartStopButton.Text = GodotMcpServerView.ServerButtonText(status);
+            _serverStartStopButton.Disabled = GodotMcpServerView.ServerButtonDisabled(status);
+
+            // Primary (cyan) when the click starts the server; secondary (gray) when it stops it.
+            if (status == GodotMcpServerStatus.Running)
+                DockStyle.ApplySecondaryButton(_serverStartStopButton);
+            else
+                DockStyle.ApplyPrimaryButton(_serverStartStopButton);
+
+            DockStyle.ApplyTimelineCircle(_timelineServerCircle, GodotMcpServerView.ServerPointState(status));
+            _renderedServerStatus = status;
+        }
+
+        /// <summary>
+        /// Handle a click on the local-server Start/Stop button. When stopped, downloads the version-matched
+        /// binary if needed then launches it with <c>client-transport=streamableHttp</c> on the port parsed
+        /// from the configured Custom host URL, passing the bearer token only when auth is required (the
+        /// token is never logged). When running, terminates it. The download/launch is fire-and-forget; the
+        /// status circle + button converge via the manager's <see cref="GodotMcpServerManager.StatusChanged"/>
+        /// stream. The button is disabled by <see cref="ApplyServerStatus"/> during transient states, so a
+        /// double-click cannot race a start/stop.
+        /// </summary>
+        void OnServerStartStopPressed()
+        {
+            if (_serverManager.Status == GodotMcpServerStatus.Running)
+            {
+                _serverManager.StopServer();
+                return;
+            }
+
+            var port = GodotMcpServerView.ResolveServerPort(
+                _connection.Config.ResolveCustomHost(),
+                com.IvanMurzak.McpPlugin.Common.Consts.Hub.DefaultPort);
+            var timeoutMs = com.IvanMurzak.McpPlugin.Common.Consts.Hub.DefaultTimeoutMs;
+            var authRequired = _connection.Config.ActiveAuthOption == GodotMcpAuthOption.Required;
+            var token = _connection.Config.ResolveCustomToken();
+
+            // Fire-and-forget: StartServerAsync downloads-if-needed then launches; status changes drive the UI.
+            _ = _serverManager.StartServerAsync(port, timeoutMs, authRequired, token);
         }
 
         /// <summary>
@@ -804,6 +913,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         {
             ApplyModeVisibility(_connection.Config.ActiveMode);
             ApplyStatus(_connection.ConnectionStatus);
+            ApplyServerStatus(_serverManager.Status);
         }
 
         public override void _ExitTree()
@@ -811,6 +921,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             // Unsubscribe so a freed panel does not receive a late main-thread push.
             _connection.ConnectionStatusChanged -= OnConnectionStatusChanged;
             _connection.AuthorizationRejected -= OnAuthorizationRejected;
+            _serverManager.StatusChanged -= OnServerStatusChanged;
 
             // Unregister the periodic re-sync so the dispatcher no longer ticks into a freed panel.
             _resyncRegistration?.Dispose();
@@ -819,6 +930,21 @@ namespace com.IvanMurzak.Godot.MCP.UI
             // Cancel any in-flight device-auth flow so its background poll loop stops touching a freed panel.
             _deviceAuthFlow?.Cancel();
             _deviceAuthFlow = null;
+
+            // NOTE: the local-server manager is NOT disposed here — _ExitTree fires on every dock reparent
+            // (#42/#56), and disposing would kill a running server on a benign layout reload. The manager is
+            // disposed only when the panel is permanently freed (NotificationPredelete below), which stops
+            // any hosted server so we never leak a process.
+        }
+
+        /// <summary>
+        /// On permanent free (plugin disabled / editor teardown — NOT a dock reparent, which is _ExitTree),
+        /// dispose the local-server manager so any hosted server process is stopped and not orphaned.
+        /// </summary>
+        public override void _Notification(int what)
+        {
+            if (what == NotificationPredelete)
+                _serverManager.Dispose();
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `GodotMcpServerManager` (`#if TOOLS`) — the Godot analog of Unity-MCP's `McpServerManager`: downloads the version-matched `godot-mcp-server-<rid>.zip` from the GitHub release, caches it under `.godot/mcp-server/<rid>/` (gitignored) with a `version` marker, unzips, `chmod 0755` on Unix, **skips download in CI**, then launches/monitors (~5s startup verification)/stops (graceful → force-kill, orphan-kill) the server process with `client-transport=streamableHttp`. The auth token is passed only in the launched process args and is **never logged**.
- **Reverse the #1 "server-less client" carve-out**: the MCP-server timeline point now has a REAL Start/Stop button (Custom mode) and the server circle reflects the LOCAL server's lifecycle. The new server-status subscription follows the existing #42/#56 dock-reparent discipline (`_EnterTree` remove-then-add + re-seed / `_ExitTree` unsub); the manager is disposed only on permanent free (`NotificationPredelete`), never on a benign reparent.
- All deterministic, cross-platform decisions live in the pure-managed `GodotMcpServerView` (outside `#if TOOLS`): platform→RID/asset-name mapping, exact version-match, download-URL construction, launch-arg builder, status→button-text/label/circle mappings, and Custom-host→port extraction.

## Test plan
- [x] Suite 1 — `dotnet build Godot-MCP.sln --configuration Debug` (0 errors, 0 warnings; compiles `#if TOOLS`, CI parity).
- [x] Suite 2 — `dotnet test Godot-MCP.Tests` (664 pass, 0 fail; **50 new cross-platform** `GodotMcpServerView` cases — no `Path.IsPathRooted`-style divergence, same assertions hold on Linux CI).
- [x] Suite 3 — headless Godot smoke (4.5.1 mono): `[Godot-MCP] plugin loaded`, dock built with the new Start/Stop button, all deps resolved, no `FileNotFoundException`.
- [ ] Live download+run — **operator-pending until the first real release** publishes the server binaries. The URL/platform/version/arg logic is structurally unit-verified and the manager wiring + dock build are confirmed.

NuGet pins unchanged (McpPlugin 6.7.0 / ReflectorNet 5.3.1); `plugin.cfg` version unchanged; the downloaded binary + cache dir are gitignored (`.godot/`).

Closes #78