### PR TITLE
fix(ui): root dock signal-handler delegates ("delegate_handle null" crash) + dev-control bridge coverage

### DIFF
--- a/Godot-MCP.Tests/DevControlRouterTests.cs
+++ b/Godot-MCP.Tests/DevControlRouterTests.cs
@@ -33,6 +33,7 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         [InlineData("POST", "/control/server-url", DevControlRouter.Command.ControlServerUrl)]
         [InlineData("POST", "/control/select-agent", DevControlRouter.Command.ControlSelectAgent)]
         [InlineData("POST", "/control/click", DevControlRouter.Command.ControlClick)]
+        [InlineData("POST", "/control/set-segment", DevControlRouter.Command.ControlSetSegment)]
         public void Route_MapsKnownRoutes(string method, string path, DevControlRouter.Command expected)
         {
             Assert.Equal(expected, DevControlRouter.Route(method, path));
@@ -119,6 +120,10 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         [InlineData("connect", "connect")]
         [InlineData("start-server", "start-server")]
         [InlineData("  generate ", "generate")]
+        [InlineData("Authorize", "authorize")]
+        [InlineData("REVOKE", "revoke")]
+        [InlineData("reveal", "reveal")]
+        [InlineData("Copy", "copy")]
         public void TryNormalizeClickTarget_NormalizesKnown(string target, string expected)
         {
             Assert.True(DevControlRouter.TryNormalizeClickTarget(target, out var normalized));
@@ -134,6 +139,35 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         {
             Assert.False(DevControlRouter.TryNormalizeClickTarget(target, out var normalized));
             Assert.Equal(string.Empty, normalized);
+        }
+
+        // --- Segmented-control vocabulary --------------------------------------------------------------------
+
+        [Theory]
+        [InlineData("mode", "custom", "mode", 0)]
+        [InlineData("mode", "Cloud", "mode", 1)]
+        [InlineData("MODE", "  cloud ", "mode", 1)]
+        [InlineData("auth", "none", "auth", 0)]
+        [InlineData("Auth", "REQUIRED", "auth", 1)]
+        public void TryNormalizeSegment_NormalizesKnown(string control, string option, string expectedControl, int expectedIndex)
+        {
+            Assert.True(DevControlRouter.TryNormalizeSegment(control, option, out var normControl, out var index));
+            Assert.Equal(expectedControl, normControl);
+            Assert.Equal(expectedIndex, index);
+        }
+
+        [Theory]
+        [InlineData(null, "custom")]      // null control
+        [InlineData("mode", null)]        // null option
+        [InlineData("", "")]              // empty
+        [InlineData("transport", "http")] // unknown control
+        [InlineData("mode", "offline")]   // unknown option for a known control
+        [InlineData("auth", "cloud")]     // option from the wrong control
+        public void TryNormalizeSegment_RejectsUnknown(string? control, string? option)
+        {
+            Assert.False(DevControlRouter.TryNormalizeSegment(control, option, out var normControl, out var index));
+            Assert.Equal(string.Empty, normControl);
+            Assert.Equal(-1, index);
         }
     }
 }

--- a/Godot-MCP.Tests/DevControlRouterTests.cs
+++ b/Godot-MCP.Tests/DevControlRouterTests.cs
@@ -124,6 +124,7 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         [InlineData("REVOKE", "revoke")]
         [InlineData("reveal", "reveal")]
         [InlineData("Copy", "copy")]
+        [InlineData("generate-token", "generate-token")]
         public void TryNormalizeClickTarget_NormalizesKnown(string target, string expected)
         {
             Assert.True(DevControlRouter.TryNormalizeClickTarget(target, out var normalized));

--- a/addons/godot_mcp/Connection/DevControl/DevControlRouter.cs
+++ b/addons/godot_mcp/Connection/DevControl/DevControlRouter.cs
@@ -147,7 +147,9 @@ namespace com.IvanMurzak.Godot.MCP.Connection.DevControl
             "configure", "reconfigure", "remove", "connect", "start-server", "generate",
             // Cloud-mode device-auth buttons (the pair that first surfaced the GC'd-signal-delegate crash) +
             // the agent-snippet Reveal/Copy buttons — so the smoke harness can exercise EVERY dock button.
-            "authorize", "revoke", "reveal", "copy",
+            // "generate" is the Skills panel's Generate button; "generate-token" is the Custom-mode token
+            // "New" button (distinct node) — both reachable so neither is left untested.
+            "authorize", "revoke", "reveal", "copy", "generate-token",
         };
 
         /// <summary>

--- a/addons/godot_mcp/Connection/DevControl/DevControlRouter.cs
+++ b/addons/godot_mcp/Connection/DevControl/DevControlRouter.cs
@@ -42,6 +42,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection.DevControl
             ControlServerUrl,
             ControlSelectAgent,
             ControlClick,
+            ControlSetSegment,
         }
 
         /// <summary>
@@ -58,6 +59,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection.DevControl
             ("POST", "/control/server-url",       Command.ControlServerUrl),
             ("POST", "/control/select-agent",     Command.ControlSelectAgent),
             ("POST", "/control/click",            Command.ControlClick),
+            ("POST", "/control/set-segment",      Command.ControlSetSegment),
         };
 
         /// <summary>
@@ -143,6 +145,9 @@ namespace com.IvanMurzak.Godot.MCP.Connection.DevControl
         static readonly HashSet<string> ClickTargets = new(StringComparer.OrdinalIgnoreCase)
         {
             "configure", "reconfigure", "remove", "connect", "start-server", "generate",
+            // Cloud-mode device-auth buttons (the pair that first surfaced the GC'd-signal-delegate crash) +
+            // the agent-snippet Reveal/Copy buttons — so the smoke harness can exercise EVERY dock button.
+            "authorize", "revoke", "reveal", "copy",
         };
 
         /// <summary>
