### PR TITLE
dev-control bridge: Cloud-auth UI introspection + simulate-authorize control

### DIFF
--- a/Godot-MCP.Tests/DevControlRouterTests.cs
+++ b/Godot-MCP.Tests/DevControlRouterTests.cs
@@ -34,6 +34,7 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         [InlineData("POST", "/control/select-agent", DevControlRouter.Command.ControlSelectAgent)]
         [InlineData("POST", "/control/click", DevControlRouter.Command.ControlClick)]
         [InlineData("POST", "/control/set-segment", DevControlRouter.Command.ControlSetSegment)]
+        [InlineData("POST", "/control/cloud-authorize", DevControlRouter.Command.ControlCloudAuthorize)]
         public void Route_MapsKnownRoutes(string method, string path, DevControlRouter.Command expected)
         {
             Assert.Equal(expected, DevControlRouter.Route(method, path));

--- a/addons/godot_mcp/Connection/DevControl/DevControlRouter.cs
+++ b/addons/godot_mcp/Connection/DevControl/DevControlRouter.cs
@@ -43,6 +43,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection.DevControl
             ControlSelectAgent,
             ControlClick,
             ControlSetSegment,
+            ControlCloudAuthorize,
         }
 
         /// <summary>
@@ -60,6 +61,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection.DevControl
             ("POST", "/control/select-agent",     Command.ControlSelectAgent),
             ("POST", "/control/click",            Command.ControlClick),
             ("POST", "/control/set-segment",      Command.ControlSetSegment),
+            ("POST", "/control/cloud-authorize",  Command.ControlCloudAuthorize),
         };
 
         /// <summary>

--- a/addons/godot_mcp/Connection/DevControl/DevControlServer.cs
+++ b/addons/godot_mcp/Connection/DevControl/DevControlServer.cs
@@ -233,6 +233,21 @@ namespace com.IvanMurzak.Godot.MCP.Connection.DevControl
                         ok ? "{\"ok\":true}" : $"{{\"ok\":false,\"error\":\"segment not present {JsonInner(control)}/{JsonInner(option)}\"}}");
                     break;
                 }
+                case DevControlRouter.Command.ControlCloudAuthorize:
+                {
+                    // DEV-ONLY: simulate a successful Cloud authorization (persist token + reconnect) so the
+                    // auth UI + reconnect path are testable without a live OAuth. The token is freeform.
+                    var token = GetString(root, "token");
+                    if (string.IsNullOrEmpty(token))
+                    {
+                        TryWrite(context, 400, "{\"ok\":false,\"error\":\"missing token\"}");
+                        break;
+                    }
+                    var ok = RunOnMainThread(() => _dock.DevCloudAuthorize(token!));
+                    TryWrite(context, ok ? 200 : 409,
+                        ok ? "{\"ok\":true}" : "{\"ok\":false,\"error\":\"connection panel not present\"}");
+                    break;
+                }
                 default:
                     TryWrite(context, 404, "{\"ok\":false,\"error\":\"unhandled command\"}");
                     break;

--- a/addons/godot_mcp/UI/ConnectionPanel.cs
+++ b/addons/godot_mcp/UI/ConnectionPanel.cs
@@ -918,6 +918,17 @@ namespace com.IvanMurzak.Godot.MCP.UI
             if (!ReferenceEquals(_deviceAuthFlow, flow))
                 return;
 
+            ApplyAuthorizedToken(token);
+        }
+
+        /// <summary>
+        /// Persist a freshly-obtained Cloud token, refresh the masked field + alerts, and reconnect so the new
+        /// bearer is used (Cloud mode only). Shared by the real device-auth flow
+        /// (<see cref="PersistAuthorizedToken"/>) and the DEV-ONLY <see cref="DevSimulateCloudAuthorized"/> so
+        /// both drive the identical persist → reconnect path. MUST run on the editor main thread.
+        /// </summary>
+        void ApplyAuthorizedToken(string token)
+        {
             _connection.Config.CloudToken = token;
             _connection.Save();
             ApplyCloudAuthState();
@@ -929,6 +940,15 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
             ConfigChanged?.Invoke(); // cloud token changed → agent section re-checks config
         }
