### PR TITLE
feat(script): surface GDScript parse errors (script-validate + engine-log capture)

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -114,6 +114,16 @@
          not here. -->
     <Compile Include="..\addons\godot_mcp\Data\ScriptInfo.cs" Link="Source\ScriptInfo.cs" />
     <Compile Include="..\addons\godot_mcp\Tools\ScriptLang.cs" Link="Source\ScriptLang.cs" />
+    <!-- script-validate diagnostics — pure-managed (no Godot native types, no #if TOOLS): the diagnostic
+         result models (ScriptDiagnostic / ScriptDiagnosticsResult + their enums) and the ScriptErrorCapture
+         router that classifies + routes engine-error callbacks (passive log capture + on-demand validation
+         session). The engine Logger subclass that feeds the router (GodotScriptErrorLogger.cs) is
+         #if GODOT4_5_OR_GREATER (4.5+ only) and the editor-driving Validate handler (Tool_Script.Validate.cs)
+         is #if TOOLS — both verified via the headless Godot smoke (test.md Suite 3); the models + router are
+         unit-tested here. -->
+    <Compile Include="..\addons\godot_mcp\Data\ScriptDiagnostic.cs" Link="Source\ScriptDiagnostic.cs" />
+    <Compile Include="..\addons\godot_mcp\Data\ScriptDiagnosticsResult.cs" Link="Source\ScriptDiagnosticsResult.cs" />
+    <Compile Include="..\addons\godot_mcp\Tools\ScriptErrorCapture.cs" Link="Source\ScriptErrorCapture.cs" />
     <!-- Screenshot tool family — pure-managed pieces only (no Godot native types, no #if TOOLS): the
          size-cap clamping, framing trig, view-direction table, and hex-color parse. The editor-driving
          handlers (Tool_Screenshot.*.cs) are #if TOOLS and encode a real Godot Image, so they are verified

--- a/Godot-MCP.Tests/ScriptDiagnosticsTests.cs
+++ b/Godot-MCP.Tests/ScriptDiagnosticsTests.cs
@@ -174,6 +174,112 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Empty(capture.EndSession());
         }
 
+        // ---- ScriptErrorCapture: path-match filter (cross-talk defense) ---------------------------
+
+        [Fact]
+        public void Session_WithTarget_DropsScriptErrorsForOtherFiles()
+        {
+            var capture = new ScriptErrorCapture();
+            capture.BeginSession("res://under_test.gd");
+
+            // The file under validation -> kept.
+            capture.Route(EngineErrorKind.Script, "res://under_test.gd", 3, "c", "real error");
+            // An off-thread reload / dependency error in ANOTHER file fires mid-session -> dropped.
+            capture.Route(EngineErrorKind.Script, "res://unrelated.gd", 1, "c", "noise");
+            // A dependency error touching a third file (e.g. preload target) -> dropped.
+            capture.Route(EngineErrorKind.Script, "res://lib/dep.gd", 7, "c", "dep noise");
+
+            var diags = capture.EndSession();
+            var only = Assert.Single(diags);
+            Assert.Equal("res://under_test.gd", only.Path);
+            Assert.Equal("real error", only.Message);
+        }
+
+        [Fact]
+        public void Session_WithTarget_KeepsPathlessScriptError_ForCallerToStamp()
+        {
+            var capture = new ScriptErrorCapture();
+            capture.BeginSession("res://under_test.gd");
+
+            // The engine occasionally omits the source path; keep it so the tool can stamp the target.
+            capture.Route(EngineErrorKind.Script, "", 5, "c", "located-less error");
+            capture.Route(EngineErrorKind.Script, null, 6, "c", "null-path error");
+
+            var diags = capture.EndSession();
+            Assert.Equal(2, diags.Length);
+            Assert.All(diags, d => Assert.True(string.IsNullOrEmpty(d.Path)));
+        }
+
+        [Fact]
+        public void Session_WithTarget_MatchesPathCaseInsensitively()
+        {
+            var capture = new ScriptErrorCapture();
+            capture.BeginSession("res://Scripts/Player.gd");
+
+            capture.Route(EngineErrorKind.Script, "res://scripts/player.gd", 2, "c", "case-variant");
+
+            var only = Assert.Single(capture.EndSession());
+            Assert.Equal("res://scripts/player.gd", only.Path);
+        }
+
+        [Fact]
+        public void Session_WithoutTarget_CollectsAllScriptErrors_LegacyBehavior()
+        {
+            var capture = new ScriptErrorCapture();
+            capture.BeginSession(); // no target -> no filtering
+
+            capture.Route(EngineErrorKind.Script, "res://a.gd", 1, "c", "a");
+            capture.Route(EngineErrorKind.Script, "res://b.gd", 2, "c", "b");
+
+            Assert.Equal(2, capture.EndSession().Length);
+        }
+
+        [Fact]
+        public void Route_IsThreadSafe_OnlyTargetFileSurvivesConcurrentNoise()
+        {
+            var capture = new ScriptErrorCapture();
+            capture.BeginSession("res://under_test.gd");
+
+            // Hammer Route from many threads: one matching error per "validation" thread plus a flood of
+            // off-thread noise for other files. The path-match filter + lock must yield ONLY matching rows,
+            // with no torn writes / lost updates.
+            const int matching = 50;
+            const int noisePerThread = 50;
+            var threads = new System.Collections.Generic.List<System.Threading.Thread>();
+            for (int t = 0; t < 8; t++)
+            {
+                var thread = new System.Threading.Thread(() =>
+                {
+                    for (int i = 0; i < matching; i++)
+                        capture.Route(EngineErrorKind.Script, "res://under_test.gd", i, "c", "match");
+                    for (int i = 0; i < noisePerThread; i++)
+                        capture.Route(EngineErrorKind.Script, "res://noise.gd", i, "c", "noise");
+                });
+                threads.Add(thread);
+                thread.Start();
+            }
+            foreach (var thread in threads)
+                thread.Join();
+
+            var diags = capture.EndSession();
+            Assert.Equal(8 * matching, diags.Length);
+            Assert.All(diags, d => Assert.Equal("res://under_test.gd", d.Path));
+        }
+
+        [Fact]
+        public void ScriptDiagnosticsResult_Truncated_SerializesAndDefaultsFalse()
+        {
+            Assert.False(new ScriptDiagnosticsResult().Truncated);
+
+            var r = new ScriptDiagnosticsResult { Truncated = true };
+            var json = JsonSerializer.Serialize(r);
+            Assert.Contains("\"truncated\"", json);
+
+            var restored = JsonSerializer.Deserialize<ScriptDiagnosticsResult>(json);
+            Assert.NotNull(restored);
+            Assert.True(restored!.Truncated);
+        }
+
         // ---- FormatLogLine -----------------------------------------------------------------------
 
         [Theory]

--- a/Godot-MCP.Tests/ScriptDiagnosticsTests.cs
+++ b/Godot-MCP.Tests/ScriptDiagnosticsTests.cs
@@ -223,6 +223,21 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         }
 
         [Fact]
+        public void Session_WithTarget_MatchesAbsoluteEnginePath_AgainstResTarget()
+        {
+            // The session target is always a res:// path, but the engine logger may report an absolute path
+            // for the same file. The genuine diagnostic for the file under test must NOT be dropped.
+            var capture = new ScriptErrorCapture();
+            capture.BeginSession("res://scripts/player.gd");
+
+            capture.Route(EngineErrorKind.Script, @"C:\proj\scripts\player.gd", 5, "c", "absolute-path error");
+            capture.Route(EngineErrorKind.Script, "/home/u/proj/scripts/other.gd", 1, "c", "absolute noise");
+
+            var only = Assert.Single(capture.EndSession());
+            Assert.Equal(@"C:\proj\scripts\player.gd", only.Path);
+        }
+
+        [Fact]
         public void Session_WithoutTarget_CollectsAllScriptErrors_LegacyBehavior()
         {
             var capture = new ScriptErrorCapture();

--- a/Godot-MCP.Tests/ScriptDiagnosticsTests.cs
+++ b/Godot-MCP.Tests/ScriptDiagnosticsTests.cs
@@ -238,6 +238,26 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         }
 
         [Fact]
