### PR TITLE
chore(release): bump version to 0.2.0 (first full Godot-MCP release)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -463,3 +463,8 @@ mono_crash.*.json
 ##
 bin/
 obj/
+
+##
+## Agent memory (per the infra workspace convention — never commit nested agent-memory dirs)
+##
+**/.claude/agent-memory/

--- a/Godot-MCP-Server/com.IvanMurzak.Godot.MCP.Server.csproj
+++ b/Godot-MCP-Server/com.IvanMurzak.Godot.MCP.Server.csproj
@@ -13,7 +13,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>godot-mcp-server</ToolCommandName>
     <PackageId>com.IvanMurzak.Godot.MCP.Server</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © 2026 Ivan Murzak</Copyright>

--- a/addons/godot_mcp/plugin.cfg
+++ b/addons/godot_mcp/plugin.cfg
@@ -3,5 +3,5 @@
 name="Godot-MCP"
 description="Model Context Protocol (MCP) integration for the Godot Editor. AI tools in C#, cloud-connected to ai-game.dev."
 author="Ivan Murzak"
-version="0.1.0"
+version="0.2.0"
 script="GodotMcpPlugin.cs"

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "godot-cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "godot-cli",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.6.2",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "godot-cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Cross-platform CLI tool for Godot-MCP (Skills & MCP). Resolves and launches the Godot editor with MCP connection env vars, runs MCP/system tools over HTTP, probes server health, configures AI agents (Claude Code, Cursor, VS Code, …), and enables/disables the godot_mcp addon. Works with Claude Code, Cursor, Copilot, and any MCP client.",
   "type": "module",
   "main": "dist/lib.js",


### PR DESCRIPTION
## Summary
- Bump version `0.1.0` → `0.2.0` across all source-of-truth files: `addons/godot_mcp/plugin.cfg` (the release gate), `cli/package.json` + `cli/package-lock.json`, and `Godot-MCP-Server/com.IvanMurzak.Godot.MCP.Server.csproj` `<Version>`.
- Add `**/.claude/agent-memory/` to `.gitignore` (durable fix for nested agent-memory dirt).
- Frozen NuGet pins (McpPlugin 6.7.0 / ReflectorNet 5.3.1) left untouched.

## Release trigger (owner-approved)
Merging this PR to `main` fires `release.yml` (gates on `plugin.cfg` version change + absent `v0.2.0` tag): GitHub Release `v0.2.0` + 7 server binaries + `godot-cli@0.2.0` published via OIDC Trusted Publishing. This is the intended, owner-approved first full release. No tag/workflow was manually dispatched — the merge is the trigger.

## Test plan
- [x] `cd cli && npm install && npm run build && npm test` — 65/65 green on 0.2.0; `--version` reads 0.2.0 dynamically.
- [x] `dotnet build Godot-MCP.sln -c Debug` — 0 errors/0 warnings.
- [x] `dotnet test Godot-MCP.Tests` — 673/673 passed.
- [x] `dotnet build Godot-MCP-Server/*.csproj -c Release` — 0 errors; assembly stamped `0.2.0`.
- [x] Confirmed `plugin.cfg` reads `0.2.0`.

Closes #84