### PR TITLE
chore(release): bump version to 0.5.0

### DIFF
--- a/addons/godot_mcp/plugin.cfg
+++ b/addons/godot_mcp/plugin.cfg
@@ -3,5 +3,5 @@
 name="Godot-MCP"
 description="Model Context Protocol (MCP) integration for the Godot Editor. AI tools in C#, cloud-connected to ai-game.dev."
 author="Ivan Murzak"
-version="0.4.0"
+version="0.5.0"
 script="GodotMcpPlugin.cs"

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "godot-cli",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "godot-cli",
-      "version": "0.3.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.6.2",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "godot-cli",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "description": "Cross-platform CLI tool for Godot-MCP (Skills & MCP). Resolves and launches the Godot editor with MCP connection env vars, runs MCP/system tools over HTTP, probes server health, configures AI agents (Claude Code, Cursor, VS Code, …), and enables/disables the godot_mcp addon. Works with Claude Code, Cursor, Copilot, and any MCP client.",
   "type": "module",
   "main": "dist/lib.js",


### PR DESCRIPTION
## Release v0.5.0

Bumps the addon version `0.4.0 -> 0.5.0` (`plugin.cfg`, single source of truth) and syncs `cli/package.json` / `package-lock.json` (advisory — the deploy workflow overwrites it at publish time).

This is the release that **ships the shared-server repoint (#101)** to users:

- The addon now auto-downloads the shared **GameDev-MCP-Server v8.0.0** (binary `gamedev-mcp-server`) from https://github.com/IvanMurzak/GameDev-MCP-Server — verified the `v8.0.0` release exists with all 7 `gamedev-mcp-server-<rid>.zip` assets before this bump (RELEASING.md ordering rule).
- `godot-mcp-server-<rid>.zip` assets are no longer attached to Godot-MCP releases.
- Docker `ivanmurzakdev/godot-mcp-server` is superseded by `aigamedeveloper/mcp-server`.

Local verification: `dotnet build` clean, `dotnet test` 691/691 passed, cli `npm test` 105/105 passed.

On merge, `release.yml` gates open (version-line bump + no `v0.5.0` tag) -> tests -> GitHub Release with `godot-mcp-addon-0.5.0.zip` -> `godot-cli` npm publish.

Approved by Ivan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)