@@ -161,6 +166,47 @@ namespace com.IvanMurzak.Godot.MCP.Connection.DevControl
             }
 
             normalized = string.Empty;
+            return false;
+        }
+
+        /// <summary>
+        /// The segmented controls the bridge can drive, each with its ordered option vocabulary (lowercase).
+        /// <c>mode</c> selects the connection mode (Custom/Cloud); <c>auth</c> selects the Custom-mode
+        /// Authorization "transport" (none/required). The option's INDEX in the list is the segment index the
+        /// dock emits <c>pressed</c> on. Kept pure-managed so the vocabulary is unit-tested.
+        /// </summary>
+        static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> SegmentVocabulary =
+            new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["mode"] = new[] { "custom", "cloud" },
+                ["auth"] = new[] { "none", "required" },
+            };
+
+        /// <summary>
+        /// Validate a segmented-control <paramref name="control"/> ("mode" | "auth") + <paramref name="option"/>
+        /// (case-insensitive) and resolve them to the canonical lowercase control name and the option's segment
+        /// <paramref name="index"/>. Returns <c>false</c> (index <c>-1</c>) for an unknown control or option so
+        /// the server can answer a 400. See <see cref="SegmentVocabulary"/>.
+        /// </summary>
+        public static bool TryNormalizeSegment(string? control, string? option, out string normalizedControl, out int index)
+        {
+            normalizedControl = string.Empty;
+            index = -1;
+
+            var c = (control ?? string.Empty).Trim().ToLowerInvariant();
+            if (!SegmentVocabulary.TryGetValue(c, out var options))
+                return false;
+
+            var o = (option ?? string.Empty).Trim().ToLowerInvariant();
+            for (int i = 0; i < options.Count; i++)
+            {
+                if (string.Equals(options[i], o, StringComparison.Ordinal))
+                {
+                    normalizedControl = c;
+                    index = i;
+                    return true;
+                }
+            }
             return false;
         }
     }

--- a/addons/godot_mcp/Connection/DevControl/DevControlServer.cs
+++ b/addons/godot_mcp/Connection/DevControl/DevControlServer.cs
@@ -166,14 +166,24 @@ namespace com.IvanMurzak.Godot.MCP.Connection.DevControl
                 case DevControlRouter.Command.InjectConnectionStatus:
                 {
                     var value = GetString(root, "status");
-                    RunOnMainThread(() => { _dock.DevInjectConnectionStatus(value ?? string.Empty); return true; });
+                    if (!DevControlRouter.TryParseConnectionStatus(value, out _))
+                    {
+                        TryWrite(context, 400, $"{{\"ok\":false,\"error\":\"invalid connection-status {JsonInner(value)}\"}}");
+                        break;
+                    }
+                    RunOnMainThread(() => { _dock.DevInjectConnectionStatus(value!); return true; });
                     TryWrite(context, 200, "{\"ok\":true}");
                     break;
                 }
                 case DevControlRouter.Command.InjectServerStatus:
                 {
                     var value = GetString(root, "status");
-                    RunOnMainThread(() => { _dock.DevInjectServerStatus(value ?? string.Empty); return true; });
+                    if (!DevControlRouter.TryParseServerStatus(value, out _))
+                    {
+                        TryWrite(context, 400, $"{{\"ok\":false,\"error\":\"invalid server-status {JsonInner(value)}\"}}");
+                        break;
+                    }
+                    RunOnMainThread(() => { _dock.DevInjectServerStatus(value!); return true; });
                     TryWrite(context, 200, "{\"ok\":true}");
                     break;
                 }
@@ -196,9 +206,31 @@ namespace com.IvanMurzak.Godot.MCP.Connection.DevControl
                 case DevControlRouter.Command.ControlClick:
                 {
                     var target = GetString(root, "target");
-                    var ok = RunOnMainThread(() => _dock.DevClick(target ?? string.Empty));
+                    // Invalid vocabulary → 400 (bad request); valid target whose button isn't present in the
+                    // current mode/state → 409 (the dock returns false). This keeps "bad input" distinct from
+                    // "button absent" and never surfaces a 500 for a client typo.
+                    if (!DevControlRouter.TryNormalizeClickTarget(target, out _))
+                    {
+                        TryWrite(context, 400, $"{{\"ok\":false,\"error\":\"invalid target {JsonInner(target)}\"}}");
+                        break;
+                    }
+                    var ok = RunOnMainThread(() => _dock.DevClick(target!));
                     TryWrite(context, ok ? 200 : 409,
                         ok ? "{\"ok\":true}" : $"{{\"ok\":false,\"error\":\"target not clickable {JsonInner(target)}\"}}");
+                    break;
+                }
+                case DevControlRouter.Command.ControlSetSegment:
+                {
+                    var control = GetString(root, "control");
+                    var option = GetString(root, "option");
+                    if (!DevControlRouter.TryNormalizeSegment(control, option, out _, out _))
+                    {
+                        TryWrite(context, 400, $"{{\"ok\":false,\"error\":\"invalid segment {JsonInner(control)}/{JsonInner(option)}\"}}");
+                        break;
+                    }
+                    var ok = RunOnMainThread(() => _dock.DevSetSegment(control!, option!));
+                    TryWrite(context, ok ? 200 : 409,
+                        ok ? "{\"ok\":true}" : $"{{\"ok\":false,\"error\":\"segment not present {JsonInner(control)}/{JsonInner(option)}\"}}");
                     break;
                 }
                 default:

