### PR TITLE
feat(cli): add godot-cli setup-skills command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,8 +71,13 @@ the headless Godot smoke (Suite 3) instead.
 <url>/api/tools/<tool>`), probes server health, writes AI-agent MCP-client config, and enables/disables the
 `godot_mcp` addon in a project. It also exports a side-effect-free library (`import { openProject, runTool,
 … } from 'godot-cli'`) whose functions return a `{ kind: 'success' | 'failure' }` discriminated union and
-never throw past the public boundary. Unlike the Unity CLI there is **no `setup-skills` command** — Godot
-skills are generated addon-side on plugin boot, so there is nothing for the CLI to invoke.
+never throw past the public boundary. It also ships a `setup-skills <agent> [path]` command that generates
+AI-agent skill files (a `SKILL.md`-per-tool-family) under the agent's skills path. Unlike the Unity CLI
+(which POSTs to a running editor's `/api/system-tools/unity-skill-generate` endpoint), the Godot CLI
+generates the files **locally** from a built-in catalog of the addon's tool families — the Godot server
+exposes no skill-generate HTTP endpoint, so no server or live editor is required. (The addon *additionally*
+auto-generates skills addon-side on plugin boot via `GenerateSkillFilesIfNeeded`; the CLI command is the
+server-less, scriptable path.)
 
 ```bash
 cd cli

--- a/cli/README.md
+++ b/cli/README.md
@@ -31,6 +31,7 @@ Requires Node `^20.19.0 || >=22.12.0`.
 | `status [path]` | Detect a running Godot editor for the project and probe MCP-server health. |
 | `wait-for-ready [path]` | Poll the MCP server until it answers `ping`. |
 | `setup-mcp <agent> [path]` | Write the agent's MCP-client config pointing at the Godot server's `<host>/mcp` URL. |
+| `setup-skills <agent> [path]` | Generate Godot-MCP skill files (a `SKILL.md`-per-tool-family) under the agent's skills path. `--list` shows each agent's skills support. |
 | `configure [path]` | List / enable / disable tools, prompts, and resources in the project-local `.godot-mcp/features.json`. |
 | `close [path]` | Gracefully stop the Godot editor running for a project (`--force` to hard-kill). |
 | `install-plugin [path]` | Enable the `godot_mcp` addon in `project.godot` `[editor_plugins]`. |
@@ -73,13 +74,28 @@ resolved as:
 
 Pass `--url http://localhost:<port>` to target a local/self-hosted server.
 
-## `setup-skills` is not in v1
+## `setup-skills`
 
-Unlike the Unity CLI, there is **no `setup-skills` command**. Godot skills are generated **addon-side** by
-the McpPlugin engine on plugin boot (`GodotMcpConnection.Start` → `GenerateSkillFilesIfNeeded`, driven by
-the `GodotMcpConfig.GenerateSkillFiles` toggle, with a manual "Generate" button in the dock's Skills card).
-The Godot MCP server exposes **no** `skill-generate` HTTP endpoint for the CLI to call, so porting
-`setup-skills` would have nothing to invoke. It is intentionally out of scope for v1.
+`godot-cli setup-skills <agent> [path]` generates AI-agent **skill files** for a Godot project under the
+selected agent's skills path (e.g. Claude Code's `.claude/skills`). Use `--list` to see every agent and its
+skills support.
+
+```bash
+godot-cli setup-skills claude-code            # generate into ./.claude/skills
+godot-cli setup-skills cursor ./MyGame        # generate into MyGame/.cursor/skills
+godot-cli setup-skills --list                 # list agents + their skills paths
+```
+
+The command writes a `SKILL.md`-per-tool-family directory (a `godot-mcp/` overview plus one per family:
+`godot-mcp-node`, `godot-mcp-scene`, `godot-mcp-resource`, …) describing the `godot_mcp` addon's tool
+families. It is **idempotent** — re-running rewrites the same bytes.
+
+Unlike the Unity CLI — which POSTs to a running editor's `/api/system-tools/unity-skill-generate`
+endpoint — the Godot CLI generates the files **locally** from a built-in catalog: the Godot MCP server
+exposes no skill-generate HTTP endpoint, so no server or running editor is required. (The addon
+*additionally* auto-generates skills in-process on plugin boot via
+`GodotMcpConnection.Start` → `GenerateSkillFilesIfNeeded`; the CLI command is the
+server-less, scriptable path that does not need a live editor.)
 
 ## Library API
 

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -10,6 +10,7 @@ export { runSystemToolCommand } from './commands/run-system-tool.js';
 export { statusCommand } from './commands/status.js';
 export { waitForReadyCommand } from './commands/wait-for-ready.js';
 export { setupMcpCommand } from './commands/setup-mcp.js';
+export { setupSkillsCommand } from './commands/setup-skills.js';
 export { configureCommand } from './commands/configure.js';
 export { closeCommand } from './commands/close.js';
 export { createUpdateCommand } from './commands/update.js';

