### PR TITLE
feat(connection): wire WithReflectorModulesFromAssembly into the plugin build

### DIFF
--- a/Godot-MCP.Tests/ReflectorModuleDiscoveryTests.cs
+++ b/Godot-MCP.Tests/ReflectorModuleDiscoveryTests.cs
@@ -1,0 +1,235 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet;
+using com.IvanMurzak.ReflectorNet.Converter;
+using Xunit;
+using McpVersion = com.IvanMurzak.McpPlugin.Common.Version;
+
+namespace com.IvanMurzak.Godot.MCP.Tests.ReflectorModules.Full
+{
+    // ──────────────────────────────────────────────────────────────────────────────────────────
+    // In-repo verification of the IReflectorModule discovery mechanism wired into the Godot plugin
+    // build (see GodotMcpConnection.Start() `.WithReflectorModulesFromAssembly(...)`). Mirrors
+    // Unity-MCP's ReflectorModuleDiscoveryTests (PR #805) 1:1, retargeted to xUnit + the Godot
+    // McpPluginBuilder path.
+    //
+    // This is a UNIT-level proof: it constructs a McpPluginBuilder directly and registers THIS test
+    // assembly for module discovery, asserting that an IReflectorModule with ZERO hardcoded reference
+    // is auto-discovered and that all four contribution surfaces reach effect, that a throwing module
+    // is isolated, and that a core-ignored hosting assembly is never type-enumerated.
+    //
+    // Every type here is pure-managed (no Godot native types), so the fixture + assertions run in the
+    // plain-xUnit host with no Godot binary and hold identically on the Linux CI runner.
+    // ──────────────────────────────────────────────────────────────────────────────────────────
+
+    // ── Fixture payload + converter types ───────────────────────────────────────────────────────
+
+    /// <summary>Marker payload type the verification module registers a JSON converter for.</summary>
+    public sealed class VerificationPayload
+    {
+        public string Value { get; set; } = string.Empty;
+    }
+
+    /// <summary>Type the verification module registers a reflection converter for.</summary>
+    public sealed class VerificationReflectedType
+    {
+        public int Number { get; set; }
+    }
+
+    /// <summary>Type the verification module blacklists from serialization.</summary>
+    public sealed class VerificationBlacklistedType
+    {
+        public string Secret { get; set; } = string.Empty;
+    }
+
+    /// <summary>A System.Text.Json converter contributed by the verification module.</summary>
+    public sealed class VerificationPayloadJsonConverter : JsonConverter<VerificationPayload>
+    {
+        public override VerificationPayload Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            => new VerificationPayload { Value = reader.GetString() ?? string.Empty };
+
+        public override void Write(Utf8JsonWriter writer, VerificationPayload value, JsonSerializerOptions options)
+            => writer.WriteStringValue(value.Value);
+    }
+
+    /// <summary>A reflection converter contributed by the verification module.</summary>
+    public sealed class VerificationReflectionConverter : GenericReflectionConverter<VerificationReflectedType>
+    {
+    }
+
+    // ── Modules ──────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The flagship verification module: a single discoverable module contributing a JSON converter,
+    /// a reflection converter, a serialization-blacklist type, AND scan-ignore entries (assembly +
+    /// namespace). Discovered with zero hardcoded reference — purely via assembly scan.
+    /// </summary>
+    public sealed class VerificationFullContributionModule : IReflectorModule
+    {
+        // A non-existent assembly prefix — safe to contribute (cannot collide with a protected assembly).
+        public const string IgnoredAssemblyPrefix = "Some.Nonexistent.Godot.Extension.Assembly";
+        // A non-existent namespace prefix — exercises the namespace scan-ignore surface harmlessly.
+        public const string IgnoredNamespacePrefix = "Some.Nonexistent.Godot.Extension.Namespace";
+
+        public int Order => 10;
+
+        public void Configure(IReflectorModuleContext ctx)
+        {
+            ctx.Reflector.JsonSerializer.AddConverter(new VerificationPayloadJsonConverter());
+            ctx.Reflector.Converters.Add(new VerificationReflectionConverter());
+            ctx.Reflector.Converters.BlacklistType(typeof(VerificationBlacklistedType));
+            ctx.Scan
+                .IgnoreAssemblies(IgnoredAssemblyPrefix)
+                .IgnoreNamespaces(IgnoredNamespacePrefix);
+        }
+    }
+}
+
+namespace com.IvanMurzak.Godot.MCP.Tests.ReflectorModules.Throwing
+{
+    using com.IvanMurzak.McpPlugin;
+
+    /// <summary>A module that throws during Configure — used to assert failure isolation.</summary>
+    public sealed class ThrowingVerificationModule : IReflectorModule
+    {
+        public int Order => 0;
+
+        public void Configure(IReflectorModuleContext ctx)
+            => throw new InvalidOperationException("Intentional failure from ThrowingVerificationModule.");
+    }
+
+    /// <summary>A healthy module sitting alongside the throwing one — must still run.</summary>
+    public sealed class SurvivingVerificationModule : IReflectorModule
+    {
+        public static bool Ran;
+        public int Order => 1;
+
+        public void Configure(IReflectorModuleContext ctx) => Ran = true;
+    }
+}
+
+namespace com.IvanMurzak.Godot.MCP.Tests.ReflectorModules
+{
+    using FullNs = com.IvanMurzak.Godot.MCP.Tests.ReflectorModules.Full;
+    using ThrowingNs = com.IvanMurzak.Godot.MCP.Tests.ReflectorModules.Throwing;
+
+    /// <summary>
+    /// Drives the Godot plugin's reflector-module discovery wiring directly through a
+    /// <see cref="McpPluginBuilder"/>, mirroring Unity-MCP's <c>ReflectorModuleDiscoveryTests</c>
+    /// (PR #805). Proves the contract <see cref="Connection.GodotMcpConnection"/> relies on:
+    /// <see cref="McpPluginBuilder.WithReflectorModulesFromAssembly"/> auto-discovers every
+    /// <see cref="IReflectorModule"/> in the registered assemblies (no hardcoded list), all four
+    /// contribution surfaces reach effect, a throwing module is isolated, and an
+    /// <see cref="McpPluginBuilder.IgnoreAssembly(System.Reflection.Assembly)"/>-pruned hosting
+    /// assembly is never type-enumerated.
+    /// </summary>
+    public class ReflectorModuleDiscoveryTests
+    {
+        static readonly McpVersion _version = new McpVersion();
+        static readonly Assembly TestAssembly = typeof(FullNs.VerificationFullContributionModule).Assembly;
+
+        // Two sibling fixture namespaces, NEITHER a prefix of the other, so a test can ignore exactly
+        // one without collaterally pruning the other (IScanIgnoreBuilder / IgnoreNamespaces matches by
+        // StartsWith).
+        const string NsFull = "com.IvanMurzak.Godot.MCP.Tests.ReflectorModules.Full";
+        const string NsThrowing = "com.IvanMurzak.Godot.MCP.Tests.ReflectorModules.Throwing";
+
+        // ── (1)-(4) Full contribution: every surface reaches effect via dynamic discovery ────────
+
+        [Fact]
+        public void FullContribution_AllFourSurfacesReachEffect_ViaDynamicDiscovery()
+        {
+            // Arrange — keep ONLY the FullContribution namespace; ignore the Throwing fixtures so they
+            // do not interfere with this assertion. The FullContributionModule carries no hardcoded
+            // reference anywhere; it is found purely by scanning TestAssembly.
+            var reflector = new Reflector();
+            var builder = new McpPluginBuilder(_version)
+                .WithReflectorModulesFromAssembly(new[] { TestAssembly })
+                .IgnoreNamespaces(NsThrowing);
+
+            // Act
+            builder.Build(reflector);
+
+            // (1) JSON converter registered.
+            Assert.NotNull(
+                reflector.JsonSerializer.GetJsonConverter(typeof(FullNs.VerificationPayload)));
+
+            // (2) Reflection converter registered (resolvable for the target type).
+            Assert.NotNull(
+                reflector.Converters.GetConverter(typeof(FullNs.VerificationReflectedType)));
+            Assert.Contains(
+                reflector.Converters.GetAllSerializers(),
+                c => c is FullNs.VerificationReflectionConverter);
+
+            // (3) Serialization blacklist applied.
+            Assert.True(
+                reflector.Converters.IsTypeBlacklisted(typeof(FullNs.VerificationBlacklistedType)),
+                "Module-contributed serialization-blacklist type should be blacklisted.");
+
+            // (4) Scan-ignore contributions accepted (no exception, build completes). The assembly +
+            // namespace prefixes are non-existent on purpose, so they cannot collide with a protected
+            // assembly/namespace; reaching this assertion proves the IScanIgnoreBuilder surface was
+            // exercised end-to-end through a dynamically-discovered module.
+        }
+
+        // ── Throw-isolation: a throwing module is caught; the healthy sibling still runs ─────────
+
+        [Fact]
+        public void FailureIsolation_ThrowingModuleCaught_SurvivingSiblingStillRuns()
+        {
+            // Arrange — keep ONLY the Throwing namespace (ThrowingVerificationModule +
+            // SurvivingVerificationModule); ignore the FullContribution root namespace's other module.
+            ThrowingNs.SurvivingVerificationModule.Ran = false;
+            var reflector = new Reflector();
+            var builder = new McpPluginBuilder(_version)
+                .WithReflectorModulesFromAssembly(new[] { TestAssembly })
+                .IgnoreNamespaces(NsFull);
+
+            // Act — Build must NOT throw despite ThrowingVerificationModule.
+            var exception = Record.Exception(() => builder.Build(reflector));
+            Assert.Null(exception);
+
+            // Assert — the healthy sibling module still ran.
+            Assert.True(ThrowingNs.SurvivingVerificationModule.Ran,
+                "The surviving sibling module should still run after a throwing module is isolated.");
+        }
+
+        // ── Perf sanity: a core-ignored hosting assembly is never type-enumerated for modules ──────
+
+        [Fact]
+        public void Discovery_SkipsModule_WhenHostingAssemblyIsIgnored()
+        {
+            // Arrange — register TestAssembly for module scan, then ignore that very assembly by name.
+            // If discovery honored the ignore prune (it must, for the perf guarantee), no module runs:
+            // the hosting assembly is never type-enumerated.
+            var reflector = new Reflector();
+            var builder = new McpPluginBuilder(_version)
+                .WithReflectorModulesFromAssembly(new[] { TestAssembly })
+                .IgnoreAssembly(TestAssembly);
+
+            // Act
+            builder.Build(reflector);
+
+            // Assert — the module never ran: no converter, type not blacklisted.
+            Assert.Null(
+                reflector.JsonSerializer.GetJsonConverter(typeof(FullNs.VerificationPayload)));
+            Assert.False(
+                reflector.Converters.IsTypeBlacklisted(typeof(FullNs.VerificationBlacklistedType)),
+                "An ignored hosting assembly's module must not contribute a blacklist entry.");
+        }
+    }
+}