--- a/addons/godot_mcp/UI/Agents/AgentConfiguratorsPanel.cs
+++ b/addons/godot_mcp/UI/Agents/AgentConfiguratorsPanel.cs
@@ -105,7 +105,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             var names = GodotAgentConfiguratorRegistry.AgentNames;
             for (int i = 0; i < names.Count; i++)
                 _agentSelector.AddItem(names[i], i);
-            _agentSelector.ItemSelected += OnAgentSelected;
+            _agentSelector.ItemSelected += DockStyle.KeepAlive(_agentSelector, (OptionButton.ItemSelectedEventHandler)OnAgentSelected);
             row.AddChild(_agentSelector);
 
             // Swappable per-agent view — wrapped in the ONE blue frame-group this section gets (Unity frames the
@@ -325,12 +325,12 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
             _revealButton = new Button { Name = "Reveal", Text = "Reveal token" };
             DockStyle.ApplySecondaryButton(_revealButton);
-            _revealButton.Pressed += OnRevealToggled;
+            DockStyle.ConnectPressed(_revealButton, OnRevealToggled);
             snippetActions.AddChild(_revealButton);
 
             var copyButton = new Button { Name = "Copy", Text = "Copy" };
             DockStyle.ApplySecondaryButton(copyButton);
-            copyButton.Pressed += OnCopyPressed;
+            DockStyle.ConnectPressed(copyButton, OnCopyPressed);
             snippetActions.AddChild(copyButton);
         }
 
@@ -391,11 +391,11 @@ namespace com.IvanMurzak.Godot.MCP.UI
             // Button order mirrors Unity: Remove first (left), Configure second (right).
             _removeButton = new Button { Name = "Remove", Text = "Remove" };
             DockStyle.ApplyAlertButton(_removeButton);
-            _removeButton.Pressed += () => OnRemovePressed(agent, configPath);
+            DockStyle.ConnectPressed(_removeButton, () => OnRemovePressed(agent, configPath));
             configActions.AddChild(_removeButton);
 
             _configureButton = new Button { Name = "Configure", Text = "Configure" };
-            _configureButton.Pressed += () => OnConfigurePressed(agent, configPath);
+            DockStyle.ConnectPressed(_configureButton, () => OnConfigurePressed(agent, configPath));
             configActions.AddChild(_configureButton);
             // Configure/Reconfigure text, primary-vs-secondary styling, and Remove visibility are all driven by
             // RefreshStatus() (called at the end of BuildAgentView) off the live IsConfigured() state.

--- a/addons/godot_mcp/UI/ConnectionPanel.cs
+++ b/addons/godot_mcp/UI/ConnectionPanel.cs
@@ -260,7 +260,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             DockStyle.ApplySubLabel(_statusLabel);
 
             _connectButton = new Button { Name = "ConnectButton" };
-            _connectButton.Pressed += OnConnectButtonPressed;
+            DockStyle.ConnectPressed(_connectButton, OnConnectButtonPressed);
 
             var godotContent = new HBoxContainer { Name = "GodotContent", SizeFlagsHorizontal = SizeFlags.ExpandFill };
             godotContent.AddThemeConstantOverride("separation", 8);
@@ -331,8 +331,8 @@ namespace com.IvanMurzak.Godot.MCP.UI
             };
             DockStyle.ApplyInput(_hostField);
             // Commit on Enter and on focus-out (mirrors the Unity reference's FocusOut commit).
-            _hostField.TextSubmitted += OnHostSubmitted;
-            _hostField.FocusExited += OnHostFocusExited;
+            _hostField.TextSubmitted += DockStyle.KeepAlive(_hostField, (LineEdit.TextSubmittedEventHandler)OnHostSubmitted);
+            _hostField.FocusExited += DockStyle.KeepAlive(_hostField, (System.Action)OnHostFocusExited);
             hostLine.AddChild(_hostField);
 
             // --- Authorization (Custom mode only): none | required (segmented) ---
@@ -368,7 +368,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             tokenLine.AddChild(_tokenField);
 
             _generateTokenButton = new Button { Name = "GenerateTokenButton", Text = "New" };
-            _generateTokenButton.Pressed += OnGenerateTokenPressed;
+            DockStyle.ConnectPressed(_generateTokenButton, OnGenerateTokenPressed);
             tokenLine.AddChild(_generateTokenButton);
 
             // --- Local-server hosting row (Custom mode only): Start/Stop the version-matched server binary ---
@@ -387,7 +387,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             serverLine.AddChild(new Control { SizeFlagsHorizontal = SizeFlags.ExpandFill });
 
             _serverStartStopButton = new Button { Name = "LocalServerStartStopButton" };
-            _serverStartStopButton.Pressed += OnServerStartStopPressed;
+            DockStyle.ConnectPressed(_serverStartStopButton, OnServerStartStopPressed);
             serverLine.AddChild(_serverStartStopButton);
 
             _localServerRow.AddChild(serverLine);
@@ -415,11 +415,11 @@ namespace com.IvanMurzak.Godot.MCP.UI
             cloudTokenLine.AddChild(_cloudTokenField);
 
             _authorizeButton = new Button { Name = "AuthorizeButton", Text = ConnectionPanelView.AuthorizeButtonText };
-            _authorizeButton.Pressed += OnAuthorizeButtonPressed;
+            DockStyle.ConnectPressed(_authorizeButton, OnAuthorizeButtonPressed);
             cloudTokenLine.AddChild(_authorizeButton);
 
             _revokeButton = new Button { Name = "RevokeButton", Text = "Revoke" };