--- a/cli/src/commands/setup-skills.ts
+++ b/cli/src/commands/setup-skills.ts
@@ -1,0 +1,82 @@
+import { Command } from 'commander';
+import * as ui from '../utils/ui.js';
+import { verbose } from '../utils/ui.js';
+import { getAgentById, getAgentIds, listAgentTable } from '../utils/agents.js';
+import { setupSkills } from '../lib/setup-skills.js';
+
+interface SetupSkillsCliOptions {
+  list?: boolean;
+}
+
+function listAgentsWithSkills(): void {
+  listAgentTable('AI Agents — Skills Support', 'Skills Path', (a) => a.skillsPath ?? '—');
+}
+
+export const setupSkillsCommand = new Command('setup-skills')
+  .description('Generate Godot-MCP skill files for an AI agent under its skills path')
+  .argument('[agent-id]', 'Agent to generate skills for (use --list to see all)')
+  .argument('[path]', 'Godot project path (defaults to cwd)')
+  .option('--list', 'List all agents and their skills-support status')
+  .action(
+    async (
+      agentId: string | undefined,
+      positionalPath: string | undefined,
+      options: SetupSkillsCliOptions,
+    ) => {
+      if (options.list) {
+        listAgentsWithSkills();
+        return;
+      }
+
+      if (!agentId) {
+        ui.error('Missing required argument: agent-id');
+        ui.info(`Available agent IDs: ${getAgentIds().join(', ')}`);
+        process.exit(1);
+      }
+
+      const agent = getAgentById(agentId);
+      if (!agent) {
+        ui.error(`Unknown agent: "${agentId}"`);
+        ui.info(`Available agent IDs: ${getAgentIds().join(', ')}`);
+        process.exit(1);
+      }
+
+      if (!agent.skillsPath) {
+        ui.error(`Agent "${agent.name}" does not support skills.`);
+        process.exit(1);
+      }
+
+      const spinner = ui.startSpinner(`Generating skills for ${agent.name}...`);
+
+      const result = await setupSkills({
+        agentId,
+        godotProjectPath: positionalPath,
+      });
+
+      if (result.kind === 'failure') {
+        spinner.error('Failed to generate skills');
+        ui.error(result.error.message);
+        process.exit(1);
+      }
+
+      if (positionalPath) {
+        verbose(`Project path: ${positionalPath}`);
+      }
+      verbose(`Skills directory: ${result.skillsDir}`);
+      for (const file of result.filesWritten) {
+        verbose(`Wrote ${file}`);
+      }
+
+      spinner.success(`Skills generated for ${agent.name}`);
+
+      console.log('');
+      ui.label('Agent', agent.name);
+      ui.label('Skills path', result.skillsDir);
+      ui.label('Files written', String(result.filesWritten.length));
+
+      for (const warning of result.warnings) {
+        console.log('');
+        ui.warn(warning);
+      }
+    },
+  );

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -6,6 +6,7 @@ import { runSystemToolCommand } from './commands/run-system-tool.js';
 import { statusCommand } from './commands/status.js';
 import { waitForReadyCommand } from './commands/wait-for-ready.js';
 import { setupMcpCommand } from './commands/setup-mcp.js';
+import { setupSkillsCommand } from './commands/setup-skills.js';
 import { configureCommand } from './commands/configure.js';
 import { createProjectCommand } from './commands/create-project.js';
 import { closeCommand } from './commands/close.js';