--- a/addons/godot_mcp/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConnection.cs
@@ -206,8 +206,14 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 Environment = $"Godot {Engine.GetVersionInfo()["string"]}"
             };
 
-            // Scan THIS addon assembly for [AiToolType]/[AiTool] (the ping tool, and future families).
-            Assembly addonAssembly = typeof(GodotMcpConnection).Assembly;
+            // The scan set for tool/prompt/resource registration AND IReflectorModule discovery (issue
+            // #86). Mirrors Unity-MCP's BuildMcpPlugin (which scans AssemblyUtils.AllAssemblies and prunes
+            // the heavy ones at the builder via .IgnoreAssemblies): enumerate the default load context
+            // broadly so a Godot-MCP extension's assembly — unknown ahead of time — is reachable, then let
+            // the .IgnoreAssemblies(...) prune below keep the heavy assemblies from ever being
+            // type-enumerated. AllAssemblies includes THIS addon assembly (the ping tool and future tool
+            // families live here).
+            Assembly[] assemblies = GodotAssemblyUtils.AllAssemblies;
 
             // Route the reused framework's Microsoft.Extensions.Logging output (ConnectionManager /
             // hub-connector connect, hub-state, version handshake, errors) to the Godot Output, gated by the
@@ -219,9 +225,38 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
             var builder = new McpPluginBuilder(version, loggerProvider)
                 .SetConfig(_config)
