### PR TITLE
Godot-line Connect/Stop toggle + status-in-label, and fix authorized-but-red (stale auth-rejection)

### DIFF
--- a/Godot-MCP.Tests/ConnectionPanelViewTests.cs
+++ b/Godot-MCP.Tests/ConnectionPanelViewTests.cs
@@ -88,35 +88,26 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Equal(expected, ConnectionPanelView.Reduce(state, keepConnected));
         }
 
-        // --- StatusLabel ---
+        // --- GodotLineLabel (the underlined "Godot" label now carries the status) ---
 
         [Theory]
-        [InlineData(ConnectionStatus.Connected, "Connected")]
-        [InlineData(ConnectionStatus.Connecting, "Connecting…")]
-        [InlineData(ConnectionStatus.Disconnected, "Disconnected")]
-        public void StatusLabel_MapsEachStatus(ConnectionStatus status, string expected)
+        [InlineData(ConnectionStatus.Connected, "Godot: connected")]
+        [InlineData(ConnectionStatus.Connecting, "Godot: connecting...")]
+        [InlineData(ConnectionStatus.Disconnected, "Godot")]
+        public void GodotLineLabel_MapsEachStatus(ConnectionStatus status, string expected)
         {
-            Assert.Equal(expected, ConnectionPanelView.StatusLabel(status));
+            Assert.Equal(expected, ConnectionPanelView.GodotLineLabel(status));
         }
 
-        // --- ButtonText + ButtonDisabled ---
+        // --- ButtonText: "Connect" when disconnected, "Stop" otherwise ---
 
         [Theory]
-        [InlineData(ConnectionStatus.Connected, ConnectionPanelView.ButtonTextDisconnect)]
-        [InlineData(ConnectionStatus.Connecting, ConnectionPanelView.ButtonTextConnecting)]
+        [InlineData(ConnectionStatus.Connected, ConnectionPanelView.ButtonTextStop)]
+        [InlineData(ConnectionStatus.Connecting, ConnectionPanelView.ButtonTextStop)]
         [InlineData(ConnectionStatus.Disconnected, ConnectionPanelView.ButtonTextConnect)]
         public void ButtonText_MapsEachStatus(ConnectionStatus status, string expected)
         {
             Assert.Equal(expected, ConnectionPanelView.ButtonText(status));
-        }
-
-        [Theory]
-        [InlineData(ConnectionStatus.Connecting, true)]
-        [InlineData(ConnectionStatus.Connected, false)]
-        [InlineData(ConnectionStatus.Disconnected, false)]
-        public void ButtonDisabled_OnlyWhileConnecting(ConnectionStatus status, bool expectedDisabled)
-        {
-            Assert.Equal(expectedDisabled, ConnectionPanelView.ButtonDisabled(status));
         }
 
         // --- StatusColor ---

--- a/addons/godot_mcp/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConnection.cs
@@ -368,21 +368,55 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                     // R3 fires off the SignalR thread; hop to the editor main thread before raising the
                     // event so subscribers (the dock) can touch Control nodes directly. A missing
                     // dispatcher (between editor reloads) degrades to a direct call rather than throwing.
+                    // Same stale-plugin guard as the auth-rejected subscription below: a status emitted by a
+                    // plugin a Reconnect() has already superseded must not overwrite the new plugin's status
+                    // (it would briefly flip the label before the re-sync corrects it). Re-checked on the main
+                    // thread too, for a callback enqueued just before the swap.
+                    if (!ReferenceEquals(_plugin, plugin))
+                        return;
+
                     if (MainThreadDispatcher.Instance != null && !MainThreadDispatcher.IsMainThread)
-                        MainThreadDispatcher.Enqueue(() => PublishStatus(status, marshalled: true));
-                    else
+                        MainThreadDispatcher.Enqueue(() =>
+                        {
+                            if (ReferenceEquals(_plugin, plugin))
+                                PublishStatus(status, marshalled: true);
+                        });
+                    else if (ReferenceEquals(_plugin, plugin))
                         PublishStatus(status, marshalled: false);
                 });
 
             // Surface the reused client's authorization-rejected stream as a main-thread event the dock can
             // act on (clear the rejected token, revert to Authorize). R3 fires off the SignalR thread, so we
             // hop to the editor main thread before raising, mirroring the status subscription above.