+
+        /// <summary>
+        /// DEV-ONLY: simulate a successful Cloud device-authorization by persisting <paramref name="token"/>
+        /// through the EXACT same path the real flow uses (<see cref="ApplyAuthorizedToken"/>) — set + save the
+        /// token, refresh the masked field / Revoke button / alerts, and Reconnect(). Lets the dev-control
+        /// bridge exercise the "authorized → persist → reconnect" path (and the stale-rejection guard) without a
+        /// live browser OAuth round-trip. No-op behavior is identical to the real flow; never logs the token.
+        /// </summary>
+        public void DevSimulateCloudAuthorized(string token) => ApplyAuthorizedToken(token);
 
         /// <summary>
         /// Revoke the stored cloud token: clear it, persist, revert the UI to the Authorize state, and (if

--- a/addons/godot_mcp/UI/GodotMcpDock.cs
+++ b/addons/godot_mcp/UI/GodotMcpDock.cs
@@ -480,6 +480,20 @@ namespace com.IvanMurzak.Godot.MCP.UI
         }
 
         /// <summary>
+        /// DEV-ONLY: simulate a successful Cloud authorization — persist <paramref name="token"/> through the
+        /// dock's REAL persist+reconnect path (<see cref="ConnectionPanel.DevSimulateCloudAuthorized"/>), so the
+        /// auth UI (masked field, Revoke button, alert visibility) and the reconnect/stale-rejection guard can be
+        /// exercised without a live browser OAuth round-trip. Returns false when the connection panel is absent.
+        /// </summary>
+        public bool DevCloudAuthorize(string token)
+        {
+            if (_connectionPanel == null)
+                return false;
+            _connectionPanel.DevSimulateCloudAuthorized(token ?? string.Empty);
+            return true;
+        }
+
+        /// <summary>
         /// DEV-ONLY: a JSON snapshot of what the dock is currently rendering — connection status label,
         /// Connect-button text, the Server URL field, the selected agent name, the agent config status text,
         /// and whether the AI-agent "AgentAlert" node is present + visible. Read by <c>GET /state</c> so a
@@ -491,8 +505,15 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 (FindChild(name, recursive: true, owned: false) as Label)?.Text;
             string? ButtonText(string name) =>
                 (FindChild(name, recursive: true, owned: false) as Button)?.Text;
+            // A node is "visible" only when present AND its IsVisibleInTree (so a hidden ancestor — e.g. the
+            // whole CloudAuthRow — correctly reports its children as not-visible).
+            bool VisibleInTree(string name) =>
+                FindChild(name, recursive: true, owned: false) is Control c && c.IsVisibleInTree();
 
             var hostField = FindChild("HostField", recursive: true, owned: false) as LineEdit;
+            var cloudTokenField = FindChild("CloudTokenField", recursive: true, owned: false) as LineEdit;
+            // Cloud vs Custom is observable from which mode-row is shown (CustomHostRow only in Custom mode).
+            var connectionMode = VisibleInTree("CustomHostRow") ? "Custom" : "Cloud";
             var agentSelector = FindChild("AgentSelector", recursive: true, owned: false) as OptionButton;
             string? selectedAgent = null;
             if (agentSelector != null && agentSelector.Selected >= 0)
@@ -515,7 +536,18 @@ namespace com.IvanMurzak.Godot.MCP.UI
             AppendJson(sb, "selectedAgent", selectedAgent); sb.Append(',');
             AppendJson(sb, "agentConfigStatus", Text("Status")); sb.Append(',');
             sb.Append("\"agentAlertPresent\":").Append(alert != null ? "true" : "false").Append(',');
-            sb.Append("\"agentAlertVisible\":").Append(alert is { Visible: true } ? "true" : "false");
+            sb.Append("\"agentAlertVisible\":").Append(alert is { Visible: true } ? "true" : "false").Append(',');
+            // --- Connection mode + Cloud-auth UI truth (so the dev-control auth flow is fully assertable) ---
+            // connectionMode reflects the DISPLAYED/persisted mode (which row is editable). When an env/.env
+            // override forces a different ACTIVE mode, the OverrideNote is shown — surface it so a tester knows
+            // the live connection mode differs from the displayed one (e.g. testbed .env pins Custom).
+            AppendJson(sb, "connectionMode", connectionMode); sb.Append(',');
+            sb.Append("\"modeOverrideNoteVisible\":").Append(VisibleInTree("OverrideNote") ? "true" : "false").Append(',');
+            sb.Append("\"cloudTokenPresent\":").Append(!string.IsNullOrEmpty(cloudTokenField?.Text) ? "true" : "false").Append(',');
+            sb.Append("\"revokeButtonVisible\":").Append(VisibleInTree("RevokeButton") ? "true" : "false").Append(',');
+            sb.Append("\"authRequiredAlertVisible\":").Append(VisibleInTree("AuthRequiredAlert") ? "true" : "false").Append(',');
+            sb.Append("\"connectionRequiredAlertVisible\":").Append(VisibleInTree("ConnectionRequiredAlert") ? "true" : "false").Append(',');
+            AppendJson(sb, "cloudAuthStatus", Text("CloudAuthStatus"));
             sb.Append('}');
             return sb.ToString();
         }