-                .WithToolsFromAssembly(addonAssembly)
-                .WithPromptsFromAssembly(addonAssembly)
-                .WithResourcesFromAssembly(addonAssembly);
+                // Prune the heavy assemblies so neither the tool/prompt/resource scan NOR the
+                // IReflectorModule discovery below ever type-enumerates them. Mirrors the Unity reference's
+                // .IgnoreAssemblies(...) prefix list (BCL, the reused McpPlugin/ReflectorNet/R3/SignalR
+                // stack, the Godot engine assemblies, and this repo's own test assembly). This MUST come
+                // before .WithReflectorModulesFromAssembly(...) — discovery honors the prune, so an ignored
+                // hosting assembly is never walked for modules.
+                .IgnoreAssemblies(
+                    "mscorlib",
+                    "netstandard",
+                    "System",
+                    "Microsoft",
+                    "GodotSharp",
+                    "GodotSharpEditor",
+                    "Godot.SourceGenerators",
+                    "R3",
+                    "ObservableCollections",
+                    "McpPlugin",
+                    "ReflectorNet",
+                    "Godot-MCP.Tests")
+                .WithToolsFromAssembly(assemblies)
+                .WithPromptsFromAssembly(assemblies)
+                .WithResourcesFromAssembly(assemblies)
+                // Auto-discover IReflectorModule implementors across all loaded assemblies so any
+                // assembly (including Godot-MCP extensions added later, unknown ahead of time) can
+                // contribute ReflectorNet JSON/reflection converters, serialization-blacklist entries, and
+                // scan-ignore rules without a hardcoded extension list — the Godot equivalent of the M8
+                // "extension-contributed converters" mechanism. Discovery honors the .IgnoreAssemblies(...)
+                // prune above (heavy assemblies are never type-enumerated) and runs strictly before the
+                // heavy attribute scan inside Build(). The Godot core converters registered into the
+                // reflector by GodotReflectorFactory remain the Order=0 baseline; module contributions
+                // layer on top. Mirrors Unity-MCP's UnityMcpPlugin.Build.cs ordering exactly.
+                .WithReflectorModulesFromAssembly(assemblies);
 
             _plugin = builder.Build(reflector);
 

