### PR TITLE
feat(dev): enable the dev-control bridge from the project .env file

### DIFF
--- a/Godot-MCP.Tests/GodotMcpEnvFileTests.cs
+++ b/Godot-MCP.Tests/GodotMcpEnvFileTests.cs
@@ -149,6 +149,44 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Empty(GodotMcpEnvFile.LoadFile(path));
         }
 
+        // --- LookupRaw: arbitrary single-key read (used by the dev-control gate, not a RecognizedKey) ---
+
+        [Fact]
+        public void LookupRaw_ReturnsValue_ForAnyKey_IncludingNonRecognized()
+        {
+            var path = Path.Combine(Path.GetTempPath(), "godot-mcp-lookup-" + Guid.NewGuid().ToString("N") + ".env");
+            File.WriteAllLines(path, new[]
+            {
+                "# comment",
+                "GODOT_MCP_DEV_CONTROL=1",
+                "GODOT_MCP_DEV_CONTROL_PORT=\"9920\"",   // quotes stripped like a process-env value
+                "GODOT_MCP_HOST=http://localhost:8090",
+            });
+            try
+            {
+                Assert.Equal("1", GodotMcpEnvFile.LookupRaw(path, "GODOT_MCP_DEV_CONTROL"));
+                Assert.Equal("9920", GodotMcpEnvFile.LookupRaw(path, "GODOT_MCP_DEV_CONTROL_PORT"));
+                Assert.Equal("http://localhost:8090", GodotMcpEnvFile.LookupRaw(path, "GODOT_MCP_HOST"));
+                Assert.Null(GodotMcpEnvFile.LookupRaw(path, "GODOT_MCP_ABSENT"));
+            }
+            finally { File.Delete(path); }
+        }
+
+        [Theory]
+        [InlineData(null, "GODOT_MCP_DEV_CONTROL")]
+        [InlineData("", "GODOT_MCP_DEV_CONTROL")]
+        public void LookupRaw_NullOrBlankPath_ReturnsNull(string? path, string key)
+        {
+            Assert.Null(GodotMcpEnvFile.LookupRaw(path, key));
+        }
+
+        [Fact]
+        public void LookupRaw_MissingFile_ReturnsNull()
+        {
+            var path = Path.Combine(Path.GetTempPath(), "godot-mcp-no-such-" + Guid.NewGuid().ToString("N") + ".env");
+            Assert.Null(GodotMcpEnvFile.LookupRaw(path, "GODOT_MCP_DEV_CONTROL"));
+        }
+
         [Fact]
         public void LoadFile_RealFile_ParsesContents()
         {

--- a/addons/godot_mcp/Connection/GodotMcpEnvFile.cs
+++ b/addons/godot_mcp/Connection/GodotMcpEnvFile.cs
@@ -295,6 +295,51 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             return GodotMcpConfig.NormalizeEnv(raw);
         }
 
+        /// <summary>
+        /// Read ONE arbitrary key's value from the <c>.env</c> file at <paramref name="path"/> — NOT limited to
+        /// the connection <see cref="RecognizedKeys"/>. Used by features outside the connection config (e.g. the
+        /// dev-control bridge gate, <c>GODOT_MCP_DEV_CONTROL</c>) that want the same "process env &gt; .env &gt;
+        /// default" precedence: the caller checks process env first, then falls back to this. Returns the sanitized
+        /// value (same normalization as <see cref="Parse"/>) or <c>null</c> when the file is missing/unreadable, the
+        /// key is absent, or its value is blank. Never throws. Pure-managed / unit-testable.
+        /// </summary>
+        public static string? LookupRaw(string? path, string key)
+        {
+            if (string.IsNullOrWhiteSpace(path) || string.IsNullOrEmpty(key))
+                return null;
+
+            string[] lines;
+            try
+            {
+                if (!File.Exists(path))
+                    return null;
+                lines = File.ReadAllLines(path);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+
+            string? found = null; // last occurrence wins (matches Parse)
+            foreach (var rawLine in lines)
+            {
+                if (rawLine == null)
+                    continue;
+                var line = rawLine.Trim();
+                if (line.Length == 0 || line[0] == '#')
+                    continue;
+                var eq = line.IndexOf('=');
+                if (eq <= 0)
+                    continue;
+                if (!string.Equals(line.Substring(0, eq).Trim(), key, StringComparison.Ordinal))
+                    continue;
+                var value = Sanitize(line.Substring(eq + 1));
+                if (!string.IsNullOrEmpty(value))
+                    found = value;
+            }
+            return found;
+        }
+
         static readonly IReadOnlyDictionary<string, string> Empty =
             new Dictionary<string, string>(StringComparer.Ordinal);
     }

--- a/addons/godot_mcp/GodotMcpPlugin.cs
+++ b/addons/godot_mcp/GodotMcpPlugin.cs
@@ -188,7 +188,17 @@ namespace com.IvanMurzak.Godot.MCP
         /// </summary>
         void StartDevControlIfEnabled()
         {
-            if (OS.GetEnvironment("GODOT_MCP_DEV_CONTROL") != "1")
+            // Resolve with precedence process env > project-root .env > default — so a developer can enable the
+            // bridge by dropping the flag into the project's `.env` (Godot is launched from the GUI with no shell
+            // exports) WITHOUT exporting a process env var. Mirrors the connection config's env-file layer.
+            var envPath = ProjectSettings.GlobalizePath("res://.env");
+            string? ResolveDevVar(string key)
+            {
+                var fromProcess = OS.GetEnvironment(key);
+                return !string.IsNullOrEmpty(fromProcess) ? fromProcess : GodotMcpEnvFile.LookupRaw(envPath, key);
+            }
+
+            if (ResolveDevVar("GODOT_MCP_DEV_CONTROL") != "1")
                 return;
 
             if (_dock == null)
@@ -198,7 +208,7 @@ namespace com.IvanMurzak.Godot.MCP
             }
 
             var port = DevControlServer.DefaultPort;
-            var portEnv = OS.GetEnvironment("GODOT_MCP_DEV_CONTROL_PORT");
+            var portEnv = ResolveDevVar("GODOT_MCP_DEV_CONTROL_PORT");
             if (!string.IsNullOrEmpty(portEnv) && int.TryParse(portEnv, out var parsed) && parsed > 0 && parsed <= 65535)
                 port = parsed;
 


### PR DESCRIPTION
The dev-control bridge gate read **only** the process env, so putting `GODOT_MCP_DEV_CONTROL=1` in the project `.env` did nothing (Godot is launched from the GUI with no shell exports — the `.env` layer is how local config is supplied).

Now resolves the flag + port with precedence **process env > project `.env` > default**, matching the connection config's env-file layer.

- `GodotMcpEnvFile.LookupRaw(path, key)` — a generic single-key `.env` reader (not limited to the connection `RecognizedKeys`), pure-managed + unit-tested (4 cases).
- `StartDevControlIfEnabled` falls back to `res://.env`.

**Live-verified:** with zero process env, dropping `GODOT_MCP_DEV_CONTROL=1` into the test project `.env` starts the server (`/health` + inject→Connected confirmed). `dotnet test` 772 pass (the lone `GodotAssemblyUtilsTests` fail is the known local-env artifact, green in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)