-            _revokeButton.Pressed += OnRevokeButtonPressed;
+            DockStyle.ConnectPressed(_revokeButton, OnRevokeButtonPressed);
             cloudTokenLine.AddChild(_revokeButton);
 
             _cloudAuthStatus = new Label

--- a/addons/godot_mcp/UI/DockStyle.cs
+++ b/addons/godot_mcp/UI/DockStyle.cs
@@ -34,6 +34,41 @@ namespace com.IvanMurzak.Godot.MCP.UI
         public static Color Rgb((float R, float G, float B) c) => new Color(c.R, c.G, c.B);
         public static Color Rgba((float R, float G, float B, float A) c) => new Color(c.R, c.G, c.B, c.A);
 
+        // --- Signal-handler retention -------------------------------------------------------------------------
+        // Godot roots a C# signal-handler delegate only via a native GCHandle on the connection. In the editor
+        // (GC pressure, assembly reloads) that delegate can be collected out from under the connection; firing
+        // the signal afterwards raises
+        //   managed_callable.cpp: Parameter "delegate_handle.value" is null
+        //   Can't get method on CallableCustom "Delegate::Invoke"
+        //   Error calling from signal 'pressed' ... Method not found
+        // and the handler SILENTLY never runs (e.g. the Authorize button does nothing). Keeping a STRONG managed
+        // reference to each connected delegate — tied to the lifetime of the control that owns the connection —
+        // prevents this (the Godot docs' "keep a reference to delegates connected to signals" rule). The table is
+        // keyed weakly by the owner, so a freed control's handlers become collectable again (no leak).
+        static readonly System.Runtime.CompilerServices.ConditionalWeakTable<GodotObject, List<System.Delegate>> _signalDelegates = new();
+
+        /// <summary>
+        /// Retain a strong managed reference to <paramref name="handler"/> for as long as <paramref name="owner"/>
+        /// (the control that owns the signal connection) is alive, then RETURN it so it can be used directly in a
+        /// <c>signal += DockStyle.KeepAlive(owner, handler)</c> connection. Always connect the RETURNED delegate so
+        /// the rooted instance is exactly the one Godot wraps in its <see cref="Callable"/>; rooting a different
+        /// (even equal) delegate would not protect the connected one. Prevents the "delegate_handle.value is null"
+        /// crash described above.
+        /// </summary>
+        public static T KeepAlive<T>(GodotObject owner, T handler) where T : System.Delegate
+        {
+            _signalDelegates.GetOrCreateValue(owner).Add(handler);
+            return handler;
+        }
+
+        /// <summary>
+        /// Connect <paramref name="button"/>'s <c>Pressed</c> signal to <paramref name="handler"/> while retaining a
+        /// strong managed reference to it (see <see cref="KeepAlive{T}"/>) so the delegate cannot be garbage-collected
+        /// out from under the connection. Prefer this over a bare <c>button.Pressed += handler</c> everywhere in the dock.
+        /// </summary>
+        public static void ConnectPressed(BaseButton button, System.Action handler)
+            => button.Pressed += KeepAlive(button, handler);
+
         // --- Bold font (Unity's `-unity-font-style: bold` on headers / section-titles / timeline-labels) ----------
         // Godot Labels have no font-style flag; bold requires a bold Font resource. In the editor the bold face is
         // available from the editor theme ("bold" under "EditorFonts"). Resolved once and cached; degrades to no-op
@@ -380,7 +415,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
             ApplyIconAndText(button, text, iconFileName);
 
-            button.Pressed += () => onPressed();
+            ConnectPressed(button, onPressed);
             return button;
         }
 
@@ -412,7 +447,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
             ApplyIconAndText(button, text, iconFileName);
 
-            button.Pressed += () => onPressed();
+            ConnectPressed(button, onPressed);
             return button;
         }
 
@@ -437,7 +472,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             button.AddThemeColorOverride("font_hover_color", link.Lightened(0.2f));
             button.AddThemeColorOverride("font_pressed_color", link);
             button.AddThemeFontSizeOverride("font_size", DockTheme.FontSizeLink); // smaller than the body (Download / Tutorial links)
-            button.Pressed += () => OS.ShellOpen(url);
+            ConnectPressed(button, () => OS.ShellOpen(url));
             return button;
         }
 
@@ -544,7 +579,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             var button = new Button { Name = "AlertButton", Text = buttonText };
             ApplyPrimaryButton(button);
             button.SizeFlagsHorizontal = Control.SizeFlags.ExpandFill;
-            button.Pressed += () => onPressed();
+            ConnectPressed(button, onPressed);
             col.AddChild(button);
 
             return panel;
@@ -721,7 +756,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 segment.AddThemeFontSizeOverride("font_size", DockTheme.SegmentFontSize);
                 ApplySegmentStyle(segment, SegmentedControlModel.IsSelected(i, clamped));
 
-                segment.Pressed += () =>
+                segment.Pressed += KeepAlive<System.Action>(segment, () =>
                 {
                     // Compare against the AUTHORITATIVE index stashed on the track, not against any probe of
                     // native ButtonPressed flags (which can report two-pressed/zero-pressed on mono/Linux).
@@ -740,7 +775,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
                     // discipline; a caller that DOES call SetSegmentedSelection just re-asserts the same index.
                     SetSegmentedSelection(track, index);
                     onSelected(index);
-                };
+                });
                 track.AddChild(segment);
             }
 
@@ -964,11 +999,11 @@ namespace com.IvanMurzak.Godot.MCP.UI
             content.AddThemeConstantOverride("separation", 2);
             container.AddChild(content);
 
