### PR TITLE
feat(addon): show skills folder path project-relative

### DIFF
--- a/Godot-MCP.Tests/SkillsTests.cs
+++ b/Godot-MCP.Tests/SkillsTests.cs
@@ -82,6 +82,62 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.False(AgentConfigPaths.IsSafeRelativeSkillsPath(path));
         }
 
+        // --- AgentConfigPaths.ToDisplayPath (issue #105) ----------------------------------------------------
+
+        [Fact]
+        public void ToDisplayPath_InsideProject_ReturnsRelative()
+        {
+            var skillsDir = Path.Combine(ProjectRoot, ".claude", "skills"); // /home/dev/MyGodotProject/.claude/skills
+            Assert.Equal(".claude/skills", AgentConfigPaths.ToDisplayPath(skillsDir, ProjectRoot));
+        }
+
+        [Fact]
+        public void ToDisplayPath_EqualToProjectRoot_ReturnsDot()
+        {
+            Assert.Equal(".", AgentConfigPaths.ToDisplayPath(ProjectRoot, ProjectRoot));
+            // Trailing-slash on the path must not defeat the equality check.
+            Assert.Equal(".", AgentConfigPaths.ToDisplayPath(ProjectRoot + "/", ProjectRoot));
+        }
+
+        [Fact]
+        public void ToDisplayPath_OutsideProject_ReturnsAbsoluteUnchanged()
+        {
+            const string outside = "/somewhere/else/.claude/skills";
+            Assert.Equal(outside, AgentConfigPaths.ToDisplayPath(outside, ProjectRoot));
+
+            // A sibling path that merely shares a prefix STRING but is not a child directory must NOT be treated as
+            // inside (the trailing-slash boundary guards against `/home/dev/MyGodotProject-other`).
+            const string sibling = "/home/dev/MyGodotProject-other/.claude/skills";
+            Assert.Equal(sibling, AgentConfigPaths.ToDisplayPath(sibling, ProjectRoot));
+        }
+
+        [Theory]
+        // Backslash separators in the absolute path normalize to '/', and the relative result uses '/'.
+        [InlineData(@"C:\proj\.claude\skills", @"C:\proj", ".claude/skills")]
+        // A trailing slash on the input path is trimmed before the containment check.
+        [InlineData("/home/dev/proj/.claude/skills/", "/home/dev/proj", ".claude/skills")]
+        // Mixed separators in the project root normalize too.
+        [InlineData("/home/dev/proj/.claude/skills", @"\home\dev\proj", ".claude/skills")]
+        public void ToDisplayPath_NormalizesSeparatorsAndTrailingSlashes(string absolutePath, string projectRoot, string expected)
+        {
+            Assert.Equal(expected, AgentConfigPaths.ToDisplayPath(absolutePath, projectRoot));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void ToDisplayPath_NullOrEmptyPath_ReturnsInputUnchanged(string? absolutePath)
+        {
+            Assert.Equal(absolutePath, AgentConfigPaths.ToDisplayPath(absolutePath!, ProjectRoot));
+        }
+
+        [Fact]
+        public void ToDisplayPath_EmptyProjectRoot_ReturnsAbsoluteUnchanged()
+        {
+            const string abs = "/home/dev/proj/.claude/skills";
+            Assert.Equal(abs, AgentConfigPaths.ToDisplayPath(abs, string.Empty));
+        }
+
         // --- Per-agent capability (SupportsSkills / SkillsDir) ----------------------------------------------
 
         [Fact]

--- a/addons/godot_mcp/UI/Agents/AgentConfigPaths.cs
+++ b/addons/godot_mcp/UI/Agents/AgentConfigPaths.cs
@@ -75,6 +75,41 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents
         public static string ClaudeCodeSkills(string projectRoot) => Combine(projectRoot, ".claude", "skills");
 
         /// <summary>
+        /// Render <paramref name="absolutePath"/> for DISPLAY relative to <paramref name="projectRoot"/>: returns the
+        /// project-relative form (e.g. <c>.claude/skills</c>) when the path is inside the project root, <c>"."</c> when
+        /// it equals the project root, and the original absolute path unchanged when it is OUTSIDE the project (or on
+        /// any error — safety fallback). Separators are normalized to <c>'/'</c> and trailing slashes trimmed before the
+        /// ordinal containment check. The Godot analog of Unity-MCP's <c>ToDisplayPath</c>: the skills card shows the
+        /// short relative path while keeping the full absolute path in the tooltip. Pure-managed (paths injected, no
+        /// Godot native types, no IO) so it is unit-testable in the plain-xUnit host.
+        /// </summary>
+        public static string ToDisplayPath(string absolutePath, string projectRoot)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(absolutePath) || string.IsNullOrEmpty(projectRoot))
+                    return absolutePath;
+
+                var normalizedPath = absolutePath.Replace('\\', '/').TrimEnd('/');
+                var normalizedRoot = projectRoot.Replace('\\', '/').TrimEnd('/');
+
+                if (string.Equals(normalizedPath, normalizedRoot, System.StringComparison.Ordinal))
+                    return ".";
+
+                var prefix = normalizedRoot + "/";
+                if (normalizedPath.StartsWith(prefix, System.StringComparison.Ordinal))
+                    return normalizedPath.Substring(prefix.Length);
+
+                // Outside the project root (or empty root) — return the original absolute path untouched.
+                return absolutePath;
+            }
+            catch
+            {
+                return absolutePath;
+            }
+        }
+
+        /// <summary>
         /// Validate a user-or-config-supplied skills path is a SAFE in-project relative path: rejects an absolute /
         /// rooted path and any <c>..</c> traversal segment (mirrors Unity-MCP's <c>Tool_Skills.GenerateAll</c> guard).
         /// Returns <c>true</c> when <paramref name="relativePath"/> is null/empty (the resolver falls back to the

