### PR TITLE
feat(ui): add "Check" button + Serialization Check window (Unity-MCP parity)

### DIFF
--- a/Godot-MCP.Tests/DevControlRouterTests.cs
+++ b/Godot-MCP.Tests/DevControlRouterTests.cs
@@ -125,6 +125,7 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         [InlineData("reveal", "reveal")]
         [InlineData("Copy", "copy")]
         [InlineData("generate-token", "generate-token")]
+        [InlineData("Check", "check")]
         public void TryNormalizeClickTarget_NormalizesKnown(string target, string expected)
         {
             Assert.True(DevControlRouter.TryNormalizeClickTarget(target, out var normalized));

--- a/addons/godot_mcp/Connection/DevControl/DevControlRouter.cs
+++ b/addons/godot_mcp/Connection/DevControl/DevControlRouter.cs
@@ -150,6 +150,10 @@ namespace com.IvanMurzak.Godot.MCP.Connection.DevControl
             // "generate" is the Skills panel's Generate button; "generate-token" is the Custom-mode token
             // "New" button (distinct node) — both reachable so neither is left untested.
             "authorize", "revoke", "reveal", "copy", "generate-token",
+            // The footer's "Check" button — opens the Serialization Check window (the Godot port of Unity's
+            // "Check" button). Reachable so the smoke harness can prove the footer button is wired + its
+            // Pressed delegate is rooted (the GC'd-signal-delegate fix).
+            "check",
         };
 
         /// <summary>

--- a/addons/godot_mcp/UI/GodotMcpDock.cs
+++ b/addons/godot_mcp/UI/GodotMcpDock.cs
@@ -429,6 +429,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 "revoke" => "RevokeButton",
                 "reveal" => "Reveal",
                 "copy" => "Copy",
+                "check" => "Check",                        // Footer "Check" → opens the Serialization Check window
                 _ => null,
             };
             if (nodeName == null)