@@ -37,6 +38,7 @@ const subcommands = [
   runToolCommand,
   runSystemToolCommand,
   setupMcpCommand,
+  setupSkillsCommand,
   statusCommand,
   createUpdateCommand(pkg.version),
   waitForReadyCommand,

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -17,6 +17,7 @@ export { openProject } from './lib/open.js';
 export { createProject } from './lib/create-project.js';
 export { runTool, runSystemTool } from './lib/run-tool.js';
 export { setupMcp, listAgentIds } from './lib/setup-mcp.js';
+export { setupSkills } from './lib/setup-skills.js';
 export { installPlugin, removePlugin } from './lib/install-plugin.js';
 
 export type {
@@ -51,6 +52,11 @@ export type {
   SetupMcpResult,
   SetupMcpSuccess,
   SetupMcpFailure,
+  // setup-skills
+  SetupSkillsOptions,
+  SetupSkillsResult,
+  SetupSkillsSuccess,
+  SetupSkillsFailure,
   // install-plugin / remove-plugin
   InstallPluginOptions,
   InstallPluginResult,

--- a/cli/src/lib/setup-skills.ts
+++ b/cli/src/lib/setup-skills.ts
@@ -17,8 +17,11 @@ import type { SetupSkillsOptions, SetupSkillsResult } from './types.js';
  * the `godot_mcp` addon's tool families (`Tool_Node`, `Tool_Scene`, …), NOT
  * Unity tool names.
  *
- * Idempotent: re-running rewrites the same bytes. A `SKILL.md`-per-family
- * directory is written under `<projectPath>/<agent.skillsPath>`.
+ * Idempotent: re-running rewrites the same bytes and prunes any
+ * `godot-mcp*` skill directories the current catalog no longer emits (so a
+ * shrunk catalog does not leave stale family dirs behind). A
+ * `SKILL.md`-per-family directory is written under
+ * `<projectPath>/<agent.skillsPath>`.
  */
 export async function setupSkills(opts: SetupSkillsOptions): Promise<SetupSkillsResult> {
   const warnings: string[] = [];
@@ -75,6 +78,23 @@ export async function setupSkills(opts: SetupSkillsOptions): Promise<SetupSkills
 
     const skillFiles = buildSkillFiles();
     const filesWritten: string[] = [];
+
+    // Prune orphaned `godot-mcp*` family dirs the current catalog no longer
+    // emits, so a shrunk catalog does not leave stale SKILL.md dirs behind.
+    // Only our own generated dirs (top-level segment of each emitted path) are
+    // ever removed — unrelated content under skillsDir is untouched.
+    const emittedDirs = new Set(skillFiles.map((f) => f.relativePath.split('/')[0]));
+    if (fs.existsSync(skillsDir)) {
+      for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+        if (
+          entry.isDirectory() &&
+          (entry.name === 'godot-mcp' || entry.name.startsWith('godot-mcp-')) &&
+          !emittedDirs.has(entry.name)
+        ) {
+          fs.rmSync(path.join(skillsDir, entry.name), { recursive: true, force: true });
+        }
+      }
+    }
 
     for (const file of skillFiles) {
       const absPath = path.join(skillsDir, file.relativePath);

--- a/cli/src/lib/setup-skills.ts
+++ b/cli/src/lib/setup-skills.ts
@@ -1,0 +1,117 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { getAgentById, getAgentIds } from '../utils/agents.js';
+import { buildSkillFiles } from '../utils/skills.js';
+import { emitProgress } from './progress.js';
+import { requireExistingPath } from './validation.js';
+import type { SetupSkillsOptions, SetupSkillsResult } from './types.js';
+
+/**
+ * Generate AI-agent skill files for a Godot project under the selected agent's
+ * `skillsPath`. Library-safe: no stdout noise, no `process.exit`, no throws past
+ * the public boundary.
+ *
+ * Unlike the Unity CLI (which POSTs to a running editor's skill-generate HTTP
+ * endpoint), this generates the files LOCALLY from the Godot-MCP tool-family
+ * catalog — no server and no running editor are required. The content describes
+ * the `godot_mcp` addon's tool families (`Tool_Node`, `Tool_Scene`, …), NOT
+ * Unity tool names.
+ *
+ * Idempotent: re-running rewrites the same bytes. A `SKILL.md`-per-family
+ * directory is written under `<projectPath>/<agent.skillsPath>`.
+ */
+export async function setupSkills(opts: SetupSkillsOptions): Promise<SetupSkillsResult> {
+  const warnings: string[] = [];
+
+  try {
+    if (!opts || typeof opts.agentId !== 'string' || opts.agentId.length === 0) {
+      return {
+        kind: 'failure',
+        success: false,
+        warnings,
+        error: new Error(`agentId is required. Available agent IDs: ${getAgentIds().join(', ')}`),
+      };
+    }
+
+    const agent = getAgentById(opts.agentId);
+    if (!agent) {
+      return {
+        kind: 'failure',
+        success: false,
+        warnings,
+        error: new Error(
+          `Unknown agent: "${opts.agentId}". Available agent IDs: ${getAgentIds().join(', ')}`,
+        ),
+      };
+    }
+
+    if (!agent.skillsPath) {
+      return {
+        kind: 'failure',
+        success: false,
+        warnings,
+        error: new Error(`Agent "${agent.name}" does not support skills.`),
+      };
+    }
+
+    // Resolve project path. If supplied it must exist; otherwise fall back to cwd.
+    let projectPath: string;
+    if (opts.godotProjectPath) {
+      const validated = requireExistingPath(opts.godotProjectPath);
+      if (!validated.ok) {
+        return { kind: 'failure', success: false, warnings, error: validated.error };
+      }
+      projectPath = validated.projectPath;
+    } else {
+      projectPath = path.resolve(process.cwd());
+    }
+
+    const skillsDir = path.join(projectPath, agent.skillsPath);
+
+    emitProgress(opts.onProgress, {
+      phase: 'start',
+      message: `Generating ${agent.name} skills in ${skillsDir}`,
+    });
+
+    const skillFiles = buildSkillFiles();
+    const filesWritten: string[] = [];
+
+    for (const file of skillFiles) {
+      const absPath = path.join(skillsDir, file.relativePath);
+      const dir = path.dirname(absPath);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+      // LF line endings; trailing newline. Deterministic → idempotent re-write.
+      const content = file.content.endsWith('\n') ? file.content : file.content + '\n';
+      fs.writeFileSync(absPath, content);
+      filesWritten.push(absPath);
+      emitProgress(opts.onProgress, {
+        phase: 'manifest-patched',
+        message: `Wrote ${absPath}`,
+        manifestPath: absPath,
+      });
+    }
+
+    emitProgress(opts.onProgress, {
+      phase: 'done',
+      message: `${agent.name} skills generated (${filesWritten.length} files).`,
+    });
+
+    return {
+      kind: 'success',
+      success: true,
+      agentId: agent.id,
+      skillsDir,
+      filesWritten,
+      warnings,
+    };
+  } catch (err: unknown) {
+    return {
+      kind: 'failure',
+      success: false,
+      warnings,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -74,6 +74,38 @@ export interface SetupMcpFailure {
 export type SetupMcpResult = SetupMcpSuccess | SetupMcpFailure;
 
 // ---------------------------------------------------------------------------
+// setup-skills
+// ---------------------------------------------------------------------------
+
+export interface SetupSkillsOptions {
+  /** Agent to generate skills for. Use `listAgentIds()` to discover valid values. */
+  agentId: string;
+  /** Optional Godot project path. Defaults to `process.cwd()` if omitted. */
+  godotProjectPath?: string;
+  onProgress?: ProgressCallback;
+}
+
+export interface SetupSkillsSuccess {
+  kind: 'success';
+  success: true;
+  agentId: string;
+  /** Absolute path to the agent's skills directory the files were written into. */
+  skillsDir: string;
+  /** Absolute paths of every skill file written, in write order. */
+  filesWritten: string[];
+  warnings: string[];
+}
+
+export interface SetupSkillsFailure {
+  kind: 'failure';
+  success: false;
+  warnings: string[];
+  error: Error;
+}
+
+export type SetupSkillsResult = SetupSkillsSuccess | SetupSkillsFailure;
+
+// ---------------------------------------------------------------------------
 // open-project
 // ---------------------------------------------------------------------------
 

--- a/cli/src/utils/skills.ts
+++ b/cli/src/utils/skills.ts
@@ -153,7 +153,14 @@ export interface SkillFile {
 
 const ROOT_SKILL_NAME = 'godot-mcp';
 
-/** YAML-escape a scalar that goes into single quotes in frontmatter. */
+/**
+ * YAML-escape a scalar that goes into single quotes in frontmatter.
+ *
+ * Correctness depends on the value staying single-line: a single-quoted YAML
+ * scalar cannot contain a literal newline, so an embedded `\n` would produce
+ * invalid frontmatter. All catalog descriptions here are single-line ASCII, so
+ * doubling `'` is sufficient; revisit if multi-line descriptions are ever added.
+ */
 function yamlSingleQuote(value: string): string {
   return `'${value.replace(/'/g, "''")}'`;
 }

--- a/cli/src/utils/skills.ts
+++ b/cli/src/utils/skills.ts
@@ -1,0 +1,242 @@
+// Godot-MCP skill catalog + SKILL.md content generation.
+//
+// The Godot analog of Unity-MCP's server-side skill generation. Unlike the
+// Unity CLI — which POSTs to a running editor's `/api/system-tools/unity-skill-
+// generate` endpoint to have the engine emit skill files — the Godot MCP server
+// exposes NO skill-generate HTTP endpoint, and the Godot addon only auto-
+// generates skills in-process on plugin boot (`GodotMcpConnection.Start` →
+// `GenerateSkillFilesIfNeeded`). That in-process path requires a live, connected
+// editor and writes into `user://`-derived locations the CLI cannot drive.
+//
+// So `godot-cli setup-skills` generates the skill files LOCALLY from this
+// catalog: a `SKILL.md`-per-tool-family directory written under the selected
+// agent's `skillsPath`, with content describing the godot_mcp addon's tool
+// families (NOT Unity's tool names). This makes the command self-contained — no
+// server, no running editor — and idempotent (re-running rewrites the same
+// bytes). The catalog mirrors `Godot-MCP/CLAUDE.md` § Tool families; keep the
+// two in lockstep when the addon's tool surface changes.
+
+/** A single Godot-MCP tool family and the individual tools it exposes. */
+export interface SkillFamily {
+  /** Stable slug used for the per-family directory name (e.g. `node`). */
+  id: string;
+  /** Human-facing family name (matches the addon's `Tool_<Family>` class). */
+  title: string;
+  /** One-line summary of what the family is for. */
+  summary: string;
+  /** The MCP tool names in this family (as exposed to MCP clients). */
+  tools: { name: string; description: string }[];
+}
+
+/**
+ * The Godot-MCP tool-family catalog. Mirrors the 10 families documented in
+ * `Godot-MCP/CLAUDE.md` § Tool families and the `[AiToolType]` classes under
+ * `addons/godot_mcp/Tools/`. Tool names are the `[AiTool("<name>")]` identifiers
+ * an MCP client invokes.
+ */
+export const SKILL_FAMILIES: readonly SkillFamily[] = [
+  {
+    id: 'node',
+    title: 'Node',
+    summary: 'Find, create, modify, reparent, duplicate, and delete nodes in the open scene tree.',
+    tools: [
+      { name: 'node-find', description: 'Find nodes in the open scene by path, name, or type.' },
+      { name: 'node-create', description: 'Create a new node (optionally instancing a sub-scene) under a parent.' },
+      { name: 'node-modify', description: 'Set properties on an existing node.' },
+      { name: 'node-set-parent', description: 'Reparent a node to a new parent in the scene tree.' },
+      { name: 'node-duplicate', description: 'Duplicate an existing node.' },
+      { name: 'node-delete', description: 'Delete a node from the scene tree.' },
+    ],
+  },
+  {
+    id: 'scene',
+    title: 'Scene',
+    summary: 'Open, save, create, list, and inspect Godot scenes (`.tscn`).',
+    tools: [
+      { name: 'scene-open', description: 'Open a scene file in the editor.' },
+      { name: 'scene-save', description: 'Save the current (or a specified) scene.' },
+      { name: 'scene-create', description: 'Create a new scene with a given root node.' },
+      { name: 'scene-list-opened', description: 'List the scenes currently open in the editor.' },
+      { name: 'scene-get-data', description: 'Read the structured node tree / data of a scene.' },
+    ],
+  },
+  {
+    id: 'resource',
+    title: 'Resource',
+    summary: 'Find, read, modify, create, move, and delete Godot resources (`.tres`/`.res` and assets).',
+    tools: [
+      { name: 'resource-find', description: 'Find resource files under `res://` by path or type.' },
+      { name: 'resource-get-data', description: 'Read the structured data of a resource.' },
+      { name: 'resource-modify', description: 'Set properties on an existing resource.' },
+      { name: 'resource-create', description: 'Create a new resource of a given type.' },
+      { name: 'resource-move', description: 'Move/rename a resource within the project.' },
+      { name: 'resource-delete', description: 'Delete a resource file from the project.' },
+    ],
+  },
+  {
+    id: 'filesystem',
+    title: 'FileSystem',
+    summary: 'List and reimport project files through the Godot editor filesystem.',
+    tools: [
+      { name: 'filesystem-list', description: 'List files/folders under a `res://` path.' },
+      { name: 'filesystem-reimport', description: 'Trigger a reimport of project assets.' },
+    ],
+  },
+  {
+    id: 'script',
+    title: 'Script',
+    summary: 'Read, create, update, delete, and attach GDScript / C# scripts.',
+    tools: [
+      { name: 'script-read', description: 'Read the source of a script file.' },
+      { name: 'script-create', description: 'Create a new script file.' },
+      { name: 'script-update', description: 'Replace or patch the contents of a script.' },
+      { name: 'script-delete', description: 'Delete a script file.' },
+      { name: 'script-attach-to-node', description: 'Attach a script to a node in the scene.' },
+    ],
+  },
+  {
+    id: 'screenshot',
+    title: 'Screenshot',
+    summary: 'Capture the editor viewport, a camera, or an isolated node as an image.',
+    tools: [
+      { name: 'screenshot-viewport', description: 'Capture the editor viewport.' },
+      { name: 'screenshot-camera', description: 'Capture from a specific camera.' },
+      { name: 'screenshot-isolated', description: 'Capture an isolated node/subtree.' },
+    ],
+  },
+  {
+    id: 'editor',
+    title: 'Editor',
+    summary: 'Read/modify editor application state and the current node selection.',
+    tools: [
+      { name: 'editor-application-get-state', description: 'Read editor application state (play mode, focus, etc.).' },
+      { name: 'editor-application-set-state', description: 'Change editor application state.' },
+      { name: 'editor-selection-get', description: 'Read the current editor node selection.' },
+      { name: 'editor-selection-set', description: 'Set the current editor node selection.' },
+    ],
+  },
+  {
+    id: 'console',
+    title: 'Console',
+    summary: 'Read and clear the editor/runtime log buffer.',
+    tools: [
+      { name: 'console-get-logs', description: 'Read collected editor/runtime log entries.' },
+      { name: 'console-clear-logs', description: 'Clear the collected log buffer.' },
+    ],
+  },
+  {
+    id: 'reflection',
+    title: 'Reflection',
+    summary: 'Discover and invoke engine methods reflectively via ReflectorNet.',
+    tools: [
+      { name: 'reflection-method-find', description: 'Find methods on an engine type by name/signature.' },
+      { name: 'reflection-method-call', description: 'Invoke a method reflectively with serialized arguments.' },
+    ],
+  },
+  {
+    id: 'ping',
+    title: 'Ping',
+    summary: 'Liveness check — confirm the MCP connection to the Godot editor is alive.',
+    tools: [
+      { name: 'ping', description: 'Return `pong` (or the echoed message) to confirm connectivity.' },
+    ],
+  },
+] as const;
+
+/** A single skill file the generator will write (path is relative to the skills dir). */
+export interface SkillFile {
+  /** Path relative to the agent's skills directory, e.g. `godot-mcp-node/SKILL.md`. */
+  relativePath: string;
+  /** Full file contents (UTF-8, LF-terminated). */
+  content: string;
+}
+
+const ROOT_SKILL_NAME = 'godot-mcp';
+
+/** YAML-escape a scalar that goes into single quotes in frontmatter. */
+function yamlSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+/**
+ * Build the root overview `SKILL.md` — a map of all tool families pointing the
+ * agent at the per-family skills.
+ */
+function buildRootSkill(): SkillFile {
+  const lines: string[] = [];
+  lines.push('---');
+  lines.push(`name: ${ROOT_SKILL_NAME}`);
+  lines.push(
+    `description: ${yamlSingleQuote(
+      'Drive the Godot editor through Godot-MCP. Use when creating/editing scenes, nodes, resources, scripts, or capturing screenshots in a Godot project connected to an MCP server.',
+    )}`,
+  );
+  lines.push('---');
+  lines.push('');
+  lines.push('# Godot-MCP');
+  lines.push('');
+  lines.push(
+    'Godot-MCP exposes the Godot editor to an MCP client via the `godot_mcp` addon. The addon connects to an MCP server (cloud `ai-game.dev` by default, or a custom local server) and surfaces the tool families below. Invoke tools by their MCP names (e.g. `node-create`, `scene-open`).',
+  );
+  lines.push('');
+  lines.push('## When to use');
+  lines.push('');
+  lines.push('- The project is a Godot project with the `godot_mcp` addon enabled and connected.');
+  lines.push('- You need to read or mutate the open scene, project resources, or scripts programmatically.');
+  lines.push('- You want to verify a change visually with a screenshot, or inspect the editor log.');
+  lines.push('');
+  lines.push('## Tool families');
+  lines.push('');
+  lines.push('| Family | Tools | Use for |');
+  lines.push('| --- | --- | --- |');
+  for (const fam of SKILL_FAMILIES) {
+    const toolNames = fam.tools.map((t) => `\`${t.name}\``).join(', ');
+    lines.push(`| ${fam.title} | ${toolNames} | ${fam.summary} |`);
+  }
+  lines.push('');
+  lines.push('See the per-family skill files in this directory for the tool list and usage of each family.');
+  lines.push('');
+  return { relativePath: `${ROOT_SKILL_NAME}/SKILL.md`, content: lines.join('\n') };
+}
+
+/** Build a per-family `SKILL.md`. */
+function buildFamilySkill(fam: SkillFamily): SkillFile {
+  const slug = `${ROOT_SKILL_NAME}-${fam.id}`;
+  const lines: string[] = [];
+  lines.push('---');
+  lines.push(`name: ${slug}`);
+  lines.push(`description: ${yamlSingleQuote(`Godot-MCP ${fam.title} tools. ${fam.summary}`)}`);
+  lines.push('---');
+  lines.push('');
+  lines.push(`# Godot-MCP — ${fam.title}`);
+  lines.push('');
+  lines.push(fam.summary);
+  lines.push('');
+  lines.push('## Tools');
+  lines.push('');
+  for (const tool of fam.tools) {
+    lines.push(`- \`${tool.name}\` — ${tool.description}`);
+  }
+  lines.push('');
+  lines.push('## Notes');
+  lines.push('');
+  lines.push(
+    '- All editor-driving tools run on the Godot editor main thread; effects are applied to the live editor state.',
+  );
+  lines.push('- Results are returned as structured data (ReflectorNet-serialized), not free-form text.');
+  lines.push('');
+  return { relativePath: `${slug}/SKILL.md`, content: lines.join('\n') };
+}
+
+/**
+ * Build the full list of skill files for a Godot project: one root overview plus
+ * one per tool family. Deterministic — the same input always yields the same
+ * bytes, so writing them is idempotent.
+ */
+export function buildSkillFiles(): SkillFile[] {
+  const files: SkillFile[] = [buildRootSkill()];
+  for (const fam of SKILL_FAMILIES) {
+    files.push(buildFamilySkill(fam));
+  }
+  return files;
+}

--- a/cli/tests/cli.test.ts
+++ b/cli/tests/cli.test.ts
@@ -37,6 +37,7 @@ describe('CLI integration', () => {
       expect(stdout).toContain('status');
       expect(stdout).toContain('wait-for-ready');
       expect(stdout).toContain('setup-mcp');
+      expect(stdout).toContain('setup-skills');
       expect(stdout).toContain('configure');
       expect(stdout).toContain('close');
       expect(stdout).toContain('install-plugin');
@@ -45,12 +46,10 @@ describe('CLI integration', () => {
       expect(stdout).toContain('create-project');
     });
 
-    it('does NOT register a setup-skills command (scoped out of v1)', () => {
+    it('registers the setup-skills command (added in #119)', () => {
       const { stdout, exitCode } = runCli(['--help']);
       expect(exitCode).toBe(0);
-      // The word "skills" may appear in prose, but there is no `setup-skills`
-      // command listed in the Commands section.
-      expect(stdout).not.toMatch(/^\s*setup-skills\b/m);
+      expect(stdout).toMatch(/setup-skills\b/);
     });
 
     it('shows version with --version', () => {

--- a/cli/tests/setup-skills.test.ts
+++ b/cli/tests/setup-skills.test.ts
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { runCliAsync } from './helpers/cli.js';
+import { setupSkills } from '../src/lib/setup-skills.js';
+import { buildSkillFiles, SKILL_FAMILIES } from '../src/utils/skills.js';
+import { getAgentById } from '../src/utils/agents.js';
+
+// ---------------------------------------------------------------------------
+// CLI surface — help / list / error cases (no filesystem mutation needed)
+// ---------------------------------------------------------------------------
+
+describe('setup-skills command (CLI surface)', () => {
+  it('shows help with --help', async () => {
+    const { stdout, exitCode } = await runCliAsync(['setup-skills', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('setup-skills');
+    expect(stdout).toContain('--list');
+  });
+
+  it('--list prints the agent/skills table and exits 0', async () => {
+    const { stdout, exitCode } = await runCliAsync(['setup-skills', '--list']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('claude-code');
+    // claude-code has a skills path; it should appear in the table
+    expect(stdout).toContain('.claude/skills');
+  });
+
+  it('exits 1 with error when agent-id is missing', async () => {
+    const { stdout, exitCode } = await runCliAsync(['setup-skills']);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('Missing required argument');
+  });
+
+  it('exits 1 with error for unknown agent-id', async () => {
+    const { stdout, exitCode } = await runCliAsync(['setup-skills', 'not-a-real-agent']);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('Unknown agent');
+  });
+
+  it('exits 1 when agent does not support skills (claude-desktop)', async () => {
+    const { stdout, exitCode } = await runCliAsync(['setup-skills', 'claude-desktop']);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('does not support skills');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Skill content catalog
+// ---------------------------------------------------------------------------
+
+describe('skill content (Godot tool families)', () => {
+  it('emits one root file plus one per family', () => {
+    const files = buildSkillFiles();
+    expect(files.length).toBe(SKILL_FAMILIES.length + 1);
+    expect(files[0].relativePath).toBe('godot-mcp/SKILL.md');
+  });
+
+  it('describes Godot tool families, not Unity tool names', () => {
+    const all = buildSkillFiles().map((f) => f.content).join('\n');
+    // Godot tool families / tool names must be present
+    expect(all).toContain('node-create');
+    expect(all).toContain('scene-open');
+    expect(all).toContain('resource-find');
+    expect(all).toContain('screenshot-viewport');
+    expect(all).toContain('reflection-method-call');
+    expect(all).toContain('godot_mcp');
+    // Unity-specific surface must NOT leak in
+    expect(all).not.toContain('unity-skill-generate');
+    expect(all.toLowerCase()).not.toContain('gameobject');
+    expect(all).not.toContain('MenuItem');
+  });
+
+  it('every skill file has valid YAML frontmatter with a name + description', () => {
+    for (const file of buildSkillFiles()) {
+      expect(file.content.startsWith('---\n')).toBe(true);
+      const fm = file.content.slice(4, file.content.indexOf('\n---', 4));
+      expect(fm).toMatch(/^name: \S/m);
+      expect(fm).toMatch(/^description: /m);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Generation + idempotency (filesystem)
+// ---------------------------------------------------------------------------
+
+describe('setupSkills generation + idempotency', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cli-skills-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // Every agent in the registry that defines a skillsPath must generate cleanly.
+  const skilledAgentIds = [
+    'claude-code',
+    'cursor',
+    'vscode',
+    'vs-copilot',
+    'rider-junie',
+    'github-copilot-cli',
+    'gemini',
+    'antigravity',
+    'cline',
+    'open-code',
+    'codex',
+    'kilo-code',
+  ];
+
+  it.each(skilledAgentIds)('generates skill files for %s under its skillsPath', async (agentId) => {
+    const agent = getAgentById(agentId);
+    expect(agent).toBeDefined();
+    expect(agent!.skillsPath).toBeTruthy();
+
+    const result = await setupSkills({ agentId, godotProjectPath: tmpDir });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+
+    const expectedDir = path.join(tmpDir, agent!.skillsPath!);
+    expect(result.skillsDir).toBe(expectedDir);
+    expect(result.filesWritten.length).toBe(SKILL_FAMILIES.length + 1);
+
+    // Root + every family file exist on disk under the agent's skills path.
+    for (const file of result.filesWritten) {
+      expect(fs.existsSync(file)).toBe(true);
+      expect(file.startsWith(expectedDir)).toBe(true);
+    }
+    expect(fs.existsSync(path.join(expectedDir, 'godot-mcp', 'SKILL.md'))).toBe(true);
+  });
+
+  it('fails for an agent without skills support (claude-desktop)', async () => {
+    const result = await setupSkills({ agentId: 'claude-desktop', godotProjectPath: tmpDir });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') {
+      expect(result.error.message).toContain('does not support skills');
+    }
+  });
+
+  it('fails for an unknown agent id', async () => {
+    const result = await setupSkills({ agentId: 'nope', godotProjectPath: tmpDir });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') {
+      expect(result.error.message).toContain('Unknown agent');
+    }
+  });
+
+  it('fails when the project path does not exist', async () => {
+    const result = await setupSkills({
+      agentId: 'claude-code',
+      godotProjectPath: path.join(tmpDir, 'does-not-exist-xyz'),
+    });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') {
+      expect(result.error.message).toContain('does not exist');
+    }
+  });
+
+  it('is idempotent — re-running writes identical bytes', async () => {
+    const first = await setupSkills({ agentId: 'claude-code', godotProjectPath: tmpDir });
+    expect(first.kind).toBe('success');
+    if (first.kind !== 'success') return;
+
+    const snapshot = first.filesWritten.map((f) => fs.readFileSync(f, 'utf-8'));
+
+    const second = await setupSkills({ agentId: 'claude-code', godotProjectPath: tmpDir });
+    expect(second.kind).toBe('success');
+    if (second.kind !== 'success') return;
+
+    expect(second.filesWritten).toEqual(first.filesWritten);
+    second.filesWritten.forEach((f, i) => {
+      expect(fs.readFileSync(f, 'utf-8')).toBe(snapshot[i]);
+    });
+  });
+
+  it('overwrites stale content on re-run (regeneration, not append)', async () => {
+    const first = await setupSkills({ agentId: 'claude-code', godotProjectPath: tmpDir });
+    expect(first.kind).toBe('success');
+    if (first.kind !== 'success') return;
+
+    const rootFile = path.join(first.skillsDir, 'godot-mcp', 'SKILL.md');
+    fs.writeFileSync(rootFile, 'STALE\n');
+
+    const second = await setupSkills({ agentId: 'claude-code', godotProjectPath: tmpDir });
+    expect(second.kind).toBe('success');
+    const after = fs.readFileSync(rootFile, 'utf-8');
+    expect(after).not.toContain('STALE');
+    expect(after).toContain('# Godot-MCP');
+  });
+});

--- a/cli/tests/setup-skills.test.ts
+++ b/cli/tests/setup-skills.test.ts
@@ -8,7 +8,7 @@ import * as os from 'os';
 import { runCliAsync } from './helpers/cli.js';
 import { setupSkills } from '../src/lib/setup-skills.js';
 import { buildSkillFiles, SKILL_FAMILIES } from '../src/utils/skills.js';
-import { getAgentById } from '../src/utils/agents.js';
+import { getAgentById, agentRegistry } from '../src/utils/agents.js';
 
 // ---------------------------------------------------------------------------
 // CLI surface — help / list / error cases (no filesystem mutation needed)
@@ -42,8 +42,11 @@ describe('setup-skills command (CLI surface)', () => {
     expect(stdout).toContain('Unknown agent');
   });
 
-  it('exits 1 when agent does not support skills (claude-desktop)', async () => {
-    const { stdout, exitCode } = await runCliAsync(['setup-skills', 'claude-desktop']);
+  // Every registry agent WITHOUT a skillsPath must fail the no-skills path.
+  const unskilledAgentIds = agentRegistry.filter((a) => !a.skillsPath).map((a) => a.id);
+
+  it.each(unskilledAgentIds)('exits 1 when agent %s does not support skills', async (agentId) => {
+    const { stdout, exitCode } = await runCliAsync(['setup-skills', agentId]);
     expect(exitCode).toBe(1);
     expect(stdout).toContain('does not support skills');
   });
@@ -101,20 +104,8 @@ describe('setupSkills generation + idempotency', () => {
   });
 
   // Every agent in the registry that defines a skillsPath must generate cleanly.
-  const skilledAgentIds = [
-    'claude-code',
-    'cursor',
-    'vscode',
-    'vs-copilot',
-    'rider-junie',
-    'github-copilot-cli',
-    'gemini',
-    'antigravity',
-    'cline',
-    'open-code',
-    'codex',
-    'kilo-code',
-  ];
+  // Derived from the registry so new skilled agents are covered automatically.
+  const skilledAgentIds = agentRegistry.filter((a) => a.skillsPath).map((a) => a.id);
 
   it.each(skilledAgentIds)('generates skill files for %s under its skillsPath', async (agentId) => {
     const agent = getAgentById(agentId);
@@ -137,8 +128,10 @@ describe('setupSkills generation + idempotency', () => {
     expect(fs.existsSync(path.join(expectedDir, 'godot-mcp', 'SKILL.md'))).toBe(true);
   });
 
-  it('fails for an agent without skills support (claude-desktop)', async () => {
-    const result = await setupSkills({ agentId: 'claude-desktop', godotProjectPath: tmpDir });
+  const unskilledAgentIds = agentRegistry.filter((a) => !a.skillsPath).map((a) => a.id);
+
+  it.each(unskilledAgentIds)('fails for agent %s without skills support', async (agentId) => {
+    const result = await setupSkills({ agentId, godotProjectPath: tmpDir });
     expect(result.kind).toBe('failure');
     if (result.kind === 'failure') {
       expect(result.error.message).toContain('does not support skills');
@@ -179,6 +172,29 @@ describe('setupSkills generation + idempotency', () => {
     second.filesWritten.forEach((f, i) => {
       expect(fs.readFileSync(f, 'utf-8')).toBe(snapshot[i]);
     });
+  });
+
+  it('prunes orphaned godot-mcp* family dirs on re-run, leaving foreign dirs', async () => {
+    const first = await setupSkills({ agentId: 'claude-code', godotProjectPath: tmpDir });
+    expect(first.kind).toBe('success');
+    if (first.kind !== 'success') return;
+
+    // A stale family dir the catalog no longer emits, plus a foreign dir.
+    const orphanDir = path.join(first.skillsDir, 'godot-mcp-obsolete');
+    const foreignDir = path.join(first.skillsDir, 'some-other-skill');
+    fs.mkdirSync(orphanDir, { recursive: true });
+    fs.writeFileSync(path.join(orphanDir, 'SKILL.md'), 'STALE\n');
+    fs.mkdirSync(foreignDir, { recursive: true });
+    fs.writeFileSync(path.join(foreignDir, 'SKILL.md'), 'KEEP\n');
+
+    const second = await setupSkills({ agentId: 'claude-code', godotProjectPath: tmpDir });
+    expect(second.kind).toBe('success');
+
+    // The orphaned godot-mcp* dir is gone; the unrelated dir is untouched.
+    expect(fs.existsSync(orphanDir)).toBe(false);
+    expect(fs.existsSync(foreignDir)).toBe(true);
+    // Current catalog dirs still present.
+    expect(fs.existsSync(path.join(first.skillsDir, 'godot-mcp', 'SKILL.md'))).toBe(true);
   });
 
   it('overwrites stale content on re-run (regeneration, not append)', async () => {


### PR DESCRIPTION
## Summary
- Adds a real `godot-cli setup-skills <agent> [path]` command — the Godot analog of `unity-mcp-cli setup-skills`, generating AI-agent skill files under each agent's `skillsPath`.
- Generates files **locally** from a built-in catalog of the `godot_mcp` addon's 10 tool families (Node/Scene/Resource/FileSystem/Script/Screenshot/Editor/Console/Reflection/Ping). Unlike Unity (which POSTs to a server skill-generate endpoint), the Godot server has no such endpoint, so no server or running editor is required.
- Writes a `SKILL.md`-per-tool-family directory; idempotent (re-runs rewrite identical bytes). Wired into the CLI, the library surface, and updated docs (`cli/README.md`, `Godot-MCP/CLAUDE.md`).

## Test plan
- [x] Target-specific local tests passed (Suite 2b — `npm run build` clean, `npm test` 165 pass, +25 new)
- [x] Functional smoke: `godot-cli setup-skills claude-code <tmp>` wrote 11 files with Godot-adapted content

Closes #119