### PR TITLE
fix(cli): discover version-stamped and nested Godot editor binaries

### DIFF
--- a/cli/src/lib/open.ts
+++ b/cli/src/lib/open.ts
@@ -146,7 +146,15 @@ export async function openProject(options: OpenProjectOptions): Promise<OpenProj
     const editorPath = findGodotBinary(options.editorPath);
     if (!editorPath) {
       throw new Error(
-        'No Godot editor binary found. Set GODOT_BIN (or GODOT4_BIN), add godot to PATH, or pass --editor-path.',
+        'No Godot editor binary found.\n' +
+          'Searched: --editor-path, the GODOT_BIN / GODOT4_BIN env vars, your PATH, and common\n' +
+          'install locations (Downloads, Program Files, LocalAppData, Scoop, Chocolatey, winget,\n' +
+          'Steam) including version-stamped release names like\n' +
+          '"Godot_v<version>-stable_mono_win64.exe" nested in their extracted folder.\n' +
+          'To fix, do one of:\n' +
+          '  • pass the full path: godot-cli open --editor-path "<path-to-Godot-executable>"\n' +
+          '  • set an env var: GODOT_BIN=<path-to-Godot-executable> (or GODOT4_BIN)\n' +
+          '  • add the Godot binary to your PATH.',
       );
     }
     resolvedEditorPath = editorPath;

