### PR TITLE
feat(cli): add create-project command + createProject export to godot-cli

### DIFF
--- a/cli/src/commands/create-project.ts
+++ b/cli/src/commands/create-project.ts
@@ -36,6 +36,15 @@ export const createProjectCommand = new Command('create-project')
     if (result.kind === 'failure') {
       spinner.error('Failed to create project');
       ui.error(result.errorMessage);
+      // Surface failure-shape diagnostics BEFORE exiting: leftover files a
+      // partial rollback could not remove, plus any rollback warnings.
+      if (result.filesWritten.length > 0) {
+        ui.label('Files left behind (cleanup failed)', result.filesWritten.join(', '));
+      }
+      for (const warning of result.warnings) {
+        console.log('');
+        ui.warn(warning);
+      }
       process.exit(1);
     }
 

--- a/cli/src/commands/create-project.ts
+++ b/cli/src/commands/create-project.ts
@@ -1,0 +1,53 @@
+import { Command } from 'commander';
+import * as path from 'path';
+import * as ui from '../utils/ui.js';
+import { verbose } from '../utils/ui.js';
+import { createProject } from '../lib/create-project.js';
+
+interface CreateProjectCliOptions {
+  path?: string;
+  name?: string;
+  dotnet?: boolean;
+}
+
+export const createProjectCommand = new Command('create-project')
+  .description(
+    'Scaffold a minimal valid Godot 4.x project (project.godot + icon.svg). Pass --dotnet to also scaffold a Godot.NET.Sdk (C#) csproj. Refuses to overwrite an existing Godot/Unity/Unreal project.',
+  )
+  .argument('[path]', 'Target directory to scaffold the project into (defaults to current directory)')
+  .option('--path <path>', 'Target directory to scaffold the project into')
+  .option('--name <name>', 'Project name (defaults to a name derived from the folder name)')
+  .option('--dotnet', 'Also scaffold a Godot.NET.Sdk (C#) csproj')
+  .action(async (positionalPath: string | undefined, options: CreateProjectCliOptions) => {
+    const resolvedPath = positionalPath ?? options.path ?? process.cwd();
+    const projectPath = path.resolve(resolvedPath);
+
+    ui.heading('Creating Godot project');
+    verbose(`Target path: ${projectPath}`);
+    verbose(`--dotnet: ${options.dotnet === true}`);
+
+    const spinner = ui.startSpinner('Scaffolding project...');
+    const result = await createProject({
+      projectPath,
+      name: options.name,
+      dotnet: options.dotnet === true,
+    });
+
+    if (result.kind === 'failure') {
+      spinner.error('Failed to create project');
+      ui.error(result.errorMessage);
+      process.exit(1);
+    }
+
+    spinner.success(`Created Godot project "${result.projectName}"`);
+    ui.label('Project path', result.projectPath);
+    ui.label('Files written', result.filesWritten.join(', '));
+    if (result.dotnet) {
+      ui.label('C# (.NET)', 'enabled');
+    }
+
+    for (const warning of result.warnings) {
+      console.log('');
+      ui.warn(warning);
+    }
+  });

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -7,6 +7,7 @@ import { statusCommand } from './commands/status.js';
 import { waitForReadyCommand } from './commands/wait-for-ready.js';
 import { setupMcpCommand } from './commands/setup-mcp.js';
 import { configureCommand } from './commands/configure.js';
+import { createProjectCommand } from './commands/create-project.js';
 import { closeCommand } from './commands/close.js';
 import { createUpdateCommand } from './commands/update.js';
 import { installPluginCommand } from './commands/install-plugin.js';
@@ -29,6 +30,7 @@ program
 const subcommands = [
   closeCommand,
   configureCommand,
+  createProjectCommand,
   installPluginCommand,
   openCommand,
   removePluginCommand,

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -14,6 +14,7 @@
 // via the `exports` field in package.json).
 
 export { openProject } from './lib/open.js';
+export { createProject } from './lib/create-project.js';
 export { runTool, runSystemTool } from './lib/run-tool.js';
 export { setupMcp, listAgentIds } from './lib/setup-mcp.js';
 export { installPlugin, removePlugin } from './lib/install-plugin.js';
@@ -30,6 +31,11 @@ export type {
   OpenProjectFailure,
   OpenProjectAuthOption,
   OpenProjectConnectionMode,
+  // create-project
+  CreateProjectOptions,
+  CreateProjectResult,
+  CreateProjectSuccess,
+  CreateProjectFailure,
   // run-tool / run-system-tool
   RunToolOptions,
   RunToolResult,

--- a/cli/src/lib/create-project.ts
+++ b/cli/src/lib/create-project.ts
@@ -186,6 +186,7 @@ export async function createProject(options: CreateProjectOptions): Promise<Crea
   const warnings: string[] = [];
   const filesWritten: string[] = [];
   let resolvedProjectPath: string | undefined;
+  let projectDirExistedBefore = true;
 
   try {
     const { projectPath } = resolveProjectPath(options.projectPath, process.cwd());
@@ -214,7 +215,10 @@ export async function createProject(options: CreateProjectOptions): Promise<Crea
       );
     }
 
-    // Create the target directory (and any parents) if absent.
+    // Create the target directory (and any parents) if absent. Record whether
+    // it pre-existed so a failed scaffold can remove a directory it created
+    // (but never one the caller already had).
+    projectDirExistedBefore = fs.existsSync(projectPath);
     fs.mkdirSync(projectPath, { recursive: true });
 
     // Write one file, recording it for rollback and warning when an existing
@@ -260,11 +264,29 @@ export async function createProject(options: CreateProjectOptions): Promise<Crea
   } catch (err: unknown) {
     // Roll back any files written before the failure (best-effort, reverse
     // order) so a failed/refused scaffold leaves the target as it was found.
+    // Only entries whose cleanup FAILED stay in `leftover` — honouring the
+    // CreateProjectFailure.filesWritten contract (non-empty only when a partial
+    // scaffold could not be fully removed).
+    const leftover: string[] = [];
     for (const filePath of [...filesWritten].reverse()) {
       try {
         fs.rmSync(filePath, { force: true });
       } catch {
         warnings.push(`Failed to roll back partially-written file: ${filePath}`);
+        leftover.push(filePath);
+      }
+    }
+    // We iterated in reverse for cleanup; restore write order for the contract.
+    leftover.reverse();
+
+    // If we created the target directory and rollback emptied it, remove it too
+    // so a failed scaffold leaves the target as it was found. Best-effort: a
+    // non-empty dir (pre-existing sibling content) keeps the rmdir from firing.
+    if (resolvedProjectPath && !projectDirExistedBefore && leftover.length === 0) {
+      try {
+        fs.rmdirSync(resolvedProjectPath);
+      } catch {
+        // Directory not empty or already gone — leave it; cleanup is best-effort.
       }
     }
 
@@ -274,7 +296,7 @@ export async function createProject(options: CreateProjectOptions): Promise<Crea
       success: false,
       projectPath: resolvedProjectPath,
       warnings,
-      filesWritten,
+      filesWritten: leftover,
       errorMessage: errorObj.message,
       error: errorObj,
     };