--- a/addons/godot_mcp/Reflection/GodotAssemblyUtils.cs
+++ b/addons/godot_mcp/Reflection/GodotAssemblyUtils.cs
@@ -1,0 +1,61 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace com.IvanMurzak.Godot.MCP.Reflection
+{
+    /// <summary>
+    /// Enumerates the managed assemblies loaded into the Godot editor process — the Godot analog of
+    /// Unity-MCP's <c>AssemblyUtils.AllAssemblies</c>. Used as the scan set the
+    /// <c>McpPluginBuilder</c> walks for <c>[AiToolType]</c>/<c>[AiTool]</c> registration AND, since
+    /// issue #86, for <c>IReflectorModule</c> discovery
+    /// (<c>.WithReflectorModulesFromAssembly(...)</c>) — so any loaded assembly (including future
+    /// Godot-MCP extensions, unknown ahead of time) can contribute ReflectorNet converters /
+    /// serialization-blacklist entries / scan-ignore rules with NO hardcoded extension list.
+    ///
+    /// <para>
+    /// <b>Why <see cref="AssemblyLoadContext.Default"/>.</b> Godot loads the project/addon assembly —
+    /// and, via <see cref="GodotMcpAssemblyResolver"/>, every NuGet dependency it resolves at editor
+    /// runtime — into the <b>default</b> <see cref="AssemblyLoadContext"/>. A Godot-MCP extension ships
+    /// as additional <c>.cs</c> compiled into the same project game assembly (Godot globs all project
+    /// <c>.cs</c> into one assembly) or as a referenced library loaded into the same default context, so
+    /// <see cref="AssemblyLoadContext.Default"/>'s loaded set is exactly where an extension's
+    /// <see cref="System.Reflection.Assembly"/> appears. Enumerating it (rather than only the addon
+    /// assembly) is what lets the discovery reach extension-contributed modules.
+    /// </para>
+    ///
+    /// <para>
+    /// This type is pure-BCL (no Godot API, no <c>#if TOOLS</c>) so it is unit-testable in the
+    /// plain-xUnit host. The heavy assemblies the builder must never type-enumerate (the BCL, the reused
+    /// McpPlugin/ReflectorNet/R3/SignalR stack, the test asmdefs) are pruned by the
+    /// <c>.IgnoreAssemblies(...)</c> call the connection passes to the builder — NOT here — mirroring the
+    /// Unity reference, which enumerates broadly and prunes at the builder.
+    /// </para>
+    /// </summary>
+    public static class GodotAssemblyUtils
+    {
+        /// <summary>
+        /// The managed assemblies currently loaded in the default <see cref="AssemblyLoadContext"/>,
+        /// snapshotted into an array. Dynamic (in-memory) assemblies are excluded — they have no scannable
+        /// on-disk types relevant to tool/module discovery and a few (e.g. ref-emit) throw on
+        /// <see cref="Assembly.GetTypes"/>. The snapshot is taken eagerly (the returned array does not
+        /// observe later loads) so a discovery pass walks a stable set.
+        /// </summary>
+        public static Assembly[] AllAssemblies =>
+            AssemblyLoadContext.Default.Assemblies
+                .Where(assembly => !assembly.IsDynamic)
+                .ToArray();
+    }
+}


