### PR TITLE
feat(dev): dev-only inject/control HTTP bridge for the dock

### DIFF
--- a/Godot-MCP.Tests/DevControlRouterTests.cs
+++ b/Godot-MCP.Tests/DevControlRouterTests.cs
@@ -1,0 +1,139 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using com.IvanMurzak.Godot.MCP.Connection;
+using com.IvanMurzak.Godot.MCP.Connection.DevControl;
+using com.IvanMurzak.Godot.MCP.UI;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the pure-managed routing + parsing core of the DEV-ONLY inject/control bridge
+    /// (<see cref="DevControlRouter"/>): the <c>(method, path)</c> → command-id route table, the connection /
+    /// server status-string parsers, and the click-target vocabulary. The editor HttpListener transport
+    /// (<c>DevControlServer.cs</c>, <c>#if TOOLS</c>) is verified live (curl the editor) — NOT here.
+    /// </summary>
+    public class DevControlRouterTests
+    {
+        // --- Route table -------------------------------------------------------------------------------------
+
+        [Theory]
+        [InlineData("GET", "/health", DevControlRouter.Command.Health)]
+        [InlineData("GET", "/state", DevControlRouter.Command.State)]
+        [InlineData("POST", "/inject/connection-status", DevControlRouter.Command.InjectConnectionStatus)]
+        [InlineData("POST", "/inject/server-status", DevControlRouter.Command.InjectServerStatus)]
+        [InlineData("POST", "/control/server-url", DevControlRouter.Command.ControlServerUrl)]
+        [InlineData("POST", "/control/select-agent", DevControlRouter.Command.ControlSelectAgent)]
+        [InlineData("POST", "/control/click", DevControlRouter.Command.ControlClick)]
+        public void Route_MapsKnownRoutes(string method, string path, DevControlRouter.Command expected)
+        {
+            Assert.Equal(expected, DevControlRouter.Route(method, path));
+        }
+
+        [Theory]
+        [InlineData("get", "/health")]
+        [InlineData("GeT", "/state")]
+        [InlineData("post", "/control/click")]
+        public void Route_MethodIsCaseInsensitive(string method, string path)
+        {
+            Assert.NotEqual(DevControlRouter.Command.Unknown, DevControlRouter.Route(method, path));
+        }
+
+        [Theory]
+        [InlineData("POST", "/health")]              // wrong method
+        [InlineData("GET", "/control/click")]        // wrong method
+        [InlineData("GET", "/nope")]                 // unknown path
+        [InlineData("GET", "/HEALTH")]               // path is case-sensitive
+        [InlineData("GET", "")]                      // empty path
+        public void Route_UnknownReturnsUnknown(string method, string path)
+        {
+            Assert.Equal(DevControlRouter.Command.Unknown, DevControlRouter.Route(method, path));
+        }
+
+        [Fact]
+        public void Route_NullArgs_ReturnUnknown()
+        {
+            Assert.Equal(DevControlRouter.Command.Unknown, DevControlRouter.Route(null!, "/health"));
+            Assert.Equal(DevControlRouter.Command.Unknown, DevControlRouter.Route("GET", null!));
+        }
+
+        // --- Connection-status parser ------------------------------------------------------------------------
+
+        [Theory]
+        [InlineData("Connected", ConnectionStatus.Connected)]
+        [InlineData("connecting", ConnectionStatus.Connecting)]
+        [InlineData("DISCONNECTED", ConnectionStatus.Disconnected)]
+        [InlineData("  Connected  ", ConnectionStatus.Connected)]
+        public void TryParseConnectionStatus_ParsesKnown(string value, ConnectionStatus expected)
+        {
+            Assert.True(DevControlRouter.TryParseConnectionStatus(value, out var status));
+            Assert.Equal(expected, status);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("bogus")]
+        public void TryParseConnectionStatus_RejectsUnknown(string? value)
+        {
+            Assert.False(DevControlRouter.TryParseConnectionStatus(value, out _));
+        }
+
+        // --- Server-status parser ----------------------------------------------------------------------------
+
+        [Theory]
+        [InlineData("Stopped", GodotMcpServerStatus.Stopped)]
+        [InlineData("starting", GodotMcpServerStatus.Starting)]
+        [InlineData("RUNNING", GodotMcpServerStatus.Running)]
+        [InlineData("Stopping", GodotMcpServerStatus.Stopping)]
+        [InlineData("external", GodotMcpServerStatus.External)]
+        public void TryParseServerStatus_ParsesKnown(string value, GodotMcpServerStatus expected)
+        {
+            Assert.True(DevControlRouter.TryParseServerStatus(value, out var status));
+            Assert.Equal(expected, status);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("paused")]
+        public void TryParseServerStatus_RejectsUnknown(string? value)
+        {
+            Assert.False(DevControlRouter.TryParseServerStatus(value, out _));
+        }
+
+        // --- Click-target vocabulary -------------------------------------------------------------------------
+
+        [Theory]
+        [InlineData("configure", "configure")]
+        [InlineData("Reconfigure", "reconfigure")]
+        [InlineData("REMOVE", "remove")]
+        [InlineData("connect", "connect")]
+        [InlineData("start-server", "start-server")]
+        [InlineData("  generate ", "generate")]
+        public void TryNormalizeClickTarget_NormalizesKnown(string target, string expected)
+        {
+            Assert.True(DevControlRouter.TryNormalizeClickTarget(target, out var normalized));
+            Assert.Equal(expected, normalized);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("explode")]
+        [InlineData("start server")]
+        public void TryNormalizeClickTarget_RejectsUnknown(string? target)
+        {
+            Assert.False(DevControlRouter.TryNormalizeClickTarget(target, out var normalized));
+            Assert.Equal(string.Empty, normalized);
+        }
+    }
+}