--- a/cli/src/lib/create-project.ts
+++ b/cli/src/lib/create-project.ts
@@ -185,6 +185,9 @@ export function renderCsproj(projectName: string): string {
 export async function createProject(options: CreateProjectOptions): Promise<CreateProjectResult> {
   const warnings: string[] = [];
   const filesWritten: string[] = [];
+  // Original bytes of any pre-existing file we overwrite, so a failed scaffold
+  // can RESTORE the caller's file rather than delete it during rollback.
+  const overwrittenOriginals = new Map<string, Buffer>();
   let resolvedProjectPath: string | undefined;
   let projectDirExistedBefore = true;
 
@@ -199,7 +202,10 @@ export async function createProject(options: CreateProjectOptions): Promise<Crea
     // chars would let a crafted `--dotnet` csproj filename escape the target.
     const nameError = validateProjectName(projectName);
     if (nameError) {
-      throw new Error(`Invalid project name "${projectName}": ${nameError}.`);
+      const hint = options.name?.trim()
+        ? ''
+        : ' (derived from the target folder name — pass --name to override)';
+      throw new Error(`Invalid project name "${projectName}": ${nameError}.${hint}`);
     }
 
     emitProgress(options.onProgress, {
@@ -224,8 +230,21 @@ export async function createProject(options: CreateProjectOptions): Promise<Crea
     // Write one file, recording it for rollback and warning when an existing
     // non-marker file is clobbered.
     const writeFile = (filePath: string, contents: string): void => {
-      if (fs.existsSync(filePath)) {
+      // Only a pre-existing regular FILE is an overwrite worth warning about /
+      // snapshotting; a directory at this path isn't a file we can clobber (the
+      // write below will throw), so it must not produce a phantom warning.
+      if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
         warnings.push(`Overwrote existing file: ${filePath}`);
+        // Snapshot the caller's original bytes (once) so rollback restores them
+        // instead of deleting a file they already had. If the read fails, fall
+        // back to delete-on-rollback (best-effort).
+        if (!overwrittenOriginals.has(filePath)) {
+          try {
+            overwrittenOriginals.set(filePath, fs.readFileSync(filePath));
+          } catch {
+            // Unreadable: treat as freshly-written (rmSync on rollback).
+          }
+        }
       }
       fs.writeFileSync(filePath, contents);
       filesWritten.push(filePath);
@@ -264,13 +283,23 @@ export async function createProject(options: CreateProjectOptions): Promise<Crea
   } catch (err: unknown) {
     // Roll back any files written before the failure (best-effort, reverse
     // order) so a failed/refused scaffold leaves the target as it was found.
-    // Only entries whose cleanup FAILED stay in `leftover` — honouring the
-    // CreateProjectFailure.filesWritten contract (non-empty only when a partial
-    // scaffold could not be fully removed).
+    // A file we OVERWROTE is restored to its original bytes (never deleted —
+    // that would leave the caller with less than they started with); a file we
+    // freshly created is removed. Only entries whose cleanup FAILED stay in
+    // `leftover` — honouring the CreateProjectFailure.filesWritten contract
+    // (non-empty only when a partial scaffold could not be fully cleaned up).
     const leftover: string[] = [];
     for (const filePath of [...filesWritten].reverse()) {
       try {
-        fs.rmSync(filePath, { force: true });
+        const original = overwrittenOriginals.get(filePath);
+        if (original !== undefined) {
+          fs.writeFileSync(filePath, original);
+          // The overwrite was reverted, so drop the now-inaccurate warning.
+          const idx = warnings.indexOf(`Overwrote existing file: ${filePath}`);
+          if (idx !== -1) warnings.splice(idx, 1);
+        } else {
+          fs.rmSync(filePath, { force: true });
+        }
       } catch {
         warnings.push(`Failed to roll back partially-written file: ${filePath}`);
         leftover.push(filePath);

--- a/cli/src/lib/create-project.ts
+++ b/cli/src/lib/create-project.ts
@@ -66,6 +66,32 @@ export function toRootNamespace(projectName: string): string {
 }
 
 /**
+ * Escape a string for embedding inside a double-quoted Godot `ConfigFile`
+ * value (the `project.godot` format): backslash -> `\\` and double-quote ->
+ * `\"`. Without this, a name containing `"` or `\` produces a `project.godot`
+ * Godot cannot parse — or, worse, lets a crafted name inject arbitrary config
+ * keys. Pure. Exported for unit tests.
+ */
+export function escapeGodotConfigString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+/**
+ * Validate a project name before any filesystem write. Rejected when the name
+ * would corrupt the generated `project.godot` (line breaks inside a quoted
+ * `ConfigFile` string) or would escape / break the `--dotnet` csproj filename
+ * (path separators, `..` traversal, or characters illegal in a filename).
+ * Returns a human-readable reason when invalid, or `null` when safe. Pure.
+ */
+export function validateProjectName(projectName: string): string | null {
+  if (/[\r\n]/.test(projectName)) return 'must not contain line breaks';
+  if (/[/\\]/.test(projectName)) return 'must not contain path separators ("/" or "\\")';
+  if (projectName.includes('..')) return 'must not contain ".." path segments';
+  if (/[<>:"|?*]/.test(projectName)) return 'must not contain reserved characters (< > : " | ? *)';
+  return null;
+}
+
+/**
  * Detect whether `dir` already hosts a project for any supported engine and, if
  * so, which marker file proves it. Checks (in order) a Godot `project.godot`, a
  * Unity `ProjectSettings/ProjectVersion.txt`, and any Unreal `*.uproject` file
@@ -104,7 +130,7 @@ export function detectExistingProjectMarker(
 export function renderProjectGodot(projectName: string, dotnet: boolean): string {
   const features = dotnet ? 'PackedStringArray("4.3", "C#")' : 'PackedStringArray("4.3")';
   const dotnetSection = dotnet
-    ? `\n[dotnet]\n\nproject/assembly_name="${toAssemblyName(projectName)}"\n`
+    ? `\n[dotnet]\n\nproject/assembly_name="${escapeGodotConfigString(toAssemblyName(projectName))}"\n`
     : '';
 
   return `; Engine configuration file.
@@ -119,7 +145,7 @@ config_version=5
 
 [application]
 
-config/name="${projectName}"
+config/name="${escapeGodotConfigString(projectName)}"
 config/features=${features}
 config/icon="res://icon.svg"
 ${dotnetSection}`;
@@ -158,6 +184,7 @@ export function renderCsproj(projectName: string): string {
  */
 export async function createProject(options: CreateProjectOptions): Promise<CreateProjectResult> {
   const warnings: string[] = [];
+  const filesWritten: string[] = [];
   let resolvedProjectPath: string | undefined;
 
   try {
@@ -165,6 +192,14 @@ export async function createProject(options: CreateProjectOptions): Promise<Crea
     resolvedProjectPath = projectPath;
     const dotnet = options.dotnet === true;
     const projectName = deriveProjectName(projectPath, options.name);
+
+    // Validate the name BEFORE any writes — line breaks would corrupt the
+    // quoted `project.godot` strings, and path separators / `..` / reserved
+    // chars would let a crafted `--dotnet` csproj filename escape the target.
+    const nameError = validateProjectName(projectName);
+    if (nameError) {
+      throw new Error(`Invalid project name "${projectName}": ${nameError}.`);
+    }
 
     emitProgress(options.onProgress, {
       phase: 'start',
@@ -182,21 +217,29 @@ export async function createProject(options: CreateProjectOptions): Promise<Crea
     // Create the target directory (and any parents) if absent.
     fs.mkdirSync(projectPath, { recursive: true });
 
-    const filesWritten: string[] = [];
+    // Write one file, recording it for rollback and warning when an existing
+    // non-marker file is clobbered.
+    const writeFile = (filePath: string, contents: string): void => {
+      if (fs.existsSync(filePath)) {
+        warnings.push(`Overwrote existing file: ${filePath}`);
+      }
+      fs.writeFileSync(filePath, contents);
+      filesWritten.push(filePath);
+    };
 
-    const projectGodotPath = path.join(projectPath, 'project.godot');
-    fs.writeFileSync(projectGodotPath, renderProjectGodot(projectName, dotnet));
-    filesWritten.push(projectGodotPath);
-
+    // Write the icon and (optional) csproj first, then `project.godot` LAST so
+    // the engine marker only exists once the scaffold fully succeeds — a
+    // mid-write failure leaves no marker to brick a corrected retry.
     const iconPath = path.join(projectPath, 'icon.svg');
-    fs.writeFileSync(iconPath, DEFAULT_ICON_SVG);
-    filesWritten.push(iconPath);
+    writeFile(iconPath, DEFAULT_ICON_SVG);
 
     if (dotnet) {
       const csprojPath = path.join(projectPath, `${toAssemblyName(projectName)}.csproj`);
-      fs.writeFileSync(csprojPath, renderCsproj(projectName));
-      filesWritten.push(csprojPath);
+      writeFile(csprojPath, renderCsproj(projectName));
     }
+
+    const projectGodotPath = path.join(projectPath, 'project.godot');
+    writeFile(projectGodotPath, renderProjectGodot(projectName, dotnet));
 
     emitProgress(options.onProgress, {
       phase: 'project-scaffolded',
@@ -215,12 +258,23 @@ export async function createProject(options: CreateProjectOptions): Promise<Crea
       warnings,
     };
   } catch (err: unknown) {
+    // Roll back any files written before the failure (best-effort, reverse
+    // order) so a failed/refused scaffold leaves the target as it was found.
+    for (const filePath of [...filesWritten].reverse()) {
+      try {
+        fs.rmSync(filePath, { force: true });
+      } catch {
+        warnings.push(`Failed to roll back partially-written file: ${filePath}`);
+      }
+    }
+
     const errorObj = err instanceof Error ? err : new Error(String(err));
     return {
       kind: 'failure',
       success: false,
       projectPath: resolvedProjectPath,
       warnings,
+      filesWritten,
       errorMessage: errorObj.message,
       error: errorObj,
     };

--- a/cli/src/lib/create-project.ts
+++ b/cli/src/lib/create-project.ts
@@ -1,0 +1,228 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { resolveProjectPath } from './open.js';
+import { emitProgress } from './progress.js';
+import type { CreateProjectOptions, CreateProjectResult } from './types.js';
+
+/**
+ * `Godot.NET.Sdk` version pinned into a scaffolded `--dotnet` csproj. Matches
+ * the addon's own min-version floor (`Godot-MCP.csproj` pins `4.3.0`) and the
+ * `config/features` "4.3" floor written into `project.godot`. A consumer can
+ * bump this to their editor version freely; the scaffold targets the floor so
+ * the generated project opens in any Godot 4.3+ editor.
+ */
+export const GODOT_SDK_VERSION = '4.3.0';
+
+/**
+ * Default `icon.svg` written into a scaffolded project — a self-contained,
+ * valid SVG using Godot's signature rounded-rect blue background. Mirrors the
+ * shape of the icon Godot writes for a fresh project (the exact glyph differs;
+ * what matters is a valid default icon the editor can load at `res://icon.svg`).
+ */
+export const DEFAULT_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <rect width="124" height="124" x="2" y="2" fill="#363d52" stroke="#212532" stroke-width="4" rx="14"/>
+  <g fill="#fff">
+    <circle cx="48" cy="58" r="10"/>
+    <circle cx="80" cy="58" r="10"/>
+    <rect x="40" y="82" width="48" height="8" rx="4"/>
+  </g>
+</svg>
+`;
+
+/** Engine project marker detected when refusing to scaffold over an existing project. */
+export type ProjectMarkerEngine = 'godot' | 'unity' | 'unreal';
+
+/**
+ * Derive the project name from an explicit option, falling back to the target
+ * folder's base name. Returns `GodotProject` only when both are empty. Pure.
+ */
+export function deriveProjectName(projectPath: string, explicitName?: string): string {
+  const trimmed = explicitName?.trim();
+  if (trimmed) return trimmed;
+  const base = path.basename(path.resolve(projectPath));
+  return base.length > 0 ? base : 'GodotProject';
+}
+
+/**
+ * The `[dotnet] project/assembly_name` value AND the csproj filename. Godot
+ * itself permits hyphens here (the infra testbed uses `Godot-Test-Project`), so
+ * the name is kept verbatim apart from trimming; falls back when empty. Pure.
+ */
+export function toAssemblyName(projectName: string): string {
+  const cleaned = projectName.trim();
+  return cleaned.length > 0 ? cleaned : 'GodotProject';
+}
+
+/**
+ * The csproj `<RootNamespace>` — must be a valid C# identifier, so every char
+ * that is not a letter/digit/underscore is stripped and a leading digit is
+ * prefixed with `_`. Mirrors the testbed's `Godot-Test-Project` ->
+ * `GodotTestProject` derivation. Pure.
+ */
+export function toRootNamespace(projectName: string): string {
+  const cleaned = projectName.replace(/[^A-Za-z0-9_]/g, '');
+  if (cleaned.length === 0) return 'GodotProject';
+  return /^[0-9]/.test(cleaned) ? `_${cleaned}` : cleaned;
+}
+
+/**
+ * Detect whether `dir` already hosts a project for any supported engine and, if
+ * so, which marker file proves it. Checks (in order) a Godot `project.godot`, a
+ * Unity `ProjectSettings/ProjectVersion.txt`, and any Unreal `*.uproject` file
+ * directly inside `dir`. Returns `null` when no marker is present (including
+ * when `dir` does not exist). Side-effect-free beyond read-only `fs` probing.
+ */
+export function detectExistingProjectMarker(
+  dir: string,
+): { engine: ProjectMarkerEngine; markerPath: string } | null {
+  const godot = path.join(dir, 'project.godot');
+  if (fs.existsSync(godot)) return { engine: 'godot', markerPath: godot };
+
+  const unity = path.join(dir, 'ProjectSettings', 'ProjectVersion.txt');
+  if (fs.existsSync(unity)) return { engine: 'unity', markerPath: unity };
+
+  if (fs.existsSync(dir)) {
+    try {
+      const uproject = fs
+        .readdirSync(dir)
+        .find((entry) => entry.toLowerCase().endsWith('.uproject'));
+      if (uproject) return { engine: 'unreal', markerPath: path.join(dir, uproject) };
+    } catch {
+      // A readdir failure here is not a marker; the scaffold's own mkdir/write
+      // below will surface any real filesystem error as a structured failure.
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Render the body of a minimal valid Godot 4.x `project.godot`
+ * (`config_version=5`). When `dotnet` is set, adds the `"C#"` feature and a
+ * `[dotnet]` section carrying the assembly name. Pure. Exported for unit tests.
+ */
+export function renderProjectGodot(projectName: string, dotnet: boolean): string {
+  const features = dotnet ? 'PackedStringArray("4.3", "C#")' : 'PackedStringArray("4.3")';
+  const dotnetSection = dotnet
+    ? `\n[dotnet]\n\nproject/assembly_name="${toAssemblyName(projectName)}"\n`
+    : '';
+
+  return `; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
+
+config_version=5
+
+[application]
+
+config/name="${projectName}"
+config/features=${features}
+config/icon="res://icon.svg"
+${dotnetSection}`;
+}
+
+/**
+ * Render a `Godot.NET.Sdk` csproj matching the infra `Godot-Test-Project/`
+ * reference shape (Sdk + `net8.0` + `Nullable` + `RootNamespace`). The testbed's
+ * addon-specific `PackageReference`s are intentionally NOT included — a freshly
+ * scaffolded project is not necessarily an addon consumer. Pure. Exported for
+ * unit tests.
+ */
+export function renderCsproj(projectName: string): string {
+  return `<Project Sdk="Godot.NET.Sdk/${GODOT_SDK_VERSION}">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <Nullable>enable</Nullable>
+    <RootNamespace>${toRootNamespace(projectName)}</RootNamespace>
+  </PropertyGroup>
+
+</Project>
+`;
+}
+
+/**
+ * Scaffold a minimal valid Godot 4.x project — the library-callable equivalent
+ * of the `create-project` CLI command. Library-safe: never calls
+ * `process.exit`, never prints, never throws past the public boundary.
+ *
+ * Writes `project.godot` (`config_version=5`) + `icon.svg`, plus a
+ * `Godot.NET.Sdk` csproj when `dotnet` is set. Refuses (structured failure, no
+ * writes) when the target already contains a Godot/Unity/Unreal project marker.
+ * Pure `fs` operations only — no Godot binary required.
+ */
+export async function createProject(options: CreateProjectOptions): Promise<CreateProjectResult> {
+  const warnings: string[] = [];
+  let resolvedProjectPath: string | undefined;
+
+  try {
+    const { projectPath } = resolveProjectPath(options.projectPath, process.cwd());
+    resolvedProjectPath = projectPath;
+    const dotnet = options.dotnet === true;
+    const projectName = deriveProjectName(projectPath, options.name);
+
+    emitProgress(options.onProgress, {
+      phase: 'start',
+      message: `Creating Godot project at ${projectPath}`,
+    });
+
+    // Refuse to scaffold over an existing project of ANY engine BEFORE writing.
+    const existing = detectExistingProjectMarker(projectPath);
+    if (existing) {
+      throw new Error(
+        `Refusing to scaffold: target already contains a ${existing.engine} project marker (${existing.markerPath}).`,
+      );
+    }
+
+    // Create the target directory (and any parents) if absent.
+    fs.mkdirSync(projectPath, { recursive: true });
+
+    const filesWritten: string[] = [];
+
+    const projectGodotPath = path.join(projectPath, 'project.godot');
+    fs.writeFileSync(projectGodotPath, renderProjectGodot(projectName, dotnet));
+    filesWritten.push(projectGodotPath);
+
+    const iconPath = path.join(projectPath, 'icon.svg');
+    fs.writeFileSync(iconPath, DEFAULT_ICON_SVG);
+    filesWritten.push(iconPath);
+
+    if (dotnet) {
+      const csprojPath = path.join(projectPath, `${toAssemblyName(projectName)}.csproj`);
+      fs.writeFileSync(csprojPath, renderCsproj(projectName));
+      filesWritten.push(csprojPath);
+    }
+
+    emitProgress(options.onProgress, {
+      phase: 'project-scaffolded',
+      message: `Scaffolded ${filesWritten.length} file(s)`,
+      projectPath,
+    });
+    emitProgress(options.onProgress, { phase: 'done', message: 'Project created.' });
+
+    return {
+      kind: 'success',
+      success: true,
+      projectPath,
+      projectName,
+      dotnet,
+      filesWritten,
+      warnings,
+    };
+  } catch (err: unknown) {
+    const errorObj = err instanceof Error ? err : new Error(String(err));
+    return {
+      kind: 'failure',
+      success: false,
+      projectPath: resolvedProjectPath,
+      warnings,
+      errorMessage: errorObj.message,
+      error: errorObj,
+    };
+  }
+}

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -178,6 +178,13 @@ export interface CreateProjectFailure {
   success: false;
   projectPath?: string;
   warnings: string[];
+  /**
+   * Absolute paths of any files written before the failure, in write order.
+   * Empty when the scaffold was refused before writing or after a successful
+   * best-effort rollback; non-empty only when cleanup of a partial scaffold
+   * could not be completed — lets the consumer finish the cleanup.
+   */
+  filesWritten: string[];
   errorMessage: string;
   error: Error;
 }

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -16,6 +16,8 @@
 export type ProgressEvent =
   | { phase: 'start'; message: string }
   | { phase: 'manifest-patched'; message: string; manifestPath: string }
+  // createProject phases
+  | { phase: 'project-scaffolded'; message: string; projectPath: string }
   // openProject phases
   | { phase: 'editor-resolved'; message: string; editorPath: string }
   | {
@@ -139,6 +141,48 @@ export interface OpenEnvInputs {
   mode?: OpenProjectOptions['mode'];
   logLevel?: OpenProjectOptions['logLevel'];
 }
+
+// ---------------------------------------------------------------------------
+// create-project
+// ---------------------------------------------------------------------------
+
+export interface CreateProjectOptions {
+  /** Target directory to scaffold the project into. Defaults to `process.cwd()`. */
+  projectPath?: string;
+  /**
+   * Project name written to `config/name` (and the `[dotnet]` assembly name /
+   * csproj filename when `dotnet` is set). Defaults to a name derived from the
+   * target folder name.
+   */
+  name?: string;
+  /** When `true`, additionally scaffold a `Godot.NET.Sdk` (C#) csproj. */
+  dotnet?: boolean;
+  onProgress?: ProgressCallback;
+}
+
+export interface CreateProjectSuccess {
+  kind: 'success';
+  success: true;
+  projectPath: string;
+  /** The resolved project name (explicit arg or folder-name derivation). */
+  projectName: string;
+  /** Whether the C# (`--dotnet`) csproj was scaffolded. */
+  dotnet: boolean;
+  /** Absolute paths of every file written, in write order. */
+  filesWritten: string[];
+  warnings: string[];
+}
+
+export interface CreateProjectFailure {
+  kind: 'failure';
+  success: false;
+  projectPath?: string;
+  warnings: string[];
+  errorMessage: string;
+  error: Error;
+}
+
+export type CreateProjectResult = CreateProjectSuccess | CreateProjectFailure;
 
 // ---------------------------------------------------------------------------
 // run-tool / run-system-tool

--- a/cli/tests/cli.test.ts
+++ b/cli/tests/cli.test.ts
@@ -42,6 +42,7 @@ describe('CLI integration', () => {
       expect(stdout).toContain('install-plugin');
       expect(stdout).toContain('remove-plugin');
       expect(stdout).toContain('update');
+      expect(stdout).toContain('create-project');
     });
 
     it('does NOT register a setup-skills command (scoped out of v1)', () => {
@@ -143,6 +144,41 @@ describe('CLI integration', () => {
       ]);
       expect(exitCode).toBe(1);
       expect(stdout).toContain('does not exist');
+    });
+  });
+
+  describe('create-project', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cli-create-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('shows help with --help', () => {
+      const { stdout, exitCode } = runCli(['create-project', '--help']);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('--path');
+      expect(stdout).toContain('--name');
+      expect(stdout).toContain('--dotnet');
+    });
+
+    it('scaffolds a project into the target directory', () => {
+      const dest = path.join(tmpDir, 'NewGame');
+      const { exitCode } = runCli(['create-project', '--path', dest, '--name', 'NewGame']);
+      expect(exitCode).toBe(0);
+      expect(fs.existsSync(path.join(dest, 'project.godot'))).toBe(true);
+      expect(fs.existsSync(path.join(dest, 'icon.svg'))).toBe(true);
+    });
+
+    it('fails when the target already hosts a Godot project', () => {
+      fs.writeFileSync(path.join(tmpDir, 'project.godot'), 'config_version=5\n');
+      const { exitCode, stdout } = runCli(['create-project', '--path', tmpDir]);
+      expect(exitCode).toBe(1);
+      expect(stdout).toContain('Refusing to scaffold');
     });
   });
 

--- a/cli/tests/cli.test.ts
+++ b/cli/tests/cli.test.ts
@@ -174,6 +174,14 @@ describe('CLI integration', () => {
       expect(fs.existsSync(path.join(dest, 'icon.svg'))).toBe(true);
     });
 
+    it('scaffolds via the positional [path] argument form', () => {
+      const dest = path.join(tmpDir, 'PositionalGame');
+      const { exitCode } = runCli(['create-project', dest, '--name', 'PositionalGame']);
+      expect(exitCode).toBe(0);
+      expect(fs.existsSync(path.join(dest, 'project.godot'))).toBe(true);
+      expect(fs.existsSync(path.join(dest, 'icon.svg'))).toBe(true);
+    });
+
     it('fails when the target already hosts a Godot project', () => {
       fs.writeFileSync(path.join(tmpDir, 'project.godot'), 'config_version=5\n');
       const { exitCode, stdout } = runCli(['create-project', '--path', tmpDir]);

--- a/cli/tests/create-project.test.ts
+++ b/cli/tests/create-project.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  createProject,
+  deriveProjectName,
+  detectExistingProjectMarker,
+  renderCsproj,
+  renderProjectGodot,
+  toAssemblyName,
+  toRootNamespace,
+} from '../src/lib/create-project.js';
+
+describe('deriveProjectName', () => {
+  it('uses the explicit name when provided', () => {
+    expect(deriveProjectName('/tmp/whatever', 'MyGame')).toBe('MyGame');
+  });
+
+  it('trims whitespace from the explicit name', () => {
+    expect(deriveProjectName('/tmp/whatever', '  MyGame  ')).toBe('MyGame');
+  });
+
+  it('falls back to the folder base name when no name is given', () => {
+    expect(deriveProjectName(path.join('/tmp', 'Cool-Project'))).toBe('Cool-Project');
+  });
+
+  it('falls back to the folder base name for an empty/whitespace name', () => {
+    expect(deriveProjectName(path.join('/tmp', 'Cool-Project'), '   ')).toBe('Cool-Project');
+  });
+});
+
+describe('toAssemblyName / toRootNamespace', () => {
+  it('keeps hyphenated names verbatim for the assembly name', () => {
+    expect(toAssemblyName('Godot-Test-Project')).toBe('Godot-Test-Project');
+  });
+
+  it('strips non-identifier chars for the root namespace', () => {
+    expect(toRootNamespace('Godot-Test-Project')).toBe('GodotTestProject');
+  });
+
+  it('prefixes an underscore when the namespace would start with a digit', () => {
+    expect(toRootNamespace('3D-Demo')).toBe('_3DDemo');
+  });
+
+  it('falls back to GodotProject when nothing usable remains', () => {
+    expect(toRootNamespace('---')).toBe('GodotProject');
+    expect(toAssemblyName('   ')).toBe('GodotProject');
+  });
+});
+
+describe('renderProjectGodot', () => {
+  it('writes config_version=5, the name, and the icon reference', () => {
+    const text = renderProjectGodot('MyGame', false);
+    expect(text).toContain('config_version=5');
+    expect(text).toContain('config/name="MyGame"');
+    expect(text).toContain('config/icon="res://icon.svg"');
+    expect(text).toContain('config/features=PackedStringArray("4.3")');
+  });
+
+  it('omits the [dotnet] section for a non-dotnet project', () => {
+    expect(renderProjectGodot('MyGame', false)).not.toContain('[dotnet]');
+  });
+
+  it('adds the C# feature and [dotnet] assembly name for a dotnet project', () => {
+    const text = renderProjectGodot('My-Game', true);
+    expect(text).toContain('config/features=PackedStringArray("4.3", "C#")');
+    expect(text).toContain('[dotnet]');
+    expect(text).toContain('project/assembly_name="My-Game"');
+  });
+});
+
+describe('renderCsproj', () => {
+  it('matches the Godot-Test-Project reference shape', () => {
+    const text = renderCsproj('Godot-Test-Project');
+    expect(text).toContain('<Project Sdk="Godot.NET.Sdk/4.3.0">');
+    expect(text).toContain('<TargetFramework>net8.0</TargetFramework>');
+    expect(text).toContain('<Nullable>enable</Nullable>');
+    expect(text).toContain('<RootNamespace>GodotTestProject</RootNamespace>');
+  });
+
+  it('does NOT include the addon-specific NuGet PackageReferences', () => {
+    const text = renderCsproj('Demo');
+    expect(text).not.toContain('com.IvanMurzak.McpPlugin');
+    expect(text).not.toContain('com.IvanMurzak.ReflectorNet');
+  });
+});
+
+describe('detectExistingProjectMarker', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-marker-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns null for an empty directory', () => {
+    expect(detectExistingProjectMarker(tmpDir)).toBeNull();
+  });
+
+  it('returns null for a non-existent directory', () => {
+    expect(detectExistingProjectMarker(path.join(tmpDir, 'nope'))).toBeNull();
+  });
+
+  it('detects a Godot project.godot', () => {
+    fs.writeFileSync(path.join(tmpDir, 'project.godot'), 'config_version=5\n');
+    expect(detectExistingProjectMarker(tmpDir)?.engine).toBe('godot');
+  });
+
+  it('detects a Unity project', () => {
+    fs.mkdirSync(path.join(tmpDir, 'ProjectSettings'));
+    fs.writeFileSync(path.join(tmpDir, 'ProjectSettings', 'ProjectVersion.txt'), 'm_EditorVersion: 6000\n');
+    expect(detectExistingProjectMarker(tmpDir)?.engine).toBe('unity');
+  });
+
+  it('detects an Unreal project', () => {
+    fs.writeFileSync(path.join(tmpDir, 'MyGame.uproject'), '{}');
+    expect(detectExistingProjectMarker(tmpDir)?.engine).toBe('unreal');
+  });
+});
+
+describe('createProject', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-create-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('scaffolds a minimal project.godot + icon.svg (non-dotnet)', async () => {
+    const dest = path.join(tmpDir, 'NewGame');
+    const result = await createProject({ projectPath: dest, name: 'NewGame' });
+
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+    expect(result.dotnet).toBe(false);
+    expect(result.projectName).toBe('NewGame');
+
+    const projectGodot = fs.readFileSync(path.join(dest, 'project.godot'), 'utf-8');
+    expect(projectGodot).toContain('config_version=5');
+    expect(projectGodot).toContain('config/name="NewGame"');
+    expect(projectGodot).not.toContain('[dotnet]');
+
+    expect(fs.existsSync(path.join(dest, 'icon.svg'))).toBe(true);
+    // No csproj for a non-dotnet scaffold.
+    expect(fs.readdirSync(dest).some((f) => f.endsWith('.csproj'))).toBe(false);
+  });
+
+  it('derives the project name from the folder when no name is given', async () => {
+    const dest = path.join(tmpDir, 'Derived-Name');
+    const result = await createProject({ projectPath: dest });
+
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+    expect(result.projectName).toBe('Derived-Name');
+    const projectGodot = fs.readFileSync(path.join(dest, 'project.godot'), 'utf-8');
+    expect(projectGodot).toContain('config/name="Derived-Name"');
+  });
+
+  it('scaffolds a Godot.NET.Sdk csproj for the --dotnet variant', async () => {
+    const dest = path.join(tmpDir, 'CsharpGame');
+    const result = await createProject({ projectPath: dest, name: 'CsharpGame', dotnet: true });
+
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+    expect(result.dotnet).toBe(true);
+
+    const csprojPath = path.join(dest, 'CsharpGame.csproj');
+    expect(fs.existsSync(csprojPath)).toBe(true);
+    const csproj = fs.readFileSync(csprojPath, 'utf-8');
+    expect(csproj).toContain('<Project Sdk="Godot.NET.Sdk/4.3.0">');
+    expect(csproj).toContain('<RootNamespace>CsharpGame</RootNamespace>');
+
+    const projectGodot = fs.readFileSync(path.join(dest, 'project.godot'), 'utf-8');
+    expect(projectGodot).toContain('[dotnet]');
+    expect(projectGodot).toContain('project/assembly_name="CsharpGame"');
+  });
+
+  it('refuses to scaffold over an existing Godot project (structured error, no writes)', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'project.godot'), 'config_version=5\n');
+    const before = fs.readFileSync(path.join(tmpDir, 'project.godot'), 'utf-8');
+
+    const result = await createProject({ projectPath: tmpDir });
+    expect(result.kind).toBe('failure');
+    if (result.kind !== 'failure') return;
+    expect(result.errorMessage).toContain('godot project marker');
+
+    // The pre-existing file was left untouched and no icon was written.
+    expect(fs.readFileSync(path.join(tmpDir, 'project.godot'), 'utf-8')).toBe(before);
+    expect(fs.existsSync(path.join(tmpDir, 'icon.svg'))).toBe(false);
+  });
+
+  it('refuses to scaffold over an existing Unity project', async () => {
+    fs.mkdirSync(path.join(tmpDir, 'ProjectSettings'));
+    fs.writeFileSync(path.join(tmpDir, 'ProjectSettings', 'ProjectVersion.txt'), 'm_EditorVersion: 6000\n');
+    const result = await createProject({ projectPath: tmpDir });
+    expect(result.kind).toBe('failure');
+    if (result.kind !== 'failure') return;
+    expect(result.errorMessage).toContain('unity project marker');
+  });
+
+  it('returns a structured failure (never throws) on a filesystem error', async () => {
+    // Make the target path an existing FILE so the scaffold's mkdir fails.
+    const filePath = path.join(tmpDir, 'iam-a-file');
+    fs.writeFileSync(filePath, 'not a directory');
+
+    const result = await createProject({ projectPath: filePath });
+    expect(result.kind).toBe('failure');
+    if (result.kind !== 'failure') return;
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.errorMessage.length).toBeGreaterThan(0);
+  });
+});

--- a/cli/tests/create-project.test.ts
+++ b/cli/tests/create-project.test.ts
@@ -280,6 +280,32 @@ describe('createProject', () => {
     expect(fs.existsSync(dest)).toBe(true);
   });
 
+  it('restores (does NOT delete) a pre-existing file it overwrote when a LATER write fails', async () => {
+    // A marker-free directory that already holds the user's icon.svg. With
+    // --dotnet the write order is icon.svg -> <name>.csproj -> project.godot;
+    // a directory at the csproj path makes that second write throw AFTER
+    // icon.svg was overwritten. Rollback must put the user's icon.svg back
+    // (not rmSync it), leaving the target with no LESS than it started with.
+    const dest = path.join(tmpDir, 'HasIcon');
+    fs.mkdirSync(dest, { recursive: true });
+    const userIcon = '<svg id="mine"/>';
+    fs.writeFileSync(path.join(dest, 'icon.svg'), userIcon);
+    fs.mkdirSync(path.join(dest, 'HasIcon.csproj'));
+
+    const result = await createProject({ projectPath: dest, name: 'HasIcon', dotnet: true });
+    expect(result.kind).toBe('failure');
+    if (result.kind !== 'failure') return;
+
+    // The user's original icon.svg survives with its ORIGINAL content restored.
+    expect(fs.existsSync(path.join(dest, 'icon.svg'))).toBe(true);
+    expect(fs.readFileSync(path.join(dest, 'icon.svg'), 'utf-8')).toBe(userIcon);
+    // Cleanup fully succeeded, so the failure-shape lists no leftover files...
+    expect(result.filesWritten).toEqual([]);
+    // ...and the "Overwrote existing file" warning was dropped, since the
+    // overwrite was reverted — the failure shape must not claim a stale clobber.
+    expect(result.warnings.some((w) => w.includes('Overwrote existing file'))).toBe(false);
+  });
+
   it('refuses (structured failure, no writes) a name with a newline / injected key', async () => {
     const dest = path.join(tmpDir, 'Injected');
     const result = await createProject({

--- a/cli/tests/create-project.test.ts
+++ b/cli/tests/create-project.test.ts
@@ -257,6 +257,29 @@ describe('createProject', () => {
     expect(result.errorMessage.length).toBeGreaterThan(0);
   });
 
+  it('rolls back already-written files when a LATER write fails', async () => {
+    // Pre-create dest with a DIRECTORY where the csproj will be written. With
+    // --dotnet the write order is icon.svg -> <name>.csproj -> project.godot, so
+    // icon.svg is written and recorded first, then writeFileSync to a directory
+    // path throws — exercising the catch-block rollback after a recorded write.
+    // (A `project.godot` directory can't be used here: detectExistingProjectMarker
+    // would treat it as an existing marker and refuse before any write.)
+    const dest = path.join(tmpDir, 'PartialGame');
+    fs.mkdirSync(dest, { recursive: true });
+    fs.mkdirSync(path.join(dest, 'PartialGame.csproj'));
+
+    const result = await createProject({ projectPath: dest, name: 'PartialGame', dotnet: true });
+    expect(result.kind).toBe('failure');
+    if (result.kind !== 'failure') return;
+
+    // icon.svg was written then rolled back; cleanup succeeded, so the
+    // CreateProjectFailure.filesWritten contract reports an empty list.
+    expect(fs.existsSync(path.join(dest, 'icon.svg'))).toBe(false);
+    expect(result.filesWritten).toEqual([]);
+    // The caller-provided directory itself is left in place (we did not create it).
+    expect(fs.existsSync(dest)).toBe(true);
+  });
+
   it('refuses (structured failure, no writes) a name with a newline / injected key', async () => {
     const dest = path.join(tmpDir, 'Injected');
     const result = await createProject({

--- a/cli/tests/create-project.test.ts
+++ b/cli/tests/create-project.test.ts
@@ -6,10 +6,12 @@ import {
   createProject,
   deriveProjectName,
   detectExistingProjectMarker,
+  escapeGodotConfigString,
   renderCsproj,
   renderProjectGodot,
   toAssemblyName,
   toRootNamespace,
+  validateProjectName,
 } from '../src/lib/create-project.js';
 
 describe('deriveProjectName', () => {
@@ -67,6 +69,46 @@ describe('renderProjectGodot', () => {
     expect(text).toContain('config/features=PackedStringArray("4.3", "C#")');
     expect(text).toContain('[dotnet]');
     expect(text).toContain('project/assembly_name="My-Game"');
+  });
+
+  it('escapes quotes and backslashes in the name so the ConfigFile stays valid', () => {
+    const text = renderProjectGodot('Ev"il\\Name', true);
+    // The raw, unescaped name must never appear verbatim inside the quoted value.
+    expect(text).toContain('config/name="Ev\\"il\\\\Name"');
+    expect(text).toContain('project/assembly_name="Ev\\"il\\\\Name"');
+    expect(text).not.toContain('config/name="Ev"il');
+  });
+});
+
+describe('escapeGodotConfigString', () => {
+  it('escapes double-quotes and backslashes per Godot ConfigFile rules', () => {
+    expect(escapeGodotConfigString('a"b')).toBe('a\\"b');
+    expect(escapeGodotConfigString('a\\b')).toBe('a\\\\b');
+    expect(escapeGodotConfigString('plain')).toBe('plain');
+  });
+});
+
+describe('validateProjectName', () => {
+  it('accepts ordinary and hyphenated names', () => {
+    expect(validateProjectName('My-Game')).toBeNull();
+    expect(validateProjectName('Godot-Test-Project')).toBeNull();
+  });
+
+  it('rejects line breaks', () => {
+    expect(validateProjectName('X\nrun/main_scene="res://evil.tscn')).not.toBeNull();
+    expect(validateProjectName('a\rb')).not.toBeNull();
+  });
+
+  it('rejects path separators and traversal', () => {
+    expect(validateProjectName('../../other/proj')).not.toBeNull();
+    expect(validateProjectName('sub\\dir')).not.toBeNull();
+    expect(validateProjectName('a..b')).not.toBeNull();
+  });
+
+  it('rejects Windows-reserved filename characters', () => {
+    expect(validateProjectName('na"me')).not.toBeNull();
+    expect(validateProjectName('na:me')).not.toBeNull();
+    expect(validateProjectName('na*me')).not.toBeNull();
   });
 });
 
@@ -213,5 +255,50 @@ describe('createProject', () => {
     if (result.kind !== 'failure') return;
     expect(result.error).toBeInstanceOf(Error);
     expect(result.errorMessage.length).toBeGreaterThan(0);
+  });
+
+  it('refuses (structured failure, no writes) a name with a newline / injected key', async () => {
+    const dest = path.join(tmpDir, 'Injected');
+    const result = await createProject({
+      projectPath: dest,
+      name: 'X"\nrun/main_scene="res://evil.tscn',
+    });
+    expect(result.kind).toBe('failure');
+    if (result.kind !== 'failure') return;
+    expect(result.errorMessage).toContain('Invalid project name');
+    // Nothing was scaffolded — the injection never reached project.godot.
+    expect(fs.existsSync(path.join(dest, 'project.godot'))).toBe(false);
+    expect(result.filesWritten).toEqual([]);
+  });
+
+  it('refuses (structured failure, no writes) a name with path separators / traversal', async () => {
+    const dest = path.join(tmpDir, 'Traversal');
+    const result = await createProject({ projectPath: dest, name: '../../evil', dotnet: true });
+    expect(result.kind).toBe('failure');
+    if (result.kind !== 'failure') return;
+    expect(result.errorMessage).toContain('Invalid project name');
+    // No csproj was written outside (or inside) the target directory.
+    expect(fs.existsSync(dest)).toBe(false);
+    expect(result.filesWritten).toEqual([]);
+  });
+
+  it('refuses a name containing a double-quote (reserved char)', async () => {
+    // `"` is rejected at the createProject boundary; the renderProjectGodot
+    // escaping (unit-tested separately) is the defense-in-depth second layer.
+    const dest = path.join(tmpDir, 'EscapeMe');
+    const result = await createProject({ projectPath: dest, name: 'Quote"Name' });
+    expect(result.kind).toBe('failure');
+    if (result.kind !== 'failure') return;
+    expect(result.errorMessage).toContain('Invalid project name');
+  });
+
+  it('warns when it overwrites a pre-existing non-marker file', async () => {
+    // A stray icon.svg in a marker-free directory must be reported, not silently clobbered.
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'icon.svg'), '<svg/>');
+    const result = await createProject({ projectPath: tmpDir, name: 'Reuse' });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+    expect(result.warnings.some((w) => w.includes('icon.svg'))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Add `createProject(options): Promise<CreateProjectResult>` to `cli/src/lib/create-project.ts`, exported from `lib.ts` — structured, never-throw result matching the `openProject` convention.
- Scaffold a minimal valid Godot 4.x project: `project.godot` (`config_version=5`, name from arg or folder-name derivation) + default `icon.svg`; `--dotnet` additionally writes a `Godot.NET.Sdk` csproj matching the `Godot-Test-Project/` reference shape.
- Refuse (structured error, no writes) when the target already holds a Godot/Unity/Unreal project marker; new `create-project` CLI command delegates to the lib function.

## Test plan
- [x] Target-specific local tests passed (`npm run build` + `npm test` in `cli/`): 92 tests pass (27 new) covering successful scaffold, name derivation, the `--dotnet` variant, existing-project refusal, and a filesystem-error path.

Closes #90