+            //
+            // STALE-REJECTION GUARD (the "authorized but stays red" bug): in Cloud mode WITHOUT a token the
+            // connection sits in a reject→retry loop, so OnAuthorizationRejected fires continuously. When the
+            // user authorizes, PersistAuthorizedToken sets CloudToken and calls Reconnect(), which disposes
+            // THIS plugin and builds a fresh one with the token. A rejection emitted by this (now-superseded)
+            // plugin must NOT reach the dock afterwards — the dock's handler nulls CloudToken, which would wipe
+            // the freshly-authorized token and flip the new connection back to "Authorization Required" (red).
+            // Guard at BOTH the emit boundary and again on the main thread (a callback enqueued just before the
+            // swap must re-check): only raise while this subscription's plugin is still the active _plugin.
             _authRejectedSubscription.Disposable = plugin.OnAuthorizationRejected
                 .Subscribe(_ =>
                 {
+                    if (!ReferenceEquals(_plugin, plugin))
+                    {
+                        // Superseded by a Reconnect — drop the stale rejection. Traced so a Cloud-auth
+                        // re-test can SEE the race being suppressed; if the dock instead logs "server
+                        // rejected the authorization token; cleared" AFTER authorizing, that is a GENUINE
+                        // rejection from the live connection (token/header/expiry), not this race.
+                        LogTrace("[Godot-MCP] dropped a stale authorization-rejection from a superseded connection (post-Reconnect).");
+                        return;
+                    }
+
                     if (MainThreadDispatcher.Instance != null && !MainThreadDispatcher.IsMainThread)
-                        MainThreadDispatcher.Enqueue(() => AuthorizationRejected?.Invoke());
-                    else
+                        MainThreadDispatcher.Enqueue(() =>
+                        {
+                            if (ReferenceEquals(_plugin, plugin))
+                                AuthorizationRejected?.Invoke();
+                        });
+                    else if (ReferenceEquals(_plugin, plugin))
                         AuthorizationRejected?.Invoke();
                 });
         }

--- a/addons/godot_mcp/UI/ConnectionPanel.cs
+++ b/addons/godot_mcp/UI/ConnectionPanel.cs
@@ -72,8 +72,9 @@ namespace com.IvanMurzak.Godot.MCP.UI
         Panel _timelineServerCircle = null!;
         Panel _timelineAgentCircle = null!;
 
-        // Godot point: status label + Connect/Disconnect.
-        Label _statusLabel = null!;
+        // Godot point: the underlined "Godot" label (now carries the status — "Godot" / "Godot: connecting..." /
+        // "Godot: connected") + a single Connect/Stop toggle button.
+        PanelContainer _godotUnderline = null!;
         Button _connectButton = null!;
 
         // MCP-server point content.
@@ -254,20 +255,18 @@ namespace com.IvanMurzak.Godot.MCP.UI
             timeline.AddThemeConstantOverride("separation", 0);
             AddChild(timeline);
 
-            // Point 1 — Godot: label + right-aligned Connect/Disconnect.
+            // Point 1 — Godot: a single underlined label that CARRIES the status + a right-aligned Connect/Stop toggle.
             _timelineGodotCircle = DockStyle.TimelineCircle("GodotCircle", ConnectionPanelView.TimelinePointState.Disconnected);
-            _statusLabel = new Label { Name = "GodotStatus" };
-            DockStyle.ApplySubLabel(_statusLabel);
 
             _connectButton = new Button { Name = "ConnectButton" };
             DockStyle.ConnectPressed(_connectButton, OnConnectButtonPressed);
 
             var godotContent = new HBoxContainer { Name = "GodotContent", SizeFlagsHorizontal = SizeFlags.ExpandFill };
             godotContent.AddThemeConstantOverride("separation", 8);