+        public void Session_WithTarget_DoesNotMatchShallowerFileSharingBasename()
+        {
+            // Collision guard: the target is nested (res://scripts/ui/player.gd) and an UNRELATED error fires
+            // for a shallower file that happens to share the basename (res://player.gd). The reversed
+            // target.EndsWith("/" + engine) match would wrongly attribute the root file's error to the file
+            // under validation, re-opening the cross-talk the filter exists to prevent. It must be DROPPED.
+            var capture = new ScriptErrorCapture();
+            capture.BeginSession("res://scripts/ui/player.gd");
+
+            // The genuine error for the file under test -> kept (clause 1, exact after normalization).
+            capture.Route(EngineErrorKind.Script, "res://scripts/ui/player.gd", 3, "c", "real error");
+            // An off-thread error for the SHALLOWER same-basename file -> must be dropped (no reversed match).
+            capture.Route(EngineErrorKind.Script, "res://player.gd", 1, "c", "shallow same-basename noise");
+
+            var only = Assert.Single(capture.EndSession());
+            Assert.Equal("res://scripts/ui/player.gd", only.Path);
+            Assert.Equal("real error", only.Message);
+        }
+
+        [Fact]
         public void Session_WithoutTarget_CollectsAllScriptErrors_LegacyBehavior()
         {
             var capture = new ScriptErrorCapture();

--- a/Godot-MCP.Tests/ScriptDiagnosticsTests.cs
+++ b/Godot-MCP.Tests/ScriptDiagnosticsTests.cs
@@ -1,0 +1,220 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Linq;
+using System.Text.Json;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.Godot.MCP.Tools;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pure-managed coverage for the <c>script-validate</c> feature: the diagnostic result models
+    /// (<see cref="ScriptDiagnostic"/> / <see cref="ScriptDiagnosticsResult"/>) and the
+    /// <see cref="ScriptErrorCapture"/> router (engine-error classification, passive log routing, and the
+    /// validation capture-session lifecycle). None touch a live Godot scripting runtime, so they run in the
+    /// plain xUnit host with no Godot binary. The editor-driving handler (<c>Tool_Script.Validate.cs</c>,
+    /// <c>#if TOOLS</c>) and the 4.5 engine Logger subclass (<c>#if GODOT4_5_OR_GREATER</c>) are verified by
+    /// the headless Godot smoke (test.md Suite 3).
+    /// </summary>
+    public class ScriptDiagnosticsTests
+    {
+        // ---- ScriptDiagnostic / ScriptDiagnosticsResult serialization ----------------------------
+
+        [Fact]
+        public void ScriptDiagnostic_Serializes_WithExpectedJsonNames()
+        {
+            var d = new ScriptDiagnostic("res://scripts/player.gd", 12, "Unexpected token",
+                ScriptDiagnosticSeverity.Error);
+
+            var json = JsonSerializer.Serialize(d);
+            Assert.Contains("\"path\"", json);
+            Assert.Contains("\"line\"", json);
+            Assert.Contains("\"message\"", json);
+            Assert.Contains("\"severity\"", json);
+
+            var restored = JsonSerializer.Deserialize<ScriptDiagnostic>(json);
+            Assert.NotNull(restored);
+            Assert.Equal("res://scripts/player.gd", restored!.Path);
+            Assert.Equal(12, restored.Line);
+            Assert.Equal("Unexpected token", restored.Message);
+            Assert.Equal(ScriptDiagnosticSeverity.Error, restored.Severity);
+        }
+
+        [Fact]
+        public void ScriptDiagnostic_UnknownLine_DefaultsToMinusOne()
+        {
+            var d = new ScriptDiagnostic("res://x.gd", -1, "ParseError");
+            Assert.Equal(-1, d.Line);
+            Assert.Contains("res://x.gd", d.ToString());
+        }
+
+        [Fact]
+        public void ScriptDiagnosticsResult_Serializes_WithExpectedJsonNames()
+        {
+            var r = new ScriptDiagnosticsResult
+            {
+                Ok = false,
+                ScannedCount = 3,
+                ErrorCount = 1,
+                WarningCount = 0,
+                ScannedPaths = { "res://a.gd", "res://b.gd", "res://c.gd" },
+                Diagnostics = { new ScriptDiagnostic("res://a.gd", 4, "boom") },
+                Fidelity = ScriptDiagnosticsFidelity.Precise,
+                Note = "1 error across 3 scanned script(s).",
+            };
+
+            var json = JsonSerializer.Serialize(r);
+            foreach (var key in new[] { "ok", "scannedCount", "errorCount", "warningCount",
+                "scannedPaths", "diagnostics", "fidelity", "note" })
+                Assert.Contains($"\"{key}\"", json);
+
+            var restored = JsonSerializer.Deserialize<ScriptDiagnosticsResult>(json);
+            Assert.NotNull(restored);
+            Assert.False(restored!.Ok);
+            Assert.Equal(3, restored.ScannedCount);
+            Assert.Equal(1, restored.ErrorCount);
+            Assert.Single(restored.Diagnostics);
+            Assert.Equal(ScriptDiagnosticsFidelity.Precise, restored.Fidelity);
+        }
+
+        // ---- ScriptErrorCapture: passive log routing ---------------------------------------------
+
+        [Fact]
+        public void Route_AlwaysAppendsToLogSink_RegardlessOfSession()
+        {
+            var captured = new System.Collections.Generic.List<(GodotLogType, string)>();
+            var capture = new ScriptErrorCapture { LogSink = (t, m) => captured.Add((t, m)) };
+
+            capture.Route(EngineErrorKind.Script, "res://x.gd", 7, "cond", "Parse error");
+            capture.Route(EngineErrorKind.Warning, "res://y.gd", 3, "cond2", "Deprecated call");
+
+            Assert.Equal(2, captured.Count);
+            Assert.Equal(GodotLogType.Error, captured[0].Item1);   // Script -> Error severity in the log
+            Assert.Contains("res://x.gd:7", captured[0].Item2);
+            Assert.Contains("Parse error", captured[0].Item2);
+            Assert.Equal(GodotLogType.Warning, captured[1].Item1);
+        }
+
+        [Fact]
+        public void Route_PrefersRationaleOverCode_FallsBackToCode()
+        {
+            var captured = new System.Collections.Generic.List<string>();
+            var capture = new ScriptErrorCapture { LogSink = (_, m) => captured.Add(m) };
+
+            // rationale present -> used.
+            capture.Route(EngineErrorKind.Error, "res://a.gd", 1, "the C++ cond", "human rationale");
+            Assert.Contains("human rationale", captured[^1]);
+
+            // rationale empty -> fall back to code.
+            capture.Route(EngineErrorKind.Error, "res://b.gd", 2, "the C++ cond", "");
+            Assert.Contains("the C++ cond", captured[^1]);
+        }
+
+        // ---- ScriptErrorCapture: validation capture session --------------------------------------
+
+        [Fact]
+        public void Session_CollectsOnlyScriptErrors()
+        {
+            var capture = new ScriptErrorCapture();
+            Assert.False(capture.SessionActive);
+
+            capture.BeginSession();
+            Assert.True(capture.SessionActive);
+
+            capture.Route(EngineErrorKind.Script, "res://broken.gd", 9, "cond", "unexpected indent");
+            capture.Route(EngineErrorKind.Error, "res://other.gd", 1, "cond", "generic error"); // not Script
+            capture.Route(EngineErrorKind.Warning, "res://w.gd", 1, "cond", "warn");             // not Script
+
+            var diags = capture.EndSession();
+            Assert.False(capture.SessionActive);
+
+            var only = Assert.Single(diags);
+            Assert.Equal("res://broken.gd", only.Path);
+            Assert.Equal(9, only.Line);
+            Assert.Equal("unexpected indent", only.Message);
+            Assert.Equal(ScriptDiagnosticSeverity.Error, only.Severity);
+        }
+
+        [Fact]
+        public void Route_OutsideSession_RecordsNoDiagnostics()
+        {
+            var capture = new ScriptErrorCapture();
+            capture.Route(EngineErrorKind.Script, "res://broken.gd", 9, "cond", "boom");
+            // No session was open; EndSession on no session yields empty.
+            Assert.Empty(capture.EndSession());
+        }
+
+        [Fact]
+        public void BeginSession_DiscardsPriorBuffer()
+        {
+            var capture = new ScriptErrorCapture();
+            capture.BeginSession();
+            capture.Route(EngineErrorKind.Script, "res://1.gd", 1, "c", "first");
+            capture.BeginSession(); // re-open discards the prior row
+            capture.Route(EngineErrorKind.Script, "res://2.gd", 2, "c", "second");
+
+            var diags = capture.EndSession();
+            var one = Assert.Single(diags);
+            Assert.Equal("res://2.gd", one.Path);
+        }
+
+        [Fact]
+        public void EndSession_WithoutBegin_ReturnsEmpty_AndIsSafe()
+        {
+            var capture = new ScriptErrorCapture();
+            Assert.Empty(capture.EndSession());
+        }
+
+        // ---- FormatLogLine -----------------------------------------------------------------------
+
+        [Theory]
+        [InlineData(EngineErrorKind.Script, "res://x.gd", 5, "msg", "[Script] res://x.gd:5 — msg")]
+        [InlineData(EngineErrorKind.Error, "res://x.gd", -1, "msg", "[Error] res://x.gd — msg")]
+        [InlineData(EngineErrorKind.Warning, "", 5, "msg", "[Warning] — msg")]
+        public void FormatLogLine_ShapesLocationPrefix(EngineErrorKind kind, string file, int line,
+            string text, string expected)
+        {
+            Assert.Equal(expected, ScriptErrorCapture.FormatLogLine(kind, file, line, text));
+        }
+
+        [Fact]
+        public void Route_StaticCurrent_IsSettableAndClearable()
+        {
+            var prior = ScriptErrorCapture.Current;
+            try
+            {
+                var c = new ScriptErrorCapture();
+                ScriptErrorCapture.Current = c;
+                Assert.Same(c, ScriptErrorCapture.Current);
+                ScriptErrorCapture.Current = null;
+                Assert.Null(ScriptErrorCapture.Current);
+            }
+            finally
+            {
+                ScriptErrorCapture.Current = prior;
+            }
+        }
+
+        [Fact]
+        public void Diagnostics_SortBySeverity_ErrorsBeforeWarnings()
+        {
+            // Mirrors the ordering Tool_Script.Validate applies before returning.
+            var list = new System.Collections.Generic.List<ScriptDiagnostic>
+            {
+                new("res://a.gd", 1, "w", ScriptDiagnosticSeverity.Warning),
+                new("res://b.gd", 2, "e", ScriptDiagnosticSeverity.Error),
+            };
+            list.Sort((a, b) => a.Severity.CompareTo(b.Severity));
+            Assert.Equal(ScriptDiagnosticSeverity.Error, list.First().Severity);
+        }
+    }
+}

