### PR TITLE
feat(cli): godot-cli AI-agent parity with unity-mcp-cli

### DIFF
--- a/cli/src/lib/setup-mcp.ts
+++ b/cli/src/lib/setup-mcp.ts
@@ -10,6 +10,7 @@ import {
   getAgentById,
   getAgentIds,
   writeJsonAgentConfig,
+  writeTomlAgentConfig,
   MCP_SERVER_NAME,
 } from '../utils/agents.js';
 import { emitProgress } from './progress.js';
@@ -104,7 +105,11 @@ export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
     const configPath = agent.getConfigPath(projectPath);
     const props = agent.getHttpProps(serverUrl, token, authRequired);
 
-    writeJsonAgentConfig(configPath, agent.bodyPath, MCP_SERVER_NAME, props, agent.httpRemoveKeys);
+    if (agent.configFormat === 'toml') {
+      writeTomlAgentConfig(configPath, agent.bodyPath, MCP_SERVER_NAME, props, agent.httpRemoveKeys);
+    } else {
+      writeJsonAgentConfig(configPath, agent.bodyPath, MCP_SERVER_NAME, props, agent.httpRemoveKeys);
+    }
 
     emitProgress(opts.onProgress, {
       phase: 'manifest-patched',

--- a/cli/src/utils/agents.ts
+++ b/cli/src/utils/agents.ts
@@ -510,7 +510,9 @@ export function writeTomlAgentConfig(
   }
 
   if (sectionIdx >= 0) {
-    // Find end of section (next [...] header or EOF)
+    // Find end of section (next [...] header or EOF). The leading-`[` test is
+    // safe for the Codex schema, which emits only flat scalars (no inline-array
+    // value lines that would also start with `[`); revisit if that changes.
     let endIdx = sectionIdx + 1;
     while (endIdx < lines.length && !lines[endIdx].trim().startsWith('[')) {
       endIdx++;
@@ -530,11 +532,21 @@ export function writeTomlAgentConfig(
 
 function tomlValue(v: unknown): string {
   if (typeof v === 'string') return `"${v.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
-  if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+  if (typeof v === 'boolean') return String(v);
+  if (typeof v === 'number') {
+    // TOML spells non-finite floats `nan` / `inf` / `-inf`, not JS's NaN/Infinity.
+    if (Number.isNaN(v)) return 'nan';
+    if (v === Infinity) return 'inf';
+    if (v === -Infinity) return '-inf';
+    return String(v);
+  }
   if (Array.isArray(v)) {
     return `[${v.map(tomlValue).join(', ')}]`;
   }
-  return String(v);
+  // null/undefined/object have no valid TOML scalar form here; emit a quoted
+  // string so we never produce an invalid bare token (the Codex schema only
+  // feeds string/number/bool/array scalars, so this is a defensive fallback).
+  return `"${String(v).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
 }
 
 export { MCP_SERVER_NAME };

--- a/cli/src/utils/agents.ts
+++ b/cli/src/utils/agents.ts
@@ -10,19 +10,34 @@ import * as path from 'path';
 /**
  * An AI-agent MCP-client configurator. Mirrors the Godot addon's
  * `GodotAgentConfigurator` registry (`addons/godot_mcp/UI/Agents/`), adapted
- * to the CLI's file-writing surface. Each agent knows where its MCP-client
- * config lives and what HTTP-transport server entry to write.
+ * to the CLI's file-writing surface, and brought to parity with the Unity CLI's
+ * agent roster (`Unity-MCP/cli/src/utils/agents.ts`). Each agent knows where its
+ * MCP-client config lives and what HTTP-transport server entry to write.
  *
  * Godot is a server-less client: the plugin connects out to a server, and an
  * external AI client connects to the same server's `<host>/mcp` streamable-HTTP
  * endpoint. So every configurator here writes an HTTP server entry pointing at
  * the resolved MCP-client URL (NOT the plugin's `<host>/hub/mcp-server` SignalR
- * endpoint).
+ * endpoint). Unlike the Unity CLI, there is NO stdio transport / local
+ * server-binary path here — the Godot CLI never spawns a local server process —
+ * so the Unity `getStdioProps` / `stdioRemoveKeys` surface is intentionally
+ * omitted.
+ *
+ * `skillsPath` mirrors the Unity definition's per-agent skills directory. The
+ * Godot CLI does not yet ship a `setup-skills` command (skills are generated
+ * addon-side on plugin boot — see `Godot-MCP/CLAUDE.md` § CLI), but the field is
+ * populated now so a follow-up `setup-skills` command can consume it without
+ * another registry migration. `null` means the agent has no project-local skills
+ * directory.
  */
 export interface AgentDefinition {
   id: string;
   name: string;
+  /** Per-agent project-relative skills directory, or `null` if the agent has none. */
+  skillsPath: string | null;
   configPathDisplay: string;
+  /** Config-file serialization format. `toml` is the Codex branch. */
+  configFormat: 'json' | 'toml';
   bodyPath: string;
   /** Resolve the absolute config-file path for a given project root. */
   getConfigPath(projectPath: string): string;
@@ -65,12 +80,20 @@ function authHeaders(token: string, authRequired: boolean): Record<string, strin
 
 const MCP_SERVER_NAME = 'ai-game-developer';
 
+/**
+ * Note on the Unity-only `unity-ai` agent: the Unity CLI registry includes a
+ * `unity-ai` entry that writes `UserSettings/mcp.json` for Unity's built-in AI
+ * assistant. That agent is intentionally OMITTED here — it targets a Unity-only
+ * surface (`UserSettings/` is a Unity project convention) with no Godot analog.
+ */
 export const agentRegistry: readonly AgentDefinition[] = [
   // ── Claude Code ──────────────────────────────────────────────
   {
     id: 'claude-code',
     name: 'Claude Code',
+    skillsPath: '.claude/skills',
     configPathDisplay: '.mcp.json',
+    configFormat: 'json',
     bodyPath: 'mcpServers',
     getConfigPath: (p) => path.join(p, '.mcp.json'),
     getHttpProps: (url, token, authRequired) => ({
@@ -85,7 +108,9 @@ export const agentRegistry: readonly AgentDefinition[] = [
   {
     id: 'claude-desktop',
     name: 'Claude Desktop',
+    skillsPath: null,
     configPathDisplay: '~/Claude/claude_desktop_config.json',
+    configFormat: 'json',
     bodyPath: 'mcpServers',
     getConfigPath: () => {
       if (isWindows()) {
@@ -108,7 +133,9 @@ export const agentRegistry: readonly AgentDefinition[] = [
   {
     id: 'cursor',
     name: 'Cursor',
+    skillsPath: '.cursor/skills',
     configPathDisplay: '.cursor/mcp.json',
+    configFormat: 'json',
     bodyPath: 'mcpServers',
     getConfigPath: (p) => path.join(p, '.cursor', 'mcp.json'),
     getHttpProps: (url, token, authRequired) => ({
@@ -123,7 +150,9 @@ export const agentRegistry: readonly AgentDefinition[] = [
   {
     id: 'vscode',
     name: 'Visual Studio Code (Copilot)',
+    skillsPath: '.github/skills',
     configPathDisplay: '.vscode/mcp.json',
+    configFormat: 'json',
     bodyPath: 'servers',
     getConfigPath: (p) => path.join(p, '.vscode', 'mcp.json'),
     getHttpProps: (url, token, authRequired) => ({
@@ -134,11 +163,187 @@ export const agentRegistry: readonly AgentDefinition[] = [
     httpRemoveKeys: ['command', 'args'],
   },
 
+  // ── Visual Studio (Copilot) ──────────────────────────────────
+  {
+    id: 'vs-copilot',
+    name: 'Visual Studio (Copilot)',
+    skillsPath: '.github/skills',
+    configPathDisplay: '.vs/mcp.json',
+    configFormat: 'json',
+    bodyPath: 'servers',
+    getConfigPath: (p) => path.join(p, '.vs', 'mcp.json'),
+    getHttpProps: (url, token, authRequired) => ({
+      type: 'http',
+      url,
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    httpRemoveKeys: ['command', 'args'],
+  },
+
+  // ── Rider (Junie) ───────────────────────────────────────────
+  {
+    id: 'rider-junie',
+    name: 'Rider (Junie)',
+    skillsPath: '.junie/skills',
+    configPathDisplay: '.junie/mcp/mcp.json',
+    configFormat: 'json',
+    bodyPath: 'mcpServers',
+    getConfigPath: (p) => path.join(p, '.junie', 'mcp', 'mcp.json'),
+    getHttpProps: (url, token, authRequired) => ({
+      enabled: true,
+      type: 'http',
+      url,
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    httpRemoveKeys: ['disabled', 'command', 'args'],
+  },
+
+  // ── GitHub Copilot CLI ──────────────────────────────────────
+  {
+    id: 'github-copilot-cli',
+    name: 'GitHub Copilot CLI',
+    skillsPath: '.github/skills',
+    configPathDisplay: '~/.copilot/mcp-config.json',
+    configFormat: 'json',
+    bodyPath: 'mcpServers',
+    getConfigPath: () => path.join(home(), '.copilot', 'mcp-config.json'),
+    getHttpProps: (url, token, authRequired) => ({
+      type: 'http',
+      url,
+      tools: ['*'],
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    httpRemoveKeys: ['command', 'args'],
+  },
+
+  // ── Gemini ──────────────────────────────────────────────────
+  {
+    id: 'gemini',
+    name: 'Gemini',
+    skillsPath: '.gemini/skills',
+    configPathDisplay: '.gemini/settings.json',
+    configFormat: 'json',
+    bodyPath: 'mcpServers',
+    getConfigPath: (p) => path.join(p, '.gemini', 'settings.json'),
+    getHttpProps: (url, token, authRequired) => ({
+      type: 'http',
+      url,
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    httpRemoveKeys: ['command', 'args'],
+  },
+
+  // ── Antigravity ─────────────────────────────────────────────
+  {
+    id: 'antigravity',
+    name: 'Antigravity',
+    skillsPath: '.agent/skills',
+    configPathDisplay: '~/.gemini/config/mcp_config.json',
+    configFormat: 'json',
+    bodyPath: 'mcpServers',
+    getConfigPath: () => path.join(home(), '.gemini', 'config', 'mcp_config.json'),
+    // Antigravity uses a `serverUrl` key (not `url`) and a `disabled` flag.
+    getHttpProps: (url, _token, _authRequired) => ({
+      disabled: false,
+      serverUrl: url,
+    }),
+    httpRemoveKeys: ['command', 'args', 'url', 'type'],
+  },
+
+  // ── Cline ───────────────────────────────────────────────────
+  {
+    id: 'cline',
+    name: 'Cline',
+    skillsPath: '.cline/skills',
+    configPathDisplay: '~/Code/globalStorage/.../cline_mcp_settings.json',
+    configFormat: 'json',
+    bodyPath: 'mcpServers',
+    getConfigPath: () => {
+      if (isWindows()) {
+        return path.join(
+          appData(),
+          'Code',
+          'User',
+          'globalStorage',
+          'saoudrizwan.claude-dev',
+          'settings',
+          'cline_mcp_settings.json',
+        );
+      }
+      const base = isMac()
+        ? path.join(home(), 'Library', 'Application Support', 'Code', 'User', 'globalStorage')
+        : path.join(home(), '.config', 'Code', 'User', 'globalStorage');
+      return path.join(base, 'saoudrizwan.claude-dev', 'settings', 'cline_mcp_settings.json');
+    },
+    getHttpProps: (url, token, authRequired) => ({
+      type: 'streamableHttp',
+      url,
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    httpRemoveKeys: ['command', 'args'],
+  },
+
+  // ── Open Code ───────────────────────────────────────────────
+  {
+    id: 'open-code',
+    name: 'Open Code',
+    skillsPath: '.opencode/skills',
+    configPathDisplay: 'opencode.json',
+    configFormat: 'json',
+    bodyPath: 'mcp',
+    getConfigPath: (p) => path.join(p, 'opencode.json'),
+    getHttpProps: (url, token, authRequired) => ({
+      type: 'remote',
+      enabled: true,
+      url,
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    httpRemoveKeys: ['command', 'args'],
+  },
+
+  // ── Codex (TOML config) ─────────────────────────────────────
+  {
+    id: 'codex',
+    name: 'Codex',
+    skillsPath: '.agents/skills',
+    configPathDisplay: '.codex/config.toml',
+    configFormat: 'toml',
+    bodyPath: 'mcp_servers',
+    getConfigPath: (p) => path.join(p, '.codex', 'config.toml'),
+    getHttpProps: (url, _token, _authRequired) => ({
+      enabled: true,
+      url,
+      tool_timeout_sec: 300,
+      startup_timeout_sec: 30,
+    }),
+    httpRemoveKeys: ['command', 'args', 'type'],
+  },
+
+  // ── Kilo Code ───────────────────────────────────────────────
+  {
+    id: 'kilo-code',
+    name: 'Kilo Code',
+    skillsPath: '.kilocode/skills',
+    configPathDisplay: '.kilocode/mcp.json',
+    configFormat: 'json',
+    bodyPath: 'mcpServers',
+    getConfigPath: (p) => path.join(p, '.kilocode', 'mcp.json'),
+    getHttpProps: (url, token, authRequired) => ({
+      type: 'streamable-http',
+      disabled: false,
+      url,
+      ...(authHeaders(token, authRequired) ? { headers: authHeaders(token, authRequired) } : {}),
+    }),
+    httpRemoveKeys: ['command', 'args'],
+  },
+
   // ── Custom (generic mcpServers entry written to a caller path) ─
   {
     id: 'custom',
     name: 'Custom (generic MCP client)',
+    skillsPath: null,
     configPathDisplay: 'mcp.json',
+    configFormat: 'json',
     bodyPath: 'mcpServers',
     getConfigPath: (p) => path.join(p, 'mcp.json'),
     getHttpProps: (url, token, authRequired) => ({
@@ -259,6 +464,77 @@ export function writeJsonAgentConfig(
   root[bodyPath] = body;
 
   fs.writeFileSync(configPath, JSON.stringify(root, null, 2) + '\n');
+}
+
+// ---------------------------------------------------------------------------
+// Config file writing — TOML (Codex only)
+// ---------------------------------------------------------------------------
+
+/**
+ * Write/merge a single `[bodyPath.serverName]` TOML section into `configPath`,
+ * mirroring the Unity CLI's Codex TOML branch. Existing sections under other
+ * headers are preserved; the target section is replaced wholesale (so a re-run
+ * is idempotent and stale keys are dropped). Keys in `removeKeys` are never
+ * written. This is a deliberately minimal TOML emitter — Codex's config schema
+ * here is flat (string/number/bool/array scalars only), so a full TOML library
+ * dependency is unwarranted.
+ */
+export function writeTomlAgentConfig(
+  configPath: string,
+  bodyPath: string,
+  serverName: string,
+  props: Record<string, unknown>,
+  removeKeys: string[],
+): void {
+  const dir = path.dirname(configPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  // Read existing content or start fresh
+  let lines: string[] = [];
+  if (fs.existsSync(configPath)) {
+    lines = fs.readFileSync(configPath, 'utf-8').split('\n');
+  }
+
+  const sectionHeader = `[${bodyPath}.${serverName}]`;
+
+  // Find existing section boundaries
+  const sectionIdx = lines.findIndex((l) => l.trim() === sectionHeader);
+
+  // Build TOML key-value pairs for the section
+  const tomlLines = [sectionHeader];
+  for (const [key, value] of Object.entries(props)) {
+    if (removeKeys.includes(key)) continue;
+    tomlLines.push(`${key} = ${tomlValue(value)}`);
+  }
+
+  if (sectionIdx >= 0) {
+    // Find end of section (next [...] header or EOF)
+    let endIdx = sectionIdx + 1;
+    while (endIdx < lines.length && !lines[endIdx].trim().startsWith('[')) {
+      endIdx++;
+    }
+    // Replace section
+    lines.splice(sectionIdx, endIdx - sectionIdx, ...tomlLines);
+  } else {
+    // Append section
+    if (lines.length > 0 && lines[lines.length - 1].trim() !== '') {
+      lines.push('');
+    }
+    lines.push(...tomlLines);
+  }
+
+  fs.writeFileSync(configPath, lines.join('\n') + '\n');
+}
+
+function tomlValue(v: unknown): string {
+  if (typeof v === 'string') return `"${v.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+  if (Array.isArray(v)) {
+    return `[${v.map(tomlValue).join(', ')}]`;
+  }
+  return String(v);
 }
 
 export { MCP_SERVER_NAME };

--- a/cli/tests/setup-mcp.test.ts
+++ b/cli/tests/setup-mcp.test.ts
@@ -1,7 +1,16 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+
+// Redirectable home dir: agents.ts resolves home-dir / global agent config paths
+// via os.homedir(); ESM forbids spying on the live export, so we mock the module
+// and back homedir() with a mutable holder the tests can repoint under tmpDir.
+const homeHolder = vi.hoisted(() => ({ dir: '' }));
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: () => homeHolder.dir || actual.homedir() };
+});
 import { setupMcp, listAgentIds } from '../src/lib/setup-mcp.js';
 import {
   agentRegistry,
@@ -18,6 +27,9 @@ const SERVER_NAME = 'ai-game-developer';
 describe('setupMcp', () => {
   let tmpDir: string;
   const saved: Record<string, string | undefined> = {};
+  // Env vars that steer home-dir / global agent config paths (agents.ts `appData()`
+  // reads APPDATA; the posix branches of `home()` read HOME/XDG_CONFIG_HOME).
+  const HOME_ENV_KEYS = ['APPDATA', 'HOME', 'XDG_CONFIG_HOME'];
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-setup-mcp-'));
@@ -25,9 +37,18 @@ describe('setupMcp', () => {
       saved[k] = process.env[k];
       delete process.env[k];
     }
+    // Redirect home-dir / global agent writes (cline, github-copilot-cli,
+    // antigravity, claude-desktop) under tmpDir so they never touch the real
+    // developer config. agents.ts resolves these via os.homedir() and APPDATA.
+    for (const k of HOME_ENV_KEYS) {
+      saved[k] = process.env[k];
+      process.env[k] = tmpDir;
+    }
+    homeHolder.dir = tmpDir;
   });
   afterEach(() => {
-    for (const k of [ENV_HOST, ENV_TOKEN]) {
+    homeHolder.dir = '';
+    for (const k of [ENV_HOST, ENV_TOKEN, ...HOME_ENV_KEYS]) {
       if (saved[k] === undefined) delete process.env[k];
       else process.env[k] = saved[k];
     }
@@ -427,5 +448,12 @@ describe('writeTomlAgentConfig — write/merge/remove round-trip (Codex)', () =>
     writeTomlAgentConfig(cfg, 'mcp_servers', MCP_SERVER_NAME, { url: 'C:\\a "b"' }, []);
     const toml = fs.readFileSync(cfg, 'utf-8');
     expect(toml).toContain('url = "C:\\\\a \\"b\\""');
+  });
+
+  it('escapes special characters inside array elements', () => {
+    const cfg = path.join(tmpDir, 'config.toml');
+    writeTomlAgentConfig(cfg, 'mcp_servers', MCP_SERVER_NAME, { args: ['C:\\x', 'a "q"'] }, []);
+    const toml = fs.readFileSync(cfg, 'utf-8');
+    expect(toml).toContain('args = ["C:\\\\x", "a \\"q\\""]');
   });
 });

--- a/cli/tests/setup-mcp.test.ts
+++ b/cli/tests/setup-mcp.test.ts
@@ -3,7 +3,17 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { setupMcp, listAgentIds } from '../src/lib/setup-mcp.js';
+import {
+  agentRegistry,
+  getAgentById,
+  getAgentIds,
+  writeJsonAgentConfig,
+  writeTomlAgentConfig,
+  MCP_SERVER_NAME,
+} from '../src/utils/agents.js';
 import { ENV_HOST, ENV_TOKEN } from '../src/utils/connection.js';
+
+const SERVER_NAME = 'ai-game-developer';
 
 describe('setupMcp', () => {
   let tmpDir: string;
@@ -24,12 +34,29 @@ describe('setupMcp', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('lists the known agent ids', () => {
+  it('lists the known agent ids (parity roster)', () => {
     const ids = listAgentIds();
+    // Original 5
     expect(ids).toContain('claude-code');
+    expect(ids).toContain('claude-desktop');
     expect(ids).toContain('cursor');
     expect(ids).toContain('vscode');
     expect(ids).toContain('custom');
+    // Ported from Unity for parity
+    expect(ids).toContain('vs-copilot');
+    expect(ids).toContain('rider-junie');
+    expect(ids).toContain('github-copilot-cli');
+    expect(ids).toContain('gemini');
+    expect(ids).toContain('antigravity');
+    expect(ids).toContain('cline');
+    expect(ids).toContain('open-code');
+    expect(ids).toContain('codex');
+    expect(ids).toContain('kilo-code');
+  });
+
+  it('excludes the Unity-only unity-ai agent', () => {
+    expect(listAgentIds()).not.toContain('unity-ai');
+    expect(getAgentById('unity-ai')).toBeUndefined();
   });
 
   it('fails for an unknown agent', async () => {
@@ -47,7 +74,7 @@ describe('setupMcp', () => {
 
     expect(result.serverUrl).toBe('https://ai-game.dev/mcp');
     const json = JSON.parse(fs.readFileSync(path.join(tmpDir, '.mcp.json'), 'utf-8'));
-    expect(json.mcpServers['ai-game-developer']).toMatchObject({
+    expect(json.mcpServers[SERVER_NAME]).toMatchObject({
       type: 'http',
       url: 'https://ai-game.dev/mcp',
     });
@@ -63,17 +90,124 @@ describe('setupMcp', () => {
     if (result.kind !== 'success') return;
     expect(result.serverUrl).toBe('http://localhost:8080/mcp');
     const json = JSON.parse(fs.readFileSync(path.join(tmpDir, '.cursor', 'mcp.json'), 'utf-8'));
-    expect(json.mcpServers['ai-game-developer'].url).toBe('http://localhost:8080/mcp');
+    expect(json.mcpServers[SERVER_NAME].url).toBe('http://localhost:8080/mcp');
   });
 
   it('writes a VS Code config under the "servers" body path', async () => {
     const result = await setupMcp({ agentId: 'vscode', godotProjectPath: tmpDir, url: 'http://localhost:8080' });
     expect(result.kind).toBe('success');
     const json = JSON.parse(fs.readFileSync(path.join(tmpDir, '.vscode', 'mcp.json'), 'utf-8'));
-    expect(json.servers['ai-game-developer'].url).toBe('http://localhost:8080/mcp');
+    expect(json.servers[SERVER_NAME].url).toBe('http://localhost:8080/mcp');
   });
 
-  it('adds an Authorization header when a token is provided', async () => {
+  it('writes a Visual Studio (vs-copilot) config under .vs/mcp.json / servers', async () => {
+    const result = await setupMcp({ agentId: 'vs-copilot', godotProjectPath: tmpDir, url: 'http://localhost:8080' });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+    expect(result.configPath).toBe(path.join(tmpDir, '.vs', 'mcp.json'));
+    const json = JSON.parse(fs.readFileSync(path.join(tmpDir, '.vs', 'mcp.json'), 'utf-8'));
+    expect(json.servers[SERVER_NAME].url).toBe('http://localhost:8080/mcp');
+  });
+
+  it('writes rider-junie with enabled:true under .junie/mcp/mcp.json', async () => {
+    const result = await setupMcp({ agentId: 'rider-junie', godotProjectPath: tmpDir, url: 'http://localhost:8080' });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+    expect(result.configPath).toBe(path.join(tmpDir, '.junie', 'mcp', 'mcp.json'));
+    const json = JSON.parse(fs.readFileSync(result.configPath, 'utf-8'));
+    expect(json.mcpServers[SERVER_NAME]).toMatchObject({
+      enabled: true,
+      type: 'http',
+      url: 'http://localhost:8080/mcp',
+    });
+  });
+
+  it('writes gemini under .gemini/settings.json / mcpServers', async () => {
+    const result = await setupMcp({ agentId: 'gemini', godotProjectPath: tmpDir, url: 'http://localhost:8080' });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+    expect(result.configPath).toBe(path.join(tmpDir, '.gemini', 'settings.json'));
+    const json = JSON.parse(fs.readFileSync(result.configPath, 'utf-8'));
+    expect(json.mcpServers[SERVER_NAME].url).toBe('http://localhost:8080/mcp');
+  });
+
+  it('writes open-code with type:remote + enabled:true under opencode.json / mcp', async () => {
+    const result = await setupMcp({ agentId: 'open-code', godotProjectPath: tmpDir, url: 'http://localhost:8080' });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+    expect(result.configPath).toBe(path.join(tmpDir, 'opencode.json'));
+    const json = JSON.parse(fs.readFileSync(result.configPath, 'utf-8'));
+    expect(json.mcp[SERVER_NAME]).toMatchObject({
+      type: 'remote',
+      enabled: true,
+      url: 'http://localhost:8080/mcp',
+    });
+  });
+
+  it('writes kilo-code with type:streamable-http + disabled:false', async () => {
+    const result = await setupMcp({ agentId: 'kilo-code', godotProjectPath: tmpDir, url: 'http://localhost:8080' });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+    expect(result.configPath).toBe(path.join(tmpDir, '.kilocode', 'mcp.json'));
+    const json = JSON.parse(fs.readFileSync(result.configPath, 'utf-8'));
+    expect(json.mcpServers[SERVER_NAME]).toMatchObject({
+      type: 'streamable-http',
+      disabled: false,
+      url: 'http://localhost:8080/mcp',
+    });
+  });
+
+  it('writes cline with type:streamableHttp', async () => {
+    const result = await setupMcp({ agentId: 'cline', godotProjectPath: tmpDir, url: 'http://localhost:8080' });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+    // cline writes to a home-dir global path; assert the entry written there.
+    const json = JSON.parse(fs.readFileSync(result.configPath, 'utf-8'));
+    expect(json.mcpServers[SERVER_NAME]).toMatchObject({
+      type: 'streamableHttp',
+      url: 'http://localhost:8080/mcp',
+    });
+  });
+
+  it('writes github-copilot-cli with the tools:["*"] passthrough', async () => {
+    const result = await setupMcp({ agentId: 'github-copilot-cli', godotProjectPath: tmpDir, url: 'http://localhost:8080' });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+    const json = JSON.parse(fs.readFileSync(result.configPath, 'utf-8'));
+    expect(json.mcpServers[SERVER_NAME]).toMatchObject({
+      type: 'http',
+      url: 'http://localhost:8080/mcp',
+      tools: ['*'],
+    });
+  });
+
+  it('writes antigravity with the serverUrl key (not url) and disabled:false', async () => {
+    const result = await setupMcp({ agentId: 'antigravity', godotProjectPath: tmpDir, url: 'http://localhost:8080' });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+    const json = JSON.parse(fs.readFileSync(result.configPath, 'utf-8'));
+    expect(json.mcpServers[SERVER_NAME]).toMatchObject({
+      disabled: false,
+      serverUrl: 'http://localhost:8080/mcp',
+    });
+    // antigravity never carries a `url` key.
+    expect(json.mcpServers[SERVER_NAME].url).toBeUndefined();
+  });
+
+  it('writes codex as TOML under .codex/config.toml / mcp_servers', async () => {
+    const result = await setupMcp({ agentId: 'codex', godotProjectPath: tmpDir, url: 'http://localhost:8080' });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+    expect(result.configPath).toBe(path.join(tmpDir, '.codex', 'config.toml'));
+    const toml = fs.readFileSync(result.configPath, 'utf-8');
+    expect(toml).toContain(`[mcp_servers.${SERVER_NAME}]`);
+    expect(toml).toContain('enabled = true');
+    expect(toml).toContain('url = "http://localhost:8080/mcp"');
+    expect(toml).toContain('tool_timeout_sec = 300');
+    expect(toml).toContain('startup_timeout_sec = 30');
+  });
+
+  it('adds an Authorization header when a token is provided (claude-code)', async () => {
     const result = await setupMcp({
       agentId: 'claude-code',
       godotProjectPath: tmpDir,
@@ -82,6 +216,216 @@ describe('setupMcp', () => {
     });
     expect(result.kind).toBe('success');
     const json = JSON.parse(fs.readFileSync(path.join(tmpDir, '.mcp.json'), 'utf-8'));
-    expect(json.mcpServers['ai-game-developer'].headers).toEqual({ Authorization: 'Bearer secret' });
+    expect(json.mcpServers[SERVER_NAME].headers).toEqual({ Authorization: 'Bearer secret' });
+  });
+
+  it('does NOT add Authorization headers to codex (token-less TOML)', async () => {
+    const result = await setupMcp({
+      agentId: 'codex',
+      godotProjectPath: tmpDir,
+      url: 'http://localhost:8080',
+      token: 'secret',
+    });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+    const toml = fs.readFileSync(result.configPath, 'utf-8');
+    expect(toml).not.toContain('Authorization');
+    expect(toml).not.toContain('headers');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-agent config-path resolution (covers home-dir / project-dir branches)
+// ---------------------------------------------------------------------------
+
+describe('agent config-path resolution', () => {
+  const projectRoot = process.platform === 'win32' ? 'C:\\proj' : '/proj';
+
+  it('every registered agent resolves a non-empty absolute config path', () => {
+    for (const agent of agentRegistry) {
+      const p = agent.getConfigPath(projectRoot);
+      expect(typeof p).toBe('string');
+      expect(p.length).toBeGreaterThan(0);
+      expect(path.isAbsolute(p)).toBe(true);
+    }
+  });
+
+  it('project-scoped agents resolve under the supplied project root', () => {
+    const cases: Array<[string, string[]]> = [
+      ['claude-code', ['.mcp.json']],
+      ['cursor', ['.cursor', 'mcp.json']],
+      ['vscode', ['.vscode', 'mcp.json']],
+      ['vs-copilot', ['.vs', 'mcp.json']],
+      ['rider-junie', ['.junie', 'mcp', 'mcp.json']],
+      ['gemini', ['.gemini', 'settings.json']],
+      ['open-code', ['opencode.json']],
+      ['codex', ['.codex', 'config.toml']],
+      ['kilo-code', ['.kilocode', 'mcp.json']],
+      ['custom', ['mcp.json']],
+    ];
+    for (const [id, segments] of cases) {
+      const agent = getAgentById(id);
+      expect(agent, `agent ${id} should exist`).toBeDefined();
+      expect(agent!.getConfigPath(projectRoot)).toBe(path.join(projectRoot, ...segments));
+    }
+  });
+
+  it('home-dir / global agents ignore the project root', () => {
+    for (const id of ['claude-desktop', 'github-copilot-cli', 'antigravity', 'cline']) {
+      const agent = getAgentById(id)!;
+      const fromA = agent.getConfigPath(projectRoot);
+      const fromB = agent.getConfigPath(process.platform === 'win32' ? 'D:\\other' : '/other');
+      expect(fromA).toBe(fromB); // project-root independent
+      expect(fromA.startsWith(projectRoot)).toBe(false);
+    }
+  });
+
+  it('exposes a skillsPath field for every agent (string or null)', () => {
+    for (const agent of agentRegistry) {
+      expect(agent.skillsPath === null || typeof agent.skillsPath === 'string').toBe(true);
+    }
+    // Spot-check a couple of known skillsPath values ported from Unity.
+    expect(getAgentById('claude-code')!.skillsPath).toBe('.claude/skills');
+    expect(getAgentById('codex')!.skillsPath).toBe('.agents/skills');
+    expect(getAgentById('claude-desktop')!.skillsPath).toBeNull();
+  });
+
+  it('declares the correct configFormat per agent (only codex is toml)', () => {
+    for (const agent of agentRegistry) {
+      expect(agent.configFormat === 'json' || agent.configFormat === 'toml').toBe(true);
+    }
+    expect(getAgentById('codex')!.configFormat).toBe('toml');
+    const tomlAgents = agentRegistry.filter((a) => a.configFormat === 'toml').map((a) => a.id);
+    expect(tomlAgents).toEqual(['codex']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Low-level writer round-trips: write / merge / remove
+// ---------------------------------------------------------------------------
+
+describe('writeJsonAgentConfig — write/merge/remove round-trip', () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-json-cfg-'));
+  });
+  afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  it('creates a fresh file with the server entry', () => {
+    const cfg = path.join(tmpDir, '.mcp.json');
+    writeJsonAgentConfig(cfg, 'mcpServers', MCP_SERVER_NAME, { type: 'http', url: 'u' }, ['command', 'args']);
+    const json = JSON.parse(fs.readFileSync(cfg, 'utf-8'));
+    expect(json.mcpServers[MCP_SERVER_NAME]).toEqual({ type: 'http', url: 'u' });
+  });
+
+  it('merges into an existing file, preserving unrelated entries', () => {
+    const cfg = path.join(tmpDir, '.mcp.json');
+    fs.writeFileSync(
+      cfg,
+      JSON.stringify({ mcpServers: { 'other-server': { type: 'http', url: 'keep' } } }, null, 2),
+    );
+    writeJsonAgentConfig(cfg, 'mcpServers', MCP_SERVER_NAME, { type: 'http', url: 'new' }, ['command', 'args']);
+    const json = JSON.parse(fs.readFileSync(cfg, 'utf-8'));
+    expect(json.mcpServers['other-server']).toEqual({ type: 'http', url: 'keep' });
+    expect(json.mcpServers[MCP_SERVER_NAME]).toEqual({ type: 'http', url: 'new' });
+  });
+
+  it('removes the deprecated Godot-MCP entry on write', () => {
+    const cfg = path.join(tmpDir, '.mcp.json');
+    fs.writeFileSync(
+      cfg,
+      JSON.stringify({ mcpServers: { 'Godot-MCP': { command: 'old', args: ['x'] } } }, null, 2),
+    );
+    writeJsonAgentConfig(cfg, 'mcpServers', MCP_SERVER_NAME, { type: 'http', url: 'u' }, ['command', 'args']);
+    const json = JSON.parse(fs.readFileSync(cfg, 'utf-8'));
+    expect(json.mcpServers['Godot-MCP']).toBeUndefined();
+    expect(json.mcpServers[MCP_SERVER_NAME]).toEqual({ type: 'http', url: 'u' });
+  });
+
+  it('removes stale keys from a pre-existing server entry before merging', () => {
+    const cfg = path.join(tmpDir, '.mcp.json');
+    fs.writeFileSync(
+      cfg,
+      JSON.stringify(
+        { mcpServers: { [MCP_SERVER_NAME]: { command: 'stale', args: ['a'], keep: 1 } } },
+        null,
+        2,
+      ),
+    );
+    writeJsonAgentConfig(cfg, 'mcpServers', MCP_SERVER_NAME, { type: 'http', url: 'u' }, ['command', 'args']);
+    const json = JSON.parse(fs.readFileSync(cfg, 'utf-8'));
+    const entry = json.mcpServers[MCP_SERVER_NAME];
+    expect(entry.command).toBeUndefined();
+    expect(entry.args).toBeUndefined();
+    expect(entry.keep).toBe(1); // untouched keys survive
+    expect(entry.type).toBe('http');
+    expect(entry.url).toBe('u');
+  });
+
+  it('recovers from a malformed existing file by starting fresh', () => {
+    const cfg = path.join(tmpDir, '.mcp.json');
+    fs.writeFileSync(cfg, '{ this is not json');
+    writeJsonAgentConfig(cfg, 'mcpServers', MCP_SERVER_NAME, { type: 'http', url: 'u' }, []);
+    const json = JSON.parse(fs.readFileSync(cfg, 'utf-8'));
+    expect(json.mcpServers[MCP_SERVER_NAME]).toEqual({ type: 'http', url: 'u' });
+  });
+});
+
+describe('writeTomlAgentConfig — write/merge/remove round-trip (Codex)', () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-toml-cfg-'));
+  });
+  afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  it('creates a fresh TOML file with the section', () => {
+    const cfg = path.join(tmpDir, 'config.toml');
+    writeTomlAgentConfig(cfg, 'mcp_servers', MCP_SERVER_NAME, { enabled: true, url: 'http://h/mcp', tool_timeout_sec: 300 }, []);
+    const toml = fs.readFileSync(cfg, 'utf-8');
+    expect(toml).toContain(`[mcp_servers.${MCP_SERVER_NAME}]`);
+    expect(toml).toContain('enabled = true');
+    expect(toml).toContain('url = "http://h/mcp"');
+    expect(toml).toContain('tool_timeout_sec = 300');
+  });
+
+  it('preserves other TOML sections when merging', () => {
+    const cfg = path.join(tmpDir, 'config.toml');
+    fs.writeFileSync(cfg, '[profile]\nname = "me"\n\n[mcp_servers.other]\nurl = "keep"\n');
+    writeTomlAgentConfig(cfg, 'mcp_servers', MCP_SERVER_NAME, { enabled: true, url: 'http://h/mcp' }, []);
+    const toml = fs.readFileSync(cfg, 'utf-8');
+    expect(toml).toContain('[profile]');
+    expect(toml).toContain('name = "me"');
+    expect(toml).toContain('[mcp_servers.other]');
+    expect(toml).toContain('url = "keep"');
+    expect(toml).toContain(`[mcp_servers.${MCP_SERVER_NAME}]`);
+    expect(toml).toContain('url = "http://h/mcp"');
+  });
+
+  it('replaces the target section wholesale on re-run (idempotent, drops stale keys)', () => {
+    const cfg = path.join(tmpDir, 'config.toml');
+    writeTomlAgentConfig(cfg, 'mcp_servers', MCP_SERVER_NAME, { enabled: true, url: 'http://old/mcp', stale: 'drop' }, []);
+    writeTomlAgentConfig(cfg, 'mcp_servers', MCP_SERVER_NAME, { enabled: true, url: 'http://new/mcp' }, []);
+    const toml = fs.readFileSync(cfg, 'utf-8');
+    // Only one section header for the server.
+    const headerCount = toml.split('\n').filter((l) => l.trim() === `[mcp_servers.${MCP_SERVER_NAME}]`).length;
+    expect(headerCount).toBe(1);
+    expect(toml).toContain('url = "http://new/mcp"');
+    expect(toml).not.toContain('http://old/mcp');
+    expect(toml).not.toContain('stale');
+  });
+
+  it('honors removeKeys (omits removed keys from the section)', () => {
+    const cfg = path.join(tmpDir, 'config.toml');
+    writeTomlAgentConfig(cfg, 'mcp_servers', MCP_SERVER_NAME, { enabled: true, url: 'http://h/mcp', type: 'http' }, ['type']);
+    const toml = fs.readFileSync(cfg, 'utf-8');
+    expect(toml).toContain('url = "http://h/mcp"');
+    expect(toml).not.toContain('type =');
+  });
+
+  it('escapes special characters in string values', () => {
+    const cfg = path.join(tmpDir, 'config.toml');
+    writeTomlAgentConfig(cfg, 'mcp_servers', MCP_SERVER_NAME, { url: 'C:\\a "b"' }, []);
+    const toml = fs.readFileSync(cfg, 'utf-8');
+    expect(toml).toContain('url = "C:\\\\a \\"b\\""');
   });
 });


### PR DESCRIPTION
## Summary
- Port the missing AI-agent definitions from the Unity CLI registry to `godot-cli`, adapting each to the Godot CLI's **HTTP-only** surface (the Godot plugin is a server-less client — no stdio transport / local server binary, so Unity's stdio props are intentionally omitted). New agents: `vs-copilot`, `rider-junie`, `github-copilot-cli`, `gemini`, `antigravity`, `cline`, `open-code`, `codex`, `kilo-code` (registry grows 5 → 14).
- Add `skillsPath` (per-agent skills dir, consumed by a future `setup-skills` command) and `configFormat` (`json` | `toml`) to `AgentDefinition`; add a TOML config writer for **Codex** and branch `setupMcp` on `configFormat` (mirrors Unity's TOML path).
- Adapt server name (`ai-game-developer`) + deprecated-entry cleanup (`Godot-MCP`) to Godot. Exclude the Unity-only `unity-ai` agent (UserSettings/ is a Unity-only surface) — documented in a code comment.

## Test plan
- [x] `npm run build` (tsc) clean
- [x] `npm test` (vitest) green — 139 passed (was 92 baseline; +47 new cases covering per-agent config-path resolution, JSON + Codex-TOML write/merge/remove round-trips, the `unity-ai` exclusion, and token/header handling)

Closes #117