-            // Underlined section label (bottom-border, bigger + vertically aligned) — not the old VBox+rule that
-            // pushed the text up. The status text beside it no longer repeats "Godot" (see ConnectionPanelView).
-            godotContent.AddChild(DockStyle.UnderlinedSubLabel("GodotLabel", "Godot"));
-            godotContent.AddChild(_statusLabel);
+            // The underlined "Godot" label now folds in the status (ApplyStatus retitles it to
+            // "Godot: connecting..." / "Godot: connected") — there is no longer a separate status suffix label.
+            _godotUnderline = DockStyle.UnderlinedSubLabel("GodotLabel", ConnectionPanelView.GodotLineLabel(ConnectionStatus.Disconnected));
+            godotContent.AddChild(_godotUnderline);
             godotContent.AddChild(new Control { SizeFlagsHorizontal = SizeFlags.ExpandFill });
             godotContent.AddChild(_connectButton);
             timeline.AddChild(MakeTimelinePoint(_timelineGodotCircle, godotContent, isLast: false, circleTopOffset: 4));
@@ -498,14 +497,15 @@ namespace com.IvanMurzak.Godot.MCP.UI
         {
             var pointState = ConnectionPanelView.PointState(status);
 
-            _statusLabel.Text = ConnectionPanelView.StatusLabel(status);
+            // The underlined "Godot" label carries the status now ("Godot" / "Godot: connecting..." / "Godot: connected").
+            DockStyle.SetUnderlinedSubLabelText(_godotUnderline, ConnectionPanelView.GodotLineLabel(status));
             _connectButton.Text = ConnectionPanelView.ButtonText(status);
-            _connectButton.Disabled = ConnectionPanelView.ButtonDisabled(status);
-            // Primary (cyan) when the click connects; secondary (gray) when it disconnects.
-            if (status == ConnectionStatus.Connected)
-                DockStyle.ApplySecondaryButton(_connectButton);
-            else
+            // A single always-enabled toggle: primary (cyan) "Connect" when disconnected; secondary (gray) "Stop"
+            // when connected OR connecting.
+            if (status == ConnectionStatus.Disconnected)
                 DockStyle.ApplyPrimaryButton(_connectButton);
+            else
+                DockStyle.ApplySecondaryButton(_connectButton);
 
             DockStyle.ApplyTimelineCircle(_timelineGodotCircle, pointState);
 
@@ -631,10 +631,12 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
         void OnConnectButtonPressed()
         {
-            if (_connection.ConnectionStatus == ConnectionStatus.Connected)
-                _connection.Disconnect();
-            else
+            // Single toggle: "Connect" only when fully disconnected; otherwise "Stop" — disconnect when connected,
+            // or cancel the in-flight attempt when connecting (Disconnect() stops the client's retry loop).
+            if (_connection.ConnectionStatus == ConnectionStatus.Disconnected)
                 _connection.Connect();
+            else
+                _connection.Disconnect();
         }
 
         /// <summary>

--- a/addons/godot_mcp/UI/ConnectionPanelView.cs
+++ b/addons/godot_mcp/UI/ConnectionPanelView.cs
@@ -62,11 +62,12 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// <summary>Button label shown when the plugin is disconnected (clicking connects).</summary>
         public const string ButtonTextConnect = "Connect";
 
-        /// <summary>Button label shown when the plugin is connected (clicking disconnects).</summary>
-        public const string ButtonTextDisconnect = "Disconnect";
-
-        /// <summary>Button label shown mid-connect (the button is disabled while this shows).</summary>
-        public const string ButtonTextConnecting = "Connecting…";
+        /// <summary>
+        /// Button label shown when the plugin is connected OR connecting — a single "Stop" that disconnects
+        /// (or cancels the in-flight connect attempt). The Godot line is one toggle button: "Connect" when
+        /// idle, "Stop" otherwise, enabled in every state.
+        /// </summary>
+        public const string ButtonTextStop = "Stop";
 
         /// <summary>
         /// Reduce SignalR's four-state <see cref="HubConnectionState"/> plus the client's
@@ -84,29 +85,25 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _ => ConnectionStatus.Disconnected
         };
 
