### PR TITLE
test(cli): audit godot-cli commands + add smoke/unit coverage for the untested ones

### DIFF
--- a/cli/tests/close.test.ts
+++ b/cli/tests/close.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  parseTimeoutSeconds,
+  isGodotProjectRoot,
+  resolveCloseProjectPath,
+  resolveEditorPid,
+} from '../src/commands/close.js';
+import { runCliAsync } from './helpers/cli.js';
+
+describe('close — parseTimeoutSeconds', () => {
+  it('defaults to 30 when undefined', () => {
+    expect(parseTimeoutSeconds(undefined)).toBe(30);
+  });
+
+  it('parses a positive integer string', () => {
+    expect(parseTimeoutSeconds('45')).toBe(45);
+  });
+
+  it('rejects zero', () => {
+    expect(parseTimeoutSeconds('0')).toBeNull();
+  });
+
+  it('rejects negatives', () => {
+    expect(parseTimeoutSeconds('-5')).toBeNull();
+  });
+
+  it('rejects non-integers', () => {
+    expect(parseTimeoutSeconds('3.5')).toBeNull();
+    expect(parseTimeoutSeconds('abc')).toBeNull();
+    expect(parseTimeoutSeconds('')).toBeNull();
+  });
+});
+
+describe('close — isGodotProjectRoot', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cli-close-unit-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('is true when project.godot exists', () => {
+    fs.writeFileSync(path.join(tmpDir, 'project.godot'), 'config_version=5\n');
+    expect(isGodotProjectRoot(tmpDir)).toBe(true);
+  });
+
+  it('is false when project.godot is absent', () => {
+    expect(isGodotProjectRoot(tmpDir)).toBe(false);
+  });
+});
+
+describe('close — resolveCloseProjectPath', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cli-close-resolve-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('resolves an explicit path to its canonical absolute form', () => {
+    const resolved = resolveCloseProjectPath(tmpDir, process.cwd());
+    expect(path.isAbsolute(resolved)).toBe(true);
+    expect(fs.realpathSync(resolved)).toBe(fs.realpathSync(tmpDir));
+  });
+
+  it('falls back to cwd when no positional path is given', () => {
+    const resolved = resolveCloseProjectPath(undefined, tmpDir);
+    expect(fs.realpathSync(resolved)).toBe(fs.realpathSync(tmpDir));
+  });
+
+  it('returns a resolved path even when the target does not exist', () => {
+    const ghost = path.join(tmpDir, 'does-not-exist-xyz');
+    const resolved = resolveCloseProjectPath(ghost, process.cwd());
+    expect(resolved).toBe(path.resolve(ghost));
+  });
+});
+
+describe('close — resolveEditorPid', () => {
+  it('returns null when no Godot editor is running for the project', () => {
+    // A random temp dir is never the --path of a live Godot process.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cli-close-pid-'));
+    try {
+      expect(resolveEditorPid(tmp)).toBeNull();
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('close — CLI smoke', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cli-close-smoke-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('shows help with --help', async () => {
+    const { stdout, exitCode } = await runCliAsync(['close', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('--timeout');
+    expect(stdout).toContain('--force');
+  });
+
+  it('exits 1 when the path does not exist', async () => {
+    const ghost = path.join(tmpDir, 'nope');
+    const { stdout, exitCode } = await runCliAsync(['close', ghost]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('Project path does not exist');
+  });
+
+  it('exits 1 when the path is not a Godot project root', async () => {
+    const { stdout, exitCode } = await runCliAsync(['close', tmpDir]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('Not a Godot project root');
+  });
+
+  it('exits 1 for an invalid --timeout value', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'project.godot'), 'config_version=5\n');
+    const { stdout, exitCode } = await runCliAsync(['close', tmpDir, '--timeout', 'abc']);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('Invalid --timeout value');
+  });
+
+  it('exits 0 with a friendly message when no editor is running for the project', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'project.godot'), 'config_version=5\n');
+    const { stdout, exitCode } = await runCliAsync(['close', tmpDir]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('no running editor for project');
+  });
+});

--- a/cli/tests/configure.test.ts
+++ b/cli/tests/configure.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { runCliAsync } from './helpers/cli.js';
+import {
+  readConfig,
+  getConfigPath,
+  CONFIG_RELATIVE_PATH,
+  updateFeatures,
+  createDefaultConfig,
+  type GodotMcpFeaturesConfig,
+} from '../src/utils/config.js';
+
+describe('configure — config util (prompts/resources, malformed input)', () => {
+  it('updateFeatures operates on prompts and resources, not just tools', () => {
+    const config = createDefaultConfig();
+    updateFeatures(config, 'prompts', { enableNames: ['p1'] });
+    updateFeatures(config, 'resources', { disableNames: ['r1'] });
+    expect(config.prompts).toEqual([{ name: 'p1', enabled: true }]);
+    expect(config.resources).toEqual([{ name: 'r1', enabled: false }]);
+  });
+
+  it('updateFeatures tolerates a feature group that is not an array', () => {
+    const config: GodotMcpFeaturesConfig = { tools: 'garbage' as unknown as never };
+    updateFeatures(config, 'tools', { enableNames: ['only'] });
+    expect(config.tools).toEqual([{ name: 'only', enabled: true }]);
+  });
+
+  it('updateFeatures filters out malformed entries before applying changes', () => {
+    const config: GodotMcpFeaturesConfig = {
+      // a non-object, a wrong-typed name, and a valid entry
+      tools: [42, { name: 5, enabled: true }, { name: 'good', enabled: false }] as unknown as never,
+    };
+    updateFeatures(config, 'tools', { enableNames: ['good'] });
+    expect(config.tools).toEqual([{ name: 'good', enabled: true }]);
+  });
+
+  it('config path is the project-local override file', () => {
+    const p = getConfigPath('/some/proj');
+    expect(p).toBe(path.join('/some/proj', CONFIG_RELATIVE_PATH));
+  });
+});
+
+describe('configure — CLI smoke (depth beyond cli.test.ts)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cli-cfg-deep-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('accepts the positional [path] argument form', async () => {
+    const { exitCode } = await runCliAsync(['configure', tmpDir, '--enable-tools', 'pos-tool']);
+    expect(exitCode).toBe(0);
+    const cfg = readConfig(tmpDir);
+    expect(cfg?.tools).toContainEqual({ name: 'pos-tool', enabled: true });
+  });
+
+  it('enables and disables prompts', async () => {
+    await runCliAsync(['configure', '--path', tmpDir, '--enable-prompts', 'pr-a,pr-b']);
+    await runCliAsync(['configure', '--path', tmpDir, '--disable-prompts', 'pr-a']);
+    const cfg = readConfig(tmpDir);
+    expect(cfg?.prompts).toContainEqual({ name: 'pr-a', enabled: false });
+    expect(cfg?.prompts).toContainEqual({ name: 'pr-b', enabled: true });
+  });
+
+  it('enables and disables resources', async () => {
+    await runCliAsync(['configure', '--path', tmpDir, '--enable-resources', 'res-a']);
+    const cfg = readConfig(tmpDir);
+    expect(cfg?.resources).toContainEqual({ name: 'res-a', enabled: true });
+  });
+
+  it('--disable-all-tools flips every present tool to disabled', async () => {
+    await runCliAsync(['configure', '--path', tmpDir, '--enable-tools', 't1,t2']);
+    await runCliAsync(['configure', '--path', tmpDir, '--disable-all-tools']);
+    const { stdout } = await runCliAsync(['configure', '--path', tmpDir, '--list']);
+    expect(stdout).toContain('[disabled] t1');
+    expect(stdout).toContain('[disabled] t2');
+  });
+
+  it('--enable-all-tools flips every present tool to enabled', async () => {
+    await runCliAsync(['configure', '--path', tmpDir, '--disable-tools', 't1,t2']);
+    await runCliAsync(['configure', '--path', tmpDir, '--enable-all-tools']);
+    const { stdout } = await runCliAsync(['configure', '--path', tmpDir, '--list']);
+    expect(stdout).toContain('[enabled] t1');
+    expect(stdout).toContain('[enabled] t2');
+  });
+
+  it('--list with no overrides reports the all-enabled-by-default state', async () => {
+    const { stdout, exitCode } = await runCliAsync(['configure', '--path', tmpDir, '--list']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('(none configured - all enabled by default)');
+  });
+
+  it('exits 1 when neither a positional path nor --path is provided', async () => {
+    const { stdout, exitCode } = await runCliAsync(['configure', '--list']);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('Path is required');
+  });
+});

--- a/cli/tests/create-project-cli.test.ts
+++ b/cli/tests/create-project-cli.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { runCliAsync } from './helpers/cli.js';
+
+describe('create-project — CLI smoke (--dotnet + name derivation)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cli-create-cli-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('scaffolds a C# (.NET) project with a csproj when --dotnet is given', async () => {
+    const dest = path.join(tmpDir, 'CsGame');
+    const { stdout, exitCode } = await runCliAsync([
+      'create-project', dest, '--name', 'CsGame', '--dotnet',
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('C# (.NET)');
+    expect(fs.existsSync(path.join(dest, 'project.godot'))).toBe(true);
+    expect(fs.existsSync(path.join(dest, 'CsGame.csproj'))).toBe(true);
+    expect(fs.existsSync(path.join(dest, 'icon.svg'))).toBe(true);
+  });
+
+  it('derives the project name from the target folder when --name is omitted', async () => {
+    const dest = path.join(tmpDir, 'DerivedName');
+    const { exitCode } = await runCliAsync(['create-project', dest]);
+    expect(exitCode).toBe(0);
+    const projectGodot = fs.readFileSync(path.join(dest, 'project.godot'), 'utf-8');
+    expect(projectGodot).toContain('DerivedName');
+  });
+
+  it('refuses to scaffold over an existing Unity project (structured failure)', async () => {
+    fs.mkdirSync(path.join(tmpDir, 'ProjectSettings'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'ProjectSettings', 'ProjectVersion.txt'), 'm_EditorVersion: 6000.0.0f1\n');
+    const { stdout, exitCode } = await runCliAsync(['create-project', tmpDir]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('Refusing to scaffold');
+  });
+});

--- a/cli/tests/godot-shutdown.test.ts
+++ b/cli/tests/godot-shutdown.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { spawn, type ChildProcess } from 'child_process';
+import {
+  isProcessAlive,
+  sendGracefulShutdown,
+  sendForceKill,
+  waitForExit,
+} from '../src/utils/godot-shutdown.js';
+
+/**
+ * Spawn a long-lived child process we can probe / signal. On every platform a
+ * sleeping node process is the most portable victim. The caller is responsible
+ * for force-killing it in a `finally`.
+ */
+function spawnSleeper(): ChildProcess {
+  // A node process that idles for a while; we control its lifecycle in tests.
+  return spawn(process.execPath, ['-e', 'setTimeout(() => {}, 60000)'], {
+    stdio: 'ignore',
+  });
+}
+
+async function untilSpawned(child: ChildProcess): Promise<number> {
+  if (child.pid) return child.pid;
+  await new Promise<void>((resolve, reject) => {
+    child.once('spawn', () => resolve());
+    child.once('error', reject);
+  });
+  return child.pid as number;
+}
+
+describe('godot-shutdown — isProcessAlive', () => {
+  it('returns true for a live process and false after it exits', async () => {
+    const child = spawnSleeper();
+    try {
+      const pid = await untilSpawned(child);
+      expect(isProcessAlive(pid)).toBe(true);
+
+      child.kill('SIGKILL');
+      const gone = await waitForExit(pid, 5000);
+      expect(gone).toBe(true);
+      expect(isProcessAlive(pid)).toBe(false);
+    } finally {
+      try { child.kill('SIGKILL'); } catch { /* noop */ }
+    }
+  });
+
+  it('returns false for a clearly-dead PID', () => {
+    // PID 0 / a very large unused PID should not be alive.
+    expect(isProcessAlive(2147483646)).toBe(false);
+  });
+});
+
+describe('godot-shutdown — sendGracefulShutdown / sendForceKill', () => {
+  it('delivers a graceful-shutdown request to a live process', async () => {
+    const child = spawnSleeper();
+    try {
+      const pid = await untilSpawned(child);
+      const sent = sendGracefulShutdown(pid);
+      if (process.platform === 'win32') {
+        // `taskkill` WITHOUT /F posts WM_CLOSE, which a windowless console
+        // process (our node sleeper) cannot receive — taskkill then reports a
+        // non-zero exit, surfaced as `sent === false`. Either outcome is valid;
+        // what matters is the call does not throw and returns a boolean.
+        expect(typeof sent).toBe('boolean');
+      } else {
+        // POSIX SIGTERM reaches any process and ends our node sleeper cleanly.
+        expect(sent).toBe(true);
+        const exited = await waitForExit(pid, 8000);
+        expect(exited).toBe(true);
+      }
+    } finally {
+      try { child.kill('SIGKILL'); } catch { /* noop */ }
+    }
+  });
+
+  it('force-kills a live process (cross-platform)', async () => {
+    const child = spawnSleeper();
+    try {
+      const pid = await untilSpawned(child);
+      const killed = sendForceKill(pid);
+      expect(killed).toBe(true);
+      const exited = await waitForExit(pid, 5000);
+      expect(exited).toBe(true);
+      expect(isProcessAlive(pid)).toBe(false);
+    } finally {
+      try { child.kill('SIGKILL'); } catch { /* noop */ }
+    }
+  });
+
+  it('returns false when trying to signal a non-existent process (posix)', () => {
+    // On win32 taskkill against a missing PID also fails; on posix process.kill
+    // throws ESRCH. Both are caught and surface as `false`.
+    const result = sendGracefulShutdown(2147483646);
+    expect(result).toBe(false);
+  });
+});
+
+describe('godot-shutdown — waitForExit', () => {
+  it('resolves true immediately for an already-dead process', async () => {
+    const exited = await waitForExit(2147483646, 1000);
+    expect(exited).toBe(true);
+  });
+
+  it('resolves false when a live process outlives the timeout', async () => {
+    const child = spawnSleeper();
+    try {
+      const pid = await untilSpawned(child);
+      const exited = await waitForExit(pid, 600);
+      expect(exited).toBe(false);
+    } finally {
+      try { child.kill('SIGKILL'); } catch { /* noop */ }
+    }
+  });
+});

--- a/cli/tests/install-remove-plugin.test.ts
+++ b/cli/tests/install-remove-plugin.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { runCliAsync } from './helpers/cli.js';
+import { installPlugin, removePlugin } from '../src/lib/install-plugin.js';
+import { GODOT_MCP_PLUGIN_PATH, parseEnabledPlugins } from '../src/utils/project-godot.js';
+
+const MINIMAL_PROJECT = '; Engine configuration file.\nconfig_version=5\n\n[application]\n\nconfig/name="Test"\n';
+
+describe('install-plugin / remove-plugin — lib logic', () => {
+  let tmpDir: string;
+  let projectGodot: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cli-plugin-lib-'));
+    projectGodot = path.join(tmpDir, 'project.godot');
+    fs.writeFileSync(projectGodot, MINIMAL_PROJECT);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('installPlugin enables the addon and reports changed:true with the plugin in the list', async () => {
+    const result = await installPlugin({ godotProjectPath: tmpDir });
+    expect(result.kind).toBe('success');
+    if (result.kind === 'success') {
+      expect(result.changed).toBe(true);
+      expect(result.enabledPlugins).toContain(GODOT_MCP_PLUGIN_PATH);
+      // It must surface the NuGet PackageReference warning.
+      expect(result.warnings.some((w) => w.includes('PackageReference'))).toBe(true);
+    }
+    expect(parseEnabledPlugins(fs.readFileSync(projectGodot, 'utf-8'))).toContain(GODOT_MCP_PLUGIN_PATH);
+  });
+
+  it('installPlugin is idempotent — re-enabling reports changed:false', async () => {
+    await installPlugin({ godotProjectPath: tmpDir });
+    const second = await installPlugin({ godotProjectPath: tmpDir });
+    expect(second.kind).toBe('success');
+    if (second.kind === 'success') expect(second.changed).toBe(false);
+  });
+
+  it('removePlugin disables a previously-enabled addon (changed:true)', async () => {
+    await installPlugin({ godotProjectPath: tmpDir });
+    const result = await removePlugin({ godotProjectPath: tmpDir });
+    expect(result.kind).toBe('success');
+    if (result.kind === 'success') {
+      expect(result.changed).toBe(true);
+      expect(result.enabledPlugins).not.toContain(GODOT_MCP_PLUGIN_PATH);
+    }
+    expect(parseEnabledPlugins(fs.readFileSync(projectGodot, 'utf-8'))).not.toContain(GODOT_MCP_PLUGIN_PATH);
+  });
+
+  it('removePlugin is idempotent — disabling an already-absent addon reports changed:false', async () => {
+    const result = await removePlugin({ godotProjectPath: tmpDir });
+    expect(result.kind).toBe('success');
+    if (result.kind === 'success') expect(result.changed).toBe(false);
+  });
+
+  it('installPlugin returns a structured failure (never throws) for a non-Godot dir', async () => {
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cli-plugin-empty-'));
+    try {
+      const result = await installPlugin({ godotProjectPath: empty });
+      expect(result.kind).toBe('failure');
+      if (result.kind === 'failure') {
+        expect(result.error).toBeInstanceOf(Error);
+      }
+    } finally {
+      fs.rmSync(empty, { recursive: true, force: true });
+    }
+  });
+
+  it('removePlugin returns a structured failure (never throws) for a non-Godot dir', async () => {
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cli-plugin-empty2-'));
+    try {
+      const result = await removePlugin({ godotProjectPath: empty });
+      expect(result.kind).toBe('failure');
+    } finally {
+      fs.rmSync(empty, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('remove-plugin — CLI smoke', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cli-rm-smoke-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('shows help with --help', async () => {
+    const { stdout, exitCode } = await runCliAsync(['remove-plugin', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('--path');
+  });
+
+  it('exits 1 when project.godot is missing', async () => {
+    const { stdout, exitCode } = await runCliAsync(['remove-plugin', '--path', tmpDir]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('Not a valid Godot project');
+  });
+
+  it('reports "was not enabled" when the addon is already absent (exit 0)', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'project.godot'), MINIMAL_PROJECT);
+    const { stdout, exitCode } = await runCliAsync(['remove-plugin', '--path', tmpDir]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('was not enabled');
+  });
+
+  it('disables an enabled addon and reports success (exit 0)', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'project.godot'), MINIMAL_PROJECT);
+    await runCliAsync(['install-plugin', '--path', tmpDir]);
+    const { stdout, exitCode } = await runCliAsync(['remove-plugin', '--path', tmpDir]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('godot_mcp addon disabled');
+    const text = fs.readFileSync(path.join(tmpDir, 'project.godot'), 'utf-8');
+    expect(text).not.toContain(GODOT_MCP_PLUGIN_PATH);
+  });
+
+  it('accepts the positional [path] argument form', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'project.godot'), MINIMAL_PROJECT);
+    await runCliAsync(['install-plugin', '--path', tmpDir]);
+    const { exitCode } = await runCliAsync(['remove-plugin', tmpDir]);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/cli/tests/run-tool-builder.test.ts
+++ b/cli/tests/run-tool-builder.test.ts
@@ -5,6 +5,22 @@ import * as os from 'os';
 import http from 'http';
 import { runCliAsync } from './helpers/cli.js';
 
+/**
+ * Bind a server on port 0 (OS-assigned), capture the port, then close it —
+ * yielding a port that is guaranteed free right now so a connection there is
+ * refused. Avoids the tiny collision risk of a hard-coded port.
+ */
+function findDeadPort(): Promise<number> {
+  return new Promise((resolve) => {
+    const server = http.createServer();
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
 /** Echo server that returns `{ ok: true, tool, body }` for any POST. */
 function startEchoServer(): Promise<{ url: string; close: () => Promise<void> }> {
   return new Promise((resolve) => {
@@ -46,8 +62,9 @@ describe('run-tool (builder) — CLI smoke', () => {
   });
 
   it('exits 1 with the connection-refused failure copy when the server is down', async () => {
+    const deadPort = await findDeadPort();
     const { stdout, exitCode } = await runCliAsync([
-      'run-tool', 'ping', '--url', 'http://127.0.0.1:59999', '--timeout', '1500',
+      'run-tool', 'ping', '--url', `http://127.0.0.1:${deadPort}`, '--timeout', '1500',
     ]);
     expect(exitCode).toBe(1);
     expect(stdout).toContain('Connection refused');
@@ -158,8 +175,9 @@ describe('run-system-tool (builder) — CLI smoke', () => {
   });
 
   it('uses the "system tool" noun in failure copy on connection refused', async () => {
+    const deadPort = await findDeadPort();
     const { stdout, exitCode } = await runCliAsync([
-      'run-system-tool', 'health', '--url', 'http://127.0.0.1:59999', '--timeout', '1500',
+      'run-system-tool', 'health', '--url', `http://127.0.0.1:${deadPort}`, '--timeout', '1500',
     ]);
     expect(exitCode).toBe(1);
     expect(stdout).toContain('Failed to call system tool');

--- a/cli/tests/run-tool-builder.test.ts
+++ b/cli/tests/run-tool-builder.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import http from 'http';
+import { runCliAsync } from './helpers/cli.js';
+
+/** Echo server that returns `{ ok: true, tool, body }` for any POST. */
+function startEchoServer(): Promise<{ url: string; close: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', (d) => (body += d));
+      req.on('end', () => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true, path: req.url, body: body || '{}' }));
+      });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        close: () => new Promise<void>((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+describe('run-tool (builder) — CLI smoke', () => {
+  it('shows help with --input / --input-file / --raw / --timeout', async () => {
+    const { stdout, exitCode } = await runCliAsync(['run-tool', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('--input');
+    expect(stdout).toContain('--input-file');
+    expect(stdout).toContain('--raw');
+    expect(stdout).toContain('--timeout');
+  });
+
+  it('exits 1 for an invalid --timeout value', async () => {
+    const { stdout, exitCode } = await runCliAsync([
+      'run-tool', 'ping', '--url', 'http://127.0.0.1:1', '--timeout', 'nope',
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('Invalid --timeout value');
+  });
+
+  it('exits 1 with the connection-refused failure copy when the server is down', async () => {
+    const { stdout, exitCode } = await runCliAsync([
+      'run-tool', 'ping', '--url', 'http://127.0.0.1:59999', '--timeout', '1500',
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('Connection refused');
+    expect(stdout).toContain('Failed to call tool');
+  });
+
+  it('exits 1 and rejects malformed --input JSON', async () => {
+    const { stdout, exitCode } = await runCliAsync([
+      'run-tool', 'ping', '--url', 'http://127.0.0.1:1', '--input', 'not-json',
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('--input must be valid JSON');
+  });
+
+  it('POSTs to /api/tools/<name> and prints the formatted response on success', async () => {
+    const srv = await startEchoServer();
+    try {
+      const { stdout, exitCode } = await runCliAsync([
+        'run-tool', 'ping', '--url', srv.url, '--timeout', '3000',
+      ]);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('ping completed');
+      expect(stdout).toContain('/api/tools/ping');
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('--raw prints only the JSON payload (no decorative headings)', async () => {
+    const srv = await startEchoServer();
+    try {
+      const { stdout, exitCode } = await runCliAsync([
+        'run-tool', 'ping', '--url', srv.url, '--timeout', '3000', '--raw',
+      ]);
+      expect(exitCode).toBe(0);
+      expect(stdout).not.toContain('Run Tool');
+      const parsed = JSON.parse(stdout.trim());
+      expect(parsed.ok).toBe(true);
+      expect(parsed.path).toBe('/api/tools/ping');
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('forwards --input as the POST body', async () => {
+    const srv = await startEchoServer();
+    try {
+      const { stdout, exitCode } = await runCliAsync([
+        'run-tool', 'echo', '--url', srv.url, '--timeout', '3000', '--raw',
+        '--input', '{"message":"hello"}',
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout.trim());
+      expect(JSON.parse(parsed.body)).toEqual({ message: 'hello' });
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('reads JSON arguments from --input-file', async () => {
+    const srv = await startEchoServer();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cli-input-'));
+    const file = path.join(tmp, 'args.json');
+    fs.writeFileSync(file, '{"from":"file"}');
+    try {
+      const { stdout, exitCode } = await runCliAsync([
+        'run-tool', 'echo', '--url', srv.url, '--timeout', '3000', '--raw',
+        '--input-file', file,
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout.trim());
+      expect(JSON.parse(parsed.body)).toEqual({ from: 'file' });
+    } finally {
+      await srv.close();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('exits 1 when --input-file does not exist', async () => {
+    const { stdout, exitCode } = await runCliAsync([
+      'run-tool', 'ping', '--url', 'http://127.0.0.1:1', '--input-file', '/no/such/file.json',
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('Input file does not exist');
+  });
+});
+
+describe('run-system-tool (builder) — CLI smoke', () => {
+  it('shows help with --help', async () => {
+    const { stdout, exitCode } = await runCliAsync(['run-system-tool', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('--input');
+    expect(stdout).toContain('--timeout');
+  });
+
+  it('targets the /api/system-tools/<name> route (not /api/tools)', async () => {
+    const srv = await startEchoServer();
+    try {
+      const { stdout, exitCode } = await runCliAsync([
+        'run-system-tool', 'health', '--url', srv.url, '--timeout', '3000', '--raw',
+      ]);
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout.trim());
+      expect(parsed.path).toBe('/api/system-tools/health');
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('uses the "system tool" noun in failure copy on connection refused', async () => {
+    const { stdout, exitCode } = await runCliAsync([
+      'run-system-tool', 'health', '--url', 'http://127.0.0.1:59999', '--timeout', '1500',
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('Failed to call system tool');
+  });
+});

--- a/cli/tests/semver.test.ts
+++ b/cli/tests/semver.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { isValidVersion, isNewerVersion } from '../src/utils/semver.js';
+
+describe('semver — isValidVersion', () => {
+  it('accepts plain numeric versions', () => {
+    expect(isValidVersion('1')).toBe(true);
+    expect(isValidVersion('1.2')).toBe(true);
+    expect(isValidVersion('1.2.3')).toBe(true);
+    expect(isValidVersion('10.20.30')).toBe(true);
+  });
+
+  it('rejects prerelease / build-metadata / non-numeric forms', () => {
+    expect(isValidVersion('1.2.3-beta')).toBe(false);
+    expect(isValidVersion('1.2.3+build')).toBe(false);
+    expect(isValidVersion('v1.2.3')).toBe(false);
+    expect(isValidVersion('')).toBe(false);
+    expect(isValidVersion('abc')).toBe(false);
+  });
+});
+
+describe('semver — isNewerVersion', () => {
+  it('detects a strictly newer latest version', () => {
+    expect(isNewerVersion('1.0.0', '1.0.1')).toBe(true);
+    expect(isNewerVersion('1.0.0', '1.1.0')).toBe(true);
+    expect(isNewerVersion('1.0.0', '2.0.0')).toBe(true);
+  });
+
+  it('returns false for an equal version', () => {
+    expect(isNewerVersion('1.2.3', '1.2.3')).toBe(false);
+  });
+
+  it('returns false when the latest is older', () => {
+    expect(isNewerVersion('2.0.0', '1.9.9')).toBe(false);
+    expect(isNewerVersion('1.2.3', '1.2.2')).toBe(false);
+  });
+
+  it('compares versions of differing segment counts (missing segments are 0)', () => {
+    expect(isNewerVersion('1.2', '1.2.0')).toBe(false);
+    expect(isNewerVersion('1.2', '1.2.1')).toBe(true);
+    expect(isNewerVersion('1.2.0', '1.2')).toBe(false);
+  });
+
+  it('does NOT compare numbers lexicographically (10 > 9)', () => {
+    expect(isNewerVersion('0.9.0', '0.10.0')).toBe(true);
+    expect(isNewerVersion('0.10.0', '0.9.0')).toBe(false);
+  });
+});

--- a/cli/tests/status.test.ts
+++ b/cli/tests/status.test.ts
@@ -5,6 +5,22 @@ import * as os from 'os';
 import http from 'http';
 import { runCliAsync } from './helpers/cli.js';
 
+/**
+ * Bind a server on port 0 (OS-assigned), capture the port, then close it —
+ * yielding a port that is guaranteed free right now so a connection there is
+ * refused. Avoids the tiny collision risk of a hard-coded port.
+ */
+function findDeadPort(): Promise<number> {
+  return new Promise((resolve) => {
+    const server = http.createServer();
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
 /** Start a throwaway HTTP server that answers the ping probe with `pong`. */
 function startPingServer(): Promise<{ url: string; close: () => Promise<void> }> {
   return new Promise((resolve) => {
@@ -59,10 +75,11 @@ describe('status — CLI smoke', () => {
   });
 
   it('exits 1 when the server is unreachable (connection refused)', async () => {
+    const deadPort = await findDeadPort();
     const { stdout, exitCode } = await runCliAsync([
       'status',
       '--url',
-      'http://127.0.0.1:59999',
+      `http://127.0.0.1:${deadPort}`,
       '--timeout',
       '1500',
     ]);

--- a/cli/tests/status.test.ts
+++ b/cli/tests/status.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import http from 'http';
+import { runCliAsync } from './helpers/cli.js';
+
+/** Start a throwaway HTTP server that answers the ping probe with `pong`. */
+function startPingServer(): Promise<{ url: string; close: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', (d) => (body += d));
+      req.on('end', () => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: 'success', structured: { result: 'pong' } }));
+      });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        close: () => new Promise<void>((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+describe('status — CLI smoke', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cli-status-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('shows help with --help', async () => {
+    const { stdout, exitCode } = await runCliAsync(['status', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('--url');
+    expect(stdout).toContain('--token');
+    expect(stdout).toContain('--timeout');
+  });
+
+  it('exits 1 for an invalid --timeout value', async () => {
+    const { stdout, exitCode } = await runCliAsync(['status', '--url', 'http://localhost:1', '--timeout', '0']);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('Invalid --timeout value');
+  });
+
+  it('exits 1 when the path is not a Godot project and no --url is given', async () => {
+    const { stdout, exitCode } = await runCliAsync(['status', tmpDir]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('Not a Godot project');
+  });
+
+  it('exits 1 when the server is unreachable (connection refused)', async () => {
+    const { stdout, exitCode } = await runCliAsync([
+      'status',
+      '--url',
+      'http://127.0.0.1:59999',
+      '--timeout',
+      '1500',
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('connection refused');
+    expect(stdout).toContain('not reachable');
+  });
+
+  it('exits 0 and reports the server reachable when the ping probe succeeds', async () => {
+    const srv = await startPingServer();
+    try {
+      const { stdout, exitCode } = await runCliAsync([
+        'status',
+        '--url',
+        srv.url,
+        '--timeout',
+        '3000',
+      ]);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('Connected');
+      expect(stdout).toContain('MCP server is reachable');
+    } finally {
+      await srv.close();
+    }
+  });
+});

--- a/cli/tests/update-check.test.ts
+++ b/cli/tests/update-check.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  fetchLatestVersion,
+  formatUpdateAvailable,
+  isRunningViaNpx,
+} from '../src/utils/update-check.js';
+
+describe('update-check — fetchLatestVersion', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the version field from a 200 registry response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ version: '9.9.9' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    await expect(fetchLatestVersion()).resolves.toBe('9.9.9');
+  });
+
+  it('throws when the registry returns a non-OK status', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 503 }));
+    await expect(fetchLatestVersion()).rejects.toThrow(/503/);
+  });
+
+  it('throws when the response body has no version field', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    await expect(fetchLatestVersion()).rejects.toThrow(/No version field/);
+  });
+});
+
+describe('update-check — formatUpdateAvailable', () => {
+  it('mentions both the current and latest versions', () => {
+    const msg = formatUpdateAvailable('1.0.0', '2.0.0');
+    expect(msg).toContain('1.0.0');
+    expect(msg).toContain('2.0.0');
+    expect(msg).toContain('Update available');
+  });
+});
+
+describe('update-check — isRunningViaNpx', () => {
+  const ORIG_EXECPATH = process.env['npm_execpath'];
+  const ORIG_COMMAND = process.env['npm_command'];
+
+  afterEach(() => {
+    if (ORIG_EXECPATH === undefined) delete process.env['npm_execpath'];
+    else process.env['npm_execpath'] = ORIG_EXECPATH;
+    if (ORIG_COMMAND === undefined) delete process.env['npm_command'];
+    else process.env['npm_command'] = ORIG_COMMAND;
+  });
+
+  it('is true when npm_command is "exec"', () => {
+    delete process.env['npm_execpath'];
+    process.env['npm_command'] = 'exec';
+    expect(isRunningViaNpx()).toBe(true);
+  });
+
+  it('is true when npm_execpath references npx', () => {
+    process.env['npm_execpath'] = '/usr/local/lib/node_modules/npm/bin/npx-cli.js';
+    delete process.env['npm_command'];
+    expect(isRunningViaNpx()).toBe(true);
+  });
+
+  it('is false for a normal global install invocation', () => {
+    process.env['npm_execpath'] = '/usr/local/lib/node_modules/npm/bin/npm-cli.js';
+    process.env['npm_command'] = 'run-script';
+    expect(isRunningViaNpx()).toBe(false);
+  });
+
+  it('is false when neither env var is set', () => {
+    delete process.env['npm_execpath'];
+    delete process.env['npm_command'];
+    expect(isRunningViaNpx()).toBe(false);
+  });
+});

--- a/cli/tests/update.test.ts
+++ b/cli/tests/update.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'child_process';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { runCliAsync } from './helpers/cli.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI_PATH = path.resolve(__dirname, '..', 'bin', 'godot-cli.js');
+
+/**
+ * Spawn the CLI with a fully-explicit environment. We do NOT spread the parent
+ * env: vitest's worker pool can hand us a sanitized/proxied `process.env` whose
+ * `npm_*` keys do not propagate predictably to a child, which would mask the
+ * npx-detection branch under test. Building the child env from scratch (plus a
+ * minimal PATH so `node` resolves) keeps these assertions hermetic.
+ */
+function runCliExplicitEnv(
+  args: string[],
+  env: Record<string, string>,
+): Promise<{ stdout: string; exitCode: number }> {
+  const childEnv: Record<string, string> = {
+    PATH: process.env['PATH'] ?? process.env['Path'] ?? '',
+    ...env,
+  };
+  // Windows resolves executables via Path (capitalized); mirror it.
+  if (process.platform === 'win32') childEnv['Path'] = childEnv['PATH'];
+
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [CLI_PATH, ...args], {
+      stdio: 'pipe',
+      env: childEnv,
+    });
+    let stdout = '';
+    const timeout = setTimeout(() => {
+      try { child.kill(); } catch { /* noop */ }
+      resolve({ stdout: stdout + '\n[timeout]\n', exitCode: 1 });
+    }, 20000);
+    child.stdout?.on('data', (d: Buffer) => (stdout += d.toString()));
+    child.stderr?.on('data', (d: Buffer) => (stdout += d.toString()));
+    child.on('close', (code) => {
+      clearTimeout(timeout);
+      resolve({ stdout, exitCode: code ?? 0 });
+    });
+  });
+}
+
+describe('update — CLI smoke', () => {
+  it('shows help with --help', async () => {
+    const { stdout, exitCode } = await runCliAsync(['update', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('--check');
+    expect(stdout).toContain('latest version');
+  });
+
+  it('short-circuits with a no-op when running via npx (npm_command=exec)', async () => {
+    const { stdout, exitCode } = await runCliExplicitEnv(['update'], { npm_command: 'exec' });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('npx');
+    expect(stdout).toContain('No update action needed');
+  });
+
+  it('short-circuits with a no-op when npm_execpath references npx', async () => {
+    const { stdout, exitCode } = await runCliExplicitEnv(['update', '--check'], {
+      npm_execpath: '/usr/lib/node_modules/npm/bin/npx-cli.js',
+    });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('npx');
+  });
+});

--- a/cli/tests/wait-for-ready.test.ts
+++ b/cli/tests/wait-for-ready.test.ts
@@ -5,6 +5,22 @@ import * as os from 'os';
 import http from 'http';
 import { runCliAsync } from './helpers/cli.js';
 
+/**
+ * Bind a server on port 0 (OS-assigned), capture the port, then close it —
+ * yielding a port that is guaranteed free right now so a connection there is
+ * refused. Avoids the tiny collision risk of a hard-coded port.
+ */
+function findDeadPort(): Promise<number> {
+  return new Promise((resolve) => {
+    const server = http.createServer();
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
 /** Start a throwaway HTTP server that answers the ping probe with `pong`. */
 function startPingServer(): Promise<{ url: string; close: () => Promise<void> }> {
   return new Promise((resolve) => {
@@ -77,10 +93,11 @@ describe('wait-for-ready — CLI smoke', () => {
   });
 
   it('times out and exits 1 when the server never comes up', async () => {
+    const deadPort = await findDeadPort();
     const { stdout, exitCode } = await runCliAsync([
       'wait-for-ready',
       '--url',
-      'http://127.0.0.1:59999',
+      `http://127.0.0.1:${deadPort}`,
       '--timeout',
       '1200',
       '--interval',

--- a/cli/tests/wait-for-ready.test.ts
+++ b/cli/tests/wait-for-ready.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import http from 'http';
+import { runCliAsync } from './helpers/cli.js';
+
+/** Start a throwaway HTTP server that answers the ping probe with `pong`. */
+function startPingServer(): Promise<{ url: string; close: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', (d) => (body += d));
+      req.on('end', () => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: 'success', structured: { result: 'pong' } }));
+      });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        close: () => new Promise<void>((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+describe('wait-for-ready — CLI smoke', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cli-wfr-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('shows help with --help', async () => {
+    const { stdout, exitCode } = await runCliAsync(['wait-for-ready', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('--url');
+    expect(stdout).toContain('--timeout');
+    expect(stdout).toContain('--interval');
+  });
+
+  it('exits 1 for an invalid --timeout value', async () => {
+    const { stdout, exitCode } = await runCliAsync([
+      'wait-for-ready',
+      '--url',
+      'http://localhost:1',
+      '--timeout',
+      '0',
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('Invalid --timeout value');
+  });
+
+  it('exits 1 for an invalid --interval value', async () => {
+    const { stdout, exitCode } = await runCliAsync([
+      'wait-for-ready',
+      '--url',
+      'http://localhost:1',
+      '--interval',
+      '-1',
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('Invalid --interval value');
+  });
+
+  it('exits 1 when the path is not a Godot project and no --url is given', async () => {
+    const { stdout, exitCode } = await runCliAsync(['wait-for-ready', tmpDir]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('Not a Godot project');
+  });
+
+  it('times out and exits 1 when the server never comes up', async () => {
+    const { stdout, exitCode } = await runCliAsync([
+      'wait-for-ready',
+      '--url',
+      'http://127.0.0.1:59999',
+      '--timeout',
+      '1200',
+      '--interval',
+      '400',
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('Timed out');
+  });
+
+  it('exits 0 as soon as the ping probe succeeds', async () => {
+    const srv = await startPingServer();
+    try {
+      const { stdout, exitCode } = await runCliAsync([
+        'wait-for-ready',
+        '--url',
+        srv.url,
+        '--timeout',
+        '5000',
+        '--interval',
+        '500',
+      ]);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('MCP server is ready');
+    } finally {
+      await srv.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Audited all 14 `godot-cli` commands by running the built CLI end-to-end (help, arg validation, failure paths, and HTTP success paths against a throwaway local node server). **Every command is fully functional — no broken command was found, so no source code was changed.** This PR is pure test coverage.
- Added dedicated smoke + unit tests for the previously-untested commands (`close`, `configure`, `status`, `update`, `wait-for-ready`, `remove-plugin`) and strengthened thin coverage (`install-plugin`, `run-tool`/`run-system-tool` via the shared builder, `create-project --dotnet`), mirroring the breadth of `Unity-MCP/cli/tests/`.
- 89 new tests across 11 new files; vitest suite **168 → 257**, all green and stable across 3 consecutive full runs. `npm run build` (tsc) clean.

### Audit findings (all commands correct)
| Command | Verified behavior |
| --- | --- |
| close | rejects non-project/missing path (1), invalid `--timeout` (1), exit 0 when no editor running |
| configure | tools/prompts/resources enable/disable + all-toggles, positional+`--path`, requires path (1) |
| status | ping probe: exit 0 reachable / 1 refused / 1 non-project / 1 bad `--timeout` |
| update | real-registry `--check`; npx-detection no-op short-circuit |
| wait-for-ready | polls ping: exit 0 on first success / 1 timeout / 1 bad `--timeout`/`--interval` |
| install-plugin / remove-plugin | toggle `plugin.cfg` in `[editor_plugins]`; idempotent; structured failure |
| run-tool / run-system-tool | POST `/api/tools` & `/api/system-tools`; `--raw`, `--input(-file)`, correct noun copy |
| create-project | scaffolds `project.godot`+`icon.svg` (+csproj `--dotnet`); refuses existing Godot/Unity/Unreal |

Note: the win32 graceful-shutdown path returns `false` for a windowless console process (`taskkill` posts WM_CLOSE, which such a process cannot receive); the test asserts this platform-honest behavior rather than forcing a clean exit.

## Test plan
- [x] `npm run build` (tsc) clean
- [x] `npm test` (vitest) green — 257 passed, stable across 3 full runs
- [x] Every godot-cli command audited by direct invocation; no broken command found

Closes #121