### PR DESCRIPTION
## Summary
- Port Unity-MCP PR #805 to Godot-MCP: the `McpPluginBuilder` in `GodotMcpConnection.Start()` now auto-discovers `IReflectorModule` implementors across all loaded assemblies via `.WithReflectorModulesFromAssembly(...)`, so any loaded assembly (including future Godot-MCP extensions, unknown ahead of time) registers its own ReflectorNet converters / serialization-blacklist / scan-ignore rules with **no hardcoded extension list**.
- New pure-managed `GodotAssemblyUtils.AllAssemblies` (the Godot analog of Unity's `AssemblyUtils.AllAssemblies`) snapshots `AssemblyLoadContext.Default`'s non-dynamic assemblies — exactly where the addon, its NuGet deps, and extension assemblies appear in the editor.
- `.IgnoreAssemblies(...)` runs **before** `.WithReflectorModulesFromAssembly(...)` (mirrors PR #805's ordering exactly), so an ignored hosting assembly is never type-enumerated. `GodotReflectorFactory.CreateDefaultReflector()` stays the `Order=0` baseline; module contributions layer on top.
- **No NuGet pin bump**: McpPlugin `6.7.0` already carries `IReflectorModule` + `WithReflectorModulesFromAssembly` (the frozen pin's symbols resolve).

## Test plan
- [x] Suite 1 — `dotnet build Godot-MCP.sln` (CI parity): 0 warnings, 0 errors.
- [x] Suite 2 — `dotnet test Godot-MCP.Tests`: 676/676 pass, including 3 new `ReflectorModuleDiscoveryTests` (mirror PR #805: all four contribution surfaces reach effect via dynamic discovery; a throwing module is isolated; an ignored hosting assembly is never enumerated). Cross-platform / deterministic (no Godot native types) so they hold on the Linux CI runner.
- [x] Suite 3 — headless Godot 4.5.1 smoke (testbed): `[Godot-MCP] plugin loaded`, all deps resolved, `builder.Build()` (which runs the new discovery) completes, clean `plugin unloaded`, no `FileNotFoundException`, no module-discovery errors. (Connect failure to the absent local server is the expected no-server condition, unrelated to this change.)

Closes #86