--- a/scripts/dev_control_smoke.py
+++ b/scripts/dev_control_smoke.py
@@ -141,6 +141,20 @@ class Smoke:
         self.step("click authorize (cancel)", "POST", "/control/click", {"target": "authorize"}, ACCEPT_CLICK)
         self.step("click revoke", "POST", "/control/click", {"target": "revoke"}, ACCEPT_CLICK)
 
+        print("\n== Cloud auth UI: simulate authorize -> persist -> revoke ==")
+        # Drive the real persist path (DevSimulateCloudAuthorized): token field fills, Revoke appears, the
+        # "Authorization Required" alert clears. (Reconnect only fires when the ACTIVE mode is Cloud — under a
+        # GODOT_MCP_CONNECTION_MODE override the testbed's active mode may be Custom; row visibility still
+        # follows the persisted mode we set here.)
+        self.step("mode=cloud (persisted)", "POST", "/control/set-segment", {"control": "mode", "option": "cloud"}, ACCEPT_OK)
+        self.step("cloud-authorize", "POST", "/control/cloud-authorize", {"token": "smoke-cloud-token-123"}, ACCEPT_OK)
+        self.assert_state("token stored", "cloudTokenPresent", "true")
+        self.assert_state("revoke now visible", "revokeButtonVisible", "true")
+        self.assert_state("auth-required alert cleared", "authRequiredAlertVisible", "false")
+        self.step("cloud-authorize (empty -> 400)", "POST", "/control/cloud-authorize", {"token": ""}, {400})
+        self.step("click revoke", "POST", "/control/click", {"target": "revoke"}, ACCEPT_CLICK)
+        self.assert_state("token cleared after revoke", "cloudTokenPresent", "false")
+
         print("\n== agent configurators: select + per-agent buttons ==")
         for agent in ("claude-code", "cursor", "vscode", "claude-desktop"):
             st, _ = self.step(f"select agent={agent}", "POST", "/control/select-agent", {"agent": agent}, {200, 404})


### PR DESCRIPTION
Extends the DEV-ONLY dock bridge so the **Cloud authorization** flow is fully testable from a
terminal / AI agent without a live browser OAuth round-trip — used to self-verify the
"authorize → persist → reconnect" path and the stale-rejection guard (PR #129).

## What's new
- **`GET /state`** now also reports: `connectionMode`, `modeOverrideNoteVisible` (so a tester
  knows the *active* mode differs from the displayed one under a `GODOT_MCP_CONNECTION_MODE`
  override — e.g. the testbed `.env` pins Custom), `cloudTokenPresent`, `revokeButtonVisible`,
  `authRequiredAlertVisible`, `connectionRequiredAlertVisible`, `cloudAuthStatus`.
- **`POST /control/cloud-authorize {token}`** drives the **real** persist+reconnect path
  (`ConnectionPanel.DevSimulateCloudAuthorized` → the shared `ApplyAuthorizedToken` the live
  device-auth flow uses). Empty token → 400.
- `PersistAuthorizedToken` refactored to share `ApplyAuthorizedToken` with the dev entry point.

## Testing
- Build 0 errors; router unit tests +2.
- **Live smoke 58/58** (new Cloud-auth section: authorize → token stored + Revoke visible +
  auth-required alert cleared → revoke clears it), no `delegate_handle` errors.
- Used this bridge to reproduce the user's "authorize → reverts to red" symptom with a *fake*
  token (correctly rejected by ai-game.dev), confirming the live-rejection path is intact and
  no stale-rejection was wrongly suppressed.