--- a/cli/src/utils/godot-editor.ts
+++ b/cli/src/utils/godot-editor.ts
@@ -43,6 +43,41 @@ function pathCandidateNames(os: NodeJS.Platform): string[] {
 const SCAN_MAX_DEPTH = 3;
 
 /**
+ * Bounded scan depth for FLAT roots — system bin dirs and PATH-like locations
+ * where the binary, if present, sits directly in the dir (no nested
+ * version-stamped wrapper). Scanning these recursively (`/usr/bin`,
+ * `/usr/local/bin`, …) would issue thousands of `readdir`/`isFile` ops for no
+ * benefit, so we probe only the root itself.
+ */
+const FLAT_SCAN_DEPTH = 0;
+
+/**
+ * Version-stamped release name → comparable numeric key. Parses the
+ * `v<major>.<minor>[.<patch>]` segment (e.g. `Godot_v4.5.1-stable_...`). Returns
+ * a single integer so larger == newer; names without a version segment sort
+ * oldest (`-1`). Pre-release builds (e.g. `4.6-beta1`) are treated by their
+ * numeric version only — the stable/build-rank distinction is handled by
+ * {@link godotBinaryRank}.
+ */
+const VERSION_RE = /v(\d+)\.(\d+)(?:\.(\d+))?/i;
+function godotVersionKey(name: string): number {
+  const m = VERSION_RE.exec(name);
+  if (!m) return -1;
+  const major = Number(m[1]);
+  const minor = Number(m[2]);
+  const patch = m[3] !== undefined ? Number(m[3]) : 0;
+  // Wide radices so a larger minor/patch can never overflow into the next major.
+  return major * 1_000_000 + minor * 1_000 + patch;
+}
+
+// Module-level regexes for version-stamped binary names (compiled once rather
+// than per scanned directory entry). Mirrors the loose, arch-tolerant matching
+// described on `isGodotBinaryName`.
+const WIN_STAMPED_RE = /^godot_v.*win.*\.exe$/;
+const MACOS_STAMPED_RE = /^godot_v.*(macos|osx).*$/;
+const LINUX_STAMPED_RE = /^godot_v.*(linux|x11).*$/;
+
+/**
  * Whether a file name looks like a Godot editor binary. Matches both the fixed
  * historical names (`Godot.exe`, `godot`, `godot_mono`) AND the official
  * version-stamped release names, e.g.
@@ -61,17 +96,17 @@ function isGodotBinaryName(name: string, os: NodeJS.Platform): boolean {
     // Fixed names.
     if (lower === 'godot.exe' || lower === 'godot_mono.exe') return true;
     // Version-stamped: Godot_v<...>...win64[...]( _console)?.exe
-    return /^godot_v.*win.*\.exe$/.test(lower);
+    return WIN_STAMPED_RE.test(lower);
   }
 
   if (os === 'darwin') {
     if (lower === 'godot' || lower === 'godot_mono') return true;
-    return /^godot_v.*macos.*$/.test(lower) || /^godot_v.*osx.*$/.test(lower);
+    return MACOS_STAMPED_RE.test(lower);
   }
 
   // linux + others
   if (lower === 'godot' || lower === 'godot_mono') return true;
-  return /^godot_v.*(linux|x11).*$/.test(lower);
+  return LINUX_STAMPED_RE.test(lower);
 }
 
 /**
@@ -124,37 +159,58 @@ function scanForGodotBinaries(root: string, os: NodeJS.Platform, maxDepth: numbe
 
   walk(root, 0);
 
-  // Prefer the best build (mono _console > mono > _console > plain); stable
-  // secondary sort by path so the result is deterministic.
+  // Order, in priority: best build (mono _console > mono > _console > plain),
+  // then newest version (so Godot_v4.5.1 beats Godot_v4.3 when both are
+  // extracted side by side), then path for a deterministic tiebreak.
   found.sort((a, b) => {
-    const rank = godotBinaryRank(path.basename(b)) - godotBinaryRank(path.basename(a));
-    return rank !== 0 ? rank : a.localeCompare(b);
+    const nameA = path.basename(a);
+    const nameB = path.basename(b);
+    const rank = godotBinaryRank(nameB) - godotBinaryRank(nameA);
+    if (rank !== 0) return rank;
+    const version = godotVersionKey(nameB) - godotVersionKey(nameA);
+    if (version !== 0) return version;
+    return a.localeCompare(b);
   });
   return found;
 }
 
 /**
- * Per-OS common install roots to shallow-recursively scan for a Godot editor
- * binary when neither an env override nor a PATH hit resolves one. The official
- * release zips extract to a version-stamped nested folder, so we scan roots
- * recursively (bounded by `SCAN_MAX_DEPTH`) rather than probing fixed leaf
- * paths.
+ * A common install root to search, paired with the depth to scan it at. System
+ * bin dirs and package-manager shim dirs are FLAT (`depth 0`) — the binary, if
+ * present, sits directly in them, and recursing would issue thousands of
+ * `readdir`/`isFile` ops for nothing. Archive-extraction roots (Downloads,
+ * `/opt`, `~/Applications`, the macOS `.app` bundles, …) are scanned
+ * recursively (`SCAN_MAX_DEPTH`) because official zips extract into a nested
+ * version-stamped folder.
+ */
+interface InstallRoot {
+  path: string;
+  depth: number;
+}
+
+/**
+ * Per-OS common install roots to scan for a Godot editor binary when neither an
+ * env override nor a PATH hit resolves one. Each root carries its own scan
+ * depth (see {@link InstallRoot}). Duplicate paths (e.g. `USERPROFILE` and
+ * `homedir()` resolving to the same Downloads dir on Windows) are collapsed,
+ * keeping the first/deepest occurrence so a dir is never scanned twice.
  *   - Windows: Downloads, Program Files (+ x86), LocalAppData Programs, home,
  *     plus package-manager locations (Scoop / Chocolatey / winget / Steam).
  *   - macOS: `/Applications`, `~/Applications`, `~/Downloads` (the `.app`
  *     bundle's inner `Contents/MacOS/Godot` binary is matched by the scan).
- *   - Linux: common extracted-binary dirs + Downloads + Steam.
+ *   - Linux: system bin dirs (flat) + extracted-binary dirs + Downloads + Steam.
  */
-function commonInstallRoots(os: NodeJS.Platform): string[] {
+function commonInstallRoots(os: NodeJS.Platform): InstallRoot[] {
   const home = homedir();
-  const roots: string[] = [];
+  const recursive: string[] = [];
+  const flat: string[] = [];
 
   if (os === 'win32') {
     const programFiles = process.env['PROGRAMFILES'] ?? 'C:\\Program Files';
     const programFilesX86 = process.env['PROGRAMFILES(X86)'] ?? 'C:\\Program Files (x86)';
     const localAppData = process.env['LOCALAPPDATA'] ?? path.join(home, 'AppData', 'Local');
     const userProfile = process.env['USERPROFILE'] ?? home;
-    roots.push(
+    recursive.push(
       path.join(userProfile, 'Downloads'),
       path.join(home, 'Downloads'),
       path.join(programFiles, 'Godot'),
@@ -170,34 +226,44 @@ function commonInstallRoots(os: NodeJS.Platform): string[] {
       path.join(programFiles, 'Steam', 'steamapps', 'common', 'Godot Engine'),
       path.join(programFilesX86, 'Steam', 'steamapps', 'common', 'Godot Engine'),
     );
-    return roots;
-  }
-
-  if (os === 'darwin') {
-    roots.push(
+  } else if (os === 'darwin') {
+    recursive.push(
       '/Applications',
       path.join(home, 'Applications'),
       path.join(home, 'Downloads'),
       // Steam.
       path.join(home, 'Library', 'Application Support', 'Steam', 'steamapps', 'common', 'Godot Engine'),
     );
-    return roots;
+  } else {
+    // linux + others. System bin dirs are flat; archive-extraction dirs recurse.
+    flat.push(
+      '/usr/local/bin',
+      '/usr/bin',
+      path.join(home, '.local', 'bin'),
+      path.join(home, 'bin'),
+    );
+    recursive.push(
+      '/opt',
+      path.join(home, '.local', 'share', 'godot'),
+      path.join(home, 'Applications'),
+      path.join(home, 'Downloads'),
+      // Steam.
+      path.join(home, '.local', 'share', 'Steam', 'steamapps', 'common', 'Godot Engine'),
+      path.join(home, '.steam', 'steam', 'steamapps', 'common', 'Godot Engine'),
+    );
   }
 
-  // linux + others
-  roots.push(
-    '/usr/local/bin',
-    '/usr/bin',
-    '/opt',
-    path.join(home, '.local', 'bin'),
-    path.join(home, '.local', 'share', 'godot'),
-    path.join(home, 'Applications'),
-    path.join(home, 'bin'),
-    path.join(home, 'Downloads'),
-    // Steam.
-    path.join(home, '.local', 'share', 'Steam', 'steamapps', 'common', 'Godot Engine'),
-    path.join(home, '.steam', 'steam', 'steamapps', 'common', 'Godot Engine'),
-  );
+  // Build the ordered list (recursive roots first, then flat), de-duplicating
+  // by resolved path so a dir reachable two ways is scanned only once.
+  const seen = new Set<string>();
+  const roots: InstallRoot[] = [];
+  const add = (p: string, depth: number): void => {
+    if (seen.has(p)) return;
+    seen.add(p);
+    roots.push({ path: p, depth });
+  };
+  for (const p of recursive) add(p, SCAN_MAX_DEPTH);
+  for (const p of flat) add(p, FLAT_SCAN_DEPTH);
   return roots;
 }
 
@@ -246,11 +312,12 @@ function existsAsFile(p: string): boolean {
  *   1. An explicit `editorPath` argument (validated to be an existing file).
  *   2. `GODOT_BIN` / `GODOT4_BIN` environment variables.
  *   3. The first matching Godot binary on `PATH` (fixed name or version-stamped).
- *   4. A bounded shallow-recursive scan of per-OS common install roots
- *      (Downloads, Program Files, LocalAppData Programs, home, plus Scoop /
- *      Chocolatey / winget / Steam locations). Matches both fixed and
- *      version-stamped names (`Godot_v<ver>-stable_mono_win64[_console].exe`),
- *      preferring the mono `_console` build. This is what resolves the common
+ *   4. A bounded scan of per-OS common install roots (Downloads, Program Files,
+ *      LocalAppData Programs, home, plus Scoop / Chocolatey / winget / Steam
+ *      locations). Archive-extraction roots are scanned recursively while system
+ *      bin dirs are probed flat. Matches both fixed and version-stamped names
+ *      (`Godot_v<ver>-stable_mono_win64[_console].exe`), preferring the mono
+ *      `_console` build and the newest version. This is what resolves the common
  *      case of an official zip extracted into a nested version-stamped folder.
  *
  * Returns the absolute path, or `null` when no Godot binary can be located.
@@ -284,10 +351,11 @@ export function findGodotBinary(
   const onPath = findOnPath(os);
   if (onPath) return onPath;
 
-  // 4. Bounded shallow-recursive scan of common install roots. Roots are tried
-  //    in priority order; within a root the best-ranked build wins.
+  // 4. Bounded scan of common install roots. Roots are tried in priority order
+  //    at each root's own depth (system bin dirs flat, archive-extraction roots
+  //    recursive); within a root the best-ranked, newest build wins.
   for (const root of commonInstallRoots(os)) {
-    const hits = scanForGodotBinaries(root, os, SCAN_MAX_DEPTH);
+    const hits = scanForGodotBinaries(root.path, os, root.depth);
     if (hits.length > 0) {
       return hits[0];
     }

--- a/cli/src/utils/godot-editor.ts
+++ b/cli/src/utils/godot-editor.ts
@@ -33,61 +33,180 @@ function pathCandidateNames(os: NodeJS.Platform): string[] {
 }
 
 /**
- * Per-OS common install directories to scan for a Godot editor binary when
- * neither an env override nor a PATH hit resolves one.
- *   - Windows: prefer the mono build under Program Files / common download dirs.
- *   - macOS: the `.app` bundle's inner `Contents/MacOS/Godot` binary.
- *   - Linux: extracted binaries under common app dirs.
+ * Maximum directory depth (inclusive) to descend when shallow-recursively
+ * scanning a common install root for a Godot editor binary. Depth 0 is the root
+ * itself; depth 1 its immediate children, etc. Official Windows zips extract to
+ * `<root>/Godot_v<ver>-stable_mono_win64/Godot_v<ver>-stable_mono_win64/<exe>`
+ * (binary two levels below `Downloads`), so we need depth >= 2; we use 3 to also
+ * cover an extra wrapper folder without scanning unbounded trees.
  */
-function commonInstallCandidates(os: NodeJS.Platform): string[] {
-  const home = homedir();
-  const candidates: string[] = [];
+const SCAN_MAX_DEPTH = 3;
+
+/**
+ * Whether a file name looks like a Godot editor binary. Matches both the fixed
+ * historical names (`Godot.exe`, `godot`, `godot_mono`) AND the official
+ * version-stamped release names, e.g.
+ *   - `Godot_v4.5.1-stable_mono_win64.exe`
+ *   - `Godot_v4.5.1-stable_mono_win64_console.exe`
+ *   - `Godot_v4.5.1-stable_win64.exe`
+ *   - `Godot_v4.3-stable_mono_linux.x86_64`
+ *   - `Godot_v4.5.1-stable_macos.universal`
+ * The match is case-insensitive (Windows) and intentionally loose on the
+ * platform/arch suffix so future arch names still resolve.
+ */
+function isGodotBinaryName(name: string, os: NodeJS.Platform): boolean {
+  const lower = name.toLowerCase();
 
   if (os === 'win32') {
-    const programFiles = process.env['PROGRAMFILES'] ?? 'C:\\Program Files';
-    const localAppData = process.env['LOCALAPPDATA'] ?? path.join(home, 'AppData', 'Local');
-    for (const root of [
-      path.join(programFiles, 'Godot'),
-      path.join(localAppData, 'Programs', 'Godot'),
-      path.join(home, 'Downloads'),
-    ]) {
-      // Prefer the mono console build (surfaces stdout), then the plain mono build.
-      candidates.push(path.join(root, 'Godot_mono.exe'));
-      candidates.push(path.join(root, 'Godot.exe'));
-    }
-    return candidates;
+    // Fixed names.
+    if (lower === 'godot.exe' || lower === 'godot_mono.exe') return true;
+    // Version-stamped: Godot_v<...>...win64[...]( _console)?.exe
+    return /^godot_v.*win.*\.exe$/.test(lower);
   }
 
   if (os === 'darwin') {
-    for (const app of [
-      '/Applications/Godot_mono.app',
-      '/Applications/Godot.app',
-      path.join(home, 'Applications', 'Godot_mono.app'),
-      path.join(home, 'Applications', 'Godot.app'),
-    ]) {
-      candidates.push(path.join(app, 'Contents', 'MacOS', 'Godot'));
-    }
-    return candidates;
+    if (lower === 'godot' || lower === 'godot_mono') return true;
+    return /^godot_v.*macos.*$/.test(lower) || /^godot_v.*osx.*$/.test(lower);
   }
 
   // linux + others
-  for (const dir of [
-    '/usr/local/bin',
-    '/usr/bin',
-    path.join(home, '.local', 'bin'),
-    path.join(home, 'Applications'),
-    path.join(home, 'bin'),
-  ]) {
-    candidates.push(path.join(dir, 'godot'));
-    candidates.push(path.join(dir, 'godot_mono'));
-    candidates.push(path.join(dir, 'Godot'));
-  }
-  return candidates;
+  if (lower === 'godot' || lower === 'godot_mono') return true;
+  return /^godot_v.*(linux|x11).*$/.test(lower);
 }
 
 /**
- * Search the directories on `PATH` for the first matching Godot binary name.
- * Pure filesystem lookup — never spawns anything.
+ * Rank a Godot binary name so we can prefer the build that surfaces the most
+ * useful output. Higher score = more preferred:
+ *   - mono `_console` build (mono + stdout)  → 3
+ *   - mono build                              → 2
+ *   - non-mono `_console` build               → 1
+ *   - everything else                         → 0
+ * Used to pick the best match within a single directory of candidates.
+ */
+function godotBinaryRank(name: string): number {
+  const lower = name.toLowerCase();
+  const mono = lower.includes('mono');
+  const console = lower.includes('_console');
+  if (mono && console) return 3;
+  if (mono) return 2;
+  if (console) return 1;
+  return 0;
+}
+
+/**
+ * Recursively scan `root` for files whose name looks like a Godot editor binary,
+ * descending at most `maxDepth` levels. Returns absolute paths, best-ranked
+ * first (so a caller can take the first hit). Symlinks are not followed and any
+ * unreadable directory is skipped silently — this is a best-effort discovery
+ * scan, never a hard failure.
+ */
+function scanForGodotBinaries(root: string, os: NodeJS.Platform, maxDepth: number): string[] {
+  const found: string[] = [];
+
+  const walk = (dir: string, depth: number): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return; // unreadable / nonexistent — skip
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isFile()) {
+        if (isGodotBinaryName(entry.name, os)) {
+          found.push(full);
+        }
+      } else if (entry.isDirectory() && depth < maxDepth) {
+        walk(full, depth + 1);
+      }
+    }
+  };
+
+  walk(root, 0);
+
+  // Prefer the best build (mono _console > mono > _console > plain); stable
+  // secondary sort by path so the result is deterministic.
+  found.sort((a, b) => {
+    const rank = godotBinaryRank(path.basename(b)) - godotBinaryRank(path.basename(a));
+    return rank !== 0 ? rank : a.localeCompare(b);
+  });
+  return found;
+}
+
+/**
+ * Per-OS common install roots to shallow-recursively scan for a Godot editor
+ * binary when neither an env override nor a PATH hit resolves one. The official
+ * release zips extract to a version-stamped nested folder, so we scan roots
+ * recursively (bounded by `SCAN_MAX_DEPTH`) rather than probing fixed leaf
+ * paths.
+ *   - Windows: Downloads, Program Files (+ x86), LocalAppData Programs, home,
+ *     plus package-manager locations (Scoop / Chocolatey / winget / Steam).
+ *   - macOS: `/Applications`, `~/Applications`, `~/Downloads` (the `.app`
+ *     bundle's inner `Contents/MacOS/Godot` binary is matched by the scan).
+ *   - Linux: common extracted-binary dirs + Downloads + Steam.
+ */
+function commonInstallRoots(os: NodeJS.Platform): string[] {
+  const home = homedir();
+  const roots: string[] = [];
+
+  if (os === 'win32') {
+    const programFiles = process.env['PROGRAMFILES'] ?? 'C:\\Program Files';
+    const programFilesX86 = process.env['PROGRAMFILES(X86)'] ?? 'C:\\Program Files (x86)';
+    const localAppData = process.env['LOCALAPPDATA'] ?? path.join(home, 'AppData', 'Local');
+    const userProfile = process.env['USERPROFILE'] ?? home;
+    roots.push(
+      path.join(userProfile, 'Downloads'),
+      path.join(home, 'Downloads'),
+      path.join(programFiles, 'Godot'),
+      path.join(programFilesX86, 'Godot'),
+      path.join(localAppData, 'Programs', 'Godot'),
+      // Scoop installs shims + apps under ~/scoop.
+      path.join(userProfile, 'scoop', 'apps', 'godot'),
+      path.join(userProfile, 'scoop', 'apps', 'godot-mono'),
+      // Chocolatey lib.
+      path.join(process.env['CHOCOLATEYINSTALL'] ?? 'C:\\ProgramData\\chocolatey', 'lib', 'godot'),
+      // winget links / Steam common.
+      path.join(localAppData, 'Microsoft', 'WinGet', 'Packages'),
+      path.join(programFiles, 'Steam', 'steamapps', 'common', 'Godot Engine'),
+      path.join(programFilesX86, 'Steam', 'steamapps', 'common', 'Godot Engine'),
+    );
+    return roots;
+  }
+
+  if (os === 'darwin') {
+    roots.push(
+      '/Applications',
+      path.join(home, 'Applications'),
+      path.join(home, 'Downloads'),
+      // Steam.
+      path.join(home, 'Library', 'Application Support', 'Steam', 'steamapps', 'common', 'Godot Engine'),
+    );
+    return roots;
+  }
+
+  // linux + others
+  roots.push(
+    '/usr/local/bin',
+    '/usr/bin',
+    '/opt',
+    path.join(home, '.local', 'bin'),
+    path.join(home, '.local', 'share', 'godot'),
+    path.join(home, 'Applications'),
+    path.join(home, 'bin'),
+    path.join(home, 'Downloads'),
+    // Steam.
+    path.join(home, '.local', 'share', 'Steam', 'steamapps', 'common', 'Godot Engine'),
+    path.join(home, '.steam', 'steam', 'steamapps', 'common', 'Godot Engine'),
+  );
+  return roots;
+}
+
+/**
+ * Search the directories on `PATH` for a matching Godot binary. Pure filesystem
+ * lookup — never spawns anything. Each PATH dir is first probed for the fixed
+ * candidate names (cheap), then, if none hit, its immediate entries are scanned
+ * for a version-stamped name (`Godot_v...`). Within a single PATH dir the
+ * best-ranked build (mono `_console` > mono > …) wins.
  */
 function findOnPath(os: NodeJS.Platform): string | null {
   const pathEnv = process.env['PATH'] ?? '';
@@ -96,11 +215,17 @@ function findOnPath(os: NodeJS.Platform): string | null {
   const dirs = pathEnv.split(sep).filter((d) => d.length > 0);
   const names = pathCandidateNames(os);
   for (const dir of dirs) {
+    // Fast path: fixed candidate names.
     for (const name of names) {
       const candidate = path.join(dir, name);
       if (existsAsFile(candidate)) {
         return candidate;
       }
+    }
+    // Slow path: version-stamped binary sitting directly on a PATH dir.
+    const stamped = scanForGodotBinaries(dir, os, 0);
+    if (stamped.length > 0) {
+      return stamped[0];
     }
   }
   return null;
@@ -120,10 +245,13 @@ function existsAsFile(p: string): boolean {
  * Resolution order (first hit wins):
  *   1. An explicit `editorPath` argument (validated to be an existing file).
  *   2. `GODOT_BIN` / `GODOT4_BIN` environment variables.
- *   3. The first matching Godot binary on `PATH`.
- *   4. Per-OS common install directories (Windows prefers the mono build;
- *      macOS resolves the `.app/Contents/MacOS` binary; Linux scans common
- *      extracted-binary locations).
+ *   3. The first matching Godot binary on `PATH` (fixed name or version-stamped).
+ *   4. A bounded shallow-recursive scan of per-OS common install roots
+ *      (Downloads, Program Files, LocalAppData Programs, home, plus Scoop /
+ *      Chocolatey / winget / Steam locations). Matches both fixed and
+ *      version-stamped names (`Godot_v<ver>-stable_mono_win64[_console].exe`),
+ *      preferring the mono `_console` build. This is what resolves the common
+ *      case of an official zip extracted into a nested version-stamped folder.
  *
  * Returns the absolute path, or `null` when no Godot binary can be located.
  * Pure / no spawn — exported for unit tests (the `os`/env are injectable via
@@ -156,10 +284,12 @@ export function findGodotBinary(
   const onPath = findOnPath(os);
   if (onPath) return onPath;
 
-  // 4. Common install dirs
-  for (const candidate of commonInstallCandidates(os)) {
-    if (existsAsFile(candidate)) {
-      return candidate;
+  // 4. Bounded shallow-recursive scan of common install roots. Roots are tried
+  //    in priority order; within a root the best-ranked build wins.
+  for (const root of commonInstallRoots(os)) {
+    const hits = scanForGodotBinaries(root, os, SCAN_MAX_DEPTH);
+    if (hits.length > 0) {
+      return hits[0];
     }
   }
 

--- a/cli/tests/godot-editor.test.ts
+++ b/cli/tests/godot-editor.test.ts
@@ -85,6 +85,98 @@ describe('findGodotBinary', () => {
       expect(result).not.toContain(path.join(tmpDir, 'empty'));
     }
   });
+
+  it('matches a version-stamped binary sitting directly on PATH (win32)', () => {
+    const bin = path.join(tmpDir, 'Godot_v4.5.1-stable_mono_win64.exe');
+    fs.writeFileSync(bin, '');
+    process.env['PATH'] = tmpDir;
+    expect(findGodotBinary(undefined, 'win32')).toBe(bin);
+  });
+
+  it('prefers the mono _console build over plainer ones on a single PATH dir (win32)', () => {
+    // Drop several builds in one dir; the mono _console variant must win.
+    fs.writeFileSync(path.join(tmpDir, 'Godot_v4.5.1-stable_win64.exe'), '');
+    fs.writeFileSync(path.join(tmpDir, 'Godot_v4.5.1-stable_mono_win64.exe'), '');
+    const consoleBin = path.join(tmpDir, 'Godot_v4.5.1-stable_mono_win64_console.exe');
+    fs.writeFileSync(consoleBin, '');
+    process.env['PATH'] = tmpDir;
+    expect(findGodotBinary(undefined, 'win32')).toBe(consoleBin);
+  });
+
+  it('discovers a version-stamped binary nested two folders deep under Downloads (win32)', () => {
+    // Mirror the real on-disk layout of an extracted official Windows zip:
+    //   <Downloads>/Godot_v4.5.1-stable_mono_win64/
+    //     Godot_v4.5.1-stable_mono_win64/
+    //       Godot_v4.5.1-stable_mono_win64.exe  (+ _console companion)
+    const ver = 'Godot_v4.5.1-stable_mono_win64';
+    const downloads = path.join(tmpDir, 'Downloads');
+    const nested = path.join(downloads, ver, ver);
+    fs.mkdirSync(nested, { recursive: true });
+    fs.writeFileSync(path.join(nested, `${ver}.exe`), '');
+    const consoleBin = path.join(nested, `${ver}_console.exe`);
+    fs.writeFileSync(consoleBin, '');
+
+    // Point the Windows common-roots scan at our sandbox via USERPROFILE/HOME so
+    // the real machine's Downloads isn't consulted, and clear PATH so step 4 runs.
+    const savedUserProfile = process.env['USERPROFILE'];
+    const savedHome = process.env['HOME'];
+    const savedProgramFiles = process.env['PROGRAMFILES'];
+    const savedLocalAppData = process.env['LOCALAPPDATA'];
+    process.env['USERPROFILE'] = tmpDir;
+    process.env['HOME'] = tmpDir;
+    // Steer the other roots at an empty dir so only Downloads can hit.
+    const emptyRoot = path.join(tmpDir, 'empty-root');
+    fs.mkdirSync(emptyRoot, { recursive: true });
+    process.env['PROGRAMFILES'] = emptyRoot;
+    process.env['LOCALAPPDATA'] = emptyRoot;
+    process.env['PATH'] = emptyRoot;
+    try {
+      // The mono _console build is preferred.
+      expect(findGodotBinary(undefined, 'win32')).toBe(consoleBin);
+    } finally {
+      if (savedUserProfile === undefined) delete process.env['USERPROFILE'];
+      else process.env['USERPROFILE'] = savedUserProfile;
+      if (savedHome === undefined) delete process.env['HOME'];
+      else process.env['HOME'] = savedHome;
+      if (savedProgramFiles === undefined) delete process.env['PROGRAMFILES'];
+      else process.env['PROGRAMFILES'] = savedProgramFiles;
+      if (savedLocalAppData === undefined) delete process.env['LOCALAPPDATA'];
+      else process.env['LOCALAPPDATA'] = savedLocalAppData;
+    }
+  });
+
+  it('does not descend past the bounded scan depth (win32)', () => {
+    // Bury a binary deeper than SCAN_MAX_DEPTH (3) below Downloads; it must NOT
+    // be found, proving the scan is bounded.
+    const downloads = path.join(tmpDir, 'Downloads');
+    const tooDeep = path.join(downloads, 'a', 'b', 'c', 'd', 'e');
+    fs.mkdirSync(tooDeep, { recursive: true });
+    fs.writeFileSync(path.join(tooDeep, 'Godot_v4.5.1-stable_mono_win64.exe'), '');
+
+    const savedUserProfile = process.env['USERPROFILE'];
+    const savedHome = process.env['HOME'];
+    const savedProgramFiles = process.env['PROGRAMFILES'];
+    const savedLocalAppData = process.env['LOCALAPPDATA'];
+    process.env['USERPROFILE'] = tmpDir;
+    process.env['HOME'] = tmpDir;
+    const emptyRoot = path.join(tmpDir, 'empty-root');
+    fs.mkdirSync(emptyRoot, { recursive: true });
+    process.env['PROGRAMFILES'] = emptyRoot;
+    process.env['LOCALAPPDATA'] = emptyRoot;
+    process.env['PATH'] = emptyRoot;
+    try {
+      expect(findGodotBinary(undefined, 'win32')).toBeNull();
+    } finally {
+      if (savedUserProfile === undefined) delete process.env['USERPROFILE'];
+      else process.env['USERPROFILE'] = savedUserProfile;
+      if (savedHome === undefined) delete process.env['HOME'];
+      else process.env['HOME'] = savedHome;
+      if (savedProgramFiles === undefined) delete process.env['PROGRAMFILES'];
+      else process.env['PROGRAMFILES'] = savedProgramFiles;
+      if (savedLocalAppData === undefined) delete process.env['LOCALAPPDATA'];
+      else process.env['LOCALAPPDATA'] = savedLocalAppData;
+    }
+  });
 });
 
 describe('launchEditor', () => {

--- a/cli/tests/godot-editor.test.ts
+++ b/cli/tests/godot-editor.test.ts
@@ -177,6 +177,123 @@ describe('findGodotBinary', () => {
       else process.env['LOCALAPPDATA'] = savedLocalAppData;
     }
   });
+
+  it('discovers a macOS .app-bundle binary at the depth-3 boundary (darwin)', () => {
+    // The real layout is <home>/Applications/Godot.app/Contents/MacOS/Godot,
+    // i.e. the binary's containing dir sits exactly at scan depth 3 below the
+    // root — a guard against an off-by-one shrinking SCAN_MAX_DEPTH. The file
+    // must be named like a Godot binary for the scan to match, so use a
+    // version-stamped macOS name inside the bundle. `commonInstallRoots` derives
+    // home via os.homedir(), which reads USERPROFILE on a Windows test host and
+    // HOME elsewhere — set both so the sandbox is consulted on either runner.
+    const savedHome = process.env['HOME'];
+    const savedUserProfile = process.env['USERPROFILE'];
+    process.env['HOME'] = tmpDir;
+    process.env['USERPROFILE'] = tmpDir;
+    const macBin = path.join(
+      tmpDir,
+      'Applications',
+      'Godot.app',
+      'Contents',
+      'MacOS',
+      'Godot_v4.5.1-stable_macos.universal',
+    );
+    fs.mkdirSync(path.dirname(macBin), { recursive: true });
+    fs.writeFileSync(macBin, '');
+    process.env['PATH'] = path.join(tmpDir, 'empty');
+    try {
+      expect(findGodotBinary(undefined, 'darwin')).toBe(macBin);
+    } finally {
+      if (savedHome === undefined) delete process.env['HOME'];
+      else process.env['HOME'] = savedHome;
+      if (savedUserProfile === undefined) delete process.env['USERPROFILE'];
+      else process.env['USERPROFILE'] = savedUserProfile;
+    }
+  });
+
+  it('discovers a version-stamped binary via a recursive linux scan root', () => {
+    // ~/Downloads is a recursive root on linux; an extracted tarball nests the
+    // binary one folder down. Confirm the linux scan path resolves it. Set both
+    // HOME and USERPROFILE so os.homedir() points at the sandbox on any runner.
+    const savedHome = process.env['HOME'];
+    const savedUserProfile = process.env['USERPROFILE'];
+    process.env['HOME'] = tmpDir;
+    process.env['USERPROFILE'] = tmpDir;
+    const nested = path.join(tmpDir, 'Downloads', 'Godot_v4.5.1-stable_linux');
+    fs.mkdirSync(nested, { recursive: true });
+    const linuxBin = path.join(nested, 'Godot_v4.5.1-stable_mono_linux.x86_64');
+    fs.writeFileSync(linuxBin, '');
+    process.env['PATH'] = path.join(tmpDir, 'empty');
+    try {
+      expect(findGodotBinary(undefined, 'linux')).toBe(linuxBin);
+    } finally {
+      if (savedHome === undefined) delete process.env['HOME'];
+      else process.env['HOME'] = savedHome;
+      if (savedUserProfile === undefined) delete process.env['USERPROFILE'];
+      else process.env['USERPROFILE'] = savedUserProfile;
+    }
+  });
+
+  it('skips an unreadable root directory without throwing (linux)', () => {
+    // A readdirSync that throws (permission denied, ENOTDIR, …) must be
+    // swallowed by the scan and not abort resolution. ESM module namespaces are
+    // non-configurable so fs.readdirSync cannot be spied; instead make a root
+    // path resolve to a FILE — readdirSync on a file throws ENOTDIR, exercising
+    // the scan's try/catch the same way an unreadable dir would.
+    const savedHome = process.env['HOME'];
+    const savedUserProfile = process.env['USERPROFILE'];
+    process.env['HOME'] = tmpDir;
+    process.env['USERPROFILE'] = tmpDir;
+    // ~/Downloads is a recursive linux root; make it a file, not a dir.
+    fs.writeFileSync(path.join(tmpDir, 'Downloads'), '');
+    process.env['PATH'] = path.join(tmpDir, 'empty');
+    try {
+      expect(() => findGodotBinary(undefined, 'linux')).not.toThrow();
+      expect(findGodotBinary(undefined, 'linux')).toBeNull();
+    } finally {
+      if (savedHome === undefined) delete process.env['HOME'];
+      else process.env['HOME'] = savedHome;
+      if (savedUserProfile === undefined) delete process.env['USERPROFILE'];
+      else process.env['USERPROFILE'] = savedUserProfile;
+    }
+  });
+
+  it('prefers the newest version when ranks tie across directories (win32)', () => {
+    // Two extracted builds of identical build-rank (both mono _console) but
+    // different versions, in sibling folders under Downloads. The newer 4.5.1
+    // must win over 4.3 despite the older path sorting first alphabetically.
+    const downloads = path.join(tmpDir, 'Downloads');
+    const old = path.join(downloads, 'a-old', 'Godot_v4.3-stable_mono_win64_console.exe');
+    const recent = path.join(downloads, 'b-new', 'Godot_v4.5.1-stable_mono_win64_console.exe');
+    fs.mkdirSync(path.dirname(old), { recursive: true });
+    fs.mkdirSync(path.dirname(recent), { recursive: true });
+    fs.writeFileSync(old, '');
+    fs.writeFileSync(recent, '');
+
+    const savedUserProfile = process.env['USERPROFILE'];
+    const savedHome = process.env['HOME'];
+    const savedProgramFiles = process.env['PROGRAMFILES'];
+    const savedLocalAppData = process.env['LOCALAPPDATA'];
+    process.env['USERPROFILE'] = tmpDir;
+    process.env['HOME'] = tmpDir;
+    const emptyRoot = path.join(tmpDir, 'empty-root');
+    fs.mkdirSync(emptyRoot, { recursive: true });
+    process.env['PROGRAMFILES'] = emptyRoot;
+    process.env['LOCALAPPDATA'] = emptyRoot;
+    process.env['PATH'] = emptyRoot;
+    try {
+      expect(findGodotBinary(undefined, 'win32')).toBe(recent);
+    } finally {
+      if (savedUserProfile === undefined) delete process.env['USERPROFILE'];
+      else process.env['USERPROFILE'] = savedUserProfile;
+      if (savedHome === undefined) delete process.env['HOME'];
+      else process.env['HOME'] = savedHome;
+      if (savedProgramFiles === undefined) delete process.env['PROGRAMFILES'];
+      else process.env['PROGRAMFILES'] = savedProgramFiles;
+      if (savedLocalAppData === undefined) delete process.env['LOCALAPPDATA'];
+      else process.env['LOCALAPPDATA'] = savedLocalAppData;
+    }
+  });
 });
 
 describe('launchEditor', () => {


### PR DESCRIPTION
## Summary
- `findGodotBinary()` now matches version-stamped release names (e.g. `Godot_v4.5.1-stable_mono_win64[_console].exe`) in addition to the fixed `Godot[_mono].exe` names, on Windows/macOS/Linux.
- Common install roots (Downloads, Program Files +x86, LocalAppData Programs, home, plus Scoop / Chocolatey / winget / Steam) are now scanned shallow-recursively with a bounded depth (3), so the binary nested two folders deep inside an extracted official zip is found. PATH lookup also catches a version-stamped binary on a PATH dir.
- Resolution prefers the mono `_console` build (`mono _console > mono > _console > plain`), and the not-found error message now lists everything searched plus concrete remedies.

## Test plan
- [x] Target-specific local tests passed (see profile test.md): `npm run build` (tsc) clean; `npm test` (vitest) 109 passed (was 92 baseline + 4 new tests covering version-stamped PATH match, mono `_console` preference, nested two-deep discovery mirroring the real on-disk layout, and the bounded-depth guard).

Closes #115