-            toggle.Toggled += pressed =>
+            toggle.Toggled += KeepAlive<BaseButton.ToggledEventHandler>(toggle, pressed =>
             {
                 content.Visible = pressed;
                 toggle.Text = (pressed ? "▾ " : "▸ ") + title;
-            };
+            });
 
             return (container, content);
         }

--- a/addons/godot_mcp/UI/ExtensionRow.cs
+++ b/addons/godot_mcp/UI/ExtensionRow.cs
@@ -78,7 +78,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 SizeFlagsVertical = SizeFlags.ShrinkBegin
             };
             DockStyle.ApplyPrimaryButton(_actionButton);
-            _actionButton.Pressed += () => _onAction(Descriptor);
+            DockStyle.ConnectPressed(_actionButton, () => _onAction(Descriptor));
             AddChild(_actionButton);
         }
 

--- a/addons/godot_mcp/UI/FeatureListWindow.cs
+++ b/addons/godot_mcp/UI/FeatureListWindow.cs
@@ -113,7 +113,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             root.AddChild(_emptyLabel);
 
             var closeButton = new Button { Name = "CloseButton", Text = "Close" };
-            closeButton.Pressed += OnClosePressed;
+            DockStyle.ConnectPressed(closeButton, OnClosePressed);
             root.AddChild(closeButton);
         }
 
@@ -131,7 +131,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             };
             DockStyle.ApplyInput(_searchField);
             // Live (no debounce): every keystroke re-filters.
-            _searchField.TextChanged += _ => RebuildRows();
+            _searchField.TextChanged += DockStyle.KeepAlive<LineEdit.TextChangedEventHandler>(_searchField, _ => RebuildRows());
             bar.AddChild(_searchField);
 
             _statusOption = new OptionButton { Name = "Status" };
@@ -141,7 +141,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _statusOption.AddItem("Disabled", (int)FeatureStatusFilter.Disabled);
             _statusOption.Select((int)FeatureStatusFilter.All);
             DockStyle.ApplyOptionButton(_statusOption);
-            _statusOption.ItemSelected += _ => RebuildRows();
+            _statusOption.ItemSelected += DockStyle.KeepAlive<OptionButton.ItemSelectedEventHandler>(_statusOption, _ => RebuildRows());
             bar.AddChild(_statusOption);
 
             _statsLabel = new Label
@@ -213,7 +213,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
             var toggle = new CheckButton { Name = "Toggle", ButtonPressed = item.Enabled };
             string itemName = item.Name;
-            toggle.Toggled += pressed => OnItemToggled(itemName, pressed);
+            toggle.Toggled += DockStyle.KeepAlive<BaseButton.ToggledEventHandler>(toggle, pressed => OnItemToggled(itemName, pressed));
             headerLine.AddChild(toggle);
             content.AddChild(headerLine);
 

--- a/addons/godot_mcp/UI/FeatureRow.cs
+++ b/addons/godot_mcp/UI/FeatureRow.cs
@@ -90,7 +90,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 SizeFlagsVertical = SizeFlags.ShrinkBegin
             };
             DockStyle.ApplyOpenButton(openButton);
-            openButton.Pressed += () => _onOpen(Kind);
+            DockStyle.ConnectPressed(openButton, () => _onOpen(Kind));
             AddChild(openButton);
         }
 

--- a/addons/godot_mcp/UI/GodotMcpDock.cs
+++ b/addons/godot_mcp/UI/GodotMcpDock.cs
@@ -253,7 +253,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _logLevelSelector = new OptionButton { Name = "LogLevelSelector" };
             foreach (GodotMcpLogLevel level in System.Enum.GetValues(typeof(GodotMcpLogLevel)))
                 _logLevelSelector.AddItem(level.ToString(), (int)level);
-            _logLevelSelector.ItemSelected += OnLogLevelSelected;
+            _logLevelSelector.ItemSelected += DockStyle.KeepAlive(_logLevelSelector, (OptionButton.ItemSelectedEventHandler)OnLogLevelSelected);
             row.AddChild(_logLevelSelector);
 
             _logLevelOverrideNote = new Label
@@ -424,6 +424,10 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 "connect" => "ConnectButton",
                 "start-server" => "LocalServerStartStopButton",
                 "generate" => "Generate",
+                "authorize" => "AuthorizeButton",
+                "revoke" => "RevokeButton",
+                "reveal" => "Reveal",
+                "copy" => "Copy",
                 _ => null,
             };
             if (nodeName == null)
@@ -434,6 +438,43 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 return false;
 
             button.EmitSignal(BaseButton.SignalName.Pressed);
+            return true;
+        }
+
+        /// <summary>
+        /// DEV-ONLY: drive a segmented control as a user tap would — emit the target segment button's
+        /// <c>pressed</c> signal so the panel runs its REAL selection handler (persist + re-render). Drives
+        /// the connection-mode switch (<c>mode</c>: custom|cloud) and the Custom-mode Authorization
+        /// "transport" switch (<c>auth</c>: none|required). Returns false when the control or its segment is
+        /// not present (e.g. the auth segmented exists in Custom mode only). This is also the path that proves
+        /// the segment's <c>Pressed</c> delegate is rooted (the GC'd-signal-delegate fix).
+        /// </summary>
+        public bool DevSetSegment(string control, string option)
+        {
+            if (!DevControlRouter.TryNormalizeSegment(control, option, out var normControl, out var index))
+                throw new System.ArgumentException($"invalid segment control/option '{control}'/'{option}'");
+
+            // The inner track HBoxContainer carries the control's Name; the segment buttons are "Segment{i}"
+            // children of it (see DockStyle.SegmentedControl). Scope the segment lookup to the track so the
+            // mode/auth tracks' identically-named "Segment0/1" children never collide.
+            var trackName = normControl switch
+            {
+                "mode" => "ModeSegmented",
+                "auth" => "AuthSegmented",
+                _ => null,
+            };
+            if (trackName == null)
+                return false;
+
+            var track = FindChild(trackName, recursive: true, owned: false);
+            if (track == null)
+                return false;
+
+            var segment = track.FindChild("Segment" + index, recursive: false, owned: false) as BaseButton;
+            if (segment == null || !IsInstanceValid(segment))
+                return false;
+
+            segment.EmitSignal(BaseButton.SignalName.Pressed);
             return true;
         }
 

