### PR TITLE
fix(plugin): tool scan misses the project assembly — Godot loads it into a non-default ALC (fixes #102)

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -40,6 +40,10 @@
     <Compile Include="..\addons\godot_mcp\Reflection\GodotStructReflectionConverters.cs" Link="Source\GodotStructReflectionConverters.cs" />
     <Compile Include="..\addons\godot_mcp\Reflection\GodotNodePathJsonConverter.cs" Link="Source\GodotNodePathJsonConverter.cs" />
     <Compile Include="..\addons\godot_mcp\Reflection\GodotReflectorFactory.cs" Link="Source\GodotReflectorFactory.cs" />
+    <!-- Scan-set enumerator — pure-BCL. Pinned by GodotAssemblyUtilsTests (issue #102): must span all
+         load contexts, because Godot loads the project assembly (hosting every [AiToolType] class)
+         into its own collectible non-default AssemblyLoadContext. -->
+    <Compile Include="..\addons\godot_mcp\Reflection\GodotAssemblyUtils.cs" Link="Source\GodotAssemblyUtils.cs" />
     <!-- Resource reference converter — pure-managed (matches Godot.Resource + derived types by inheritance
          distance; (de)serializes the ResourceRef shape). The native ResourceLoader.Load resolution is
          injected under #if TOOLS (Tool_Resource.ReflectionResolver.cs, verified via the Suite-3 smoke); the

--- a/Godot-MCP.Tests/GodotAssemblyUtilsTests.cs
+++ b/Godot-MCP.Tests/GodotAssemblyUtilsTests.cs
@@ -1,0 +1,82 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.Loader;
+using com.IvanMurzak.Godot.MCP.Reflection;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the scan-set contract of <see cref="GodotAssemblyUtils.AllAssemblies"/> (issue #102).
+    ///
+    /// <para>
+    /// The Godot editor loads the project assembly — the one hosting the addon and every
+    /// <c>[AiToolType]</c> tool class — into its own collectible non-default
+    /// <see cref="AssemblyLoadContext"/>. The scan set must therefore span ALL load contexts; when it
+    /// enumerated only <see cref="AssemblyLoadContext.Default"/>, the <c>McpPluginBuilder</c> attribute
+    /// scan never saw the tool assembly and the plugin registered zero tools (empty <c>tools/list</c>,
+    /// <c>ping</c> not found) with no error anywhere. The non-default-context test below simulates
+    /// Godot's plugin context with a collectible ALC; it fails against the
+    /// <see cref="AssemblyLoadContext.Default"/>-only implementation and passes against
+    /// <see cref="AppDomain.GetAssemblies"/>. Pure-BCL, CI-friendly (no Godot binary needed).
+    /// </para>
+    /// </summary>
+    public class GodotAssemblyUtilsTests
+    {
+        [Fact]
+        public void AllAssemblies_IncludesAssemblyLoadedInNonDefaultContext()
+        {
+            // Simulate Godot's plugin context: load a copy of this test assembly into a fresh
+            // collectible ALC (a copy, so the path differs and the load is not deduplicated into
+            // an already-loaded assembly identity).
+            var sourcePath = typeof(GodotAssemblyUtilsTests).Assembly.Location;
+            var copyPath = Path.Combine(Path.GetTempPath(), $"alc-probe-{Guid.NewGuid():N}.dll");
+            File.Copy(sourcePath, copyPath);
+
+            var alc = new AssemblyLoadContext($"test-plugin-context-{Guid.NewGuid():N}", isCollectible: true);
+            try
+            {
+                var loaded = alc.LoadFromAssemblyPath(copyPath);
+                Assert.NotEqual(AssemblyLoadContext.Default, AssemblyLoadContext.GetLoadContext(loaded));
+
+                Assert.Contains(loaded, GodotAssemblyUtils.AllAssemblies);
+            }
+            finally
+            {
+                alc.Unload();
+                try { File.Delete(copyPath); } catch (IOException) { /* still mapped; temp cleanup */ }
+            }
+        }
+
+        [Fact]
+        public void AllAssemblies_IncludesTheCallingAssemblyItself()
+        {
+            // The addon assembly must always be in its own scan set — the ping tool lives there.
+            Assert.Contains(typeof(GodotAssemblyUtilsTests).Assembly, GodotAssemblyUtils.AllAssemblies);
+        }
+
+        [Fact]
+        public void AllAssemblies_ExcludesDynamicAssemblies()
+        {
+            var dynamic = AssemblyBuilder.DefineDynamicAssembly(
+                new AssemblyName($"dynamic-probe-{Guid.NewGuid():N}"), AssemblyBuilderAccess.Run);
+            // Materialize a type so the dynamic assembly is fully realized in the AppDomain.
+            dynamic.DefineDynamicModule("m");
+
+            Assert.DoesNotContain(dynamic, GodotAssemblyUtils.AllAssemblies);
+        }
+    }
+}

--- a/addons/godot_mcp/Reflection/GodotAssemblyUtils.cs
+++ b/addons/godot_mcp/Reflection/GodotAssemblyUtils.cs
@@ -26,14 +26,18 @@ namespace com.IvanMurzak.Godot.MCP.Reflection
     /// serialization-blacklist entries / scan-ignore rules with NO hardcoded extension list.
     ///
     /// <para>
-    /// <b>Why <see cref="AssemblyLoadContext.Default"/>.</b> Godot loads the project/addon assembly —
-    /// and, via <see cref="GodotMcpAssemblyResolver"/>, every NuGet dependency it resolves at editor
-    /// runtime — into the <b>default</b> <see cref="AssemblyLoadContext"/>. A Godot-MCP extension ships
-    /// as additional <c>.cs</c> compiled into the same project game assembly (Godot globs all project
-    /// <c>.cs</c> into one assembly) or as a referenced library loaded into the same default context, so
-    /// <see cref="AssemblyLoadContext.Default"/>'s loaded set is exactly where an extension's
-    /// <see cref="System.Reflection.Assembly"/> appears. Enumerating it (rather than only the addon
-    /// assembly) is what lets the discovery reach extension-contributed modules.
+    /// <b>Why <see cref="AppDomain.GetAssemblies"/> and NOT <see cref="AssemblyLoadContext.Default"/>
+    /// (issue #102).</b> The Godot editor loads the project assembly into its own <b>collectible
+    /// plugin <see cref="AssemblyLoadContext"/></b>, not the default one — and that project assembly
+    /// is exactly where this addon, its <c>[AiToolType]</c> tool classes, and any extension
+    /// <c>.cs</c> live (Godot globs all project <c>.cs</c> into one assembly). Its NuGet dependencies
+    /// (McpPlugin / ReflectorNet) resolve into that same context. Enumerating only
+    /// <see cref="AssemblyLoadContext.Default"/> therefore misses the very assembly hosting the
+    /// tools, and the builder's attribute scan silently registers ZERO tools (empty
+    /// <c>tools/list</c>, <c>ping</c> not found). Unity-MCP's <c>AssemblyUtils.AllAssemblies</c> can
+    /// enumerate the default context because Unity loads user code there; Godot does not.
+    /// <see cref="AppDomain.GetAssemblies"/> spans every load context in the process, so both the
+    /// plugin-context project assembly and any default-context extension library are reachable.
     /// </para>
     ///
     /// <para>
@@ -47,14 +51,15 @@ namespace com.IvanMurzak.Godot.MCP.Reflection
     public static class GodotAssemblyUtils
     {
         /// <summary>
-        /// The managed assemblies currently loaded in the default <see cref="AssemblyLoadContext"/>,
-        /// snapshotted into an array. Dynamic (in-memory) assemblies are excluded — they have no scannable
-        /// on-disk types relevant to tool/module discovery and a few (e.g. ref-emit) throw on
-        /// <see cref="Assembly.GetTypes"/>. The snapshot is taken eagerly (the returned array does not
-        /// observe later loads) so a discovery pass walks a stable set.
+        /// The managed assemblies currently loaded in the process across ALL load contexts (Godot's
+        /// collectible plugin context included — that is where the project assembly hosting the tools
+        /// lives; see issue #102), snapshotted into an array. Dynamic (in-memory) assemblies are
+        /// excluded — they have no scannable on-disk types relevant to tool/module discovery and a few
+        /// (e.g. ref-emit) throw on <see cref="Assembly.GetTypes"/>. The snapshot is taken eagerly (the
+        /// returned array does not observe later loads) so a discovery pass walks a stable set.
         /// </summary>
         public static Assembly[] AllAssemblies =>
-            AssemblyLoadContext.Default.Assemblies
+            AppDomain.CurrentDomain.GetAssemblies()
                 .Where(assembly => !assembly.IsDynamic)
                 .ToArray();
     }


### PR DESCRIPTION
Fixes #102.

## Root cause

`GodotAssemblyUtils.AllAssemblies` builds the scan set for `WithToolsFromAssembly` / `WithPromptsFromAssembly` / `WithResourcesFromAssembly` / `WithReflectorModulesFromAssembly` from `AssemblyLoadContext.Default.Assemblies` — but the Godot editor loads the **project assembly into its own collectible plugin `AssemblyLoadContext`**, not the default one. That project assembly is exactly where the addon and all of its `[AiToolType]` classes (`Tool_Ping`, `Tool_Node`, `Tool_Scene`, …) live, since Godot globs all project `.cs` into one assembly; its NuGet deps (`McpPlugin`, `ReflectorNet`) resolve into the same context.

So `McpPluginBuilder.ProcessAllAssemblies` never sees the one assembly hosting the tools: the registry is built empty with no exception anywhere — transport fine, handshake fine, `tools/list` → 0, even `ping` missing. This is **not headless-specific**; we reproduced it identically in windowed sessions (v0.5.0, Godot 4.6.3-stable, Linux, .NET 8). Unity-MCP's equivalent (`AssemblyUtils.AllAssemblies`) gets away with the default context because Unity loads user code there; the Godot port inherited that assumption.

Diagnostic from inside a failing editor session:

```
[MCP-DIAG] Default-ALC assemblies: 49; contains game asm: False; contains McpPlugin: False
[MCP-DIAG] GetTypes OK: 276                      (project assembly, via AppDomain enumeration)
[MCP-DIAG] [AiToolType] by NAME: 11 classes
[MCP-DIAG] [AiToolType] by IDENTITY: 11 classes
```

## Fix

Enumerate `AppDomain.CurrentDomain.GetAssemblies()` — every load context in the process — keeping the `IsDynamic` filter and the builder-side `.IgnoreAssemblies(...)` prune unchanged.

Verified live: after the one-line change, `tools/list` through gamedev-mcp-server returns all **36 tools** and tool calls execute, in both windowed and headless (`--headless -e`) sessions.

## Regression test

`GodotAssemblyUtilsTests` (new; `GodotAssemblyUtils.cs` added to the test project's compile set) pins the contract:

- an assembly loaded into a **collectible non-default ALC** (simulating Godot's plugin context) must appear in the scan set — this test **fails against the previous implementation** and passes after the fix;
- the calling assembly is always in its own scan set;
- dynamic assemblies stay excluded.

Full suite: 694 passed / 0 failed.

One caveat worth knowing: `AppDomain.GetAssemblies()` can briefly see both old and new copies of the project assembly mid-reload (Godot's plugin ALC is collectible and torn down on rebuild). Since the plugin itself is unloaded/rebooted across that reload, the scan always runs against a settled state in practice — no duplicate-registration observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)