-        /// <summary>The connection status line text. NO "Godot:" prefix — the timeline point already shows the
-        /// "Godot" label, so prefixing here would print "Godot" twice on the line (Unity shows the bare status).</summary>
-        public static string StatusLabel(ConnectionStatus status) => status switch
+        /// <summary>
+        /// The Godot timeline point's (underlined) label text, which now CARRIES the connection status:
+        /// "Godot" when disconnected, "Godot: connecting..." mid-handshake, "Godot: connected" when connected.
+        /// Replaces the old separate status suffix so the one underlined label conveys both the point name and
+        /// its live state.
+        /// </summary>
+        public static string GodotLineLabel(ConnectionStatus status) => status switch
         {
-            ConnectionStatus.Connected => "Connected",
-            ConnectionStatus.Connecting => "Connecting…",
-            _ => "Disconnected"
-        };
-
-        /// <summary>The connect/disconnect button text for a given <see cref="ConnectionStatus"/>.</summary>
-        public static string ButtonText(ConnectionStatus status) => status switch
-        {
-            ConnectionStatus.Connected => ButtonTextDisconnect,
-            ConnectionStatus.Connecting => ButtonTextConnecting,
-            _ => ButtonTextConnect
+            ConnectionStatus.Connected => "Godot: connected",
+            ConnectionStatus.Connecting => "Godot: connecting...",
+            _ => "Godot"
         };
 
         /// <summary>
-        /// True when the connect/disconnect button should be disabled — only while
-        /// <see cref="ConnectionStatus.Connecting"/>, where neither "Connect" nor "Disconnect" is a clean
-        /// action (the client is mid-handshake / retrying).
+        /// The Godot-line toggle button text: "Connect" when disconnected, "Stop" when connected OR connecting
+        /// (a single always-enabled button — clicking "Stop" disconnects / cancels the in-flight attempt).
         /// </summary>
-        public static bool ButtonDisabled(ConnectionStatus status) => status == ConnectionStatus.Connecting;
+        public static string ButtonText(ConnectionStatus status) =>
+            status == ConnectionStatus.Disconnected ? ButtonTextConnect : ButtonTextStop;
 
         /// <summary>The status-dot RGB for a given <see cref="ConnectionStatus"/>.</summary>
         public static (float R, float G, float B) StatusColor(ConnectionStatus status) => status switch

--- a/addons/godot_mcp/UI/DockStyle.cs
+++ b/addons/godot_mcp/UI/DockStyle.cs
@@ -224,6 +224,18 @@ namespace com.IvanMurzak.Godot.MCP.UI
             return panel;
         }
 
+        /// <summary>
+        /// Update the text of an <see cref="UnderlinedSubLabel"/> (its inner "Text" <see cref="Label"/>), so the
+        /// bottom-border underline re-hugs the new text width. Used to make the "Godot" timeline label carry the
+        /// live connection status ("Godot" / "Godot: connecting..." / "Godot: connected"). No-op if the expected
+        /// inner label is absent.
+        /// </summary>
+        public static void SetUnderlinedSubLabelText(PanelContainer underlinedLabel, string text)
+        {
+            if (underlinedLabel.GetChildCount() > 0 && underlinedLabel.GetChild(0) is Label inner)
+                inner.Text = text;
+        }
+
         // --- Buttons -------------------------------------------------------------------------------------------
 
         /// <summary>Skin <paramref name="button"/> as the PRIMARY action (cyan bg, dark text) — e.g. Configure when not configured.</summary>

--- a/addons/godot_mcp/UI/GodotMcpDock.cs
+++ b/addons/godot_mcp/UI/GodotMcpDock.cs
@@ -504,8 +504,12 @@ namespace com.IvanMurzak.Godot.MCP.UI
             // DevControlServer embeds this verbatim under a "dock" key. All values are escaped.
             var sb = new System.Text.StringBuilder();
             sb.Append('{');