--- a/addons/godot_mcp/UI/SerializationCheckWindow.cs
+++ b/addons/godot_mcp/UI/SerializationCheckWindow.cs
@@ -1,0 +1,371 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using System.Diagnostics;
+using com.IvanMurzak.Godot.MCP.Reflection;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using com.IvanMurzak.ReflectorNet;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.UI
+{
+    /// <summary>
+    /// A nested editor <see cref="Window"/> for testing object serialization through the MCP
+    /// <see cref="Reflector"/> — the Godot analog of Unity-MCP's <c>SerializationCheckWindow</c>. The user
+    /// picks a target (a scene <see cref="Node"/> via the current editor selection, or a
+    /// <see cref="Resource"/> via the resource picker), toggles <c>Recursive</c>, presses <b>Serialize</b>,
+    /// and inspects the pretty-printed JSON the reflector produced. Layout, top → bottom: an "Information"
+    /// foldout (collapsed), a divider, the input row (target picker + "Use Editor Selection" + Recursive
+    /// toggle + Serialize), a divider, an "Output (NN ms)" header, the scrollable monospace JSON output, and
+    /// a floating "Copy" button (bottom-right) that flips to "Copied!" for ~1.5s.
+    ///
+    /// <para>
+    /// The reflector is read from the ambient <see cref="GodotMcpReflector.GetOrCreate"/> (the same converter
+    /// set the connection registered, with a default-built fallback when no connection is live), mirroring
+    /// Unity's <c>UnityMcpPluginEditor.Instance.Reflector</c>. The <see cref="Reflector.Serialize"/> call
+    /// shape (<c>obj</c>, <c>name</c>, <c>recursive</c>) matches the existing Godot tool handlers
+    /// (e.g. <c>resource-get-data</c>).
+    /// </para>
+    ///
+    /// <para>
+    /// Editor-only (<c>#if TOOLS</c>): it builds live Godot UI <see cref="Node"/>s and reads the editor
+    /// selection, so it is verified via the headless Godot smoke (<c>test.md</c> Suite 3), not the plain-xUnit
+    /// host. Every signal connection retains a strong managed reference to its delegate via
+    /// <see cref="DockStyle.KeepAlive{T}"/> / <see cref="DockStyle.ConnectPressed"/> so the "delegate_handle.value
+    /// is null" GC crash cannot occur (mirrors the dock-wide signal-retention discipline).
+    /// </para>
+    /// </summary>
+    [Tool]
+    public partial class SerializationCheckWindow : Window
+    {
+        // The information block shown in the collapsed foldout — what serialization is, how to use the window.
+        const string InformationText =
+            "This window serializes a Godot object through the MCP reflector (ReflectorNet) — the exact same " +
+            "serializer the MCP tools use — and shows the resulting JSON.\n\n" +
+            "• Target: pick a Resource with the picker, or select a Node in the scene tree and press " +
+            "\"Use Editor Selection\".\n" +
+            "• Recursive: ON serializes nested / child references; OFF stays shallow.\n" +
+            "• Set the dock's Log Level to Debug for the reflector's detailed trace in the Output panel.";
+
+        EditorResourcePicker _resourcePicker = null!;
+        Label _selectionLabel = null!;
+        CheckButton _recursiveToggle = null!;
+        Label _outputHeader = null!;
+        TextEdit _outputText = null!;
+        Button _copyButton = null!;
+
+        // The current target. A Node chosen from the editor selection takes precedence over the resource
+        // picker's value; cleared back to the picker's Resource when the picker changes.
+        GodotObject? _target;
+        string _fullOutputText = string.Empty;
+
+        public SerializationCheckWindow()
+        {
+            Name = "SerializationCheckWindow";
+            Title = "Serialization Check";
+            Size = new Vector2I(460, 560);
+            MinSize = new Vector2I(400, 500);
+            Unresizable = false;
+
+            // Free the window when the OS/editor close button (the X) is pressed — no leaks.
+            CloseRequested += DockStyle.KeepAlive<Action>(this, OnClosePressed);
+
+            BuildUi();
+        }
+
+        void BuildUi()
+        {
+            var margin = new MarginContainer { Name = "Margin" };
+            margin.AddThemeConstantOverride("margin_left", 8);
+            margin.AddThemeConstantOverride("margin_right", 8);
+            margin.AddThemeConstantOverride("margin_top", 8);
+            margin.AddThemeConstantOverride("margin_bottom", 8);
+            margin.SetAnchorsPreset(Control.LayoutPreset.FullRect);
+            AddChild(margin);
+
+            var root = new VBoxContainer { Name = "Root" };
+            root.AddThemeConstantOverride("separation", 6);
+            margin.AddChild(root);
+
+            // --- Information foldout (collapsed) --------------------------------------------------------------
+            var (infoFoldout, infoBody) = DockStyle.Foldout("Information");
+            var infoLabel = new Label
+            {
+                Name = "InformationText",
+                Text = InformationText,
+                AutowrapMode = TextServer.AutowrapMode.WordSmart
+            };
+            DockStyle.ApplyDescription(infoLabel);
+            infoBody.AddChild(infoLabel);
+            root.AddChild(infoFoldout);
+
+            root.AddChild(DockStyle.Divider("InfoDivider"));
+
+            // --- Input row: target picker + "Use Editor Selection" + Recursive + Serialize -------------------
+            var pickerLabel = new Label { Name = "TargetLabel", Text = "Target" };
+            DockStyle.ApplyDescription(pickerLabel);
+            root.AddChild(pickerLabel);
+
+            _resourcePicker = new EditorResourcePicker
+            {
+                Name = "TargetPicker",
+                BaseType = nameof(Resource),
+                SizeFlagsHorizontal = Control.SizeFlags.ExpandFill
+            };
+            _resourcePicker.ResourceChanged += DockStyle.KeepAlive<EditorResourcePicker.ResourceChangedEventHandler>(
+                _resourcePicker, OnResourcePicked);
+            root.AddChild(_resourcePicker);
+
+            var selectionRow = new HBoxContainer { Name = "SelectionRow", SizeFlagsHorizontal = Control.SizeFlags.ExpandFill };
+            selectionRow.AddThemeConstantOverride("separation", 6);
+
+            var useSelectionButton = new Button
+            {
+                Name = "UseSelection",
+                Text = "Use Editor Selection",
+                MouseDefaultCursorShape = Control.CursorShape.PointingHand
+            };
+            DockStyle.ApplySecondaryButton(useSelectionButton);
+            DockStyle.ConnectPressed(useSelectionButton, OnUseSelectionPressed);
+            selectionRow.AddChild(useSelectionButton);
+
+            _selectionLabel = new Label
+            {
+                Name = "SelectionLabel",
+                Text = string.Empty,
+                SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
+                AutowrapMode = TextServer.AutowrapMode.WordSmart
+            };
+            DockStyle.ApplyDescription(_selectionLabel);
+            selectionRow.AddChild(_selectionLabel);
+            root.AddChild(selectionRow);
+
+            var actionRow = new HBoxContainer { Name = "ActionRow", SizeFlagsHorizontal = Control.SizeFlags.ExpandFill };
+            actionRow.AddThemeConstantOverride("separation", 8);
+
+            _recursiveToggle = new CheckButton { Name = "RecursiveToggle", Text = "Recursive", ButtonPressed = true };
+            actionRow.AddChild(_recursiveToggle);
+
+            actionRow.AddChild(new Control { SizeFlagsHorizontal = Control.SizeFlags.ExpandFill });
+
+            var serializeButton = new Button
+            {
+                Name = "Serialize",
+                Text = "Serialize",
+                MouseDefaultCursorShape = Control.CursorShape.PointingHand
+            };
+            DockStyle.ApplyCompactPrimaryButton(serializeButton);
+            DockStyle.ConnectPressed(serializeButton, OnSerializePressed);
+            actionRow.AddChild(serializeButton);
+            root.AddChild(actionRow);
+
+            root.AddChild(DockStyle.Divider("OutputDivider"));
+
+            // --- Output header + scrollable monospace JSON output (with the floating Copy button) ------------
+            _outputHeader = new Label { Name = "OutputHeader", Text = "Output" };
+            DockStyle.ApplySectionTitle(_outputHeader);
+            root.AddChild(_outputHeader);
+
+            // The output area + the floating Copy button share one cell so Copy floats over the JSON's
+            // bottom-right corner (Unity anchors it bottom-right of the output container).
+            var outputCell = new MarginContainer
+            {
+                Name = "OutputCell",
+                SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
+                SizeFlagsVertical = Control.SizeFlags.ExpandFill
+            };
+            root.AddChild(outputCell);
+
+            _outputText = new TextEdit
+            {
+                Name = "OutputText",
+                Editable = false,
+                ScrollFitContentHeight = false,
+                SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
+                SizeFlagsVertical = Control.SizeFlags.ExpandFill,
+                PlaceholderText = "Serialize a target to see its ReflectorNet JSON here."
+            };
+            ApplyMonospaceOutputStyle(_outputText);
+            outputCell.AddChild(_outputText);
+
+            // Floating Copy button, bottom-right of the output cell.
+            var copyAnchor = new Control
+            {
+                Name = "CopyAnchor",
+                MouseFilter = Control.MouseFilterEnum.Ignore,
+                SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
+                SizeFlagsVertical = Control.SizeFlags.ExpandFill
+            };
+            outputCell.AddChild(copyAnchor);
+
+            _copyButton = new Button
+            {
+                Name = "Copy",
+                Text = "Copy",
+                MouseDefaultCursorShape = Control.CursorShape.PointingHand
+            };
+            DockStyle.ApplySecondaryButton(_copyButton);
+            _copyButton.SetAnchorsPreset(Control.LayoutPreset.BottomRight);
+            _copyButton.OffsetLeft = -88;
+            _copyButton.OffsetTop = -34;
+            _copyButton.OffsetRight = -8;
+            _copyButton.OffsetBottom = -8;
+            DockStyle.ConnectPressed(_copyButton, OnCopyPressed);
+            copyAnchor.AddChild(_copyButton);
+        }
+
+        /// <summary>Skin the output <see cref="TextEdit"/> as a subtle dark, rounded, monospace JSON panel.</summary>
+        static void ApplyMonospaceOutputStyle(TextEdit textEdit)
+        {
+            var box = new StyleBoxFlat { BgColor = DockStyle.Rgb(DockTheme.WindowBackground).Darkened(0.25f) };
+            box.SetCornerRadiusAll(8);
+            box.ContentMarginLeft = 8;
+            box.ContentMarginRight = 8;
+            box.ContentMarginTop = 8;
+            box.ContentMarginBottom = 8;
+            textEdit.AddThemeStyleboxOverride("normal", box);
+            textEdit.AddThemeStyleboxOverride("read_only", box);
+
+            // Monospace face from the editor theme when available (degrades to the default font headless).
+            try
+            {
+                var theme = EditorInterface.Singleton?.GetEditorTheme();
+                if (theme != null && theme.HasFont("source", "EditorFonts"))
+                    textEdit.AddThemeFontOverride("font", theme.GetFont("source", "EditorFonts"));
+            }
+            catch { /* no editor theme (headless/test) — stay default font */ }
+        }
+
+        /// <summary>The resource picker changed → make that Resource the target and clear any node selection.</summary>
+        void OnResourcePicked(Resource? resource)
+        {
+            _target = resource;
+            _selectionLabel.Text = resource != null ? string.Empty : _selectionLabel.Text;
+            if (resource != null)
+                _selectionLabel.Text = string.Empty;
+        }
+
+        /// <summary>
+        /// Adopt the first node of the current editor selection as the target. Clears the resource picker so
+        /// the two pickers do not silently disagree about which object is "the target".
+        /// </summary>
+        void OnUseSelectionPressed()
+        {
+            Node? node = null;
+            try
+            {
+                var nodes = EditorInterface.Singleton?.GetSelection()?.GetSelectedNodes();
+                if (nodes != null && nodes.Count > 0)
+                    node = nodes[0];
+            }
+            catch (Exception ex)
+            {
+                _selectionLabel.Text = $"Selection unavailable: {ex.Message}";
+                return;
+            }
+
+            if (node == null)
+            {
+                _selectionLabel.Text = "No node selected in the scene tree.";
+                return;
+            }
+
+            _target = node;
+            _resourcePicker.EditedResource = null; // node target wins; keep the pickers consistent.
+            _selectionLabel.Text = $"Node: {node.Name} ({node.GetClass()})";
+        }
+
+        void OnSerializePressed()
+        {
+            // The resource picker is the target when no node was explicitly adopted via "Use Editor Selection".
+            var target = _target ?? _resourcePicker.EditedResource;
+            var recursive = _recursiveToggle.ButtonPressed;
+
+            try
+            {
+                var reflector = GodotMcpReflector.GetOrCreate();
+                var name = TargetName(target);
+
+                var stopwatch = Stopwatch.StartNew();
+                var serialized = reflector.Serialize(
+                    obj: target,
+                    name: name,
+                    recursive: recursive);
+                var json = serialized.ToPrettyJson();
+                stopwatch.Stop();
+
+                _outputHeader.Text = $"Output ({stopwatch.ElapsedMilliseconds} ms)";
+                SetOutput(json);
+            }
+            catch (Exception ex)
+            {
+                _outputHeader.Text = "Output";
+                SetOutput($"Error: {ex.Message}\n\n{ex.StackTrace}");
+                GD.PrintErr($"[Godot-MCP] Serialization Check failed: {ex}");
+            }
+        }
+
+        /// <summary>A human-readable name for the serialized member, mirroring the tool handlers' naming.</summary>
+        static string? TargetName(GodotObject? target)
+        {
+            switch (target)
+            {
+                case null:
+                    return null;
+                case Node node:
+                    return node.Name;
+                case Resource resource:
+                    return string.IsNullOrEmpty(resource.ResourceName)
+                        ? (string.IsNullOrEmpty(resource.ResourcePath) ? resource.GetClass() : resource.ResourcePath)
+                        : resource.ResourceName;
+                default:
+                    return target.GetClass();
+            }
+        }
+
+        void SetOutput(string text)
+        {
+            _fullOutputText = text ?? string.Empty;
+            _outputText.Text = _fullOutputText;
+        }
+
+        void OnCopyPressed()
+        {
+            DisplayServer.ClipboardSet(_fullOutputText);
+
+            var original = _copyButton.Text;
+            _copyButton.Text = "Copied!";
+
+            // Flip the label back after ~1.5s. The timer is owned by the button (freed with the window), and
+            // the callback re-checks validity so a window closed mid-flash never touches a freed control.
+            var timer = GetTree().CreateTimer(1.5);
+            timer.Timeout += DockStyle.KeepAlive<Action>(_copyButton, () =>
+            {
+                if (IsInstanceValid(_copyButton))
+                    _copyButton.Text = original;
+            });
+        }
+
+        /// <summary>Pop the window up centred and visible. Called by the footer after parenting it into the tree.</summary>
+        public void PopupCenteredAndShow()
+        {
+            PopupCentered(Size);
+        }
+
+        void OnClosePressed()
+        {
+            // QueueFree frees the window and all children next idle frame — no leaks.
+            QueueFree();
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/UI/SerializationCheckWindow.cs
+++ b/addons/godot_mcp/UI/SerializationCheckWindow.cs
@@ -289,6 +289,17 @@ namespace com.IvanMurzak.Godot.MCP.UI
             var target = _target ?? _resourcePicker.EditedResource;
             var recursive = _recursiveToggle.ButtonPressed;
 
+            // A null target is fine (TargetName returns null and the reflector serializes it), but a
+            // non-null target the user deleted after adopting it is a freed GodotObject — marshalling that
+            // into Serialize is a native access to freed memory that is not guaranteed to surface as a
+            // catchable managed exception. Reject it cleanly before reaching the reflector.
+            if (target != null && !GodotObject.IsInstanceValid(target))
+            {
+                _outputHeader.Text = "Output";
+                SetOutput("Target is no longer valid (was it deleted?)");
+                return;
+            }
+
             try
             {
                 var reflector = GodotMcpReflector.GetOrCreate();

--- a/addons/godot_mcp/UI/SerializationCheckWindow.cs
+++ b/addons/godot_mcp/UI/SerializationCheckWindow.cs
@@ -249,7 +249,6 @@ namespace com.IvanMurzak.Godot.MCP.UI
         void OnResourcePicked(Resource? resource)
         {
             _target = resource;
-            _selectionLabel.Text = resource != null ? string.Empty : _selectionLabel.Text;
             if (resource != null)
                 _selectionLabel.Text = string.Empty;
         }

--- a/addons/godot_mcp/UI/SupportFooter.cs
+++ b/addons/godot_mcp/UI/SupportFooter.cs
@@ -58,9 +58,11 @@ namespace com.IvanMurzak.Godot.MCP.UI
             prompt.AddThemeFontSizeOverride("font_size", FooterFontSize);
             AddChild(prompt);
 
-            // --- Support buttons: secondary icon buttons (Discord "Help / Talk", GitHub "Bug Report").
-            // Styled like Unity's .btn-secondary.btn-with-icon (gray bordered, leading icon). Open externally;
-            // no live state. (Unity's "Check" serialization button has no Godot equivalent — intentionally omitted.)
+            // --- Support buttons: secondary icon buttons (Discord "Help / Talk", GitHub "Bug Report", and the
+            // "Check" serialization tool). Styled like Unity's .btn-secondary.btn-with-icon (gray bordered,
+            // leading icon). Discord/GitHub open external URLs; "Check" opens the in-editor Serialization Check
+            // window (the Godot port of Unity's "Check" button — ReflectorNet is in-process here, so this DOES
+            // have a Godot equivalent: it was previously omitted only because the dock had no window for it yet).
             var buttonRow = new HBoxContainer { Name = "SupportButtons" };
             buttonRow.AddThemeConstantOverride("separation", 6);
             buttonRow.AddChild(DockStyle.IconButton(
@@ -69,6 +71,8 @@ namespace com.IvanMurzak.Godot.MCP.UI
             buttonRow.AddChild(DockStyle.IconButton(
                 "GitHubIssue", "Bug Report", DockTheme.GitHubIconFileName,
                 () => OS.ShellOpen(SupportFooterLinks.IssuesUrl)));
+            buttonRow.AddChild(DockStyle.IconButton(
+                "Check", "Check", iconFileName: null, OnCheckPressed));
             AddChild(buttonRow);
 
             // --- Divider between the support buttons and the thanks block (Unity's .divider). ---
@@ -111,6 +115,19 @@ namespace com.IvanMurzak.Godot.MCP.UI
             signRow.AddChild(star);
 
             AddChild(signRow);
+        }
+
+        /// <summary>
+        /// Open the <see cref="SerializationCheckWindow"/> — the Godot port of Unity's "Check" button. A fresh
+        /// window is parented under the footer (a Godot <see cref="Window"/> renders as its own OS window
+        /// regardless of where it sits in the tree) and popped centred; it frees itself on close (mirrors how
+        /// <c>FeaturesPanel</c> opens its <c>FeatureListWindow</c>).
+        /// </summary>
+        void OnCheckPressed()
+        {
+            var window = new SerializationCheckWindow();
+            AddChild(window);
+            window.PopupCenteredAndShow();
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add a "Check" button to the dock footer support row (beside Help/Talk + Bug Report) that opens a new **Serialization Check** window — the Godot port of Unity-MCP's `SerializationCheckWindow`, reversing the prior intentional omission.
- The window: an Information foldout, a target picker (Resource via `EditorResourcePicker`, or a scene Node via "Use Editor Selection"), a Recursive toggle, a primary Serialize button, an "Output (NN ms)" elapsed-time header, a scrollable read-only monospace JSON panel, and a floating Copy button that flips to "Copied!" for ~1.5s. Serializes through the in-process `GodotMcpReflector.GetOrCreate()` (same converter set the MCP tools use); errors render as `Error: {msg}\n\n{stack}`.
- Every signal connection retains a strong managed delegate ref via `DockStyle.KeepAlive` / `ConnectPressed` (the "delegate_handle.value is null" GC-crash discipline).
- Wire the dev-control bridge `check` click target (`DevControlRouter` + `GodotMcpDock.DevClick` → node name `Check`) so the footer button is smoke-testable, with a matching `DevControlRouterTests` case.

## Test plan
- [x] Suite 1 — `dotnet build Godot-MCP.sln` (Debug): 0 errors.
- [x] Suite 2 — `dotnet test Godot-MCP.Tests`: 790 passed; the only failure is the documented benign Windows-host-only `alc-probe` `UnauthorizedAccessException` cleanup (green on Linux CI).
- [x] Headless Godot `--build-solutions` (TOOLS defined): 0 errors — confirmed the new `#if TOOLS` window code compiles (probed in-set).
- [ ] Live-editor behavioral verification (open the window, serialize a Node/Resource) — pending operator (Suite 3).

Closes #128