--- a/addons/godot_mcp/UI/GodotMcpDock.cs
+++ b/addons/godot_mcp/UI/GodotMcpDock.cs
@@ -423,7 +423,8 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 "remove" => "Remove",
                 "connect" => "ConnectButton",
                 "start-server" => "LocalServerStartStopButton",
-                "generate" => "Generate",
+                "generate" => "Generate",                  // Skills panel's "Generate" button
+                "generate-token" => "GenerateTokenButton", // Custom-mode auth token "New" button (distinct)
                 "authorize" => "AuthorizeButton",
                 "revoke" => "RevokeButton",
                 "reveal" => "Reveal",

--- a/addons/godot_mcp/UI/SkillsPanel.cs
+++ b/addons/godot_mcp/UI/SkillsPanel.cs
@@ -160,14 +160,14 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 Name = "AutoGenerateToggle",
                 ButtonPressed = _connection.Config.GenerateSkillFiles
             };
-            _autoGenerateToggle.Toggled += OnAutoGenerateToggled;
+            _autoGenerateToggle.Toggled += DockStyle.KeepAlive(_autoGenerateToggle, (BaseButton.ToggledEventHandler)OnAutoGenerateToggled);
             controlRow.AddChild(_autoGenerateToggle);
 
             controlRow.AddChild(new Control { Name = "SkillsSpacer", SizeFlagsHorizontal = SizeFlags.ExpandFill });
 
             var generateButton = new Button { Name = "Generate", Text = "Generate" };
             DockStyle.ApplySecondaryButton(generateButton); // compact gray (Unity's .btn-compact), not the big primary
-            generateButton.Pressed += OnGeneratePressed;
+            DockStyle.ConnectPressed(generateButton, OnGeneratePressed);
             controlRow.AddChild(generateButton);
 
             // --- Last-result status line (muted; turns amber on failure). HIDDEN until there's a result, so the

--- a/scripts/dev_control_smoke.py
+++ b/scripts/dev_control_smoke.py
@@ -120,7 +120,8 @@ class Smoke:
         self.assert_state("server-url applied", "serverUrl", "localhost:5300")
         self.step("auth=none", "POST", "/control/set-segment", {"control": "auth", "option": "none"}, ACCEPT_OK)
         self.step("auth=required", "POST", "/control/set-segment", {"control": "auth", "option": "required"}, ACCEPT_OK)
-        self.step("click generate (token)", "POST", "/control/click", {"target": "generate"}, ACCEPT_CLICK)
+        self.step("click generate-token (New)", "POST", "/control/click", {"target": "generate-token"}, ACCEPT_CLICK)
+        self.step("click generate (skills)", "POST", "/control/click", {"target": "generate"}, ACCEPT_CLICK)
         self.step("click connect", "POST", "/control/click", {"target": "connect"}, ACCEPT_CLICK)
         self.step("click start-server", "POST", "/control/click", {"target": "start-server"}, ACCEPT_CLICK)
 