--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -231,6 +231,11 @@
     <Compile Include="..\addons\godot_mcp\Extensions\IConsumerProjectFile.cs" Link="Source\IConsumerProjectFile.cs" />
     <Compile Include="..\addons\godot_mcp\Extensions\ExtensionInstaller.cs" Link="Source\ExtensionInstaller.cs" />
     <Compile Include="..\addons\godot_mcp\Extensions\ExtensionsPanelText.cs" Link="Source\ExtensionsPanelText.cs" />
+    <!-- DEV-ONLY inject/control bridge ROUTER — pure-managed (no Godot native types, no #if TOOLS): the
+         (method, path) → command-id route table + the connection/server status-string parsers + the click-
+         target vocabulary. The editor HttpListener transport (DevControlServer.cs) is #if TOOLS and verified
+         live (curl the editor), NOT compiled here; the routing/parsing core is unit-tested here. -->
+    <Compile Include="..\addons\godot_mcp\Connection\DevControl\DevControlRouter.cs" Link="Source\DevControlRouter.cs" />
   </ItemGroup>
 
 </Project>

--- a/addons/godot_mcp/Connection/DevControl/DevControlRouter.cs
+++ b/addons/godot_mcp/Connection/DevControl/DevControlRouter.cs
@@ -1,0 +1,167 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using com.IvanMurzak.Godot.MCP.Connection;
+using com.IvanMurzak.Godot.MCP.UI;
+
+namespace com.IvanMurzak.Godot.MCP.Connection.DevControl
+{
+    /// <summary>
+    /// PURE-MANAGED (no Godot native types, no <c>#if TOOLS</c>) routing + parsing core for the DEV-ONLY
+    /// inject/control HTTP bridge (<see cref="DevControlServer"/>). It owns the table-driven
+    /// <c>(method, path)</c> → command-id mapping plus the status-string parsers, so the editor-side server
+    /// stays a thin transport shell and ALL the routing decisions are CI-unit-testable in the plain-xUnit
+    /// host (mirrors how <see cref="ConnectionPanelView"/> / <see cref="GodotMcpServerView"/> hold the
+    /// connection panel's logic). The <see cref="DevControlServer"/> (editor-only) consumes this; this file
+    /// references only the pure-managed <see cref="ConnectionStatus"/> / <see cref="GodotMcpServerStatus"/>
+    /// enums and BCL types.
+    /// </summary>
+    public static class DevControlRouter
+    {
+        /// <summary>
+        /// The command a routed request maps to — the editor server switches on this instead of re-parsing
+        /// the raw <c>(method, path)</c>. <see cref="Unknown"/> is the sentinel for an unmatched route (the
+        /// server answers it with 404).
+        /// </summary>
+        public enum Command
+        {
+            Unknown = 0,
+            Health,
+            State,
+            InjectConnectionStatus,
+            InjectServerStatus,
+            ControlServerUrl,
+            ControlSelectAgent,
+            ControlClick,
+        }
+
+        /// <summary>
+        /// The declarative route table: each entry maps an exact <c>(METHOD, /path)</c> to a
+        /// <see cref="Command"/>. Method is matched case-insensitively; path is matched exactly (no trailing
+        /// slash, no query string — the server strips both before calling <see cref="Route"/>).
+        /// </summary>
+        static readonly IReadOnlyList<(string Method, string Path, Command Command)> Routes = new[]
+        {
+            ("GET",  "/health",                   Command.Health),
+            ("GET",  "/state",                    Command.State),
+            ("POST", "/inject/connection-status", Command.InjectConnectionStatus),
+            ("POST", "/inject/server-status",     Command.InjectServerStatus),
+            ("POST", "/control/server-url",       Command.ControlServerUrl),
+            ("POST", "/control/select-agent",     Command.ControlSelectAgent),
+            ("POST", "/control/click",            Command.ControlClick),
+        };
+
+        /// <summary>
+        /// Resolve an HTTP <paramref name="method"/> + <paramref name="path"/> to a <see cref="Command"/>.
+        /// Method matching is case-insensitive; the path must match exactly (the caller is responsible for
+        /// stripping any trailing slash + query string first). Returns <see cref="Command.Unknown"/> for an
+        /// unmatched route (→ 404 at the server).
+        /// </summary>
+        public static Command Route(string method, string path)
+        {
+            if (method == null || path == null)
+                return Command.Unknown;
+
+            foreach (var route in Routes)
+            {
+                if (string.Equals(route.Method, method, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(route.Path, path, StringComparison.Ordinal))
+                    return route.Command;
+            }
+
+            return Command.Unknown;
+        }
+
+        /// <summary>
+        /// Parse a connection-status string ("Connected" / "Connecting" / "Disconnected", case-insensitive)
+        /// into a <see cref="ConnectionStatus"/>. Returns <c>false</c> (and a default <paramref name="status"/>)
+        /// for null / empty / unrecognized input so the server can answer a 400 instead of throwing.
+        /// </summary>
+        public static bool TryParseConnectionStatus(string? value, out ConnectionStatus status)
+        {
+            switch ((value ?? string.Empty).Trim().ToLowerInvariant())
+            {
+                case "connected":
+                    status = ConnectionStatus.Connected;
+                    return true;
+                case "connecting":
+                    status = ConnectionStatus.Connecting;
+                    return true;
+                case "disconnected":
+                    status = ConnectionStatus.Disconnected;
+                    return true;
+                default:
+                    status = ConnectionStatus.Disconnected;
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Parse a server-status string ("Stopped" / "Starting" / "Running" / "Stopping" / "External",
+        /// case-insensitive) into a <see cref="GodotMcpServerStatus"/>. Returns <c>false</c> (and a default
+        /// <paramref name="status"/>) for null / empty / unrecognized input so the server can answer a 400.
+        /// </summary>
+        public static bool TryParseServerStatus(string? value, out GodotMcpServerStatus status)
+        {
+            switch ((value ?? string.Empty).Trim().ToLowerInvariant())
+            {
+                case "stopped":
+                    status = GodotMcpServerStatus.Stopped;
+                    return true;
+                case "starting":
+                    status = GodotMcpServerStatus.Starting;
+                    return true;
+                case "running":
+                    status = GodotMcpServerStatus.Running;
+                    return true;
+                case "stopping":
+                    status = GodotMcpServerStatus.Stopping;
+                    return true;
+                case "external":
+                    status = GodotMcpServerStatus.External;
+                    return true;
+                default:
+                    status = GodotMcpServerStatus.Stopped;
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// The set of click targets accepted by <c>POST /control/click</c>, normalized to lowercase. The
+        /// editor server maps a valid target to a dock node name + emits its "pressed" signal; an
+        /// unrecognized target is a 400. Kept here (pure-managed) so the accepted vocabulary is unit-tested.
+        /// </summary>
+        static readonly HashSet<string> ClickTargets = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "configure", "reconfigure", "remove", "connect", "start-server", "generate",
+        };
+
+        /// <summary>
+        /// Validate + normalize a click <paramref name="target"/> (case-insensitive) to its canonical
+        /// lowercase form. Returns <c>false</c> for null / empty / unrecognized input. "reconfigure" is a
+        /// synonym of "configure" at the dock level (the same Configure button is re-pressed), but both are
+        /// accepted here and the dock collapses them.
+        /// </summary>
+        public static bool TryNormalizeClickTarget(string? target, out string normalized)
+        {
+            var trimmed = (target ?? string.Empty).Trim();
+            if (ClickTargets.Contains(trimmed))
+            {
+                normalized = trimmed.ToLowerInvariant();
+                return true;
+            }
+
+            normalized = string.Empty;
+            return false;
+        }
+    }
+}

--- a/addons/godot_mcp/Connection/DevControl/DevControlServer.cs
+++ b/addons/godot_mcp/Connection/DevControl/DevControlServer.cs
@@ -1,0 +1,305 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.Godot.MCP.MainThreadDispatch;
+using com.IvanMurzak.Godot.MCP.UI;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Connection.DevControl
+{
+    /// <summary>
+    /// DEV-ONLY inject/control HTTP bridge for the "AI Game Developer" editor dock. A
+    /// <see cref="HttpListener"/> bound to <c>http://127.0.0.1:&lt;port&gt;/</c> (loopback ONLY) whose accept
+    /// loop runs on a background thread; it parses JSON in/out (<see cref="System.Text.Json"/>), routes via the
+    /// pure-managed <see cref="DevControlRouter"/>, and hops every dock-touching handler onto the editor main
+    /// thread (a <see cref="TaskCompletionSource{TResult}"/> + <see cref="MainThreadDispatcher.Enqueue"/>),
+    /// because ALL Godot Control access must happen on the main thread.
+    ///
+    /// <para>
+    /// SECURITY: the security boundary IS this server. It binds 127.0.0.1 only (never a routable interface)
+    /// and is started ONLY when <c>GODOT_MCP_DEV_CONTROL=1</c> (see <c>GodotMcpPlugin.BootMcp</c>), so a
+    /// shipped addon never listens. Editor-only (<c>#if TOOLS</c>); disposed on plugin <c>_ExitTree</c>.
+    /// </para>
+    /// </summary>
+    public sealed class DevControlServer : IDisposable
+    {
+        /// <summary>Default port when <c>GODOT_MCP_DEV_CONTROL_PORT</c> is unset.</summary>
+        public const int DefaultPort = 9920;
+
+        /// <summary>Loopback-only bind host — never a routable interface (the security boundary).</summary>
+        const string BindHost = "127.0.0.1";
+
+        /// <summary>How long a main-thread hop may take before the handler gives up and 500s (dispatcher stalled).</summary>
+        static readonly TimeSpan MainThreadTimeout = TimeSpan.FromSeconds(10);
+
+        readonly GodotMcpDock _dock;
+        readonly int _port;
+        readonly HttpListener _listener = new HttpListener();
+        readonly CancellationTokenSource _cts = new CancellationTokenSource();
+        Thread? _acceptThread;
+        bool _disposed;
+
+        /// <summary>The base URL this server listens on (after <see cref="Start"/>).</summary>
+        public string BaseUrl => $"http://{BindHost}:{_port}/";
+
+        /// <summary>
+        /// Construct the bridge bound to <paramref name="dock"/>, listening on <paramref name="port"/>
+        /// (loopback only). Call <see cref="Start"/> to begin accepting; the ctor does not open the socket.
+        /// </summary>
+        public DevControlServer(GodotMcpDock dock, int port)
+        {
+            _dock = dock ?? throw new ArgumentNullException(nameof(dock));
+            _port = port;
+        }
+
+        /// <summary>
+        /// Open the loopback listener and start the background accept loop. Idempotent-safe to call once.
+        /// Logs <c>[dev-control] Listening on http://127.0.0.1:&lt;port&gt;</c> on success; a bind failure
+        /// (port in use) is logged as an error and leaves the server inert rather than throwing into plugin boot.
+        /// </summary>
+        public void Start()
+        {
+            try
+            {
+                _listener.Prefixes.Add(BaseUrl);
+                _listener.Start();
+            }
+            catch (Exception ex)
+            {
+                GD.PushError($"[dev-control] failed to bind {BaseUrl}: {ex.Message}");
+                return;
+            }
+
+            _acceptThread = new Thread(AcceptLoop)
+            {
+                IsBackground = true,
+                Name = "godot-mcp-dev-control",
+            };
+            _acceptThread.Start();
+
+            GD.Print($"[dev-control] Listening on http://{BindHost}:{_port}");
+        }
+
+        void AcceptLoop()
+        {
+            while (!_cts.IsCancellationRequested && _listener.IsListening)
+            {
+                HttpListenerContext context;
+                try
+                {
+                    context = _listener.GetContext(); // blocks until a request or the listener is stopped
+                }
+                catch (Exception)
+                {
+                    // Listener stopped/disposed (teardown) or a transient accept error — exit the loop on
+                    // cancellation, otherwise keep accepting. Never let one bad accept kill the server.
+                    if (_cts.IsCancellationRequested || !_listener.IsListening)
+                        break;
+                    continue;
+                }
+
+                try
+                {
+                    HandleRequest(context);
+                }
+                catch (Exception ex)
+                {
+                    // A handler-level failure must never kill the accept loop: answer 500 and keep serving.
+                    TryWrite(context, 500, $"{{\"ok\":false,\"error\":{JsonString(ex.Message)}}}");
+                }
+            }
+        }
+
+        void HandleRequest(HttpListenerContext context)
+        {
+            var request = context.Request;
+            var method = request.HttpMethod ?? string.Empty;
+            // Strip query string + a trailing slash so the router matches the canonical path.
+            var path = (request.Url?.AbsolutePath ?? string.Empty).TrimEnd('/');
+            if (path.Length == 0)
+                path = "/";
+
+            var command = DevControlRouter.Route(method, path);
+            if (command == DevControlRouter.Command.Unknown)
+            {
+                TryWrite(context, 404, $"{{\"ok\":false,\"error\":\"no route for {method} {JsonInner(path)}\"}}");
+                return;
+            }
+
+            // Health is the only route that does not touch a Control off the bat (it reports dock presence).
+            if (command == DevControlRouter.Command.Health)
+            {
+                var status = RunOnMainThread(() => _dock.DevStateJson());
+                TryWrite(context, 200, $"{{\"ok\":true,\"dockPresent\":true,\"state\":{status}}}");
+                return;
+            }
+
+            if (command == DevControlRouter.Command.State)
+            {
+                var state = RunOnMainThread(() => _dock.DevStateJson());
+                TryWrite(context, 200, $"{{\"ok\":true,\"dock\":{state}}}");
+                return;
+            }
+
+            // The remaining commands read a JSON body.
+            var body = ReadBody(request);
+            using var doc = ParseJson(body);
+            var root = doc?.RootElement;
+
+            switch (command)
+            {
+                case DevControlRouter.Command.InjectConnectionStatus:
+                {
+                    var value = GetString(root, "status");
+                    RunOnMainThread(() => { _dock.DevInjectConnectionStatus(value ?? string.Empty); return true; });
+                    TryWrite(context, 200, "{\"ok\":true}");
+                    break;
+                }
+                case DevControlRouter.Command.InjectServerStatus:
+                {
+                    var value = GetString(root, "status");
+                    RunOnMainThread(() => { _dock.DevInjectServerStatus(value ?? string.Empty); return true; });
+                    TryWrite(context, 200, "{\"ok\":true}");
+                    break;
+                }
+                case DevControlRouter.Command.ControlServerUrl:
+                {
+                    var url = GetString(root, "url");
+                    RunOnMainThread(() => { _dock.DevSetServerUrl(url ?? string.Empty); return true; });
+                    TryWrite(context, 200, "{\"ok\":true}");
+                    break;
+                }
+                case DevControlRouter.Command.ControlSelectAgent:
+                {
+                    // Accept either {agent} or {agentId} (the spec uses both across endpoint docs).
+                    var agent = GetString(root, "agent") ?? GetString(root, "agentId");
+                    var ok = RunOnMainThread(() => _dock.DevSelectAgent(agent ?? string.Empty));
+                    TryWrite(context, ok ? 200 : 404,
+                        ok ? "{\"ok\":true}" : $"{{\"ok\":false,\"error\":\"unknown agent {JsonInner(agent)}\"}}");
+                    break;
+                }
+                case DevControlRouter.Command.ControlClick:
+                {
+                    var target = GetString(root, "target");
+                    var ok = RunOnMainThread(() => _dock.DevClick(target ?? string.Empty));
+                    TryWrite(context, ok ? 200 : 409,
+                        ok ? "{\"ok\":true}" : $"{{\"ok\":false,\"error\":\"target not clickable {JsonInner(target)}\"}}");
+                    break;
+                }
+                default:
+                    TryWrite(context, 404, "{\"ok\":false,\"error\":\"unhandled command\"}");
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Run <paramref name="work"/> on the editor main thread and return its result, marshalling any
+        /// exception back to this background thread. Hops via <see cref="MainThreadDispatcher.Enqueue"/> + a
+        /// <see cref="TaskCompletionSource{TResult}"/>; when already on the main thread (or no dispatcher is in
+        /// the tree) it runs inline. Throws on a <see cref="MainThreadTimeout"/> stall so the handler 500s
+        /// rather than hanging the request forever.
+        /// </summary>
+        static T RunOnMainThread<T>(Func<T> work)
+        {
+            if (MainThreadDispatcher.Instance == null || MainThreadDispatcher.IsMainThread)
+                return work();
+
+            var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+            MainThreadDispatcher.Enqueue(() =>
+            {
+                try { tcs.TrySetResult(work()); }
+                catch (Exception ex) { tcs.TrySetException(ex); }
+            });
+
+            if (!tcs.Task.Wait(MainThreadTimeout))
+                throw new TimeoutException("editor main-thread hop timed out (dispatcher stalled).");
+
+            return tcs.Task.GetAwaiter().GetResult();
+        }
+
+        static string ReadBody(HttpListenerRequest request)
+        {
+            if (!request.HasEntityBody)
+                return string.Empty;
+            using var reader = new StreamReader(request.InputStream, request.ContentEncoding ?? Encoding.UTF8);
+            return reader.ReadToEnd();
+        }
+
+        static JsonDocument? ParseJson(string body)
+        {
+            if (string.IsNullOrWhiteSpace(body))
+                return null;
+            try { return JsonDocument.Parse(body); }
+            catch { return null; }
+        }
+
+        static string? GetString(JsonElement? root, string property)
+        {
+            if (root is not { ValueKind: JsonValueKind.Object } obj)
+                return null;
+            if (!obj.TryGetProperty(property, out var el))
+                return null;
+            return el.ValueKind == JsonValueKind.String ? el.GetString() : el.ToString();
+        }
+
+        static void TryWrite(HttpListenerContext context, int statusCode, string json)
+        {
+            try
+            {
+                var bytes = Encoding.UTF8.GetBytes(json);
+                context.Response.StatusCode = statusCode;
+                context.Response.ContentType = "application/json";
+                context.Response.ContentLength64 = bytes.Length;
+                context.Response.OutputStream.Write(bytes, 0, bytes.Length);
+                context.Response.OutputStream.Close();
+            }
+            catch
+            {
+                // Client hung up mid-write — nothing actionable; the accept loop keeps serving.
+            }
+        }
+
+        /// <summary>JSON-encode a string AS a complete JSON string literal (with surrounding quotes).</summary>
+        static string JsonString(string? value) => JsonSerializer.Serialize(value ?? string.Empty);
+
+        /// <summary>JSON-escape a string WITHOUT surrounding quotes (for embedding inside a larger literal).</summary>
+        static string JsonInner(string? value)
+        {
+            var s = JsonString(value);
+            return s.Length >= 2 ? s.Substring(1, s.Length - 2) : s;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+
+            try { _cts.Cancel(); } catch { /* already disposed */ }
+
+            // Stop unblocks the GetContext() call in the accept loop.
+            try { if (_listener.IsListening) _listener.Stop(); } catch { }
+            try { _listener.Close(); } catch { }
+
+            try { _acceptThread?.Join(TimeSpan.FromSeconds(2)); } catch { }
+
+            _cts.Dispose();
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/GodotMcpPlugin.cs
+++ b/addons/godot_mcp/GodotMcpPlugin.cs
@@ -12,6 +12,7 @@
 using System.Runtime.CompilerServices;
 using Godot;
 using com.IvanMurzak.Godot.MCP.Connection;
+using com.IvanMurzak.Godot.MCP.Connection.DevControl;
 using com.IvanMurzak.Godot.MCP.Data;
 using com.IvanMurzak.Godot.MCP.MainThreadDispatch;
 using com.IvanMurzak.Godot.MCP.Tools;
@@ -38,6 +39,11 @@ namespace com.IvanMurzak.Godot.MCP
         MainThreadDispatcher? _dispatcher;
         GodotMcpConnection? _connection;
         GodotMcpDock? _dock;
+
+        // DEV-ONLY inject/control HTTP bridge (Connection/DevControl/). Started ONLY when
+        // GODOT_MCP_DEV_CONTROL=1 (127.0.0.1, off by default → a shipped addon never listens); disposed in
+        // _ExitTree. Lets a terminal / AI agent inject fake states + simulate user actions on the live dock.
+        DevControlServer? _devControl;
 
         public override void _EnterTree()
         {
@@ -155,6 +161,11 @@ namespace com.IvanMurzak.Godot.MCP
             // Register the dock (wired to the connection if one was built; header-only otherwise).
             RegisterDock(_connection);
 
+            // DEV-ONLY: start the inject/control bridge AFTER the dock exists, gated on GODOT_MCP_DEV_CONTROL=1
+            // (off by default → a shipped addon never listens). Binds 127.0.0.1 only. A failure here must not
+            // take down the connection boot — the bridge is dev scaffolding.
+            StartDevControlIfEnabled();
+
             if (_connection == null)
                 return;
 
@@ -168,8 +179,49 @@ namespace com.IvanMurzak.Godot.MCP
             }
         }
 
+        /// <summary>
+        /// Start the DEV-ONLY inject/control bridge when <c>GODOT_MCP_DEV_CONTROL=1</c>. The port comes from
+        /// <c>GODOT_MCP_DEV_CONTROL_PORT</c> (default <see cref="DevControlServer.DefaultPort"/>) — an unset or
+        /// unparseable value falls back to the default. No-op (and never listens) when the flag is not exactly
+        /// <c>"1"</c>, OR when the dock failed to register (there is nothing to drive). Defensively wrapped so a
+        /// bridge failure cannot take down plugin boot.
+        /// </summary>
+        void StartDevControlIfEnabled()
+        {
+            if (OS.GetEnvironment("GODOT_MCP_DEV_CONTROL") != "1")
+                return;
+
+            if (_dock == null)
+            {
+                LogWarning("[dev-control] GODOT_MCP_DEV_CONTROL=1 but the dock failed to register; not starting.");
+                return;
+            }
+
+            var port = DevControlServer.DefaultPort;
+            var portEnv = OS.GetEnvironment("GODOT_MCP_DEV_CONTROL_PORT");
+            if (!string.IsNullOrEmpty(portEnv) && int.TryParse(portEnv, out var parsed) && parsed > 0 && parsed <= 65535)
+                port = parsed;
+
+            try
+            {
+                _devControl = new DevControlServer(_dock, port);
+                _devControl.Start();
+            }
+            catch (System.Exception ex)
+            {
+                LogError($"[dev-control] failed to start: {ex.Message}");
+                _devControl = null;
+            }
+        }
+
         public override void _ExitTree()
         {
+            if (_devControl != null)
+            {
+                _devControl.Dispose();
+                _devControl = null;
+            }
+
             if (_connection != null)
             {
                 _connection.Dispose();

--- a/addons/godot_mcp/UI/ConnectionPanel.cs
+++ b/addons/godot_mcp/UI/ConnectionPanel.cs
@@ -121,6 +121,14 @@ namespace com.IvanMurzak.Godot.MCP.UI
         // when the live status has drifted from what is on screen — keeping the per-tick check cheap and quiet.
         ConnectionStatus? _renderedStatus;
 
+        // DEV-ONLY status override (set by the dev-control bridge's inject endpoint). When non-null the
+        // periodic re-sync (SyncFromConnection) is short-circuited so an injected status STICKS on screen
+        // instead of being reverted to the live connection status within ~0.5s. Cleared by
+        // DevClearStatusOverride, after which the panel re-converges to the real live status. This field is
+        // ONLY ever written by the DevControlServer (env-gated, 127.0.0.1) — it has no effect in a shipped
+        // addon (the server never starts unless GODOT_MCP_DEV_CONTROL=1).
+        ConnectionStatus? _devStatusOverride;
+
         // Accumulated frame delta for the periodic re-sync. Reset each time it crosses the interval so the
         // re-sync runs at a steady ~ResyncIntervalSeconds cadence regardless of frame rate.
         double _resyncAccumulator;
@@ -607,6 +615,11 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// </summary>
         void SyncFromConnection()
         {
+            // A dev-injected status pins the label: skip the live re-sync so the injection sticks on screen
+            // (see _devStatusOverride). DEV-ONLY — never set in a shipped addon.
+            if (_devStatusOverride != null)
+                return;
+
             var live = _connection.ConnectionStatus;
             if (_renderedStatus == live)
                 return;
@@ -962,6 +975,42 @@ namespace com.IvanMurzak.Godot.MCP.UI
             ApplyStatus(_connection.ConnectionStatus);
             ApplyServerStatus(_serverManager.Status);
         }
+
+        // --- DEV-ONLY inject API (driven by the env-gated, 127.0.0.1 DevControlServer) ------------------------
+        //
+        // These exist purely so a terminal / AI agent can paint a FAKE state onto the LIVE dock for test +
+        // AI-driven development. They are no-ops in a shipped addon because the server that calls them only
+        // starts when GODOT_MCP_DEV_CONTROL=1. ALL of them must run on the editor main thread (the caller
+        // hops via MainThreadDispatcher).
+
+        /// <summary>
+        /// DEV-ONLY: paint a fake <see cref="ConnectionStatus"/> onto the dock and PIN it — the periodic
+        /// re-sync is suppressed (see <see cref="_devStatusOverride"/>) so the injected status sticks instead
+        /// of being reverted to the live status within ~<see cref="ResyncIntervalSeconds"/>s. Clear it with
+        /// <see cref="DevClearStatusOverride"/>.
+        /// </summary>
+        public void DevInjectStatus(ConnectionStatus status)
+        {
+            _devStatusOverride = status;
+            ApplyStatus(status);
+        }
+
+        /// <summary>
+        /// DEV-ONLY: drop the injected-status pin and re-converge to the LIVE connection status (so the dock
+        /// resumes reflecting reality). Pairs with <see cref="DevInjectStatus"/>.
+        /// </summary>
+        public void DevClearStatusOverride()
+        {
+            _devStatusOverride = null;
+            ApplyStatus(_connection.ConnectionStatus);
+        }
+
+        /// <summary>
+        /// DEV-ONLY: paint a fake local-server <see cref="GodotMcpServerStatus"/> onto the MCP-server timeline
+        /// point. No override is needed — the server status has no periodic re-sync (unlike the connection
+        /// status), so the injected value persists until the next real <c>StatusChanged</c>.
+        /// </summary>
+        public void DevInjectServerStatus(GodotMcpServerStatus status) => ApplyServerStatus(status);
 
         public override void _ExitTree()
         {

--- a/addons/godot_mcp/UI/GodotMcpDock.cs
+++ b/addons/godot_mcp/UI/GodotMcpDock.cs
@@ -10,6 +10,7 @@
 #if TOOLS
 #nullable enable
 using com.IvanMurzak.Godot.MCP.Connection;
+using com.IvanMurzak.Godot.MCP.Connection.DevControl;
 using Godot;
 
 namespace com.IvanMurzak.Godot.MCP.UI
@@ -318,6 +319,189 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _agentConfiguratorsPanel?.Refresh();
             _extensionsPanel?.Refresh();
             SyncLogLevelSelector();
+        }
+
+        // ===================================================================================================
+        //  DEV-ONLY inject / control / state API
+        // ---------------------------------------------------------------------------------------------------
+        //  Surface for the env-gated, 127.0.0.1-bound DevControlServer (Connection/DevControl/) so a terminal
+        //  / AI agent can (a) INJECT fake states onto the LIVE dock to test UI rendering and (b) CONTROL it —
+        //  simulate user actions (set Server URL, switch agent, click Configure/Connect/Start) — without
+        //  clicking by hand. INERT in a shipped addon: the server only starts when GODOT_MCP_DEV_CONTROL=1.
+        //
+        //  Inject delegates to ConnectionPanel's dev API; control + state walk the live dock tree by node
+        //  Name (the Names are stable, assigned in BuildUi here / in ConnectionPanel / AgentConfiguratorsPanel)
+        //  and drive the real controls (set Text + EmitSignal, Select + EmitSignal, EmitSignal "pressed"), so
+        //  the same code paths a human click would hit run. ALL of these MUST be called on the editor main
+        //  thread (the DevControlServer hops via MainThreadDispatcher).
+        // ===================================================================================================
+
+        /// <summary>DEV-ONLY: inject a fake connection status (Connected/Connecting/Disconnected) onto the dock and pin it.</summary>
+        public void DevInjectConnectionStatus(string status)
+        {
+            if (!DevControlRouter.TryParseConnectionStatus(status, out var parsed))
+                throw new System.ArgumentException($"invalid connection-status '{status}'", nameof(status));
+            if (_connectionPanel == null)
+                throw new System.InvalidOperationException("connection panel not present (no live connection)");
+            _connectionPanel.DevInjectStatus(parsed);
+        }
+
+        /// <summary>DEV-ONLY: inject a fake local-server status (Stopped/Starting/Running/Stopping/External) onto the dock.</summary>
+        public void DevInjectServerStatus(string status)
+        {
+            if (!DevControlRouter.TryParseServerStatus(status, out var parsed))
+                throw new System.ArgumentException($"invalid server-status '{status}'", nameof(status));
+            if (_connectionPanel == null)
+                throw new System.InvalidOperationException("connection panel not present (no live connection)");
+            _connectionPanel.DevInjectServerStatus(parsed);
+        }
+
+        /// <summary>
+        /// DEV-ONLY: drive the Custom-mode Server URL field as a user would — set the LineEdit text and emit
+        /// its <c>text_submitted</c> signal so the panel runs its real commit/validate/reconnect path.
+        /// </summary>
+        public void DevSetServerUrl(string url)
+        {
+            var field = FindChild("HostField", recursive: true, owned: false) as LineEdit
+                ?? throw new System.InvalidOperationException("HostField not found (Custom mode may be hidden)");
+            field.Text = url ?? string.Empty;
+            field.EmitSignal(LineEdit.SignalName.TextSubmitted, field.Text);
+        }
+
+        /// <summary>
+        /// DEV-ONLY: select an AI agent by its display NAME or registry agent-id — sets the OptionButton
+        /// selection and emits <c>item_selected</c> so the panel runs its real persist + re-render path.
+        /// </summary>
+        public bool DevSelectAgent(string idOrName)
+        {
+            var selector = FindChild("AgentSelector", recursive: true, owned: false) as OptionButton
+                ?? throw new System.InvalidOperationException("AgentSelector not found");
+
+            // Resolve by registry agent-id first (stable), then fall back to the visible display name.
+            var index = Agents.GodotAgentConfiguratorRegistry.GetIndexByAgentId(idOrName);
+            if (index < 0)
+            {
+                var names = Agents.GodotAgentConfiguratorRegistry.AgentNames;
+                for (int i = 0; i < names.Count; i++)
+                {
+                    if (string.Equals(names[i], idOrName, System.StringComparison.OrdinalIgnoreCase))
+                    {
+                        index = i;
+                        break;
+                    }
+                }
+            }
+            if (index < 0)
+                return false;
+
+            // The OptionButton item id IS the registry index (see AgentConfiguratorsPanel.BuildUi).
+            var itemIndex = selector.GetItemIndex(index);
+            if (itemIndex < 0)
+                return false;
+
+            selector.Selected = itemIndex;
+            selector.EmitSignal(OptionButton.SignalName.ItemSelected, itemIndex);
+            return true;
+        }
+
+        /// <summary>
+        /// DEV-ONLY: simulate a click on one of the dock's primary buttons by emitting its <c>pressed</c>
+        /// signal — running the exact handler a human click would. Returns false when the target's button is
+        /// not present (e.g. the Remove button is hidden until the agent is configured, the Start-server
+        /// button only exists in Custom mode). Targets: configure|reconfigure|remove|connect|start-server|generate.
+        /// </summary>
+        public bool DevClick(string target)
+        {
+            if (!DevControlRouter.TryNormalizeClickTarget(target, out var normalized))
+                throw new System.ArgumentException($"invalid click target '{target}'", nameof(target));
+
+            // Map the normalized target to the live button's node Name. "reconfigure" is the same button as
+            // "configure" (its label flips to "Reconfigure" once configured — the node Name stays "Configure").
+            var nodeName = normalized switch
+            {
+                "configure" or "reconfigure" => "Configure",
+                "remove" => "Remove",
+                "connect" => "ConnectButton",
+                "start-server" => "LocalServerStartStopButton",
+                "generate" => "Generate",
+                _ => null,
+            };
+            if (nodeName == null)
+                return false;
+
+            var button = FindChild(nodeName, recursive: true, owned: false) as BaseButton;
+            if (button == null || !IsInstanceValid(button))
+                return false;
+
+            button.EmitSignal(BaseButton.SignalName.Pressed);
+            return true;
+        }
+
+        /// <summary>
+        /// DEV-ONLY: a JSON snapshot of what the dock is currently rendering — connection status label,
+        /// Connect-button text, the Server URL field, the selected agent name, the agent config status text,
+        /// and whether the AI-agent "AgentAlert" node is present + visible. Read by <c>GET /state</c> so a
+        /// terminal / AI agent can assert on the live UI without scraping pixels.
+        /// </summary>
+        public string DevStateJson()
+        {
+            string? Text(string name) =>
+                (FindChild(name, recursive: true, owned: false) as Label)?.Text;
+            string? ButtonText(string name) =>
+                (FindChild(name, recursive: true, owned: false) as Button)?.Text;
+
+            var hostField = FindChild("HostField", recursive: true, owned: false) as LineEdit;
+            var agentSelector = FindChild("AgentSelector", recursive: true, owned: false) as OptionButton;
+            string? selectedAgent = null;
+            if (agentSelector != null && agentSelector.Selected >= 0)
+                selectedAgent = agentSelector.GetItemText(agentSelector.Selected);
+
+            var alert = FindChild("AgentAlert", recursive: true, owned: false) as Control;
+
+            // Hand-built JSON so this file stays free of a System.Text.Json dependency in the dock layer; the
+            // DevControlServer embeds this verbatim under a "dock" key. All values are escaped.
+            var sb = new System.Text.StringBuilder();
+            sb.Append('{');
+            AppendJson(sb, "dockTitle", DockTitle); sb.Append(',');
+            AppendJson(sb, "connectionStatus", Text("GodotStatus")); sb.Append(',');
+            AppendJson(sb, "connectButtonText", ButtonText("ConnectButton")); sb.Append(',');
+            AppendJson(sb, "serverUrl", hostField?.Text); sb.Append(',');
+            AppendJson(sb, "selectedAgent", selectedAgent); sb.Append(',');
+            AppendJson(sb, "agentConfigStatus", Text("Status")); sb.Append(',');
+            sb.Append("\"agentAlertPresent\":").Append(alert != null ? "true" : "false").Append(',');
+            sb.Append("\"agentAlertVisible\":").Append(alert is { Visible: true } ? "true" : "false");
+            sb.Append('}');
+            return sb.ToString();
+        }
+
+        /// <summary>Append a JSON <c>"key":"value"</c> pair (value JSON-escaped; null → JSON null) to <paramref name="sb"/>.</summary>
+        static void AppendJson(System.Text.StringBuilder sb, string key, string? value)
+        {
+            sb.Append('"').Append(key).Append("\":");
+            if (value == null)
+            {
+                sb.Append("null");
+                return;
+            }
+            sb.Append('"');
+            foreach (var ch in value)
+            {
+                switch (ch)
+                {
+                    case '"': sb.Append("\\\""); break;
+                    case '\\': sb.Append("\\\\"); break;
+                    case '\n': sb.Append("\\n"); break;
+                    case '\r': sb.Append("\\r"); break;
+                    case '\t': sb.Append("\\t"); break;
+                    default:
+                        if (ch < 0x20)
+                            sb.Append("\\u").Append(((int)ch).ToString("x4"));
+                        else
+                            sb.Append(ch);
+                        break;
+                }
+            }
+            sb.Append('"');
         }
     }
 }


### PR DESCRIPTION
A **dev-only** HTTP bridge so a terminal / AI agent can **inject fake states** into the live "AI Game Developer" dock and **simulate user actions** — for writing tests and AI-driven dev of the dock UI. (Unreal-MCP gets the sibling feature in a separate PR.)

## Security (the boundary is the server)
- Binds **127.0.0.1 only**; starts **only** when `GODOT_MCP_DEV_CONTROL=1` (port `GODOT_MCP_DEV_CONTROL_PORT`, default 9920). **OFF by default** → a shipped/installed addon never listens. `.scripts/worktree.py` (infra) allocates the port per-worktree + sets the flag, so multiple worktrees run dev servers on unique ports simultaneously.

## Pieces
- `DevControlServer` (`#if TOOLS`) — `HttpListener` accept loop; dock-touching work hops to the editor main thread via `MainThreadDispatcher.Enqueue` + a `TaskCompletionSource` (10s stall guard).
- `DevControlRouter` (pure-managed, **41 unit tests**) — `(method, path)` → command + status/click-target parsers.
- Dock dev API (`GodotMcpDock`): inject delegates to `ConnectionPanel` (a `_devStatusOverride` stops the periodic re-sync from reverting an injected status); control/state node-walk via `FindChild` + `EmitSignal`.

## Endpoints
`GET /health`, `GET /state`; `POST /inject/connection-status`, `/inject/server-status`, `/control/server-url`, `/control/select-agent`, `/control/click`. Responses `{ok:true,…}` / `{ok:false,error:…}`.

## Verification
- `dotnet build` 0/0; `dotnet test` 768 pass (the lone `GodotAssemblyUtilsTests` fail is a local-env artifact, green in CI).
- **Live-verified** against a running editor: injected "Connected" sticks (override), `select-agent`→Cursor, `server-url` change applied (+ reconfigure alert), `server-status`→Running, unknown route → 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)