### PR TITLE
ci(deploy): upgrade npm for OIDC trusted publishing + rename to godot-cli

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@
 # │  See the LICENSE file in the project root for more information.  │
 # └──────────────────────────────────────────────────────────────────┘
 #
-# Deploy: publish the godot-mcp-cli npm package (cli/) to the public npm
+# Deploy: publish the godot-cli npm package (cli/) to the public npm
 # registry via OIDC Trusted Publishing with build provenance. Mirrors
 # Unity-MCP/.github/workflows/deploy.yml's `deploy-cli-to-npm` job 1:1.
 #
@@ -16,7 +16,7 @@
 # with an explicit version for re-publish.
 #
 # IMPORTANT — first publish prerequisite (owner action, separate from this PR):
-#   npm OIDC Trusted Publishing requires the `godot-mcp-cli` package to have a
+#   npm OIDC Trusted Publishing requires the `godot-cli` package to have a
 #   Trusted Publisher configured on npmjs.com that authorizes THIS repository +
 #   workflow. Until the owner sets that up, the `npm publish` step will fail
 #   auth. There is NO NPM_TOKEN secret — auth is exchanged at runtime via the
@@ -41,7 +41,7 @@ on:
 
 jobs:
   deploy-cli-to-npm:
-    name: publish godot-mcp-cli to npm
+    name: publish godot-cli to npm
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -59,12 +59,19 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
+      # The GitHub-hosted runner's Node 22 bundle ships npm 10.9.8, but npm OIDC
+      # Trusted Publishing requires npm >= 11.5.1 (older npm never performs the
+      # OIDC token exchange, so the publish PUT fails auth with a masked E404).
+      # Upgrade npm before any publish step. See: https://docs.npmjs.com/trusted-publishers
+      - name: Upgrade npm (OIDC Trusted Publishing requires npm >= 11.5.1)
+        run: npm install -g npm@latest
+
       - name: Resolve version
         id: version
         run: |
           version="${{ inputs.version }}"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "Publishing godot-mcp-cli version: ${version}"
+          echo "Publishing godot-cli version: ${version}"
 
       # Align the cli package.json version to the release version so the
       # published artifact matches the GitHub Release tag. plugin.cfg is the


### PR DESCRIPTION
## Summary
- Add an `Upgrade npm (npm install -g npm@latest)` step after `Setup Node.js` in the `deploy-cli-to-npm` job. The Node 22 runner ships npm 10.9.8, but npm OIDC Trusted Publishing requires npm >= 11.5.1 — without it npm never performs the OIDC token exchange and the publish PUT fails auth with a masked `E404` (evidence: run 27072761348).
- Rename stale `godot-mcp-cli` references (header comment, prerequisite comment, job `name:`, version echo) to `godot-cli` to match the package the workflow already publishes from `cli/package.json`. Comments/labels only.
- No version bump (plugin.cfg / cli/package.json untouched — the merge stays inert, `should_release` remains false). Publish logic unchanged (`npm publish --access public --provenance` via OIDC, `id-token: write`, no `NPM_TOKEN`).

## Test plan
- [x] All workflow YAML parses (`yaml.safe_load` over `.github/workflows/*.yml`, UTF-8).
- [x] `grep godot-mcp-cli .github/workflows/deploy.yml` returns nothing.
- [x] Suite 1 — `dotnet build Godot-MCP.sln --configuration Debug`: 0 warnings, 0 errors.
- [x] Suite 2 — `dotnet test Godot-MCP.Tests`: 673 passed, 0 failures.
- [ ] OIDC Trusted Publishing verified by a post-merge `deploy.yml` workflow_dispatch smoke (operator — the publish path only runs on a real release / dispatch).

Closes #82