+            // The Godot timeline label (PanelContainer "GodotLabel" → inner Label "Text") now carries the
+            // status ("Godot" / "Godot: connecting..." / "Godot: connected"); read it for connectionStatus.
+            var godotLabel = FindChild("GodotLabel", recursive: true, owned: false)?
+                .FindChild("Text", recursive: false, owned: false) as Label;
             AppendJson(sb, "dockTitle", DockTitle); sb.Append(',');
-            AppendJson(sb, "connectionStatus", Text("GodotStatus")); sb.Append(',');
+            AppendJson(sb, "connectionStatus", godotLabel?.Text); sb.Append(',');
             AppendJson(sb, "connectButtonText", ButtonText("ConnectButton")); sb.Append(',');
             AppendJson(sb, "serverUrl", hostField?.Text); sb.Append(',');
             AppendJson(sb, "selectedAgent", selectedAgent); sb.Append(',');

--- a/scripts/dev_control_smoke.py
+++ b/scripts/dev_control_smoke.py
@@ -105,9 +105,18 @@ class Smoke:
         self.step("health", "GET", "/health", None, ACCEPT_OK)
         self.step("state", "GET", "/state", None, ACCEPT_OK)
 
-        print("\n== inject connection states ==")
-        for s in ("connected", "connecting", "disconnected"):
+        print("\n== inject connection states -> Godot line label + Connect/Stop button ==")
+        # The underlined "Godot" label carries the status, and the single toggle is "Connect" when
+        # disconnected / "Stop" otherwise. A dev-injected status pins the dock, so /state reflects it.
+        conn_expectations = {
+            "connected": ("Godot: connected", "Stop"),
+            "connecting": ("Godot: connecting", "Stop"),
+            "disconnected": ("Godot", "Connect"),
+        }
+        for s, (label, btn) in conn_expectations.items():
             self.step(f"inject connection={s}", "POST", "/inject/connection-status", {"status": s}, ACCEPT_OK)
+            self.assert_state(f"  {s}: Godot label", "connectionStatus", label)
+            self.assert_state(f"  {s}: Connect/Stop button", "connectButtonText", btn)
         self.step("inject connection=connected", "POST", "/inject/connection-status", {"status": "connected"}, ACCEPT_OK)
 
         print("\n== inject server states ==")


### PR DESCRIPTION
Two connection-section changes.

## 1. Godot line: single Connect/Stop toggle + status folded into the label
The "Godot" timeline point is now one underlined label that carries the status plus one
always-enabled toggle button:

| State | Label | Button |
|---|---|---|
| disconnected | `Godot` | `Connect` |
| connecting | `Godot: connecting...` | `Stop` |
| connected | `Godot: connected` | `Stop` |

Removes the separate status-suffix label and the mid-connect *disabled* state (`Stop` while
connecting cancels the in-flight attempt). `ConnectionPanelView` gains `GodotLineLabel(...)`;
`ButtonText` now returns Connect/Stop; `DockStyle.SetUnderlinedSubLabelText` retitles the label.

**Verified live** via the dev-control bridge — all three states assert the exact label + button
text (smoke 50/50 green).

## 2. Fix: "Authorize succeeds but MCP server stays red"
In Cloud mode without a token the connection sits in a reject→retry loop, so
`OnAuthorizationRejected` fires continuously. When the user authorizes, `Reconnect()` disposes
the old plugin and builds a fresh one **with** the token — but a rejection emitted by the
*superseded* plugin could still land on the main thread **after** the swap, and the dock's
handler nulls `CloudToken`, wiping the just-authorized token → back to red.

Guards the auth-rejected (and, for symmetry, the status) subscription so it only raises while
its plugin is still the active `_plugin` — stale rejections from the pre-`Reconnect` connection
are dropped (and traced).

> **Note / limitation:** this fixes the stale-rejection *race* (the most likely client-side
> cause). If the cloud **genuinely** rejects the device-flow token over SignalR (header/expiry/
> audience), the dock will still log `server rejected the authorization token; cleared` after
> authorizing — that's a separate, server-side cause. The new trace line distinguishes the two.

## Testing
- Build 0 errors; unit suite green except the known local-only `NonDefaultContext` flake.
- Live smoke 50/50 (Godot-line label/button across all states; no `delegate_handle` errors).