--- a/addons/godot_mcp/UI/SkillsPanel.cs
+++ b/addons/godot_mcp/UI/SkillsPanel.cs
@@ -136,10 +136,11 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 return;
             }
 
-            // Show the resolved skills output path in the header (full path as tooltip; the label ellipsis-truncates).
+            // Show the resolved skills output path in the header project-root-relative (e.g. `.claude/skills`); keep the
+            // full absolute path as the tooltip. The label still ellipsis-truncates if the relative form is long.
             if (_pathLabel != null)
             {
-                _pathLabel.Text = plan.SkillsDir!;
+                _pathLabel.Text = AgentConfigPaths.ToDisplayPath(plan.SkillsDir!, ProjectRoot());
                 _pathLabel.TooltipText = plan.SkillsDir!;
             }
 


### PR DESCRIPTION
## Summary
- Add pure-managed `AgentConfigPaths.ToDisplayPath(absolutePath, projectRoot)` — renders a path project-root-relative (e.g. `.claude/skills`), `"."` when equal to root, absolute fallback when outside the project or on error. Mirrors Unity-MCP's `ToDisplayPath`.
- `SkillsPanel` now shows the skills folder path project-relative in the dock header label while keeping the full absolute path in the tooltip.
- Unit tests for the new helper (inside-project → relative, exact-root → `.`, outside/sibling → absolute fallback, separator + trailing-slash normalization, null/empty edges).

## Test plan
- [x] Suite 1 — `dotnet build Godot-MCP.sln` (.NET 8): 0 errors, 0 warnings.
- [x] Suite 2 — `dotnet test`: 9 new `ToDisplayPath` tests pass; full suite 702/703 (the single failure, `GodotAssemblyUtilsTests.AllAssemblies_IncludesAssemblyLoadedInNonDefaultContext`, is a Windows-only temp-DLL-cleanup issue unrelated to this change — its `finally` catches only `IOException` but a locked loaded DLL throws `UnauthorizedAccessException` on this box; passes in Linux CI).

Closes #105