--- a/addons/godot_mcp/Data/ScriptDiagnostic.cs
+++ b/addons/godot_mcp/Data/ScriptDiagnostic.cs
@@ -1,0 +1,87 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.Godot.MCP.Data
+{
+    /// <summary>
+    /// One script diagnostic surfaced by the <c>script-validate</c> tool — a parse / compile error (or
+    /// warning) tied to a specific <c>res://</c> script file. Mirrors the shape of an editor "Errors" panel
+    /// row so the agent gets structured, actionable feedback instead of a silent "the game runs fine".
+    ///
+    /// <para>
+    /// Field availability depends on the live Godot version (the addon's SDK floor is 4.3, but the editor
+    /// may be newer — see <see cref="ScriptDiagnosticSeverity"/>):
+    /// <list type="bullet">
+    /// <item><b>Godot 4.5+</b>: the engine's <c>Logger</c> hook delivers file + line + message, so
+    /// <see cref="Line"/> and <see cref="Message"/> are populated precisely.</item>
+    /// <item><b>Godot 4.3 / 4.4</b>: no managed log hook exists, so validation falls back to a coarse
+    /// per-file <c>Reload()</c> probe — <see cref="Line"/> is <c>-1</c> (unknown) and <see cref="Message"/>
+    /// carries the engine <c>Error</c> code (e.g. <c>"ParseError"</c>) rather than the human text.</item>
+    /// </list>
+    /// </para>
+    ///
+    /// Pure-managed (no Godot API surface, no <c>#if TOOLS</c>), so it is unit-testable in the plain xUnit
+    /// host.
+    /// </summary>
+    [System.Serializable]
+    [Description("A single script diagnostic (parse/compile error or warning): the res:// path, 1-based " +
+        "line (-1 when unknown), message, and severity.")]
+    public class ScriptDiagnostic
+    {
+        [JsonInclude, JsonPropertyName("path")]
+        [Description("res:// path of the script the diagnostic belongs to, e.g. 'res://scripts/player.gd'.")]
+        public string Path { get; set; } = string.Empty;
+
+        [JsonInclude, JsonPropertyName("line")]
+        [Description("1-based source line of the diagnostic, or -1 when the live Godot version cannot report " +
+            "a line (Godot < 4.5 falls back to a per-file error code with no line).")]
+        public int Line { get; set; } = -1;
+
+        [JsonInclude, JsonPropertyName("message")]
+        [Description("Human-readable diagnostic text (Godot 4.5+), or the engine Error code name (e.g. " +
+            "'ParseError') on older versions where the message text is not reachable.")]
+        public string Message { get; set; } = string.Empty;
+
+        [JsonInclude, JsonPropertyName("severity")]
+        [Description("Diagnostic severity: Error or Warning.")]
+        public ScriptDiagnosticSeverity Severity { get; set; } = ScriptDiagnosticSeverity.Error;
+
+        public ScriptDiagnostic() { }
+
+        public ScriptDiagnostic(string path, int line, string message,
+            ScriptDiagnosticSeverity severity = ScriptDiagnosticSeverity.Error)
+        {
+            Path = path ?? string.Empty;
+            Line = line;
+            Message = message ?? string.Empty;
+            Severity = severity;
+        }
+
+        public override string ToString()
+            => $"[{Severity}] {Path}{(Line >= 0 ? $":{Line}" : string.Empty)} — {Message}";
+    }
+
+    /// <summary>
+    /// Severity of a <see cref="ScriptDiagnostic"/>. GDScript parse/compile problems are reported as
+    /// <see cref="Error"/>; the Godot 4.5 <c>Logger</c> hook can additionally surface engine
+    /// <see cref="Warning"/> lines captured during validation.
+    /// </summary>
+    [Description("Severity of a script diagnostic: Error or Warning.")]
+    public enum ScriptDiagnosticSeverity
+    {
+        [Description("A parse / compile error — the script will not run as written.")]
+        Error = 0,
+        [Description("A non-fatal warning surfaced during validation.")]
+        Warning = 1,
+    }
+}

--- a/addons/godot_mcp/Data/ScriptDiagnosticsResult.cs
+++ b/addons/godot_mcp/Data/ScriptDiagnosticsResult.cs
@@ -65,9 +65,16 @@ namespace com.IvanMurzak.Godot.MCP.Data
             "message captured) or 'Coarse' (Godot < 4.5: per-file pass/fail with the engine error code, no line).")]
         public ScriptDiagnosticsFidelity Fidelity { get; set; } = ScriptDiagnosticsFidelity.Coarse;
 
+        [JsonInclude, JsonPropertyName("truncated")]
+        [Description("True when a full-project scan hit the file cap and only the first N '.gd' files were " +
+            "validated — so 'ok' is NOT a guaranteed all-clear for the whole project. Validate a specific " +
+            "'scriptPath' (or sub-tree) to cover the rest. Always false for a single-path validation.")]
+        public bool Truncated { get; set; } = false;
+
         [JsonInclude, JsonPropertyName("note")]
         [Description("Human-readable summary, e.g. 'No script errors found (12 scanned).' or '2 errors in 1 " +
-            "script.'. Includes a fidelity caveat on older Godot versions.")]
+            "script.'. Includes a fidelity caveat on older Godot versions and a truncation hint when the " +
+            "full-scan cap was hit.")]
         public string Note { get; set; } = string.Empty;
 
         public ScriptDiagnosticsResult() { }

--- a/addons/godot_mcp/Data/ScriptDiagnosticsResult.cs
+++ b/addons/godot_mcp/Data/ScriptDiagnosticsResult.cs
@@ -1,0 +1,91 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.Godot.MCP.Data
+{
+    /// <summary>
+    /// Structured result of the <c>script-validate</c> tool — the answer to "is this script (or the whole
+    /// project) free of parse/compile errors?". Carries an explicit <see cref="Ok"/> verdict, the set of
+    /// scanned script paths, the captured <see cref="Diagnostics"/>, and a <see cref="Fidelity"/> note that
+    /// tells the agent how precise the result is on the live Godot version (4.5+ gives line+message; older
+    /// versions give a coarse per-file pass/fail).
+    ///
+    /// <para>
+    /// This exists to close the gap reported on Discord (plugin 0.6.0): "the plugin lacks a way to
+    /// communicate parse errors in GDScript files ... Claude Code doesn't get any feedback on parse errors,
+    /// so it thinks the game is running without errors." An agent can now call <c>script-validate</c> and
+    /// branch on <see cref="Ok"/> instead of guessing from a screenshot.
+    /// </para>
+    ///
+    /// Pure-managed (no Godot API surface, no <c>#if TOOLS</c>), so it is unit-testable in the plain xUnit
+    /// host.
+    /// </summary>
+    [System.Serializable]
+    [Description("Result of 'script-validate': an Ok verdict, the scanned script paths, captured " +
+        "diagnostics, and a fidelity note about how precise the diagnostics are on the live Godot version.")]
+    public class ScriptDiagnosticsResult
+    {
+        [JsonInclude, JsonPropertyName("ok")]
+        [Description("True when no error-severity diagnostics were found across every scanned script.")]
+        public bool Ok { get; set; } = true;
+
+        [JsonInclude, JsonPropertyName("scannedCount")]
+        [Description("Number of script files that were validated.")]
+        public int ScannedCount { get; set; } = 0;
+
+        [JsonInclude, JsonPropertyName("errorCount")]
+        [Description("Number of error-severity diagnostics in 'diagnostics'.")]
+        public int ErrorCount { get; set; } = 0;
+
+        [JsonInclude, JsonPropertyName("warningCount")]
+        [Description("Number of warning-severity diagnostics in 'diagnostics'.")]
+        public int WarningCount { get; set; } = 0;
+
+        [JsonInclude, JsonPropertyName("scannedPaths")]
+        [Description("res:// paths of the script files that were validated.")]
+        public List<string> ScannedPaths { get; set; } = new();
+
+        [JsonInclude, JsonPropertyName("diagnostics")]
+        [Description("The captured diagnostics (errors first, then warnings). Empty when 'ok' is true.")]
+        public List<ScriptDiagnostic> Diagnostics { get; set; } = new();
+
+        [JsonInclude, JsonPropertyName("fidelity")]
+        [Description("How precise the diagnostics are on the live Godot version: 'Precise' (4.5+: line + " +
+            "message captured) or 'Coarse' (Godot < 4.5: per-file pass/fail with the engine error code, no line).")]
+        public ScriptDiagnosticsFidelity Fidelity { get; set; } = ScriptDiagnosticsFidelity.Coarse;
+
+        [JsonInclude, JsonPropertyName("note")]
+        [Description("Human-readable summary, e.g. 'No script errors found (12 scanned).' or '2 errors in 1 " +
+            "script.'. Includes a fidelity caveat on older Godot versions.")]
+        public string Note { get; set; } = string.Empty;
+
+        public ScriptDiagnosticsResult() { }
+
+        public override string ToString() => Note;
+    }
+
+    /// <summary>
+    /// How precise a <see cref="ScriptDiagnosticsResult"/> is, driven by the live Godot version's logging
+    /// surface. <see cref="Precise"/> means line + message were captured (Godot 4.5+ <c>Logger</c> hook);
+    /// <see cref="Coarse"/> means only a per-file pass/fail + engine error code was available (Godot &lt; 4.5).
+    /// </summary>
+    [Description("Diagnostic precision: Precise (line + message) or Coarse (per-file pass/fail, no line).")]
+    public enum ScriptDiagnosticsFidelity
+    {
+        [Description("Per-file pass/fail with the engine error code, no line (Godot < 4.5).")]
+        Coarse = 0,
+        [Description("Line + message captured via the engine Logger hook (Godot 4.5+).")]
+        Precise = 1,
+    }
+}

--- a/addons/godot_mcp/GodotMcpPlugin.cs
+++ b/addons/godot_mcp/GodotMcpPlugin.cs
@@ -47,6 +47,20 @@ namespace com.IvanMurzak.Godot.MCP
             // the plugin's own logging path (Log/LogWarning/LogError helpers) — see GodotLogCollector.
             GodotLogCollector.Current = new GodotLogCollector();
 