--- a/scripts/dev_control_smoke.py
+++ b/scripts/dev_control_smoke.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+DEV-ONLY dock smoke test — drives EVERY interactive control of the "AI Game Developer"
+Godot editor dock through the dev-control bridge (Connection/DevControl/), across all
+connection modes (Custom / Cloud), the Custom-mode Authorization "transport" (none /
+required), and all injected connection / server states.
+
+Why this exists: dock buttons connect their Godot signals to C# handler delegates. If a
+delegate is not kept strongly referenced, the editor's GC/assembly-reload can collect it,
+after which clicking the button raises
+    managed_callable.cpp: Parameter "delegate_handle.value" is null
+    Can't get method on CallableCustom "Delegate::Invoke"
+    Error calling from signal 'pressed' ... Method not found
+and the click SILENTLY does nothing. This harness clicks every button via the bridge and
+(optionally) scans the editor log for those signatures — so the regression can never come
+back unnoticed.
+
+It does NOT launch the editor; point it at an already-running bridge:
+
+    # 1) boot the testbed editor with the bridge on (see the Godot-MCP testbed runbook):
+    GODOT_MCP_DEV_CONTROL=1 GODOT_MCP_DEV_CONTROL_PORT=9920 \
+        Godot_..._console.exe --editor --path <infra>/Godot-Test-Project
+    # 2) run the smoke against it:
+    python scripts/dev_control_smoke.py --base-url http://127.0.0.1:9920 \
+        --log-file "<infra>/Godot-Test-Project/.godot/editor.log"
+
+Exit code 0 = every step behaved + no forbidden log line; non-zero otherwise.
+Pure stdlib (urllib) — no third-party deps, so it runs anywhere Python 3.8+ does.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+# Log signatures that mean a signal-handler delegate was collected (the bug this guards).
+FORBIDDEN_LOG = [
+    "delegate_handle.value",
+    'CallableCustom "Delegate::Invoke"',
+    "Error calling from signal",
+    "Method not found",
+]
+
+
+class Smoke:
+    def __init__(self, base_url: str, timeout: float):
+        self.base = base_url.rstrip("/")
+        self.timeout = timeout
+        self.passed = 0
+        self.failed = 0
+        self.notes: list[str] = []
+
+    # --- HTTP -------------------------------------------------------------------------------
+    def _request(self, method: str, path: str, body: dict | None):
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(self.base + path, data=data, method=method)
+        if data is not None:
+            req.add_header("Content-Type", "application/json")
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                return resp.status, resp.read().decode()
+        except urllib.error.HTTPError as e:
+            return e.code, e.read().decode()
+
+    # --- assertions -------------------------------------------------------------------------
+    def step(self, label: str, method: str, path: str, body: dict | None, accept):
+        """Run one request; PASS when status is in `accept`. A 500 (handler crash) is ALWAYS a hard fail."""
+        status, text = self._request(method, path, body)
+        ok = status in accept and status != 500
+        mark = "PASS" if ok else "FAIL"
+        if ok:
+            self.passed += 1
+        else:
+            self.failed += 1
+        snippet = text if len(text) <= 160 else text[:157] + "..."
+        print(f"  [{mark}] {label:<42} {method} {path} -> {status}  {snippet}")
+        return status, text
+
+    def state(self):
+        _, text = self._request("GET", "/state", None)
+        try:
+            return json.loads(text).get("dock", {})
+        except json.JSONDecodeError:
+            return {}
+
+    def assert_state(self, label: str, key: str, expected_substr: str):
+        dock = self.state()
+        actual = str(dock.get(key, ""))
+        ok = expected_substr.lower() in actual.lower()
+        mark = "PASS" if ok else "FAIL"
+        self.passed += 1 if ok else 0
+        self.failed += 0 if ok else 1
+        print(f"  [{mark}] {label:<42} state.{key} = {actual!r} (want ~{expected_substr!r})")
+
+    # --- the matrix -------------------------------------------------------------------------
+    def run(self):
+        ACCEPT_CLICK = {200, 409}   # 200 = clicked; 409 = button not present in this mode/state (NOT a crash)
+        ACCEPT_OK = {200}
+        ACCEPT_REJECT = {400, 404, 409}
+
+        print("\n== health / state ==")
+        self.step("health", "GET", "/health", None, ACCEPT_OK)
+        self.step("state", "GET", "/state", None, ACCEPT_OK)
+
+        print("\n== inject connection states ==")
+        for s in ("connected", "connecting", "disconnected"):
+            self.step(f"inject connection={s}", "POST", "/inject/connection-status", {"status": s}, ACCEPT_OK)
+        self.step("inject connection=connected", "POST", "/inject/connection-status", {"status": "connected"}, ACCEPT_OK)
+
+        print("\n== inject server states ==")
+        for s in ("stopped", "starting", "running", "stopping", "external"):
+            self.step(f"inject server={s}", "POST", "/inject/server-status", {"status": s}, ACCEPT_OK)
+
+        print("\n== CUSTOM mode: transport none/required + buttons ==")
+        self.step("mode=custom", "POST", "/control/set-segment", {"control": "mode", "option": "custom"}, ACCEPT_OK)
+        self.step("server-url", "POST", "/control/server-url", {"url": "http://localhost:5300"}, ACCEPT_OK)
+        self.assert_state("server-url applied", "serverUrl", "localhost:5300")
+        self.step("auth=none", "POST", "/control/set-segment", {"control": "auth", "option": "none"}, ACCEPT_OK)
+        self.step("auth=required", "POST", "/control/set-segment", {"control": "auth", "option": "required"}, ACCEPT_OK)
+        self.step("click generate (token)", "POST", "/control/click", {"target": "generate"}, ACCEPT_CLICK)
+        self.step("click connect", "POST", "/control/click", {"target": "connect"}, ACCEPT_CLICK)
+        self.step("click start-server", "POST", "/control/click", {"target": "start-server"}, ACCEPT_CLICK)
+
+        print("\n== CLOUD mode: Authorize / Revoke (the buttons that surfaced the bug) ==")
+        self.step("mode=cloud", "POST", "/control/set-segment", {"control": "mode", "option": "cloud"}, ACCEPT_OK)
+        # Authorize starts the device-auth flow (handler MUST fire — that's the regression). A second click cancels it.
+        self.step("click authorize (start)", "POST", "/control/click", {"target": "authorize"}, ACCEPT_CLICK)
+        self.step("click authorize (cancel)", "POST", "/control/click", {"target": "authorize"}, ACCEPT_CLICK)
+        self.step("click revoke", "POST", "/control/click", {"target": "revoke"}, ACCEPT_CLICK)
+
+        print("\n== agent configurators: select + per-agent buttons ==")
+        for agent in ("claude-code", "cursor", "vscode", "claude-desktop"):
+            st, _ = self.step(f"select agent={agent}", "POST", "/control/select-agent", {"agent": agent}, {200, 404})
+            if st == 200:
+                self.assert_state(f"agent={agent} applied", "selectedAgent", "")  # just confirm /state still serves
+        self.step("click configure", "POST", "/control/click", {"target": "configure"}, ACCEPT_CLICK)
+        self.step("click reveal", "POST", "/control/click", {"target": "reveal"}, ACCEPT_CLICK)
+        self.step("click copy", "POST", "/control/click", {"target": "copy"}, ACCEPT_CLICK)
+        self.step("click remove", "POST", "/control/click", {"target": "remove"}, ACCEPT_CLICK)
+
+        print("\n== re-exercise the bug button after the whole matrix (rooting must persist) ==")
+        self.step("mode=cloud again", "POST", "/control/set-segment", {"control": "mode", "option": "cloud"}, ACCEPT_OK)
+        self.step("click authorize again", "POST", "/control/click", {"target": "authorize"}, ACCEPT_CLICK)
+        self.step("click authorize cancel", "POST", "/control/click", {"target": "authorize"}, ACCEPT_CLICK)
+
+        print("\n== negative paths (must be rejected, never 500) ==")
+        self.step("bad route", "GET", "/nope", None, {404})
+        self.step("bad click target", "POST", "/control/click", {"target": "explode"}, ACCEPT_REJECT)
+        self.step("bad segment control", "POST", "/control/set-segment", {"control": "transport", "option": "http"}, ACCEPT_REJECT)
+        self.step("bad segment option", "POST", "/control/set-segment", {"control": "mode", "option": "offline"}, ACCEPT_REJECT)
+
+    # --- log scan ---------------------------------------------------------------------------
+    def scan_log(self, log_file: str):
+        print(f"\n== scanning editor log for delegate-collection signatures: {log_file} ==")
+        try:
+            with open(log_file, "r", encoding="utf-8", errors="replace") as f:
+                content = f.read()
+        except OSError as e:
+            self.notes.append(f"log scan skipped ({e})")
+            print(f"  [WARN] could not read log: {e}")
+            return
+        hits = [pat for pat in FORBIDDEN_LOG if pat in content]
+        if hits:
+            self.failed += 1
+            print(f"  [FAIL] forbidden log signatures present: {hits}")
+        else:
+            self.passed += 1
+            print("  [PASS] no delegate_handle / Delegate::Invoke / signal-call errors in the log")
+
+
+def wait_for_health(base_url: str, deadline_s: float) -> bool:
+    end = time.time() + deadline_s
+    url = base_url.rstrip("/") + "/health"
+    while time.time() < end:
+        try:
+            with urllib.request.urlopen(url, timeout=2) as resp:
+                if resp.status == 200:
+                    return True
+        except (urllib.error.URLError, OSError):
+            time.sleep(1.0)
+    return False
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="DEV-ONLY Godot dock dev-control smoke test")
+    p.add_argument("--base-url", default="http://127.0.0.1:9920", help="bridge base URL (default 127.0.0.1:9920)")
+    p.add_argument("--log-file", default=None, help="editor log to scan for delegate-collection errors")
+    p.add_argument("--timeout", type=float, default=12.0, help="per-request timeout seconds")
+    p.add_argument("--wait", type=float, default=60.0, help="seconds to wait for the bridge /health before giving up")
+    args = p.parse_args()
+
+    print(f"dev-control smoke -> {args.base_url}")
+    if not wait_for_health(args.base_url, args.wait):
+        print(f"FATAL: bridge /health never came up at {args.base_url} within {args.wait}s", file=sys.stderr)
+        return 2
+
+    smoke = Smoke(args.base_url, args.timeout)
+    smoke.run()
+    if args.log_file:
+        smoke.scan_log(args.log_file)
+
+    print(f"\n==== RESULT: {smoke.passed} passed, {smoke.failed} failed ====")
+    for n in smoke.notes:
+        print(f"  note: {n}")
+    return 0 if smoke.failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem
Clicking dock buttons (repro: cloud-row **Authorize**) raised:
```
managed_callable.cpp:96 - Parameter "delegate_handle.value" is null.
Can't get method on CallableCustom "Delegate::Invoke".
Error calling from signal 'pressed' ... Method not found.
```
and the click **silently did nothing** — the handler never ran.

