### PR TITLE
feat(server): default streamable-http idle timeout to 6h for local server

### DIFF
--- a/Godot-MCP-Server/src/Program.cs
+++ b/Godot-MCP-Server/src/Program.cs
@@ -31,6 +31,14 @@ namespace com.IvanMurzak.Godot.MCP.Server
             // Configure NLog
             LogManager.Setup().LoadConfigurationFromFile("NLog.config");
 
+            // Default the streamableHttp idle-session window to 6 hours for this local server.
+            // The plugin's built-in default is 600s (10 min), which is too aggressive for a
+            // single-user local editor session and drops the MCP session mid-work. We only seed
+            // the env var when it is unset, and DataArguments parses CLI args after env vars, so an
+            // explicit MCP_PLUGIN_IDLE_TIMEOUT_SECONDS or --idle-timeout-seconds still overrides this.
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Consts.MCP.Server.Env.IdleTimeoutSeconds)))
+                Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.IdleTimeoutSeconds, "21600"); // 6 hours
+
             var dataArguments = new DataArguments(args);
 
             // In STDIO mode, redirect console logs to stderr to avoid polluting stdout with non-JSON content


### PR DESCRIPTION
## Problem
The local Godot-MCP-Server inherits the MCP plugin's built-in idle-session window default, which is too aggressive for a single-user local editor session and can drop the streamableHttp MCP session mid-work.

## Fix
In `Godot-MCP-Server/src/Program.cs`, seed `MCP_PLUGIN_IDLE_TIMEOUT_SECONDS=21600` (6h) immediately before `new DataArguments(args)`, **only when the env var is unset**. `DataArguments` reads env vars first and CLI args second, so an explicit `MCP_PLUGIN_IDLE_TIMEOUT_SECONDS` env or `--idle-timeout-seconds` CLI arg still overrides this default. The constant `Consts.MCP.Server.Env.IdleTimeoutSeconds` resolves to `MCP_PLUGIN_IDLE_TIMEOUT_SECONDS`.

## Scope
Local `Godot-MCP-Server` host only — no addon, plugin, or shared-package changes. The Apache header and unrelated lines are untouched.

## Verification
`dotnet build com.IvanMurzak.Godot.MCP.Server.csproj` → **Build succeeded, 0 warnings, 0 errors** (public NuGet restore of `com.IvanMurzak.McpPlugin.Server` 6.7.0).

## Note
With the currently pinned McpPlugin 6.7.0, `Consts.MCP.Server.DefaultIdleTimeoutSeconds` is already 21600, so this seed is effectively a no-op against today's package default — but it explicitly pins the 6h local-server behavior so a future package default change cannot silently shorten it.