+            // Tap the engine's global error stream (Godot 4.5+ OS.AddLogger) so engine-wide GDScript parse
+            // errors land in 'console-get-logs' passively AND can be harvested on demand by 'script-validate'.
+            // A no-op on Godot < 4.5 (the bridge's #else stub returns null) — script-validate then falls back
+            // to a per-file Reload() error-code probe. Wrapped defensively: a logger-registration failure must
+            // not take down plugin load.
+            try
+            {
+                GodotScriptErrorLoggerBridge.TryInstall(GodotLogCollector.Current);
+            }
+            catch (System.Exception ex)
+            {
+                LogWarning($"[Godot-MCP] engine error-logger not installed: {ex.Message}");
+            }
+
             // FIRST: teach the editor's default AssemblyLoadContext how to find the addon's transitive
             // NuGet dependency assemblies (ReflectorNet / McpPlugin / ...). Godot does not probe the
             // project's *.deps.json, so without this hook the first touch of a NuGet-dependency type
@@ -181,6 +195,12 @@ namespace com.IvanMurzak.Godot.MCP
             // Release the collector so a stale buffer does not outlive this plugin instance (a fresh one
             // is installed on the next _EnterTree).
             GodotLogCollector.Current = null;
+
+            // Drop the engine error-capture router too. The registered Godot Logger (4.5+) lives in the
+            // engine's logger list; we intentionally do NOT remove it (Godot has no remove-logger managed
+            // API and the editor process owns its lifetime), but clearing Current stops validation sessions
+            // from leaking across a plugin reload and lets the router be GC-eligible once the engine drops it.
+            ScriptErrorCapture.Current = null;
         }
     }
 }