## Root cause
Godot roots a C# signal-handler delegate only via a native GCHandle on the connection; under editor GC pressure / assembly reload that delegate gets collected out from under the connection, leaving `delegate_handle.value` null. The dock's ~25 signal connections (`Pressed` / `Toggled` / `ItemSelected` / `TextSubmitted` / `TextChanged` / `FocusExited`) connected inline delegates with **no strong managed root** — the Godot docs' "keep a reference to delegates connected to signals" rule wasn't followed.

## Fix
- `DockStyle.KeepAlive<T>(GodotObject owner, T handler)` + `DockStyle.ConnectPressed(...)` retain a strong reference to every connected delegate for the lifetime of the owning control, via a **weakly-keyed `ConditionalWeakTable`** (a freed control's handlers become collectable again — no leak).
- All ~25 dock signal connections now route through them (DockStyle, ConnectionPanel, AgentConfiguratorsPanel, SkillsPanel, GodotMcpDock, Feature/Extension rows, FeatureListWindow).

## Dev-control bridge + smoke (verification)
So the regression can't silently return, the DEV-ONLY bridge now reaches **every** dock button:
- new `POST /control/set-segment` (mode `custom|cloud`, auth `none|required`),
- new click targets `authorize` / `revoke` / `reveal` / `copy` / `generate-token`,
- bad client input → **400** (was 500).
- `scripts/dev_control_smoke.py` — operator smoke harness that drives every button across all modes/transports/states and scans the editor log for the delegate signatures.

## Testing
- Build: 0 errors. Unit suite: **+17 router cases**, all green (only the known local-only `NonDefaultContext` temp-DLL flake fails locally; green in CI).
- **Live editor smoke: 44/44 green**, `click authorize → 200` (was the crash), and **no `delegate_handle` / `Delegate::Invoke` / signal-call errors** in the editor log — re-verified after expanding coverage.

Closes #126