### PR TITLE
ci(release): auto-submit Godot Asset Library version edit on release

### DIFF
--- a/.github/assetlib/edit.hbs
+++ b/.github/assetlib/edit.hbs
@@ -1,0 +1,13 @@
+{
+  "title": "Godot-MCP",
+  "description": "Model Context Protocol (MCP) integration for the Godot Editor. AI tools in C#, cloud-connected to ai-game.dev.\n\nGodot-MCP connects AI agents (Claude, Cursor, GitHub Copilot, Gemini, or any MCP-aware client) to the Godot Editor so they can inspect and drive your project — create nodes, edit scenes, manage resources and scripts, capture screenshots, and more.\n\nIt is the Godot counterpart of Unity-MCP: a C# editor addon that exposes Godot Editor operations as AI Tools and connects them to an MCP server through the hosted cloud backend at ai-game.dev, or your own self-hosted server. The MCP / reflection stack is shared with Unity-MCP and consumed from nuget.org as NuGet package references (not forked).\n\n36 built-in tools across 10 families: ping, node, scene, resource, filesystem, script, screenshot, editor, console, and reflection. Tool names mirror Unity-MCP where sensible (scene-*, node-*, ...).\n\nRequirements:\n- Godot 4.3+ — the C#/.NET (mono) edition. The standard GDScript-only build cannot compile the addon.\n- .NET 8 SDK.\n\nImportant install note: Godot compiles every .cs file under your project into one assembly, so your project's .csproj must declare the two NuGet package references the addon depends on:\n  com.IvanMurzak.ReflectorNet  version 5.3.1\n  com.IvanMurzak.McpPlugin     version 6.7.0\nWithout them the addon's C# will not compile. Run dotnet restore after adding them. No manual DLL copying is required — at editor runtime the addon's assembly resolver locates the DLLs in your NuGet global-packages folder.\n\nFull documentation, the complete tool list, and connection setup:\nhttps://github.com/IvanMurzak/Godot-MCP\n\nLicense: Apache-2.0.",
+  "category_id": "5",
+  "godot_version": "4.3",
+  "version_string": "{{ env.ASSETLIB_VERSION }}",
+  "cost": "Apache-2.0",
+  "download_provider": "GitHub",
+  "download_commit": "{{ env.ASSETLIB_DOWNLOAD_COMMIT }}",
+  "browse_url": "https://github.com/IvanMurzak/Godot-MCP",
+  "issues_url": "https://github.com/IvanMurzak/Godot-MCP/issues",
+  "icon_url": "https://raw.githubusercontent.com/IvanMurzak/Godot-MCP/main/addons/godot_mcp/icon.png"
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,6 +295,51 @@ jobs:
         id: mark
         run: echo "published=true" >> "$GITHUB_OUTPUT"
 
+  # Auto-submit the Godot Asset Library VERSION EDIT for the just-released
+  # version. Runs AFTER the GitHub Release (needs release-addon) and only on a
+  # real version bump (should_release == 'true'). This job is intentionally
+  # ISOLATED: nothing downstream needs it, so an AssetLib failure shows up as a
+  # red job for visibility but never blocks or fails the npm `deploy` job (which
+  # only needs release-addon.published). The one-time INITIAL submission +
+  # moderator approval remain manual (see docs/RELEASING.md); this automates the
+  # per-release EDIT only.
+  #
+  # Credentials/ids come ONLY from GitHub-managed config (never hardcoded):
+  #   secrets.GODOT_ASSETLIB_USERNAME / secrets.GODOT_ASSETLIB_PASSWORD
+  #   vars.GODOT_ASSETLIB_ASSET_ID
+  # If they are not configured, the action fails auth (job red) but the release
+  # and npm publish are unaffected.
+  assetlib-edit:
+    runs-on: ubuntu-latest
+    needs: [check-version-tag, release-addon]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    steps:
+      - name: Checkout repository
+        # The action reads the handlebars template (.github/assetlib/edit.hbs)
+        # from the workspace, so the repo must be checked out.
+        uses: actions/checkout@v4
+
+      - name: Submit Asset Library version edit
+        # deep-entertainment/godot-asset-lib-action @ v0.6.0
+        # Pinned to the commit SHA for supply-chain safety (the action runs
+        # arbitrary JS with the AssetLib credentials). Bump the SHA + the
+        # version comment together when upgrading.
+        uses: deep-entertainment/godot-asset-lib-action@056fa4060f062a8b209a5a6744a2726ad48d6bb0 # v0.6.0
+        env:
+          # Canonical version (from plugin.cfg via check-version-tag) and the
+          # released commit (github.sha is the commit the v<version> tag points
+          # at — release-addon cut the tag on this same commit). The handlebars
+          # template reads these as {{ env.ASSETLIB_VERSION }} and
+          # {{ env.ASSETLIB_DOWNLOAD_COMMIT }}.
+          ASSETLIB_VERSION: ${{ needs.check-version-tag.outputs.version }}
+          ASSETLIB_DOWNLOAD_COMMIT: ${{ github.sha }}
+        with:
+          action: addEdit
+          username: ${{ secrets.GODOT_ASSETLIB_USERNAME }}
+          password: ${{ secrets.GODOT_ASSETLIB_PASSWORD }}
+          assetId: ${{ vars.GODOT_ASSETLIB_ASSET_ID }}
+          assetTemplate: .github/assetlib/edit.hbs
+
   # Publish godot-mcp-cli to npm (OIDC Trusted Publishing). Gated on the GitHub
   # Release having been created. The cli version is set to the release version
   # at publish time inside deploy.yml.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -99,17 +99,53 @@ version-gate applies: if the tag already exists, the dispatch run is a no-op.
 
 ---
 
-## Godot Asset Library submission (manual, Ivan-gated)
+## Godot Asset Library submission
 
-The Godot Asset Library is the discoverable in-editor channel (*AssetLib* tab). Submission is a
-**manual web-form step** performed by the maintainer at
-<https://godotengine.org/asset-library/> after a GitHub Release exists. It is **not** automated and
-**not** performed by this pipeline.
+The Godot Asset Library is the discoverable in-editor channel (*AssetLib* tab). It has two distinct
+operations:
+
+- The **one-time INITIAL submission** of a brand-new asset entry, and the **moderator approval** that
+  follows it — these remain **manual web-form steps** performed by the maintainer at
+  <https://godotengine.org/asset-library/>. They are NOT automated (see
+  [First submission](#first-submission-one-time) and [GATES](#gates--what-requires-the-maintainer-ivan)).
+- The **per-release VERSION EDIT** (bumping **Version** + **Download Commit** on the *existing* entry on
+  every later release) is now **automated** by the `assetlib-edit` job in
+  [`release.yml`](../.github/workflows/release.yml). On each real version bump that cuts a release, after
+  the GitHub Release is created, the job submits the edit via the pinned
+  [`deep-entertainment/godot-asset-lib-action`](https://github.com/deep-entertainment/godot-asset-lib-action)
+  (`addEdit` mode). The Godot moderator still reviews each submitted edit before it goes live.
+
+The version edit no longer requires opening the web form by hand for routine releases — but the
+**INITIAL** submission (which creates the asset id the automation targets) is still a manual first step.
 
 A **ready-to-paste submission package** — every form field's exact value, plus the icon and preview
-URLs — is maintained at [`docs/assetlib/SUBMISSION.md`](assetlib/SUBMISSION.md). Open it next to the
-web form and copy each field across. The notes below are the procedure; the values live in that file so
-they are versioned and easy to update on each release.
+URLs — is maintained at [`docs/assetlib/SUBMISSION.md`](assetlib/SUBMISSION.md). Use it for the manual
+INITIAL submission; the automated per-release edit renders the same field values from
+[`.github/assetlib/edit.hbs`](../.github/assetlib/edit.hbs) (keep the two in sync).
+
+### Automated version edit — required GitHub config
+
+The `assetlib-edit` job reads its credentials and the asset id ONLY from GitHub-managed config (nothing
+is hardcoded). Set these in the repository **Settings → Secrets and variables → Actions**:
+
+| Name | Kind | Purpose |
+| --- | --- | --- |
+| `GODOT_ASSETLIB_USERNAME` | **Secret** | The maintainer's godotengine.org Asset Library username. |
+| `GODOT_ASSETLIB_PASSWORD` | **Secret** | That account's Asset Library password (the action logs in and obtains a session token). |
+| `GODOT_ASSETLIB_ASSET_ID` | **Variable** | The numeric asset id of the existing Godot-MCP entry (assigned by the Asset Library after the INITIAL submission is approved). |
+
+Until all three are configured, the `assetlib-edit` job fails authentication and shows up as a **red
+job** — but it is isolated: the GitHub Release and the npm `deploy` publish are unaffected (they do not
+depend on it). The asset id only exists after the INITIAL submission, so this automation becomes
+effective from the **second** release onward.
+
+The rendered field values (title, description, category, godot_version, license, repo/issues URLs, icon
+URL) live in [`.github/assetlib/edit.hbs`](../.github/assetlib/edit.hbs); `version_string` and
+`download_commit` are injected at run time from the canonical version (`plugin.cfg` via
+`check-version-tag`) and the released commit (`github.sha`).
+
+The notes below are the manual-procedure reference; the field values live in `SUBMISSION.md` /
+`edit.hbs` so they are versioned and easy to update.
 
 ### Form-field requirements (verified against the Asset Library docs)
 
@@ -177,18 +213,26 @@ afterwards.
    the `v<version>` tag points at (`git rev-list -n1 v<version>`).
 4. Submit. A Godot Asset Library moderator reviews and approves the entry (this can take days).
 
-### Subsequent-version updates (every later release)
+### Subsequent-version updates (every later release — AUTOMATED)
 
-The Asset Library entry is **edited in place** — you do NOT create a new entry per version:
+The Asset Library entry is **edited in place** — you do NOT create a new entry per version. Once the
+INITIAL submission exists and the three GitHub config entries above are set, this is **automated**:
 
 1. Cut the new GitHub Release (bump `plugin.cfg`, merge → `release.yml` tags `v<newversion>`).
-2. Sign in, open the existing **Godot-MCP** asset, click **Edit**.
-3. Bump the **Version** field to the new semver and set **Download Commit** to the new tag's commit
-   hash (`git rev-list -n1 v<newversion>`). Update the description / previews only if they changed.
-4. Submit the edit — it goes through moderator review again before going live.
+2. The `assetlib-edit` job runs after the Release and submits the edit automatically — it bumps the
+   **Version** to the new `plugin.cfg` semver (`version_string`) and sets **Download Commit** to the
+   released commit (`github.sha`). The other field values come from `.github/assetlib/edit.hbs`.
+3. The Godot Asset Library moderator reviews the submitted edit before it goes live (same as a manual
+   edit — automation only fills + submits the form, it does not bypass moderation).
 
-> Each edit refreshes the values in [`docs/assetlib/SUBMISSION.md`](assetlib/SUBMISSION.md) too, so the
-> versioned package always reflects what is live.
+If the automated edit fails (red `assetlib-edit` job — e.g. credentials not yet configured, or the
+asset id is wrong), fall back to the manual edit: sign in, open the existing **Godot-MCP** asset, click
+**Edit**, bump **Version** + **Download Commit** (`git rev-list -n1 v<newversion>`), and submit.
+
+> Keep [`.github/assetlib/edit.hbs`](../.github/assetlib/edit.hbs) and
+> [`docs/assetlib/SUBMISSION.md`](assetlib/SUBMISSION.md) in sync, and update both (plus the long
+> description / previews) only when a field actually changes — so the automated edit and the manual
+> reference always reflect what is live.
 
 ---
 
@@ -225,8 +269,14 @@ by the maintainer:
   A manual step on npmjs.com authorizing this repo + `deploy.yml` to publish via OIDC. Until it is
   done, the `npm publish` step fails auth (the GitHub Release still succeeds). See
   [npm Trusted Publisher prerequisite](#npm-trusted-publisher-prerequisite-first-publish-only).
-- **Godot Asset Library submission (and version edits).** A manual web-form step at
-  <https://godotengine.org/asset-library/>, never automated.
+- **Godot Asset Library INITIAL submission + moderator approval.** Creating the brand-new asset entry
+  is a manual web-form step at <https://godotengine.org/asset-library/>, and every submission (initial
+  or edit) is reviewed by a Godot moderator. These are NOT automated. (The per-release **version edit**
+  on the existing entry IS automated — see
+  [Automated version edit](#automated-version-edit--required-github-config) — but it still goes through
+  moderator review, and it depends on the maintainer having configured the
+  `GODOT_ASSETLIB_USERNAME` / `GODOT_ASSETLIB_PASSWORD` secrets and the `GODOT_ASSETLIB_ASSET_ID`
+  variable.)
 - **Adding the addon icon** required by the Asset Library form (none ships today).
 - **Any future NuGet publishing** — new package IDs, `dotnet nuget push` steps, or NuGet
   publish secrets / trusted-publishing config. None exist today and none should be added without an


### PR DESCRIPTION
## Summary
- Add an isolated `assetlib-edit` job to `release.yml` that auto-submits the per-release Godot Asset Library **version edit** after the GitHub Release, via `deep-entertainment/godot-asset-lib-action` (`addEdit` mode) **pinned to commit `056fa40` = `v0.6.0`** for supply-chain safety.
- The job `needs: [check-version-tag, release-addon]` and is gated on `should_release == 'true'`. It is **isolated**: nothing depends on it, so an AssetLib failure shows red for visibility but never blocks or fails the npm `deploy` job (`deploy` still only `needs` `release-addon.published`).
- Credentials/ids come **only** from GitHub-managed config (nothing hardcoded): `secrets.GODOT_ASSETLIB_USERNAME` / `secrets.GODOT_ASSETLIB_PASSWORD` and `vars.GODOT_ASSETLIB_ASSET_ID`.
- New `.github/assetlib/edit.hbs` renders the Asset model (category Tools=`5`, `godot_version` `4.3`, `Apache-2.0`, GitHub download provider, repo/issues/icon URLs, and the canonical `plugin.cfg` description). `version_string` + `download_commit` are injected at run time from `plugin.cfg`'s version (via `check-version-tag`) and `github.sha`.
- `docs/RELEASING.md`: per-release version edits are now automated; the one-time INITIAL submission + moderator approval stay manual; documents the two secrets + the variable (set in Settings → Secrets and variables → Actions).

## Notes
- Secrets/variable are **declared, not populated** — merge + secret population stay human-gated (the asset id only exists after the manual initial submission, so the automation is effective from the second release onward).

## Test plan
- [x] `dotnet build Godot-MCP.sln` (CI parity, Suite 1) — 0 errors / 0 warnings.
- [x] `yaml.safe_load` (UTF-8) parses all workflow YAML; `assetlib-edit` wiring + `deploy` independence verified.
- [x] `edit.hbs` validated as well-formed JSON (handlebars substituted); description first line matches `plugin.cfg`.

Closes #113