--- a/addons/godot_mcp/Tools/GodotScriptErrorLogger.Stub.cs
+++ b/addons/godot_mcp/Tools/GodotScriptErrorLogger.Stub.cs
@@ -1,0 +1,34 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+// Godot < 4.5 fallback for the engine-error logger bridge. On the addon's SDK floor (Godot.NET.Sdk/4.3.0,
+// which the required `dotnet build (.NET 8)` CI gate pins) Godot.Logger / OS.AddLogger do not exist, so the
+// real bridge (GodotScriptErrorLogger.cs, guarded by #if GODOT4_5_OR_GREATER) is compiled OUT and this stub
+// is compiled IN. It reports Available == false and installs nothing, so passive engine-log capture is
+// unavailable and script-validate falls back to the per-file Reload() error-code probe (Coarse fidelity).
+#if TOOLS && !GODOT4_5_OR_GREATER
+#nullable enable
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// No-op stub of the engine-error logger bridge for Godot &lt; 4.5 (no <c>OS.AddLogger</c> /
+    /// <c>Godot.Logger</c>). Keeps <c>Tool_Script.Validate.cs</c> compiling on the SDK floor; the tool
+    /// branches on <see cref="Available"/> and uses the coarse per-file <c>Reload()</c> probe instead.
+    /// </summary>
+    public static class GodotScriptErrorLoggerBridge
+    {
+        /// <summary>False on Godot &lt; 4.5 — the engine-Logger capture path is not compiled in.</summary>
+        public const bool Available = false;
+
+        /// <summary>No-op on Godot &lt; 4.5; always returns null. (Signature matches the 4.5+ bridge.)</summary>
+        public static ScriptErrorCapture? TryInstall(GodotLogCollector collector) => null;
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/GodotScriptErrorLogger.Stub.cs
+++ b/addons/godot_mcp/Tools/GodotScriptErrorLogger.Stub.cs
@@ -10,8 +10,9 @@
 // Godot < 4.5 fallback for the engine-error logger bridge. On the addon's SDK floor (Godot.NET.Sdk/4.3.0,
 // which the required `dotnet build (.NET 8)` CI gate pins) Godot.Logger / OS.AddLogger do not exist, so the
 // real bridge (GodotScriptErrorLogger.cs, guarded by #if GODOT4_5_OR_GREATER) is compiled OUT and this stub
-// is compiled IN. It reports Available == false and installs nothing, so passive engine-log capture is
-// unavailable and script-validate falls back to the per-file Reload() error-code probe (Coarse fidelity).
+// is compiled IN. TryInstall is a no-op that installs nothing, so ScriptErrorCapture.Current stays null:
+// passive engine-log capture is unavailable and script-validate falls back to the per-file Reload()
+// error-code probe (Coarse fidelity).
 #if TOOLS && !GODOT4_5_OR_GREATER
 #nullable enable
 
@@ -19,14 +20,12 @@ namespace com.IvanMurzak.Godot.MCP.Tools
 {
     /// <summary>
     /// No-op stub of the engine-error logger bridge for Godot &lt; 4.5 (no <c>OS.AddLogger</c> /
-    /// <c>Godot.Logger</c>). Keeps <c>Tool_Script.Validate.cs</c> compiling on the SDK floor; the tool
-    /// branches on <see cref="Available"/> and uses the coarse per-file <c>Reload()</c> probe instead.
+    /// <c>Godot.Logger</c>). Keeps <c>Tool_Script.Validate.cs</c> compiling on the SDK floor; with no live
+    /// capture installed, <see cref="ScriptErrorCapture.Current"/> stays null and the tool uses the coarse
+    /// per-file <c>Reload()</c> probe instead.
     /// </summary>
     public static class GodotScriptErrorLoggerBridge
     {
-        /// <summary>False on Godot &lt; 4.5 — the engine-Logger capture path is not compiled in.</summary>
-        public const bool Available = false;
-
         /// <summary>No-op on Godot &lt; 4.5; always returns null. (Signature matches the 4.5+ bridge.)</summary>
         public static ScriptErrorCapture? TryInstall(GodotLogCollector collector) => null;
     }

--- a/addons/godot_mcp/Tools/GodotScriptErrorLogger.cs
+++ b/addons/godot_mcp/Tools/GodotScriptErrorLogger.cs
@@ -90,12 +90,6 @@ namespace com.IvanMurzak.Godot.MCP.Tools
     public static class GodotScriptErrorLoggerBridge
     {
         /// <summary>
-        /// True on this build because the 4.5+ engine-Logger path is compiled in. The 4.3/4.4 stub returns
-        /// false (see the <c>#else</c> partial), letting the tool report a Coarse fidelity result.
-        /// </summary>
-        public const bool Available = true;
-
-        /// <summary>
         /// Install the engine-error logger and return the router it feeds. The router's <see cref="ScriptErrorCapture.LogSink"/>
         /// is wired to <paramref name="collector"/> so passive engine errors land in <c>console-get-logs</c>.
         /// Returns null only if <paramref name="collector"/> is null (nothing to wire) — callers treat null as

--- a/addons/godot_mcp/Tools/GodotScriptErrorLogger.cs
+++ b/addons/godot_mcp/Tools/GodotScriptErrorLogger.cs
@@ -1,0 +1,122 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+// GODOT 4.5+ ONLY. Godot.Logger / OS.AddLogger do NOT exist in the addon's SDK floor (Godot.NET.Sdk/4.3.0),
+// so referencing them outside this guard would break the required `dotnet build (.NET 8)` CI gate (which
+// pins 4.3.0) with CS0246. The Godot.NET.Sdk defines GODOT4_5_OR_GREATER only when building against the
+// 4.5+ SDK (e.g. the infra testbed pins 4.5.1), so this whole file compiles in on 4.5+ and out on 4.3/4.4.
+// On the floor, GodotScriptErrorLoggerBridge.TryInstall is a no-op stub (see the #else partial below) and
+// script-validate falls back to the per-file Reload() error-code probe (Tool_Script.Validate.cs).
+#if TOOLS && GODOT4_5_OR_GREATER
+#nullable enable
+using System;
+using com.IvanMurzak.Godot.MCP.Data;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// Godot 4.5+ <see cref="Logger"/> that taps the engine's global error stream and forwards every
+    /// error/warning to the pure-managed <see cref="ScriptErrorCapture"/> router. This is the single
+    /// registration (via <see cref="OS.AddLogger"/>) that powers BOTH feature deliverables: passive
+    /// engine-log capture into <c>console-get-logs</c> AND on-demand <c>script-validate</c> diagnostics
+    /// (the router collects <see cref="EngineErrorKind.Script"/> rows while a validation session is open).
+    ///
+    /// <para>
+    /// Godot calls <see cref="_LogError"/> from the thread the error originated on, so all buffer writes
+    /// happen inside <see cref="ScriptErrorCapture"/> under its lock. We do NOT touch any non-thread-safe
+    /// Godot object here — only forward primitives — so the multi-threaded callback is safe.
+    /// </para>
+    /// </summary>
+    public sealed partial class GodotScriptErrorLogger : Logger
+    {
+        readonly ScriptErrorCapture _capture;
+
+        public GodotScriptErrorLogger(ScriptErrorCapture capture)
+        {
+            _capture = capture ?? throw new ArgumentNullException(nameof(capture));
+        }
+
+        // NOTE: the engine's abstract _LogError binds 'errorType' as Int32 (not the Logger.ErrorType enum),
+        // so the override MUST use 'int' to match — the enum values (Error=0/Warning=1/Script=2/Shader=3)
+        // are mapped from the int below. The 'scriptBacktraces' parameter is accepted but unused (we forward
+        // primitives only, keeping the multi-threaded callback free of non-thread-safe Godot object access).
+        public override void _LogError(
+            string function,
+            string file,
+            int line,
+            string code,
+            string rationale,
+            bool editorNotify,
+            int errorType,
+            // Fully-qualified with global:: — the enclosing 'com.IvanMurzak.Godot.MCP.Tools' namespace would
+            // otherwise bind 'Godot.Collections' to 'com.IvanMurzak.Godot.Collections' (CS0234).
+            global::Godot.Collections.Array<global::Godot.ScriptBacktrace> scriptBacktraces)
+        {
+            _capture.Route(
+                kind: MapKind(errorType),
+                filePath: file,
+                line: line,
+                // 'code' is the failed C++ condition string; 'rationale' is the human error text.
+                message: code,
+                rationale: rationale);
+        }
+
+        // We intentionally do NOT override _LogMessage: ordinary print()/stdout traffic is already covered by
+        // the plugin's own GD.* capture path (GodotMcpPlugin.Log*). Tapping it here would double-capture and
+        // flood the ring buffer. The error stream (_LogError) is the gap this feature closes.
+
+        static EngineErrorKind MapKind(int errorType) => errorType switch
+        {
+            (int)Logger.ErrorType.Error => EngineErrorKind.Error,
+            (int)Logger.ErrorType.Warning => EngineErrorKind.Warning,
+            (int)Logger.ErrorType.Script => EngineErrorKind.Script,
+            (int)Logger.ErrorType.Shader => EngineErrorKind.Shader,
+            _ => EngineErrorKind.Error,
+        };
+    }
+
+    /// <summary>
+    /// 4.5+ implementation of the version-agnostic install bridge: constructs the <see cref="Logger"/>,
+    /// registers it via <see cref="OS.AddLogger"/>, and wires the router's passive log sink to the supplied
+    /// collector. Returns the live capture so the tool layer can drive validation sessions. Main-thread only.
+    /// </summary>
+    public static class GodotScriptErrorLoggerBridge
+    {
+        /// <summary>
+        /// True on this build because the 4.5+ engine-Logger path is compiled in. The 4.3/4.4 stub returns
+        /// false (see the <c>#else</c> partial), letting the tool report a Coarse fidelity result.
+        /// </summary>
+        public const bool Available = true;
+
+        /// <summary>
+        /// Install the engine-error logger and return the router it feeds. The router's <see cref="ScriptErrorCapture.LogSink"/>
+        /// is wired to <paramref name="collector"/> so passive engine errors land in <c>console-get-logs</c>.
+        /// Returns null only if <paramref name="collector"/> is null (nothing to wire) — callers treat null as
+        /// "unavailable". Idempotent-friendly: the caller installs once at boot.
+        /// </summary>
+        public static ScriptErrorCapture? TryInstall(GodotLogCollector collector)
+        {
+            if (collector == null)
+                return null;
+
+            var capture = new ScriptErrorCapture
+            {
+                LogSink = (logType, message) => collector.Append(logType, message),
+            };
+
+            var logger = new GodotScriptErrorLogger(capture);
+            OS.AddLogger(logger); // static API in GodotSharp 4.5
+
+            ScriptErrorCapture.Current = capture;
+            return capture;
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/ScriptErrorCapture.cs
+++ b/addons/godot_mcp/Tools/ScriptErrorCapture.cs
@@ -181,14 +181,20 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         /// An absolute engine path matches when its tail equals the scheme-stripped res:// target (e.g.
         /// <c>C:/proj/scripts/p.gd</c> ⊃ <c>scripts/p.gd</c> from <c>res://scripts/p.gd</c>). Kept pure-managed
         /// (no <c>ProjectSettings.LocalizePath</c>) so the router stays unit-testable in the plain xUnit host.
+        /// <para>
+        /// The match is asymmetric on purpose: only the ENGINE path may be the longer (absolute) form of the
+        /// target — never the reverse. A reversed <c>target.EndsWith("/" + engine)</c> clause would over-match
+        /// when a deeper target shares a basename with a shallower unrelated file (e.g. target
+        /// <c>res://scripts/ui/player.gd</c> wrongly collecting an error for <c>res://player.gd</c>), re-opening
+        /// the exact cross-talk this filter exists to prevent — so it is deliberately omitted.
+        /// </para>
         /// </summary>
         static bool PathsMatch(string enginePath, string target)
         {
             var a = NormalizePath(enginePath);
             var b = NormalizePath(target);
             return string.Equals(a, b, StringComparison.OrdinalIgnoreCase)
-                || a.EndsWith("/" + b, StringComparison.OrdinalIgnoreCase)
-                || b.EndsWith("/" + a, StringComparison.OrdinalIgnoreCase);
+                || a.EndsWith("/" + b, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>Strip the Godot resource scheme and normalize separators for path comparison.</summary>

--- a/addons/godot_mcp/Tools/ScriptErrorCapture.cs
+++ b/addons/godot_mcp/Tools/ScriptErrorCapture.cs
@@ -1,0 +1,153 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using com.IvanMurzak.Godot.MCP.Data;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// Coarse engine-error category surfaced by Godot's logging hook — the pure-managed mirror of Godot
+    /// 4.5's <c>Logger.ErrorType</c> (Error / Warning / Script / Shader), so the routing/classification
+    /// logic can be unit-tested in the plain xUnit host with no Godot binary. The 4.5-only <c>Logger</c>
+    /// subclass (behind <c>#if GODOT4_5_OR_GREATER</c>) maps the engine enum onto this one before forwarding.
+    /// </summary>
+    public enum EngineErrorKind
+    {
+        /// <summary>A generic engine error (<c>ERROR_TYPE_ERROR</c>).</summary>
+        Error = 0,
+        /// <summary>A generic engine warning (<c>ERROR_TYPE_WARNING</c>).</summary>
+        Warning = 1,
+        /// <summary>A GDScript parse/compile error (<c>ERROR_TYPE_SCRIPT</c>) — the one this feature targets.</summary>
+        Script = 2,
+        /// <summary>A shader error (<c>ERROR_TYPE_SHADER</c>).</summary>
+        Shader = 3,
+    }
+
+    /// <summary>
+    /// Pure-managed router for engine log/error callbacks captured via Godot 4.5's <c>OS.AddLogger</c> hook.
+    /// It does TWO independent jobs from a single engine callback, decoupled from the Godot type so both are
+    /// unit-testable:
+    ///
+    /// <list type="number">
+    /// <item><b>Passive log capture</b> (always on): every engine error/warning is appended to the supplied
+    /// <see cref="GodotLogCollector"/> so <c>console-get-logs</c> finally sees engine-wide GDScript parse
+    /// errors — not just the plugin's own <c>GD.Print</c> output.</item>
+    /// <item><b>On-demand validation</b> (only while a capture session is active): when
+    /// <see cref="BeginSession"/> has opened a session, <see cref="EngineErrorKind.Script"/> callbacks are
+    /// additionally collected as structured <see cref="ScriptDiagnostic"/> rows that the
+    /// <c>script-validate</c> tool harvests after a deliberate <c>Reload()</c>.</item>
+    /// </list>
+    ///
+    /// <para>
+    /// Godot's logger callback is multi-threaded, so every buffer mutation is guarded by a lock. The
+    /// session is a simple single-active-session model (validation runs serially on the editor main thread),
+    /// captured under the same lock.
+    /// </para>
+    /// </summary>
+    public sealed class ScriptErrorCapture
+    {
+        readonly object _gate = new();
+        List<ScriptDiagnostic>? _session;
+
+        /// <summary>
+        /// Process-wide capture installed by the 4.5 <c>Logger</c> hook at editor boot. Null when the live
+        /// Godot version predates 4.5 (no <c>OS.AddLogger</c>) or before boot wiring runs; callers must
+        /// null-check / fall back to the per-file <c>Reload()</c> probe in that case.
+        /// </summary>
+        public static ScriptErrorCapture? Current { get; set; }
+
+        /// <summary>
+        /// Optional sink for passive log capture — typically <see cref="GodotLogCollector.Append(LogEntry)"/>
+        /// bound at boot. Kept as a delegate so this router stays pure-managed (the editor boot injects the
+        /// real collector; unit tests inject a fake). May be null (capture-session-only mode).
+        /// </summary>
+        public Action<GodotLogType, string>? LogSink { get; set; }
+
+        /// <summary>True while a validation capture session is open (see <see cref="BeginSession"/>).</summary>
+        public bool SessionActive
+        {
+            get { lock (_gate) { return _session != null; } }
+        }
+
+        /// <summary>
+        /// Open a fresh validation capture session, discarding any prior session's buffer. While open,
+        /// <see cref="EngineErrorKind.Script"/> callbacks are collected as <see cref="ScriptDiagnostic"/>
+        /// rows. Pair with <see cref="EndSession"/> in a finally so a thrown reload never leaks a session.
+        /// </summary>
+        public void BeginSession()
+        {
+            lock (_gate)
+            {
+                _session = new List<ScriptDiagnostic>();
+            }
+        }
+
+        /// <summary>
+        /// Close the active session and return the diagnostics it captured (a fresh copy). Returns an empty
+        /// array when no session was open. Safe to call without a matching <see cref="BeginSession"/>.
+        /// </summary>
+        public ScriptDiagnostic[] EndSession()
+        {
+            lock (_gate)
+            {
+                var captured = _session?.ToArray() ?? Array.Empty<ScriptDiagnostic>();
+                _session = null;
+                return captured;
+            }
+        }
+
+        /// <summary>
+        /// Route one engine callback. Appends to <see cref="LogSink"/> (passive capture, always) and — when a
+        /// session is open and the callback is a <see cref="EngineErrorKind.Script"/> error — records a
+        /// structured diagnostic. <paramref name="line"/> may be -1 when unknown; <paramref name="filePath"/>
+        /// is the engine source path (kept as-is; it may be a <c>res://</c> or absolute path). Thread-safe.
+        /// </summary>
+        public void Route(EngineErrorKind kind, string? filePath, int line, string? message, string? rationale)
+        {
+            // Build the human line: prefer the engine "rationale" (the actual error text) and fall back to
+            // the C++ assertion "message" (the failed condition) when no rationale is present.
+            var text = !string.IsNullOrEmpty(rationale) ? rationale!
+                     : !string.IsNullOrEmpty(message) ? message!
+                     : "(no message)";
+
+            var logType = kind == EngineErrorKind.Warning ? GodotLogType.Warning : GodotLogType.Error;
+
+            // Passive capture: surface a path:line prefix so console-get-logs is self-describing.
+            LogSink?.Invoke(logType, FormatLogLine(kind, filePath, line, text));
+
+            // Validation capture: only script errors, only while a session is open.
+            if (kind != EngineErrorKind.Script)
+                return;
+
+            lock (_gate)
+            {
+                _session?.Add(new ScriptDiagnostic(
+                    path: filePath ?? string.Empty,
+                    line: line,
+                    message: text,
+                    severity: ScriptDiagnosticSeverity.Error));
+            }
+        }
+
+        /// <summary>
+        /// Format a captured engine error/warning into a single console line:
+        /// <c>"[Script] res://x.gd:12 — unexpected token"</c>. Pure string logic, unit-tested.
+        /// </summary>
+        public static string FormatLogLine(EngineErrorKind kind, string? filePath, int line, string text)
+        {
+            var loc = string.IsNullOrEmpty(filePath)
+                ? string.Empty
+                : (line >= 0 ? $" {filePath}:{line}" : $" {filePath}");
+            return $"[{kind}]{loc} — {text}";
+        }
+    }
+}

--- a/addons/godot_mcp/Tools/ScriptErrorCapture.cs
+++ b/addons/godot_mcp/Tools/ScriptErrorCapture.cs
@@ -67,7 +67,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         public static ScriptErrorCapture? Current { get; set; }
 
         /// <summary>
-        /// Optional sink for passive log capture — typically <see cref="GodotLogCollector.Append(LogEntry)"/>
+        /// Optional sink for passive log capture — typically <see cref="GodotLogCollector.Append(GodotLogType, string, string)"/>
         /// bound at boot. Kept as a delegate so this router stays pure-managed (the editor boot injects the
         /// real collector; unit tests inject a fake). May be null (capture-session-only mode).
         /// </summary>
@@ -168,12 +168,39 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         }
 
         /// <summary>
-        /// Compare an engine-reported source path against the session target. Case-insensitive ordinal
-        /// equality — Godot reports <c>res://</c> paths consistently, but file systems (and the engine on
-        /// some platforms) can vary letter case, so an exact-case match would drop legitimate rows.
+        /// Compare an engine-reported source path against the session target. The session target is always a
+        /// <c>res://</c> path (from <c>RequireScriptResPath</c> / the res:// scan), but Godot's logger callback
+        /// documents the reported file as possibly a <c>res://</c> OR an absolute/<c>user://</c> path. A plain
+        /// equality check would therefore SILENTLY DROP the genuine diagnostic when the engine reports an
+        /// absolute path for the file under test. Both sides are normalized before comparing:
+        /// <list type="bullet">
+        /// <item>strip the <c>res://</c> / <c>user://</c> scheme,</item>
+        /// <item>normalize back-slashes to forward-slashes (Windows absolute paths),</item>
+        /// <item>case-insensitive ordinal comparison (file systems and the engine vary letter case).</item>
+        /// </list>
+        /// An absolute engine path matches when its tail equals the scheme-stripped res:// target (e.g.
+        /// <c>C:/proj/scripts/p.gd</c> ⊃ <c>scripts/p.gd</c> from <c>res://scripts/p.gd</c>). Kept pure-managed
+        /// (no <c>ProjectSettings.LocalizePath</c>) so the router stays unit-testable in the plain xUnit host.
         /// </summary>
         static bool PathsMatch(string enginePath, string target)
-            => string.Equals(enginePath, target, StringComparison.OrdinalIgnoreCase);
+        {
+            var a = NormalizePath(enginePath);
+            var b = NormalizePath(target);
+            return string.Equals(a, b, StringComparison.OrdinalIgnoreCase)
+                || a.EndsWith("/" + b, StringComparison.OrdinalIgnoreCase)
+                || b.EndsWith("/" + a, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>Strip the Godot resource scheme and normalize separators for path comparison.</summary>
+        static string NormalizePath(string path)
+        {
+            var p = path.Replace('\\', '/');
+            if (p.StartsWith("res://", StringComparison.OrdinalIgnoreCase))
+                return p.Substring("res://".Length);
+            if (p.StartsWith("user://", StringComparison.OrdinalIgnoreCase))
+                return p.Substring("user://".Length);
+            return p;
+        }
 
         /// <summary>
         /// Format a captured engine error/warning into a single console line:

--- a/addons/godot_mcp/Tools/ScriptErrorCapture.cs
+++ b/addons/godot_mcp/Tools/ScriptErrorCapture.cs
@@ -57,6 +57,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
     {
         readonly object _gate = new();
         List<ScriptDiagnostic>? _session;
+        string? _sessionTarget;
 
         /// <summary>
         /// Process-wide capture installed by the 4.5 <c>Logger</c> hook at editor boot. Null when the live
@@ -83,11 +84,21 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         /// <see cref="EngineErrorKind.Script"/> callbacks are collected as <see cref="ScriptDiagnostic"/>
         /// rows. Pair with <see cref="EndSession"/> in a finally so a thrown reload never leaks a session.
         /// </summary>
-        public void BeginSession()
+        /// <param name="targetPath">
+        /// The <c>res://</c> path being validated. When non-empty, ONLY engine errors whose reported file
+        /// matches this path are collected — this prevents cross-talk, since Godot's logger callback is
+        /// multi-threaded and an unrelated off-thread script error (a background reimport, the next file in
+        /// a full scan, or a dependency error touching ANOTHER file) can fire during this session's window
+        /// and would otherwise be silently mis-attributed to <paramref name="targetPath"/>. Pass null/empty
+        /// to collect every script error regardless of path (legacy behavior; used only when no specific
+        /// file is under test).
+        /// </param>
+        public void BeginSession(string? targetPath = null)
         {
             lock (_gate)
             {
                 _session = new List<ScriptDiagnostic>();
+                _sessionTarget = string.IsNullOrEmpty(targetPath) ? null : targetPath;
             }
         }
 
@@ -101,15 +112,17 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             {
                 var captured = _session?.ToArray() ?? Array.Empty<ScriptDiagnostic>();
                 _session = null;
+                _sessionTarget = null;
                 return captured;
             }
         }
 
         /// <summary>
         /// Route one engine callback. Appends to <see cref="LogSink"/> (passive capture, always) and — when a
-        /// session is open and the callback is a <see cref="EngineErrorKind.Script"/> error — records a
-        /// structured diagnostic. <paramref name="line"/> may be -1 when unknown; <paramref name="filePath"/>
-        /// is the engine source path (kept as-is; it may be a <c>res://</c> or absolute path). Thread-safe.
+        /// session is open and the callback is a <see cref="EngineErrorKind.Script"/> error whose file matches
+        /// the session target (see <see cref="BeginSession"/>) — records a structured diagnostic.
+        /// <paramref name="line"/> may be -1 when unknown; <paramref name="filePath"/> is the engine source
+        /// path (kept as-is; it may be a <c>res://</c> or absolute path). Thread-safe.
         /// </summary>
         public void Route(EngineErrorKind kind, string? filePath, int line, string? message, string? rationale)
         {
@@ -130,13 +143,37 @@ namespace com.IvanMurzak.Godot.MCP.Tools
 
             lock (_gate)
             {
-                _session?.Add(new ScriptDiagnostic(
+                if (_session == null)
+                    return;
+
+                // Path-match filter: when the session targets a specific file, drop script errors the engine
+                // reported against a DIFFERENT file. Godot's logger callback is multi-threaded, so an error
+                // from an unrelated off-thread reload (a background reimport, the next scanned file, or a
+                // dependency error in ANOTHER script) can fire mid-session and would otherwise be silently
+                // mis-attributed to the file under validation. An empty engine path is kept (the caller stamps
+                // the target path on it) since the engine occasionally omits the source for a script error.
+                if (_sessionTarget != null
+                    && !string.IsNullOrEmpty(filePath)
+                    && !PathsMatch(filePath, _sessionTarget))
+                {
+                    return;
+                }
+
+                _session.Add(new ScriptDiagnostic(
                     path: filePath ?? string.Empty,
                     line: line,
                     message: text,
                     severity: ScriptDiagnosticSeverity.Error));
             }
         }
+
+        /// <summary>
+        /// Compare an engine-reported source path against the session target. Case-insensitive ordinal
+        /// equality — Godot reports <c>res://</c> paths consistently, but file systems (and the engine on
+        /// some platforms) can vary letter case, so an exact-case match would drop legitimate rows.
+        /// </summary>
+        static bool PathsMatch(string enginePath, string target)
+            => string.Equals(enginePath, target, StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
         /// Format a captured engine error/warning into a single console line:

--- a/addons/godot_mcp/Tools/Tool_Script.Validate.cs
+++ b/addons/godot_mcp/Tools/Tool_Script.Validate.cs
@@ -66,9 +66,9 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                     ScannedCount = targets.Count,
                     Truncated = truncated,
                     // Precise ONLY when a live capture session actually exists (the 4.5 Logger hook was
-                    // installed). Keying off the compile-time GodotScriptErrorLoggerBridge.Available const
-                    // would over-claim Precise on a 4.5 build where TryInstall returned null / Current is
-                    // null and the coarse per-file Reload()-code path is the one actually taken.
+                    // installed). Keying off a compile-time "is 4.5 compiled in?" flag would over-claim Precise
+                    // on a 4.5 build where TryInstall returned null / Current is null and the coarse per-file
+                    // Reload()-code path is the one actually taken.
                     Fidelity = ScriptErrorCapture.Current != null
                         ? ScriptDiagnosticsFidelity.Precise
                         : ScriptDiagnosticsFidelity.Coarse,
@@ -204,7 +204,9 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 }
             }
 
-            // 4.5+ precise path: if the engine Logger captured script errors, those ARE the diagnostics.
+            // 4.5+ precise path: the session captured the engine's script errors for THIS file (the session's
+            // path-match filter restricts rows to resPath, plus any pathless rows the engine emitted, which are
+            // stamped with resPath below). When present, those structured rows ARE the diagnostics.
             if (capture != null && diagnostics.Count > 0)
             {
                 // Stamp the path on any rows the engine reported without a file (defensive).

--- a/addons/godot_mcp/Tools/Tool_Script.Validate.cs
+++ b/addons/godot_mcp/Tools/Tool_Script.Validate.cs
@@ -1,0 +1,235 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_Script
+    {
+        public const string ScriptValidateToolId = "script-validate";
+
+        // Cap a full-project scan so a huge project can't validate thousands of files in one call. A targeted
+        // single-path validation ignores this. The agent can target a path when the project is large.
+        const int FullScanFileCap = 500;
+
+        [AiTool
+        (
+            ScriptValidateToolId,
+            Title = "Script / Validate",
+            ReadOnlyHint = true,
+            IdempotentHint = true,
+            OpenWorldHint = false
+        )]
+        [Description("Validate GDScript ('.gd') files and return STRUCTURED parse/compile diagnostics — the " +
+            "on-demand 'is the project error-free?' query. Closes the gap where the agent gets NO feedback on " +
+            "GDScript parse errors and assumes the game runs fine.\n" +
+            "Inputs:\n" +
+            "  - 'scriptPath' (optional): a single res:// '.gd' path to validate. Omit to scan every '.gd' " +
+            "under res:// (capped at " + nameof(FullScanFileCap) + ").\n" +
+            "Result (ScriptDiagnosticsResult): 'ok' (true when no errors), 'diagnostics' [{ path, line, " +
+            "message, severity }], counts, and a 'fidelity' note:\n" +
+            "  - Godot 4.5+: 'Precise' — exact line + message captured via the engine Logger hook.\n" +
+            "  - Godot < 4.5: 'Coarse' — per-file pass/fail with the engine error code (no line/message text).\n" +
+            "C# ('.cs') files are NOT validated here (Godot has no in-editor C# compiler to reach cheaply); " +
+            "their compile errors surface through the project build. Pair with 'console-get-logs', which on " +
+            "Godot 4.5+ now also captures engine GDScript parse errors passively.")]
+        public ScriptDiagnosticsResult Validate
+        (
+            [Description("Optional single res:// '.gd' script path to validate, e.g. 'res://scripts/player.gd'. " +
+                "Omit (null/empty) to scan every '.gd' file under res://.")]
+            string? scriptPath = null
+        )
+        {
+            return MainThread.Instance.Run(() =>
+            {
+                var targets = ResolveTargets(scriptPath);
+
+                var result = new ScriptDiagnosticsResult
+                {
+                    ScannedPaths = targets,
+                    ScannedCount = targets.Count,
+                    Fidelity = GodotScriptErrorLoggerBridge.Available
+                        ? ScriptDiagnosticsFidelity.Precise
+                        : ScriptDiagnosticsFidelity.Coarse,
+                };
+
+                var diagnostics = new List<ScriptDiagnostic>();
+                foreach (var path in targets)
+                    diagnostics.AddRange(ValidateOne(path));
+
+                // Errors first, then warnings, each in scan order.
+                diagnostics.Sort((a, b) => a.Severity.CompareTo(b.Severity));
+                result.Diagnostics = diagnostics;
+                result.ErrorCount = diagnostics.FindAll(d => d.Severity == ScriptDiagnosticSeverity.Error).Count;
+                result.WarningCount = diagnostics.FindAll(d => d.Severity == ScriptDiagnosticSeverity.Warning).Count;
+                result.Ok = result.ErrorCount == 0;
+                result.Note = BuildNote(result);
+                return result;
+            });
+        }
+
+        /// <summary>
+        /// Resolve the set of '.gd' paths to validate: a single explicit path (validated for res:// + '.gd'),
+        /// or a full res:// scan capped at <see cref="FullScanFileCap"/>. Main-thread only (scan touches the
+        /// editor filesystem). C# paths are rejected for the single-path case with an actionable message.
+        /// </summary>
+        static List<string> ResolveTargets(string? scriptPath)
+        {
+            var raw = (scriptPath ?? string.Empty).Trim();
+            if (raw.Length > 0)
+            {
+                var resPath = ScriptLang_.RequireScriptResPath(raw, nameof(scriptPath), out var lang);
+                if (lang != ScriptLang.GDScript)
+                    throw new ArgumentException(
+                        $"'{ScriptValidateToolId}' validates GDScript ('.gd') only; '{resPath}' is C#. " +
+                        $"C# compile errors surface through the project build, not this tool.", nameof(scriptPath));
+                if (!FileAccess.FileExists(resPath))
+                    throw new System.IO.FileNotFoundException($"No script file exists at '{resPath}'.", resPath);
+                return new List<string> { resPath };
+            }
+
+            var found = new List<string>();
+            // Walk res:// with DirAccess rather than the editor filesystem INDEX: the index is empty/partial
+            // mid-scan (e.g. right after editor boot, IsScanning()==true) so an index walk silently returns 0
+            // scripts, whereas DirAccess reads the real directory tree on disk regardless of scan state — the
+            // same robust path the single-file FileAccess.FileExists check above relies on. Main-thread only.
+            CollectGdScripts(ResPathNormalizer.ResScheme, found);
+            if (found.Count > FullScanFileCap)
+                found = found.GetRange(0, FullScanFileCap);
+            return found;
+        }
+
+        /// <summary>
+        /// Depth-first walk of the on-disk <c>res://</c> tree (via <see cref="DirAccess"/>) collecting every
+        /// '.gd' file path. Skips hidden dot-directories (e.g. <c>.godot/</c>) so generated caches aren't
+        /// validated. Main-thread only (touches Godot <see cref="DirAccess"/>).
+        /// </summary>
+        static void CollectGdScripts(string dirResPath, List<string> into)
+        {
+            using var dir = DirAccess.Open(dirResPath);
+            if (dir == null)
+                return;
+
+            dir.IncludeNavigational = false; // skip "." and ".."
+            dir.IncludeHidden = false;       // skip .godot/, .import, etc.
+
+            // Files first.
+            foreach (var fileName in dir.GetFiles())
+            {
+                if (ScriptLang_.TryGetLang(fileName, out var lang) && lang == ScriptLang.GDScript)
+                    into.Add(dirResPath + fileName);
+            }
+
+            // Then recurse into sub-directories. Defensively skip any dot-directory the flags missed.
+            foreach (var subName in dir.GetDirectories())
+            {
+                if (subName.StartsWith('.'))
+                    continue;
+                CollectGdScripts(dirResPath + subName + "/", into);
+            }
+        }
+
+        /// <summary>
+        /// Validate a single '.gd' file and return its diagnostics. On Godot 4.5+ a capture session harvests
+        /// the engine's precise <c>ERROR_TYPE_SCRIPT</c> callbacks emitted during a deliberate
+        /// <see cref="GDScript.Reload"/>; on older versions only the <c>Reload()</c> <see cref="Error"/> code
+        /// is available, yielding a single coarse diagnostic with line -1. Main-thread only (touches GDScript).
+        /// </summary>
+        static List<ScriptDiagnostic> ValidateOne(string resPath)
+        {
+            var diagnostics = new List<ScriptDiagnostic>();
+
+            // Load the on-disk source through a throwaway GDScript instance (same probe technique as the
+            // pre-write ValidateSyntax helper, but reading the file rather than a candidate string).
+            string content;
+            using (var file = FileAccess.Open(resPath, FileAccess.ModeFlags.Read))
+            {
+                if (file == null)
+                {
+                    diagnostics.Add(new ScriptDiagnostic(resPath, -1,
+                        $"Failed to open for validation: {FileAccess.GetOpenError()}."));
+                    return diagnostics;
+                }
+                content = file.GetAsText();
+            }
+
+            var probe = new GDScript { SourceCode = content, ResourcePath = resPath };
+
+            var capture = GodotScriptErrorLoggerBridge.Available ? ScriptErrorCapture.Current : null;
+            capture?.BeginSession();
+            Error err;
+            try
+            {
+                err = probe.Reload(keepState: false);
+            }
+            finally
+            {
+                if (capture != null)
+                {
+                    var captured = capture.EndSession();
+                    diagnostics.AddRange(captured);
+                }
+            }
+
+            // 4.5+ precise path: if the engine Logger captured script errors, those ARE the diagnostics.
+            if (capture != null && diagnostics.Count > 0)
+            {
+                // Stamp the path on any rows the engine reported without a file (defensive).
+                foreach (var d in diagnostics)
+                    if (string.IsNullOrEmpty(d.Path))
+                        d.Path = resPath;
+                return diagnostics;
+            }
+
+            // Coarse path (Godot < 4.5, OR 4.5 reported no structured row but Reload still failed): emit a
+            // single per-file diagnostic from the Error code. ParseError is a genuine syntax error; other
+            // non-Ok results MAY be a resolution failure the standalone probe can't see (extends/class_name/
+            // preload of project state) — mirror ValidateSyntax and treat only ParseError as a hard error.
+            if (err == Error.ParseError)
+            {
+                diagnostics.Add(new ScriptDiagnostic(resPath, -1,
+                    GodotScriptErrorLoggerBridge.Available
+                        ? $"{err} (engine reported no structured location)."
+                        : $"{err} (Godot < 4.5: no line/message detail available; open the script in the editor)."));
+            }
+
+            return diagnostics;
+        }
+
+        /// <summary>Compose the human-readable summary note, including a fidelity caveat where relevant.</summary>
+        static string BuildNote(ScriptDiagnosticsResult result)
+        {
+            if (result.Ok)
+            {
+                var clean = $"No GDScript errors found ({result.ScannedCount} scanned).";
+                return result.Fidelity == ScriptDiagnosticsFidelity.Coarse
+                    ? clean + " NOTE: Godot < 4.5 — only a per-file pass/fail was checked (no semantic detail)."
+                    : clean;
+            }
+
+            var noun = result.ErrorCount == 1 ? "error" : "errors";
+            var summary = $"{result.ErrorCount} {noun} across {result.ScannedCount} scanned script(s).";
+            if (result.WarningCount > 0)
+                summary += $" {result.WarningCount} warning(s).";
+            return result.Fidelity == ScriptDiagnosticsFidelity.Coarse
+                ? summary + " NOTE: Godot < 4.5 — line/message detail is unavailable; open the failing script in the editor."
+                : summary;
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Tools/Tool_Script.Validate.cs
+++ b/addons/godot_mcp/Tools/Tool_Script.Validate.cs
@@ -42,7 +42,8 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             "  - 'scriptPath' (optional): a single res:// '.gd' path to validate. Omit to scan every '.gd' " +
             "under res:// (capped at " + nameof(FullScanFileCap) + ").\n" +
             "Result (ScriptDiagnosticsResult): 'ok' (true when no errors), 'diagnostics' [{ path, line, " +
-            "message, severity }], counts, and a 'fidelity' note:\n" +
+            "message, severity }], counts, a 'truncated' flag (true when a full scan hit the file cap, so " +
+            "'ok' is NOT a whole-project all-clear), and a 'fidelity' note:\n" +
             "  - Godot 4.5+: 'Precise' — exact line + message captured via the engine Logger hook.\n" +
             "  - Godot < 4.5: 'Coarse' — per-file pass/fail with the engine error code (no line/message text).\n" +
             "C# ('.cs') files are NOT validated here (Godot has no in-editor C# compiler to reach cheaply); " +
@@ -57,13 +58,18 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         {
             return MainThread.Instance.Run(() =>
             {
-                var targets = ResolveTargets(scriptPath);
+                var targets = ResolveTargets(scriptPath, out var truncated);
 
                 var result = new ScriptDiagnosticsResult
                 {
                     ScannedPaths = targets,
                     ScannedCount = targets.Count,
-                    Fidelity = GodotScriptErrorLoggerBridge.Available
+                    Truncated = truncated,
+                    // Precise ONLY when a live capture session actually exists (the 4.5 Logger hook was
+                    // installed). Keying off the compile-time GodotScriptErrorLoggerBridge.Available const
+                    // would over-claim Precise on a 4.5 build where TryInstall returned null / Current is
+                    // null and the coarse per-file Reload()-code path is the one actually taken.
+                    Fidelity = ScriptErrorCapture.Current != null
                         ? ScriptDiagnosticsFidelity.Precise
                         : ScriptDiagnosticsFidelity.Coarse,
                 };
@@ -88,8 +94,9 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         /// or a full res:// scan capped at <see cref="FullScanFileCap"/>. Main-thread only (scan touches the
         /// editor filesystem). C# paths are rejected for the single-path case with an actionable message.
         /// </summary>
-        static List<string> ResolveTargets(string? scriptPath)
+        static List<string> ResolveTargets(string? scriptPath, out bool truncated)
         {
+            truncated = false;
             var raw = (scriptPath ?? string.Empty).Trim();
             if (raw.Length > 0)
             {
@@ -110,7 +117,10 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             // same robust path the single-file FileAccess.FileExists check above relies on. Main-thread only.
             CollectGdScripts(ResPathNormalizer.ResScheme, found);
             if (found.Count > FullScanFileCap)
+            {
+                truncated = true; // surface the cap so an ok:true result isn't read as a whole-project all-clear.
                 found = found.GetRange(0, FullScanFileCap);
+            }
             return found;
         }
 
@@ -168,21 +178,29 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 content = file.GetAsText();
             }
 
-            var probe = new GDScript { SourceCode = content, ResourcePath = resPath };
-
-            var capture = GodotScriptErrorLoggerBridge.Available ? ScriptErrorCapture.Current : null;
-            capture?.BeginSession();
+            // Probe with a throwaway GDScript. Do NOT set ResourcePath to the REAL res:// path: Reload()
+            // would then register/replace this throwaway in Godot's global class registry and resource cache,
+            // perturbing the live cached script. Leaving ResourcePath unset keeps the probe out of the cache;
+            // the engine still reports the source path via the Logger hook (and we stamp resPath on any rows
+            // that lack one below). Dispose it after use, mirroring the using blocks for FileAccess/DirAccess.
+            // Current is non-null only on a 4.5+ build where the engine Logger hook installed (the #else stub
+            // never sets it), so it alone decides precise-vs-coarse — no separate compile-time const needed.
+            var capture = ScriptErrorCapture.Current;
+            capture?.BeginSession(resPath);
             Error err;
-            try
+            using (var probe = new GDScript { SourceCode = content })
             {
-                err = probe.Reload(keepState: false);
-            }
-            finally
-            {
-                if (capture != null)
+                try
                 {
-                    var captured = capture.EndSession();
-                    diagnostics.AddRange(captured);
+                    err = probe.Reload(keepState: false);
+                }
+                finally
+                {
+                    if (capture != null)
+                    {
+                        var captured = capture.EndSession();
+                        diagnostics.AddRange(captured);
+                    }
                 }
             }
 
@@ -203,7 +221,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             if (err == Error.ParseError)
             {
                 diagnostics.Add(new ScriptDiagnostic(resPath, -1,
-                    GodotScriptErrorLoggerBridge.Available
+                    capture != null
                         ? $"{err} (engine reported no structured location)."
                         : $"{err} (Godot < 4.5: no line/message detail available; open the script in the editor)."));
             }
@@ -211,24 +229,34 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             return diagnostics;
         }
 
-        /// <summary>Compose the human-readable summary note, including a fidelity caveat where relevant.</summary>
+        /// <summary>
+        /// Compose the human-readable summary note, including a fidelity caveat (Godot &lt; 4.5) and a
+        /// truncation hint (full-scan cap hit) where relevant.
+        /// </summary>
         static string BuildNote(ScriptDiagnosticsResult result)
         {
+            string note;
             if (result.Ok)
             {
-                var clean = $"No GDScript errors found ({result.ScannedCount} scanned).";
-                return result.Fidelity == ScriptDiagnosticsFidelity.Coarse
-                    ? clean + " NOTE: Godot < 4.5 — only a per-file pass/fail was checked (no semantic detail)."
-                    : clean;
+                note = $"No GDScript errors found ({result.ScannedCount} scanned).";
+                if (result.Fidelity == ScriptDiagnosticsFidelity.Coarse)
+                    note += " NOTE: Godot < 4.5 — only a per-file pass/fail was checked (no semantic detail).";
+            }
+            else
+            {
+                var noun = result.ErrorCount == 1 ? "error" : "errors";
+                note = $"{result.ErrorCount} {noun} across {result.ScannedCount} scanned script(s).";
+                if (result.WarningCount > 0)
+                    note += $" {result.WarningCount} warning(s).";
+                if (result.Fidelity == ScriptDiagnosticsFidelity.Coarse)
+                    note += " NOTE: Godot < 4.5 — line/message detail is unavailable; open the failing script in the editor.";
             }
 
-            var noun = result.ErrorCount == 1 ? "error" : "errors";
-            var summary = $"{result.ErrorCount} {noun} across {result.ScannedCount} scanned script(s).";
-            if (result.WarningCount > 0)
-                summary += $" {result.WarningCount} warning(s).";
-            return result.Fidelity == ScriptDiagnosticsFidelity.Coarse
-                ? summary + " NOTE: Godot < 4.5 — line/message detail is unavailable; open the failing script in the editor."
-                : summary;
+            if (result.Truncated)
+                note += $" NOTE: full-scan cap of {FullScanFileCap} files hit — only the first {result.ScannedCount} " +
+                        "'.gd' files were validated, so this is NOT a whole-project all-clear; validate a specific path/sub-tree to cover the rest.";
+
+            return note;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds an on-demand **`script-validate`** tool returning structured GDScript diagnostics `{ path, line, message, severity }` for a single `.gd` path or a full `res://` scan — closes the gap where the agent gets no feedback on parse errors and assumes the game runs fine (reported on Discord, plugin 0.6.0).
- Adds **passive engine-error capture**: a Godot 4.5 `OS.AddLogger` `Logger` forwards `ERROR_TYPE_SCRIPT` errors into the log ring buffer, so `console-get-logs` now sees engine GDScript parse errors (previously only the plugin's own `GD.Print` output).
- The 4.5 path is feature-guarded with `#if GODOT4_5_OR_GREATER` (the addon's SDK floor 4.3.0 lacks `Godot.Logger`/`OS.AddLogger`, and CI builds against 4.3.0); a `#else` stub falls back to a coarse per-file `Reload()` error-code probe on Godot < 4.5.

## Test plan
- [x] Suite 1 — `dotnet build` (CI parity, 4.3.0 SDK): 0 errors, the 4.5 Logger file correctly excluded.
- [x] Suite 2 — `dotnet test`: 716 passed / 1 failed (the documented benign Windows-only `alc-probe` cleanup exception, green on Linux CI); 15 new xUnit cases for the pure-managed models + router.
- [x] Suite 3 — headless Godot **4.5.1** smoke: `script-validate` returned line 4 + exact message (`Parse Error: Unexpected "Indent" in class body.`) for a deliberately broken `.gd`; the same error appeared in `console-get-logs`; full `res://` scan correctly found and reported the broken file.

Closes #108