### PR TITLE
fix(addon): stop delegate_handle-null flood on Build Project hot-reload

### DIFF
--- a/Godot-MCP.Tests/AssemblyResolverTests.cs
+++ b/Godot-MCP.Tests/AssemblyResolverTests.cs
@@ -130,4 +130,100 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Equal(before, after);
         }
     }
+
+    /// <summary>
+    /// Pins the pure-managed core of the assembly-unload teardown hook (issue #132): on a Godot
+    /// "Build Project" hot-reload the addon's collectible <see cref="System.Runtime.Loader.AssemblyLoadContext"/>
+    /// unloads WITHOUT the editor calling the plugin's <c>_ExitTree</c>, so the plugin arms
+    /// <see cref="GodotMcpAssemblyResolver.ReloadTeardown"/> and the resolver's private
+    /// <c>OnAssemblyUnloading</c> handler invokes it when the ALC's <c>Unloading</c> event fires.
+    ///
+    /// <para>
+    /// These tests exercise the handler directly via reflection (it is a private static taking an
+    /// <see cref="System.Runtime.Loader.AssemblyLoadContext"/>). They are pure-BCL and CI-friendly — no
+    /// Godot binary, no real ALC unload (which cannot be forced deterministically in-process). The two
+    /// load-bearing properties: (1) the handler runs the registered teardown, and (2) a throwing teardown
+    /// is swallowed so the handler NEVER throws — an exception escaping an <c>Unloading</c> handler would
+    /// abort the very unload it exists to enable.
+    /// </para>
+    /// </summary>
+    public class AssemblyUnloadingHookTests
+    {
+        static void InvokeOnAssemblyUnloading()
+        {
+            var method = typeof(GodotMcpAssemblyResolver).GetMethod(
+                "OnAssemblyUnloading",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+
+            // The handler reads only the registered ReloadTeardown; the AssemblyLoadContext argument is
+            // unused by it, so the default (collectible) context for this test assembly is a fine stand-in.
+            var ctx = System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(
+                typeof(AssemblyUnloadingHookTests).Assembly);
+            method!.Invoke(null, new object?[] { ctx });
+        }
+
+        [Fact]
+        public void OnAssemblyUnloading_InvokesRegisteredReloadTeardown()
+        {
+            var saved = GodotMcpAssemblyResolver.ReloadTeardown;
+            try
+            {
+                var ran = 0;
+                GodotMcpAssemblyResolver.ReloadTeardown = () => ran++;
+
+                InvokeOnAssemblyUnloading();
+
+                Assert.Equal(1, ran);
+            }
+            finally
+            {
+                GodotMcpAssemblyResolver.ReloadTeardown = saved;
+            }
+        }
+
+        [Fact]
+        public void OnAssemblyUnloading_IsNoOp_WhenNoTeardownRegistered()
+        {
+            var saved = GodotMcpAssemblyResolver.ReloadTeardown;
+            try
+            {
+                GodotMcpAssemblyResolver.ReloadTeardown = null;
+
+                // No teardown registered (CI/xUnit host where the plugin never booted) → must not throw.
+                var ex = Record.Exception(InvokeOnAssemblyUnloading);
+                Assert.Null(ex);
+            }
+            finally
+            {
+                GodotMcpAssemblyResolver.ReloadTeardown = saved;
+            }
+        }
+
+        [Fact]
+        public void OnAssemblyUnloading_SwallowsThrowingTeardown_NeverPropagates()
+        {
+            var saved = GodotMcpAssemblyResolver.ReloadTeardown;
+            try
+            {
+                var ran = false;
+                GodotMcpAssemblyResolver.ReloadTeardown = () =>
+                {
+                    ran = true;
+                    throw new System.InvalidOperationException("boom — must be swallowed by the unload handler");
+                };
+
+                // Reflection wraps a thrown exception in TargetInvocationException; if the handler let the
+                // teardown's exception escape, this would be non-null. The contract is that it must NOT.
+                var ex = Record.Exception(InvokeOnAssemblyUnloading);
+
+                Assert.True(ran, "the teardown should have been invoked before throwing");
+                Assert.Null(ex);
+            }
+            finally
+            {
+                GodotMcpAssemblyResolver.ReloadTeardown = saved;
+            }
+        }
+    }
 }

--- a/addons/godot_mcp/Connection/GodotMcpAssemblyResolver.cs
+++ b/addons/godot_mcp/Connection/GodotMcpAssemblyResolver.cs
@@ -120,6 +120,19 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             {
                 // Never let a module initializer throw — that would fail the whole assembly load.
             }
+
+            try
+            {
+                // Subscribe to the addon ALC's Unloading event from the same earliest-possible hook. On a
+                // Godot "Build Project" hot-reload the EditorPlugin's _ExitTree is NOT called before the ALC
+                // unload, so this event is the only place the live connection threads / GC handles that pin
+                // the collectible context can be released. No-op in the non-collectible CI/xUnit host.
+                InstallUnloadingHook();
+            }
+            catch
+            {
+                // Never let a module initializer throw.
+            }
         }
 
         /// <summary>
@@ -130,6 +143,101 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// after the plugin sets <see cref="Log"/> are surfaced.
         /// </summary>
         public static Action<string>? Log { get; set; }
+
+        /// <summary>
+        /// Reload-safe teardown invoked when the addon's (collectible) <see cref="AssemblyLoadContext"/>
+        /// begins unloading — the Godot "Build Project" hot-reload path. This is the hook the plugin's
+        /// <c>_ExitTree</c> MISSES: a C# rebuild raises an ALC unload WITHOUT first calling the
+        /// <c>EditorPlugin</c>'s <c>_ExitTree</c>, so all teardown wired only into <c>_ExitTree</c> is dead
+        /// code on a reload. The live SignalR connection (HubConnection + HttpClient + the auto-reconnect
+        /// loop + R3 subscriptions) and the dev-control listener thread keep running threads / strong GC
+        /// handles that PIN this collectible context open, so the CLR reports
+        /// <c>gd_mono.cpp:791 Failed to unload assemblies</c> and floods
+        /// <c>delegate_handle.value == nullptr</c> (the downstream symptom of the failed unload).
+        ///
+        /// <para>
+        /// The editor plugin assigns this in <c>_EnterTree</c>/<c>BootMcp</c> to a SYNCHRONOUS, idempotent
+        /// teardown (stop dev-control → <c>DisconnectImmediate()</c> → dispose subscriptions/plugin → free
+        /// dock/dispatcher on the main thread) and clears it when teardown runs. Null means "no live plugin
+        /// to tear down" (safe no-op). In the CI/xUnit host the addon assembly is loaded into a
+        /// NON-collectible context, so <see cref="AssemblyLoadContext.Unloading"/> never fires there and
+        /// this stays null — keeping the unit-test host unaffected.
+        /// </para>
+        /// </summary>
+        public static Action? ReloadTeardown { get; set; }
+
+        static bool _unloadingHooked;
+
+        /// <summary>
+        /// Subscribe <see cref="OnAssemblyUnloading"/> to the Unloading event of the load context that owns
+        /// THIS assembly. Installed once from <see cref="ModuleInit"/> (same earliest-possible hook the
+        /// resolver itself uses). When this assembly is in the DEFAULT (non-collectible) context — the
+        /// xUnit/CI host — <c>GetLoadContext(...)</c> returns the default context whose Unloading never
+        /// fires, so the subscription is a harmless no-op. When Godot loads the addon into a COLLECTIBLE
+        /// context for editor hot-reload, the event fires on the editor main thread at the start of the
+        /// unload, giving the plugin its only chance to release the threads/handles pinning the context.
+        /// Idempotent and fully wrapped — a failure to hook must never fail the module load.
+        /// </summary>
+        static void InstallUnloadingHook()
+        {
+            lock (_gate)
+            {
+                if (_unloadingHooked)
+                    return;
+
+                try
+                {
+                    var context = AssemblyLoadContext.GetLoadContext(typeof(GodotMcpAssemblyResolver).Assembly);
+                    if (context != null)
+                    {
+                        context.Unloading += OnAssemblyUnloading;
+                        _unloadingHooked = true;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log?.Invoke($"[Godot-MCP] could not install ALC unloading hook: {ex.Message}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Fires when the addon's load context starts unloading (Godot hot-reload). Runs the plugin's
+        /// registered <see cref="ReloadTeardown"/>, if any. NEVER throws — an exception escaping an
+        /// Unloading handler would abort the unload it is trying to enable. The event is raised on the
+        /// editor main thread (where the rebuild is driven), so the teardown's main-thread-only steps
+        /// (Node.Free) are legal here; the teardown itself still guards them defensively.
+        /// </summary>
+        static void OnAssemblyUnloading(AssemblyLoadContext context)
+        {
+            try
+            {
+                Log?.Invoke("[Godot-MCP] assembly unloading — running reload-safe teardown.");
+                ReloadTeardown?.Invoke();
+            }
+            catch (Exception ex)
+            {
+                // Last-ditch: never let the Unloading handler throw.
+                try { Log?.Invoke($"[Godot-MCP] reload teardown error (ignored): {ex.Message}"); }
+                catch { /* logging itself must not throw here */ }
+            }
+
+            // Remove the strong ref that the NON-collectible Default ALC holds into THIS (collectible)
+            // addon assembly: the Resolving handler installed by our ModuleInitializer is a delegate over
+            // OnResolving, a static method in this assembly, so Default.Resolving keeps the collectible ALC
+            // pinned and contributes to "Failed to unload assemblies". On unload the addon is going away, so
+            // dropping the old resolver is correct — the reloaded assembly re-installs its own resolver via
+            // its own ModuleInitializer. Wrapped so it can never throw out of the Unloading handler.
+            try
+            {
+                AssemblyLoadContext.Default.Resolving -= OnResolving;
+            }
+            catch (Exception ex)
+            {
+                try { Log?.Invoke($"[Godot-MCP] could not detach Default.Resolving on unload (ignored): {ex.Message}"); }
+                catch { /* logging itself must not throw here */ }
+            }
+        }
 
         /// <summary>
         /// Determine the on-disk path of the project/addon assembly whose sibling <c>*.deps.json</c>

--- a/addons/godot_mcp/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConnection.cs
@@ -920,6 +920,85 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             }
         }
 
+        /// <summary>
+        /// Reload-safe, fully-SYNCHRONOUS disconnect for the editor hot-reload / assembly-unload path. Calls
+        /// the reused client's <see cref="IConnection.DisconnectImmediate"/> (exposed on
+        /// <see cref="IMcpPlugin"/> via the McpPlugin package): it cancels the internal CTS, flips the
+        /// client's own <c>KeepConnected</c>/reconnect intent to <c>false</c> (killing the auto-reconnect
+        /// loop), and fire-and-forgets <c>HubConnection.DisposeAsync()</c> — spawning NO awaited Task. This
+        /// is the LOAD-BEARING step that lets the addon's collectible <see cref="System.Runtime.Loader.AssemblyLoadContext"/>
+        /// actually unload on a Godot "Build Project": the live SignalR connection (HubConnection +
+        /// HttpClient + reconnect loop + R3 subscriptions) otherwise keeps running threads / strong GC
+        /// handles that pin the context open, producing <c>Failed to unload assemblies</c> +
+        /// <c>delegate_handle.value == nullptr</c>. Deliberately does NOT call the graceful async
+        /// <see cref="Disconnect"/> path — awaiting it can deadlock the unload thread. Idempotent and
+        /// defensively wrapped: safe to call when no plugin exists or when already torn down. Mirrors the
+        /// Unity reference's <c>Startup.TryDisconnectAndCleanup</c> → <c>plugin.DisconnectImmediate()</c>.
+        /// </summary>
+        public void DisconnectImmediate()
+        {
+            var plugin = _plugin;
+            if (plugin == null)
+                return;
+
+            try
+            {
+                plugin.DisconnectImmediate();
+            }
+            catch (Exception ex)
+            {
+                // Emergency-shutdown path: never let a disconnect failure escape into the ALC-unloading
+                // handler (an exception there would abort the very unload we are trying to enable).
+                try { GD.PushError($"[Godot-MCP] immediate disconnect failed: {ex.Message}"); }
+                catch { /* GD may be unavailable mid-reload; swallow */ }
+            }
+        }
+
+        /// <summary>
+        /// Reload-safe, best-effort teardown for the Godot "Build Project" hot-reload / assembly-unload path,
+        /// built ONLY on the McpPlugin 6.7.0 public API. Cancels the live connection via the reused client's
+        /// synchronous <see cref="IConnection.DisconnectImmediate"/> (kills the auto-reconnect loop + fire-and-
+        /// forgets the HubConnection teardown) and then disposes the plugin (releases R3 subscriptions + the
+        /// manager). Both steps are independently try/catch-wrapped and never throw — safe to call from the
+        /// ALC-unloading handler, where a throw would abort the very unload it is trying to enable.
+        ///
+        /// <para>
+        /// This is intentionally a fire-and-forget stop, NOT a blocking drain: live testing established that
+        /// the connection threads are NOT what pins the collectible <see cref="System.Runtime.Loader.AssemblyLoadContext"/>
+        /// open (the residual "Failed to unload assemblies" come from static refs into the collectible
+        /// assembly, addressed separately — see <see cref="GodotMcpAssemblyResolver.OnAssemblyUnloading"/>).
+        /// So there is no need to block the editor main thread on any async API here. The
+        /// <paramref name="timeout"/> is accepted for call-site compatibility and is otherwise unused.
+        /// </para>
+        ///
+        /// Idempotent and defensively wrapped: safe to call with no plugin (no-op) and never throws into the
+        /// ALC-unloading handler.
+        /// </summary>
+        /// <param name="timeout">Accepted for call-site compatibility; not used by this synchronous teardown.</param>
+        public void DisconnectAndDrain(TimeSpan timeout)
+        {
+            var plugin = _plugin;
+            if (plugin == null)
+                return;
+
+            // 1) Synchronous immediate disconnect (6.7.0): cancels the CTS, flips the client's KeepConnected
+            //    to false (killing the auto-reconnect loop), and fire-and-forgets the HubConnection teardown.
+            try { plugin.DisconnectImmediate(); }
+            catch (Exception ex)
+            {
+                try { GD.PushError($"[Godot-MCP] immediate disconnect (drain) failed: {ex.Message}"); }
+                catch { /* GD may be unavailable mid-reload; swallow */ }
+            }
+
+            // 2) Final plugin Dispose (6.7.0): releases the R3 subscriptions + the manager (idempotent).
+            try { plugin.Dispose(); }
+            catch (Exception ex)
+            {
+                try { GD.PushError($"[Godot-MCP] plugin dispose (drain) failed: {ex.Message}"); }
+                catch { /* GD may be unavailable mid-reload; swallow */ }
+            }
+        }
+
         public void Dispose()
         {
             _stateSubscription.Dispose();
@@ -951,6 +1030,22 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
             if (_plugin != null)
             {
+                try
+                {
+                    // Reload-safe disconnect BEFORE Dispose: cancel the CTS, kill the reconnect loop, and
+                    // tear down the HubConnection synchronously so no running thread / GC handle survives to
+                    // pin a collectible ALC open. Cheap and idempotent when already disconnected. Doing it
+                    // here (not only in the unload handler) means EVERY teardown path — _ExitTree, Reconnect,
+                    // ALC-unloading — gets the immediate disconnect, so the symptom can never depend on which
+                    // path tore the plugin down.
+                    _plugin.DisconnectImmediate();
+                }
+                catch (Exception ex)
+                {
+                    try { GD.PushError($"[Godot-MCP] immediate disconnect (pre-dispose) failed: {ex.Message}"); }
+                    catch { /* GD may be unavailable mid-reload */ }
+                }
+
                 try
                 {
                     _plugin.Dispose();

--- a/addons/godot_mcp/GodotMcpPlugin.cs
+++ b/addons/godot_mcp/GodotMcpPlugin.cs
@@ -45,6 +45,21 @@ namespace com.IvanMurzak.Godot.MCP
         // _ExitTree. Lets a terminal / AI agent inject fake states + simulate user actions on the live dock.
         DevControlServer? _devControl;
 
+        // Guards Teardown() so the body runs at most once per plugin instance — it is reachable from BOTH
+        // _ExitTree (the normal plugin-disable path) AND the GodotMcpAssemblyResolver.ReloadTeardown hook
+        // (the Godot "Build Project" hot-reload path, which never calls _ExitTree). Whichever fires first
+        // wins; the second is a no-op. Not volatile/locked: both entry points run on the editor main thread
+        // (Godot raises the ALC Unloading event on the main thread, and _ExitTree is a main-thread callback),
+        // so there is no cross-thread race to protect against.
+        bool _torndown;
+
+        // The live plugin instance the static ReloadTeardown closure reaches. Set in _EnterTree, cleared in
+        // Teardown. The ALC-unloading hook (a static event handler in GodotMcpAssemblyResolver) has no
+        // instance to call into otherwise — this is the Godot analog of Unity's static
+        // UnityMcpPluginRuntime.Instance. Only the most-recent _EnterTree owns it; a stale instance never
+        // overwrites a newer one because _EnterTree always sets Current = this last.
+        static GodotMcpPlugin? Current;
+
         public override void _EnterTree()
         {
             // Install the process-wide log collector first so every lifecycle line below (resolver
@@ -76,6 +91,18 @@ namespace com.IvanMurzak.Godot.MCP
             // GodotMcpAssemblyResolver for the full rationale.
             GodotMcpAssemblyResolver.Log = msg => Log(msg);
             GodotMcpAssemblyResolver.Install();
+
+            // Arm the reload-safe teardown for the Godot "Build Project" hot-reload path. A C# rebuild
+            // raises an AssemblyLoadContext unload WITHOUT first calling this EditorPlugin's _ExitTree, so
+            // the connection threads + GC handles that pin the (collectible) addon ALC open would otherwise
+            // never be released — producing "Failed to unload assemblies" and a flood of
+            // "delegate_handle.value == nullptr". GodotMcpAssemblyResolver subscribes the ALC's Unloading
+            // event (from its ModuleInitializer) and invokes ReloadTeardown when it fires. We point it at
+            // THIS instance's Teardown via Current; the same Teardown also runs from _ExitTree, guarded so it
+            // executes at most once. Set Current LAST so this instance owns the static hook.
+            Current = this;
+            _torndown = false;
+            GodotMcpAssemblyResolver.ReloadTeardown = static () => Current?.Teardown(fromReload: true);
 
             // Pump for off-thread → main-thread work. Added as a child of this EditorPlugin Node so it
             // lives in the editor SceneTree and gets _Process ticks for the lifetime of the plugin.
@@ -226,43 +253,200 @@ namespace com.IvanMurzak.Godot.MCP
 
         public override void _ExitTree()
         {
-            if (_devControl != null)
+            // Route through the single idempotent teardown. On a normal plugin-disable this is the only
+            // teardown trigger; on a "Build Project" hot-reload the ALC-unloading hook usually fires FIRST
+            // (and _ExitTree may not fire at all), so this call is then a no-op via the _torndown guard.
+            Teardown(fromReload: false);
+        }
+
+        /// <summary>
+        /// Single, idempotent teardown reachable from BOTH <see cref="_ExitTree"/> (normal plugin disable)
+        /// and the <see cref="GodotMcpAssemblyResolver.ReloadTeardown"/> hook (the Godot "Build Project"
+        /// hot-reload, which raises an <see cref="System.Runtime.Loader.AssemblyLoadContext"/> unload WITHOUT
+        /// calling <see cref="_ExitTree"/> — the path the old <c>_ExitTree</c>-only teardown missed entirely).
+        ///
+        /// <para>
+        /// Order matters and each step is independently wrapped so one failure cannot abort the rest (and,
+        /// critically, cannot escape the ALC-unloading handler, where a throw would abort the unload):
+        /// <list type="number">
+        ///   <item><b>Dev-control listener FIRST</b> — its <c>Dispose</c> stops the <c>HttpListener</c> and
+        ///   joins the accept thread, releasing a running thread that pins the collectible context.</item>
+        ///   <item><b><c>DisconnectAndDrain(2s)</c></b> — the LOAD-BEARING step: cancels the reconnect intent
+        ///   then runs the reused client's GRACEFUL <c>Disconnect</c> (StopAsync + DisposeAsync) on a
+        ///   background thread and bounded-waits for it on the main thread, so the SignalR receive loop + any
+        ///   in-flight HTTP reconnect are actually JOINED — not just fire-and-forgotten. A bare
+        ///   <c>DisconnectImmediate()</c> left those threads running inside the collectible ALC, so Godot's
+        ///   unload (which does not abort threads) failed; draining them first is what lets the unload
+        ///   succeed and makes both "Failed to unload assemblies" and the <c>delegate_handle null</c> flood
+        ///   vanish.</item>
+        ///   <item><b>Dispose the connection</b> — releases the R3 subscriptions + the plugin instance.</item>
+        ///   <item><b>Free the dock + dispatcher (MAIN-THREAD ONLY)</b> — severs the native signal Callables by
+        ///   tearing down the dock subtree. (All dock Godot-signal connections are now OBJECT+METHOD Callables,
+        ///   which can no longer emit the <c>delegate_handle.value == nullptr</c> symptom regardless; freeing the
+        ///   subtree still severs them deterministically.)
+        ///   These call <c>Node.Free()</c>, which is only legal on the editor main thread; the ALC Unloading
+        ///   event is raised on the main thread so that holds here, but the block is still guarded so that
+        ///   if it ever runs off-main-thread the (pure-managed) steps 1–3 still run and the Node frees are
+        ///   skipped rather than crashing. We do NOT marshal through <see cref="MainThreadDispatcher"/> — it
+        ///   is being torn down and its <c>Enqueue</c> throws once its instance is gone.</item>
+        ///   <item><b>Null the process-wide statics</b> — log collector, error-capture router, and the
+        ///   <see cref="Current"/>/<see cref="GodotMcpAssemblyResolver.ReloadTeardown"/> hook.</item>
+        /// </list>
+        /// </para>
+        /// </summary>
+        /// <param name="fromReload">
+        /// <c>true</c> when invoked from the ALC-unloading hook (diagnostic only — the teardown body is the
+        /// same on both paths).
+        /// </param>
+        void Teardown(bool fromReload)
+        {
+            if (_torndown)
+                return;
+            _torndown = true;
+
+            // 1) Stop the dev-control listener FIRST — releases its bound socket + joins the accept thread.
+            try
             {
-                _devControl.Dispose();
-                _devControl = null;
+                if (_devControl != null)
+                {
+                    _devControl.Dispose();
+                    _devControl = null;
+                }
+            }
+            catch (System.Exception ex) { TryLogTeardownError("dev-control dispose", ex); }
+
+            // 2) Reload-safe disconnect that DRAINS (joins) the connection's background threads — THE key fix.
+            //    A bare DisconnectImmediate() only cancels + fire-and-forgets HubConnection.DisposeAsync(), so
+            //    the SignalR receive loop + an in-flight HTTP reconnect kept running inside the collectible ALC
+            //    and made Godot's unload fail (it does not abort threads). DisconnectAndDrain runs the graceful
+            //    StopAsync+DisposeAsync on a background thread and bounded-waits (2s) on the main thread, so
+            //    those threads are joined before the unload proceeds. 2s keeps the whole hook bounded (~3s):
+            //    a refused-localhost reconnect aborts fast (RST); a black-holed host could exceed the timeout,
+            //    in which case the bounded wait returns and we proceed anyway. Must precede the connection
+            //    Dispose (Dispose also disconnects, but doing the drain explicitly first joins the threads
+            //    while the plugin is still live and keeps the ordering obvious).
+            try
+            {
+                _connection?.DisconnectAndDrain(System.TimeSpan.FromSeconds(2));
+            }
+            catch (System.Exception ex) { TryLogTeardownError("disconnect-and-drain", ex); }
+
+            // 3) Dispose the connection — releases the R3 subscriptions and the plugin instance.
+            try
+            {
+                if (_connection != null)
+                {
+                    _connection.Dispose();
+                    _connection = null;
+                }
+            }
+            catch (System.Exception ex) { TryLogTeardownError("connection dispose", ex); }
+
+            // 4) MAIN-THREAD ONLY: free the dock + dispatcher. These touch Godot Nodes (Node.Free), which is
+            //    only legal on the editor main thread. The ALC Unloading event and _ExitTree both run on the
+            //    main thread, so this normally executes; the guard is a safety net so an unexpected off-thread
+            //    caller skips the Node frees instead of crashing the host. Steps 1–3 above are pure-managed and
+            //    always run.
+            if (MainThreadDispatcher.IsMainThread)
+            {
+                FreeNodes();
+            }
+            else
+            {
+                TryLog("[Godot-MCP] teardown ran off the main thread; skipping Node.Free (connection torn down).");
             }
 
-            if (_connection != null)
+            TryLog("[Godot-MCP] plugin unloaded");
+
+            // 5) Null the process-wide statics so a stale buffer/router/hook does not outlive this instance.
+            try { GodotLogCollector.Current = null; } catch { /* swallow during unload */ }
+
+            // Drop the engine error-capture router. The registered Godot Logger (4.5+) stays in the engine's
+            // logger list (no managed remove API), but clearing Current stops validation sessions leaking
+            // across a reload and lets the router be GC-eligible once the engine drops it.
+            try { ScriptErrorCapture.Current = null; } catch { /* swallow during unload */ }
+
+            // Release the static reload hook so a torn-down instance is not reachable from the resolver and
+            // can be collected. Only clear if WE are the current owner (a newer _EnterTree may already have
+            // claimed it).
+            try
             {
-                _connection.Dispose();
-                _connection = null;
+                if (ReferenceEquals(Current, this))
+                {
+                    Current = null;
+                    GodotMcpAssemblyResolver.ReloadTeardown = null;
+                }
             }
+            catch { /* swallow during unload */ }
+        }
 
-            if (_dock != null)
+        /// <summary>
+        /// The main-thread-only portion of <see cref="Teardown"/>: synchronously free the dock subtree and the
+        /// dispatcher. Split out so the main-thread guard in <see cref="Teardown"/> reads cleanly. No managed
+        /// signal-delegate sweep is needed — all dock Godot-signal connections are object+method Callables that
+        /// are severed when the subtree is freed.
+        /// </summary>
+        void FreeNodes()
+        {
+            try
             {
-                // Remove from the dock slot before freeing so Godot does not hold a dangling control ref.
-                RemoveControlFromDocks(_dock);
-                _dock.QueueFree();
-                _dock = null;
-            }
+                if (_dock != null)
+                {
+                    // Remove from the dock slot before freeing so Godot does not hold a dangling control ref.
+                    RemoveControlFromDocks(_dock);
 
-            if (_dispatcher != null)
+                    // SYNCHRONOUS free (Free, not QueueFree) on the unload path. A DEFERRED QueueFree would not
+                    // run the dock subtree's own _ExitTree disconnect logic until the next idle frame — AFTER the
+                    // ALC unload has already been attempted — leaving the panels' pure-managed C# EVENT
+                    // subscriptions (the connection/server-manager events the panels +=/-= in _EnterTree/_ExitTree)
+                    // still rooted into the unloading context. Free() tears the whole subtree down NOW, running
+                    // every child's _ExitTree (panels unsubscribe their connection events) and severing every
+                    // native signal connection deterministically before the context unloads. (The dock's
+                    // Godot-signal connections are object+method Callables, which never enter the ManagedCallable
+                    // registry and so can no longer emit the historical "delegate_handle.value == nullptr" flood;
+                    // see godotengine/godot#78513.) Transient child windows (FeatureListWindow /
+                    // SerializationCheckWindow) are parented under the dock, so this frees them too.
+                    _dock.Free();
+                    _dock = null;
+                }
+            }
+            catch (System.Exception ex) { TryLogTeardownError("dock free", ex); }
+
+            try
             {
-                _dispatcher.QueueFree();
-                _dispatcher = null;
+                if (_dispatcher != null)
+                {
+                    // Synchronous free for the same reason as the dock: the dispatcher pumps main-thread work
+                    // and holds registered per-tick delegates; freeing it deterministically here ensures no
+                    // dispatcher-rooted managed state survives into the unload.
+                    _dispatcher.Free();
+                    _dispatcher = null;
+                }
             }
+            catch (System.Exception ex) { TryLogTeardownError("dispatcher free", ex); }
 
-            Log("[Godot-MCP] plugin unloaded");
+            // No KeepAlive sweep is needed anymore: every dock signal connection is an OBJECT+METHOD Callable
+            // (not a C# delegate/lambda), so none of them is a ManagedCallable and none can survive into the ALC
+            // unload as a leftover managed connection. The dock Free() above severs every native connection
+            // deterministically as it tears the subtree down.
+        }
 
-            // Release the collector so a stale buffer does not outlive this plugin instance (a fresh one
-            // is installed on the next _EnterTree).
-            GodotLogCollector.Current = null;
+        /// <summary>
+        /// Best-effort log helper for the teardown path. Wrapped because mid-reload the Godot logging API
+        /// (<c>GD.Print</c>) or the log collector may already be unavailable; a teardown diagnostic must
+        /// never throw on the ALC-unloading path.
+        /// </summary>
+        static void TryLog(string message)
+        {
+            try { Log(message); }
+            catch { /* logging itself must not break teardown */ }
+        }
 
-            // Drop the engine error-capture router too. The registered Godot Logger (4.5+) lives in the
-            // engine's logger list; we intentionally do NOT remove it (Godot has no remove-logger managed
-            // API and the editor process owns its lifetime), but clearing Current stops validation sessions
-            // from leaking across a plugin reload and lets the router be GC-eligible once the engine drops it.
-            ScriptErrorCapture.Current = null;
+        /// <summary>Best-effort error-log helper for a named teardown step (never throws).</summary>
+        static void TryLogTeardownError(string step, System.Exception ex)
+        {
+            try { LogError($"[Godot-MCP] teardown step '{step}' failed: {ex.Message}"); }
+            catch { /* swallow — teardown must not throw on the unload path */ }
         }
     }
 }

--- a/addons/godot_mcp/UI/Agents/AgentConfiguratorsPanel.cs
+++ b/addons/godot_mcp/UI/Agents/AgentConfiguratorsPanel.cs
@@ -105,7 +105,8 @@ namespace com.IvanMurzak.Godot.MCP.UI
             var names = GodotAgentConfiguratorRegistry.AgentNames;
             for (int i = 0; i < names.Count; i++)
                 _agentSelector.AddItem(names[i], i);
-            _agentSelector.ItemSelected += DockStyle.KeepAlive(_agentSelector, (OptionButton.ItemSelectedEventHandler)OnAgentSelected);
+            // Object+method Callable (not a delegate +=) so it never enters the ManagedCallable hot-reload registry.
+            _agentSelector.Connect(OptionButton.SignalName.ItemSelected, new Callable(this, MethodName.OnAgentSelected));
             row.AddChild(_agentSelector);
 
             // Swappable per-agent view — wrapped in the ONE blue frame-group this section gets (Unity frames the
@@ -125,7 +126,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             ShowAgent(index);
         }
 
-        void OnAgentSelected(long index)
+        public void OnAgentSelected(long index)
         {
             var i = (int)index;
             var all = GodotAgentConfiguratorRegistry.All;
@@ -325,12 +326,12 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
             _revealButton = new Button { Name = "Reveal", Text = "Reveal token" };
             DockStyle.ApplySecondaryButton(_revealButton);
-            DockStyle.ConnectPressed(_revealButton, OnRevealToggled);
+            DockStyle.ConnectPressed(_revealButton, this, MethodName.OnRevealToggled);
             snippetActions.AddChild(_revealButton);
 
             var copyButton = new Button { Name = "Copy", Text = "Copy" };
             DockStyle.ApplySecondaryButton(copyButton);
-            DockStyle.ConnectPressed(copyButton, OnCopyPressed);
+            DockStyle.ConnectPressed(copyButton, this, MethodName.OnCopyPressed);
             snippetActions.AddChild(copyButton);
         }
 
@@ -388,14 +389,16 @@ namespace com.IvanMurzak.Godot.MCP.UI
             var configActions = new HBoxContainer { Name = "ConfigActions" };
             statusRow.AddChild(configActions);
 
-            // Button order mirrors Unity: Remove first (left), Configure second (right).
+            // Button order mirrors Unity: Remove first (left), Configure second (right). Connected via
+            // object+method Callables to parameterless instance handlers that re-resolve the agent + config path
+            // off the panel's live state (no captured-lambda delegate connection).
             _removeButton = new Button { Name = "Remove", Text = "Remove" };
             DockStyle.ApplyAlertButton(_removeButton);
-            DockStyle.ConnectPressed(_removeButton, () => OnRemovePressed(agent, configPath));
+            DockStyle.ConnectPressed(_removeButton, this, MethodName.OnRemoveButtonPressed);
             configActions.AddChild(_removeButton);
 
             _configureButton = new Button { Name = "Configure", Text = "Configure" };
-            DockStyle.ConnectPressed(_configureButton, () => OnConfigurePressed(agent, configPath));
+            DockStyle.ConnectPressed(_configureButton, this, MethodName.OnConfigureButtonPressed);
             configActions.AddChild(_configureButton);
             // Configure/Reconfigure text, primary-vs-secondary styling, and Remove visibility are all driven by
             // RefreshStatus() (called at the end of BuildAgentView) off the live IsConfigured() state.
@@ -446,7 +449,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             }
         }
 
-        void OnRevealToggled()
+        public void OnRevealToggled()
         {
             _revealToken = !_revealToken;
             if (_revealButton != null)
@@ -454,7 +457,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             RefreshSnippet();
         }
 
-        void OnCopyPressed()
+        public void OnCopyPressed()
         {
             if (_current == null)
                 return;
@@ -462,6 +465,32 @@ namespace com.IvanMurzak.Godot.MCP.UI
             // Copy ALWAYS uses the real token — writing the user's own client config is the point. Never logged.
             var snippet = _current.BuildSnippet(McpUrl, Token, maskToken: false);
             DisplayServer.ClipboardSet(snippet);
+        }
+
+        /// <summary>
+        /// Configure-button <c>pressed</c> handler (object+method Callable). Re-resolves the current agent + its
+        /// config path off the live panel state (the same values the row was built from) so no captured-lambda
+        /// delegate is needed. No-op if the agent has no writable config path.
+        /// </summary>
+        public void OnConfigureButtonPressed()
+        {
+            if (_current == null)
+                return;
+            var configPath = ResolveConfigPath(_current);
+            if (configPath == null)
+                return;
+            OnConfigurePressed(_current, configPath);
+        }
+
+        /// <summary>Remove-button <c>pressed</c> handler (object+method Callable). Mirrors <see cref="OnConfigureButtonPressed"/>.</summary>
+        public void OnRemoveButtonPressed()
+        {
+            if (_current == null)
+                return;
+            var configPath = ResolveConfigPath(_current);
+            if (configPath == null)
+                return;
+            OnRemovePressed(_current, configPath);
         }
 
         void OnConfigurePressed(GodotAgentConfigurator agent, string configPath)
@@ -607,6 +636,11 @@ namespace com.IvanMurzak.Godot.MCP.UI
             "macOS" => AgentOs.MacOS,
             _ => AgentOs.Linux,
         };
+
+        // No KeepAlive teardown is needed: every signal here is an OBJECT+METHOD Callable (the agent selector +
+        // the per-agent Reveal/Copy/Configure/Remove buttons all connect to this panel's instance methods), which
+        // is not a ManagedCallable and never enters the native registry the Build-Project hot-reload iterates. The
+        // target controls are kept alive by the tree and freed with the panel.
     }
 }
 #endif

--- a/addons/godot_mcp/UI/ConnectionPanel.cs
+++ b/addons/godot_mcp/UI/ConnectionPanel.cs
@@ -259,7 +259,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _timelineGodotCircle = DockStyle.TimelineCircle("GodotCircle", ConnectionPanelView.TimelinePointState.Disconnected);
 
             _connectButton = new Button { Name = "ConnectButton" };
-            DockStyle.ConnectPressed(_connectButton, OnConnectButtonPressed);
+            DockStyle.ConnectPressed(_connectButton, this, MethodName.OnConnectButtonPressed);
 
             var godotContent = new HBoxContainer { Name = "GodotContent", SizeFlagsHorizontal = SizeFlags.ExpandFill };
             godotContent.AddThemeConstantOverride("separation", 8);
@@ -329,9 +329,10 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 SizeFlagsHorizontal = SizeFlags.ExpandFill
             };
             DockStyle.ApplyInput(_hostField);
-            // Commit on Enter and on focus-out (mirrors the Unity reference's FocusOut commit).
-            _hostField.TextSubmitted += DockStyle.KeepAlive(_hostField, (LineEdit.TextSubmittedEventHandler)OnHostSubmitted);
-            _hostField.FocusExited += DockStyle.KeepAlive(_hostField, (System.Action)OnHostFocusExited);
+            // Commit on Enter and on focus-out (mirrors the Unity reference's FocusOut commit). Connected via
+            // object+method Callables (not delegate +=) so they never enter the ManagedCallable hot-reload registry.
+            _hostField.Connect(LineEdit.SignalName.TextSubmitted, new Callable(this, MethodName.OnHostSubmitted));
+            _hostField.Connect(Control.SignalName.FocusExited, new Callable(this, MethodName.OnHostFocusExited));
             hostLine.AddChild(_hostField);
 
             // --- Authorization (Custom mode only): none | required (segmented) ---
@@ -367,7 +368,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             tokenLine.AddChild(_tokenField);
 
             _generateTokenButton = new Button { Name = "GenerateTokenButton", Text = "New" };
-            DockStyle.ConnectPressed(_generateTokenButton, OnGenerateTokenPressed);
+            DockStyle.ConnectPressed(_generateTokenButton, this, MethodName.OnGenerateTokenPressed);
             tokenLine.AddChild(_generateTokenButton);
 
             // --- Local-server hosting row (Custom mode only): Start/Stop the version-matched server binary ---
@@ -386,7 +387,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             serverLine.AddChild(new Control { SizeFlagsHorizontal = SizeFlags.ExpandFill });
 
             _serverStartStopButton = new Button { Name = "LocalServerStartStopButton" };
-            DockStyle.ConnectPressed(_serverStartStopButton, OnServerStartStopPressed);
+            DockStyle.ConnectPressed(_serverStartStopButton, this, MethodName.OnServerStartStopPressed);
             serverLine.AddChild(_serverStartStopButton);
 
             _localServerRow.AddChild(serverLine);
@@ -414,11 +415,11 @@ namespace com.IvanMurzak.Godot.MCP.UI
             cloudTokenLine.AddChild(_cloudTokenField);
 
             _authorizeButton = new Button { Name = "AuthorizeButton", Text = ConnectionPanelView.AuthorizeButtonText };
-            DockStyle.ConnectPressed(_authorizeButton, OnAuthorizeButtonPressed);
+            DockStyle.ConnectPressed(_authorizeButton, this, MethodName.OnAuthorizeButtonPressed);
             cloudTokenLine.AddChild(_authorizeButton);
 
             _revokeButton = new Button { Name = "RevokeButton", Text = "Revoke" };
-            DockStyle.ConnectPressed(_revokeButton, OnRevokeButtonPressed);
+            DockStyle.ConnectPressed(_revokeButton, this, MethodName.OnRevokeButtonPressed);
             cloudTokenLine.AddChild(_revokeButton);
 
             _cloudAuthStatus = new Label
@@ -567,7 +568,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// stream. The button is disabled by <see cref="ApplyServerStatus"/> during transient states, so a
         /// double-click cannot race a start/stop.
         /// </summary>
-        void OnServerStartStopPressed()
+        public void OnServerStartStopPressed()
         {
             if (_serverManager.Status == GodotMcpServerStatus.Running)
             {
@@ -629,7 +630,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             ApplyStatus(live);
         }
 
-        void OnConnectButtonPressed()
+        public void OnConnectButtonPressed()
         {
             // Single toggle: "Connect" only when fully disconnected; otherwise "Stop" — disconnect when connected,
             // or cancel the in-flight attempt when connecting (Disconnect() stops the client's retry loop).
@@ -710,7 +711,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// token is never logged and is shown only as a masked field. Generating implies the user wants
         /// auth, so this also flips <see cref="GodotMcpAuthOption"/> to <c>Required</c> if it was off.
         /// </summary>
-        void OnGenerateTokenPressed()
+        public void OnGenerateTokenPressed()
         {
             _connection.Config.CustomToken = GodotMcpTokenGenerator.Generate();
             if (_connection.Config.AuthOption == GodotMcpAuthOption.None)
@@ -725,9 +726,9 @@ namespace com.IvanMurzak.Godot.MCP.UI
             ConfigChanged?.Invoke(); // new token → agent section re-checks config
         }
 
-        void OnHostSubmitted(string text) => CommitHost(text);
+        public void OnHostSubmitted(string text) => CommitHost(text);
 
-        void OnHostFocusExited() => CommitHost(_hostField.Text);
+        public void OnHostFocusExited() => CommitHost(_hostField.Text);
 
         /// <summary>
         /// Validate + persist a Custom-mode server URL, then reconnect. Invalid input (not an absolute
@@ -844,7 +845,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// browser; on <see cref="GodotDeviceAuthFlowState.Authorized"/> the returned token is persisted and
         /// the connection reconnects. The token is never logged.
         /// </summary>
-        void OnAuthorizeButtonPressed()
+        public void OnAuthorizeButtonPressed()
         {
             // A click while a flow is running means "Cancel".
             if (_deviceAuthFlow != null && GodotDeviceAuthFlow.IsRunning(_deviceAuthFlow.State))
@@ -954,7 +955,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// Revoke the stored cloud token: clear it, persist, revert the UI to the Authorize state, and (if
         /// the live mode is Cloud) disconnect so the now-unauthenticated session does not linger.
         /// </summary>
-        void OnRevokeButtonPressed()
+        public void OnRevokeButtonPressed()
         {
             _connection.Config.CloudToken = null;
             _connection.Save();

--- a/addons/godot_mcp/UI/DockControls.cs
+++ b/addons/godot_mcp/UI/DockControls.cs
@@ -1,0 +1,178 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.UI
+{
+    /// <summary>
+    /// A <see cref="Button"/> whose <c>pressed</c> signal is connected via an OBJECT+METHOD <see cref="Callable"/>
+    /// (<c>new Callable(this, MethodName.OnPressed)</c>) to its own instance method, which invokes a stored
+    /// <see cref="System.Action"/>. The action is plain managed state on this GodotObject — it is NOT a signal
+    /// connection, so (unlike a <c>button.Pressed += handler</c> delegate connection) it never enters the native
+    /// <c>ManagedCallable::instances</c> registry that a Build-Project hot-reload iterates, and therefore cannot
+    /// raise the <c>delegate_handle.value == nullptr</c> flood. Used by <see cref="DockStyle.IconButton"/> /
+    /// <see cref="DockStyle.GoldenButton"/> / <see cref="DockStyle.AlertPanel"/> so the reusable factories keep
+    /// their <c>System.Action</c> API while connecting object+method.
+    /// </summary>
+    [Tool]
+    public partial class DockActionButton : Button
+    {
+        System.Action? _onPressed;
+
+        /// <summary>Connect <c>pressed</c> object+method (NOT a delegate) once the button enters the tree.</summary>
+        public override void _Ready()
+            => Connect(BaseButton.SignalName.Pressed, new Callable(this, MethodName.OnPressed));
+
+        /// <summary>Store the click action invoked by <see cref="OnPressed"/>; call once after construction.</summary>
+        public void BindPressed(System.Action onPressed) => _onPressed = onPressed;
+
+        /// <summary>Instance handler connected to <c>pressed</c> via an object+method <see cref="Callable"/>.</summary>
+        public void OnPressed() => _onPressed?.Invoke();
+    }
+
+    /// <summary>
+    /// A flat link-style <see cref="Button"/> that opens a stored URL via <see cref="OS.ShellOpen"/> from its own
+    /// instance method, connected object+method (see <see cref="DockActionButton"/> for why this avoids the
+    /// hot-reload <c>delegate_handle</c> flood). Backs <see cref="DockStyle.LinkButton"/>.
+    /// </summary>
+    [Tool]
+    public partial class DockLinkButton : Button
+    {
+        string _url = string.Empty;
+
+        /// <summary>Connect <c>pressed</c> object+method (NOT a delegate) once the button enters the tree.</summary>
+        public override void _Ready()
+            => Connect(BaseButton.SignalName.Pressed, new Callable(this, MethodName.OnPressed));
+
+        /// <summary>Store the URL opened by <see cref="OnPressed"/>; call once after construction.</summary>
+        public void BindUrl(string url) => _url = url ?? string.Empty;
+
+        /// <summary>Instance handler connected to <c>pressed</c>: opens the stored URL in the OS browser.</summary>
+        public void OnPressed()
+        {
+            if (!string.IsNullOrEmpty(_url))
+                OS.ShellOpen(_url);
+        }
+    }
+
+    /// <summary>
+    /// One segment of a <see cref="DockStyle.SegmentedControl"/>. Carries its own option index, the track
+    /// <see cref="HBoxContainer"/> it reports its selection into (the authoritative selection meta lives there),
+    /// and the caller's <c>onSelected</c> callback. The click handler (<see cref="OnPressed"/>) is an instance
+    /// method connected via an object+method <see cref="Callable"/>, replicating the former capturing-lambda body
+    /// exactly — so the segment's selection logic no longer rides a delegate Callable.
+    /// </summary>
+    [Tool]
+    public partial class DockSegmentButton : Button
+    {
+        int _index;
+        HBoxContainer _track = null!;
+        System.Action<int>? _onSelected;
+
+        /// <summary>Bind this segment's option index, the track it reports into, and the selection callback.</summary>
+        public void Bind(int index, HBoxContainer track, System.Action<int> onSelected)
+        {
+            _index = index;
+            _track = track;
+            _onSelected = onSelected;
+        }
+
+        /// <summary>
+        /// Instance handler connected to <c>pressed</c> via an object+method <see cref="Callable"/>. Identical
+        /// behaviour to the previous capturing lambda: compare against the authoritative track index, no-op on a
+        /// re-click of the active segment (re-assert visuals), otherwise advance the selection optimistically and
+        /// notify the caller.
+        /// </summary>
+        public void OnPressed()
+        {
+            // Compare against the AUTHORITATIVE index stashed on the track, not against any probe of native
+            // ButtonPressed flags (which can report two-pressed/zero-pressed on mono/Linux).
+            var current = DockStyle.GetSegmentedSelection(_track);
+            if (SegmentedControlModel.IsSelected(_index, current))
+            {
+                // Re-clicking the active segment is a true no-op: re-assert visuals (Godot just toggled this
+                // button OFF on the second click) and leave the authoritative index alone.
+                DockStyle.SetSegmentedSelection(_track, current);
+                return;
+            }
+            // Advance the authoritative selection OPTIMISTICALLY before notifying the caller, so the track meta and
+            // the visual pressed-state cannot diverge if a consumer of onSelected persists the new mode but does
+            // NOT round-trip through SetSegmentedSelection (e.g. an early-return on a no-op/persist-failure path).
+            DockStyle.SetSegmentedSelection(_track, _index);
+            _onSelected?.Invoke(_index);
+        }
+    }
+
+    /// <summary>
+    /// A <see cref="CheckButton"/> whose <c>toggled</c> signal is connected via an object+method
+    /// <see cref="Callable"/> to its own instance method, which invokes a stored <c>Action&lt;bool&gt;</c>. The
+    /// action is plain managed state (not a signal connection), so it never enters the ManagedCallable hot-reload
+    /// registry. Used for per-row enable/disable toggles whose handler closes over row-specific state (e.g. the
+    /// feature item name) without a delegate Callable.
+    /// </summary>
+    [Tool]
+    public partial class DockCheckToggle : CheckButton
+    {
+        System.Action<bool>? _onToggled;
+
+        /// <summary>Store the toggle action invoked by <see cref="OnToggled"/>; call once after construction.</summary>
+        public void BindToggled(System.Action<bool> onToggled) => _onToggled = onToggled;
+
+        /// <summary>Instance handler connected to <c>toggled</c> via an object+method <see cref="Callable"/>.</summary>
+        public void OnToggled(bool pressed) => _onToggled?.Invoke(pressed);
+    }
+
+    /// <summary>
+    /// A <see cref="CheckBox"/> variant of <see cref="DockCheckToggle"/> (object+method <c>toggled</c> connection
+    /// driving a stored <c>Action&lt;bool&gt;</c>). Used by the Skills auto-generate checkbox.
+    /// </summary>
+    [Tool]
+    public partial class DockCheckBox : CheckBox
+    {
+        System.Action<bool>? _onToggled;
+
+        /// <summary>Store the toggle action invoked by <see cref="OnToggled"/>; call once after construction.</summary>
+        public void BindToggled(System.Action<bool> onToggled) => _onToggled = onToggled;
+
+        /// <summary>Instance handler connected to <c>toggled</c> via an object+method <see cref="Callable"/>.</summary>
+        public void OnToggled(bool pressed) => _onToggled?.Invoke(pressed);
+    }
+
+    /// <summary>
+    /// The toggle button of a <see cref="DockStyle.Foldout"/>. Carries its title text + the content
+    /// <see cref="VBoxContainer"/> it shows/hides, and flips them in its own <see cref="OnToggled"/> instance
+    /// method (connected via an object+method <see cref="Callable"/> to the <c>toggled</c> signal) — replacing the
+    /// former capturing-lambda delegate connection.
+    /// </summary>
+    [Tool]
+    public partial class DockFoldoutToggle : Button
+    {
+        string _title = string.Empty;
+        VBoxContainer _content = null!;
+
+        /// <summary>Bind the foldout title + the content it reveals.</summary>
+        public void Bind(string title, VBoxContainer content)
+        {
+            _title = title;
+            _content = content;
+        }
+
+        /// <summary>Instance handler connected to <c>toggled</c>: show/hide the content and flip the arrow glyph.</summary>
+        public void OnToggled(bool pressed)
+        {
+            if (_content != null)
+                _content.Visible = pressed;
+            Text = (pressed ? "▾ " : "▸ ") + _title;
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/UI/DockStyle.cs
+++ b/addons/godot_mcp/UI/DockStyle.cs
@@ -34,40 +34,28 @@ namespace com.IvanMurzak.Godot.MCP.UI
         public static Color Rgb((float R, float G, float B) c) => new Color(c.R, c.G, c.B);
         public static Color Rgba((float R, float G, float B, float A) c) => new Color(c.R, c.G, c.B, c.A);
 
-        // --- Signal-handler retention -------------------------------------------------------------------------
-        // Godot roots a C# signal-handler delegate only via a native GCHandle on the connection. In the editor
-        // (GC pressure, assembly reloads) that delegate can be collected out from under the connection; firing
-        // the signal afterwards raises
-        //   managed_callable.cpp: Parameter "delegate_handle.value" is null
-        //   Can't get method on CallableCustom "Delegate::Invoke"
-        //   Error calling from signal 'pressed' ... Method not found
-        // and the handler SILENTLY never runs (e.g. the Authorize button does nothing). Keeping a STRONG managed
-        // reference to each connected delegate — tied to the lifetime of the control that owns the connection —
-        // prevents this (the Godot docs' "keep a reference to delegates connected to signals" rule). The table is
-        // keyed weakly by the owner, so a freed control's handlers become collectable again (no leak).
-        static readonly System.Runtime.CompilerServices.ConditionalWeakTable<GodotObject, List<System.Delegate>> _signalDelegates = new();
+        // --- Signal connection (object+method form) -----------------------------------------------------------
+        // Every Godot-signal connection in the dock is made via an OBJECT+METHOD Callable
+        // (`new Callable(ownerGodotObject, "<MethodName>")`), NOT a C# delegate/lambda. Object+method Callables
+        // are NOT ManagedCallables — they never enter the native `ManagedCallable::instances` registry that
+        // `CSharpLanguage::reload_assemblies` iterates on a Build-Project hot-reload, so they CANNOT raise the
+        //   ERROR: csharp_script.cpp - managed_callable->delegate_handle.value == nullptr
+        // flood that delegate/lambda connections produced. The target Godot Object is kept alive by the scene
+        // tree, so no managed GC-rooting (the old KeepAlive ConditionalWeakTable) is needed or used.
+        //
+        // The convenience helpers below own a tiny `[Tool] partial` GodotObject subclass (LinkButton,
+        // IconButton, GoldenButton, AlertPanel, SegmentedControl, Foldout) so the click logic is an INSTANCE
+        // METHOD on a real GodotObject, connectable via MethodName.
 
         /// <summary>
-        /// Retain a strong managed reference to <paramref name="handler"/> for as long as <paramref name="owner"/>
-        /// (the control that owns the signal connection) is alive, then RETURN it so it can be used directly in a
-        /// <c>signal += DockStyle.KeepAlive(owner, handler)</c> connection. Always connect the RETURNED delegate so
-        /// the rooted instance is exactly the one Godot wraps in its <see cref="Callable"/>; rooting a different
-        /// (even equal) delegate would not protect the connected one. Prevents the "delegate_handle.value is null"
-        /// crash described above.
+        /// Connect <paramref name="button"/>'s <c>Pressed</c> signal to the instance method named
+        /// <paramref name="methodName"/> on <paramref name="owner"/> via an OBJECT+METHOD <see cref="Callable"/>.
+        /// Object+method Callables are not ManagedCallables, so they never trigger the
+        /// <c>delegate_handle.value == nullptr</c> hot-reload flood that <c>button.Pressed += handler</c> (a C#
+        /// delegate) would. The handler MUST be an instance method on <paramref name="owner"/> visible to Godot.
         /// </summary>
-        public static T KeepAlive<T>(GodotObject owner, T handler) where T : System.Delegate
-        {
-            _signalDelegates.GetOrCreateValue(owner).Add(handler);
-            return handler;
-        }
-
-        /// <summary>
-        /// Connect <paramref name="button"/>'s <c>Pressed</c> signal to <paramref name="handler"/> while retaining a
-        /// strong managed reference to it (see <see cref="KeepAlive{T}"/>) so the delegate cannot be garbage-collected
-        /// out from under the connection. Prefer this over a bare <c>button.Pressed += handler</c> everywhere in the dock.
-        /// </summary>
-        public static void ConnectPressed(BaseButton button, System.Action handler)
-            => button.Pressed += KeepAlive(button, handler);
+        public static void ConnectPressed(BaseButton button, GodotObject owner, StringName methodName)
+            => button.Connect(BaseButton.SignalName.Pressed, new Callable(owner, methodName));
 
         // --- Bold font (Unity's `-unity-font-style: bold` on headers / section-titles / timeline-labels) ----------
         // Godot Labels have no font-style flag; bold requires a bold Font resource. In the editor the bold face is
@@ -417,7 +405,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// </summary>
         public static Button IconButton(string name, string text, string? iconFileName, System.Action onPressed)
         {
-            var button = new Button
+            var button = new DockActionButton
             {
                 Name = name,
                 MouseDefaultCursorShape = Control.CursorShape.PointingHand
@@ -427,7 +415,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
             ApplyIconAndText(button, text, iconFileName);
 
-            ConnectPressed(button, onPressed);
+            button.BindPressed(onPressed);
             return button;
         }
 
@@ -440,7 +428,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// </summary>
         public static Button GoldenButton(string name, string text, string? iconFileName, System.Action onPressed)
         {
-            var button = new Button
+            var button = new DockActionButton
             {
                 Name = name,
                 MouseDefaultCursorShape = Control.CursorShape.PointingHand
@@ -459,7 +447,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
             ApplyIconAndText(button, text, iconFileName);
 
-            ConnectPressed(button, onPressed);
+            button.BindPressed(onPressed);
             return button;
         }
 
@@ -471,7 +459,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// </summary>
         public static Button LinkButton(string name, string text, string url)
         {
-            var button = new Button
+            var button = new DockLinkButton
             {
                 Name = name,
                 Text = text,
@@ -484,7 +472,8 @@ namespace com.IvanMurzak.Godot.MCP.UI
             button.AddThemeColorOverride("font_hover_color", link.Lightened(0.2f));
             button.AddThemeColorOverride("font_pressed_color", link);
             button.AddThemeFontSizeOverride("font_size", DockTheme.FontSizeLink); // smaller than the body (Download / Tutorial links)
-            ConnectPressed(button, () => OS.ShellOpen(url));
+            // Object+method Callable: the button opens its own stored URL via its OnPressed instance method.
+            button.BindUrl(url);
             return button;
         }
 
@@ -588,10 +577,10 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
             // Full-width, centered cyan button — Unity's alert button is a `.btn-primary` that fills the frame
             // (`alertButton` spans the panel), not a left-hugging compact button.
-            var button = new Button { Name = "AlertButton", Text = buttonText };
+            var button = new DockActionButton { Name = "AlertButton", Text = buttonText };
             ApplyPrimaryButton(button);
             button.SizeFlagsHorizontal = Control.SizeFlags.ExpandFill;
-            ConnectPressed(button, onPressed);
+            button.BindPressed(onPressed);
             col.AddChild(button);
 
             return panel;
@@ -753,8 +742,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             track.SetMeta(SegmentedSelectionMetaKey, clamped);
             for (int i = 0; i < options.Count; i++)
             {
-                int index = i; // capture for the lambda
-                var segment = new Button
+                var segment = new DockSegmentButton
                 {
                     Name = "Segment" + i,
                     Text = options[i],
@@ -762,32 +750,17 @@ namespace com.IvanMurzak.Godot.MCP.UI
                     Flat = true,
                     CustomMinimumSize = new Vector2(DockTheme.SegmentMinWidth, 0)
                 };
+                // Carry the per-segment click state on the segment instance (index + the track it reports into +
+                // the caller's onSelected) so the click handler is a real INSTANCE METHOD connected via an
+                // object+method Callable — no captured-lambda delegate enters the ManagedCallable registry.
+                segment.Bind(i, track, onSelected);
                 // Set the pressed state WITHOUT emitting Pressed/Toggled so initial build never re-enters
                 // the click handler.
                 segment.SetPressedNoSignal(SegmentedControlModel.IsSelected(i, clamped));
                 segment.AddThemeFontSizeOverride("font_size", DockTheme.SegmentFontSize);
                 ApplySegmentStyle(segment, SegmentedControlModel.IsSelected(i, clamped));
 
-                segment.Pressed += KeepAlive<System.Action>(segment, () =>
-                {
-                    // Compare against the AUTHORITATIVE index stashed on the track, not against any probe of
-                    // native ButtonPressed flags (which can report two-pressed/zero-pressed on mono/Linux).
-                    var current = GetSegmentedSelection(track);
-                    if (SegmentedControlModel.IsSelected(index, current))
-                    {
-                        // Re-clicking the active segment is a true no-op: re-assert visuals (Godot just
-                        // toggled this button OFF on the second click) and leave the authoritative index alone.
-                        SetSegmentedSelection(track, current);
-                        return;
-                    }
-                    // Advance the authoritative selection OPTIMISTICALLY before notifying the caller, so the
-                    // track meta and the visual pressed-state cannot diverge if a consumer of onSelected
-                    // persists the new mode but does NOT round-trip through SetSegmentedSelection (e.g. an
-                    // early-return on a no-op/persist-failure path). Correctness no longer depends on caller
-                    // discipline; a caller that DOES call SetSegmentedSelection just re-asserts the same index.
-                    SetSegmentedSelection(track, index);
-                    onSelected(index);
-                });
+                segment.Connect(BaseButton.SignalName.Pressed, new Callable(segment, DockSegmentButton.MethodName.OnPressed));
                 track.AddChild(segment);
             }
 
@@ -827,7 +800,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// native <c>ButtonPressed</c> flags — those are unreliable for a group of independent toggle buttons
         /// with no <c>ButtonGroup</c> (issue #107). Falls back to <c>0</c> when the meta is absent.
         /// </summary>
-        static int GetSegmentedSelection(HBoxContainer track)
+        internal static int GetSegmentedSelection(HBoxContainer track)
         {
             if (track.HasMeta(SegmentedSelectionMetaKey))
                 return (int)track.GetMeta(SegmentedSelectionMetaKey);
@@ -996,7 +969,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             var container = new VBoxContainer { Name = title.Replace(" ", string.Empty) + "Foldout" };
             container.AddThemeConstantOverride("separation", 2);
 
-            var toggle = new Button
+            var toggle = new DockFoldoutToggle
             {
                 Name = "Toggle",
                 ToggleMode = true,
@@ -1011,11 +984,10 @@ namespace com.IvanMurzak.Godot.MCP.UI
             content.AddThemeConstantOverride("separation", 2);
             container.AddChild(content);
 
-            toggle.Toggled += KeepAlive<BaseButton.ToggledEventHandler>(toggle, pressed =>
-            {
-                content.Visible = pressed;
-                toggle.Text = (pressed ? "▾ " : "▸ ") + title;
-            });
+            // Object+method Callable on the toggle instance: it carries the title + the content it reveals and
+            // flips them in its own OnToggled instance method (no captured-lambda delegate connection).
+            toggle.Bind(title, content);
+            toggle.Connect(BaseButton.SignalName.Toggled, new Callable(toggle, DockFoldoutToggle.MethodName.OnToggled));
 
             return (container, content);
         }

--- a/addons/godot_mcp/UI/ExtensionRow.cs
+++ b/addons/godot_mcp/UI/ExtensionRow.cs
@@ -78,9 +78,13 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 SizeFlagsVertical = SizeFlags.ShrinkBegin
             };
             DockStyle.ApplyPrimaryButton(_actionButton);
-            DockStyle.ConnectPressed(_actionButton, () => _onAction(Descriptor));
+            // Object+method Callable to this row's own instance method (no captured-lambda delegate connection).
+            DockStyle.ConnectPressed(_actionButton, this, MethodName.OnActionPressed);
             AddChild(_actionButton);
         }
+
+        /// <summary>Action-button <c>pressed</c> handler (object+method Callable): raise the panel's install/update callback.</summary>
+        public void OnActionPressed() => _onAction(Descriptor);
 
         /// <summary>
         /// Reflect <paramref name="state"/> in the action button: NotInstalled → enabled "Install",

--- a/addons/godot_mcp/UI/FeatureListWindow.cs
+++ b/addons/godot_mcp/UI/FeatureListWindow.cs
@@ -58,8 +58,9 @@ namespace com.IvanMurzak.Godot.MCP.UI
             Size = new Vector2I(480, 560);
             Unresizable = false;
 
-            // Free the window when the OS/editor close button (the X) is pressed.
-            CloseRequested += OnClosePressed;
+            // Free the window when the OS/editor close button (the X) is pressed. Object+method Callable (not a
+            // delegate +=) so it never enters the ManagedCallable hot-reload registry.
+            Connect(Window.SignalName.CloseRequested, new Callable(this, MethodName.OnClosePressed));
 
             BuildUi();
             ReloadItems();
@@ -113,7 +114,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             root.AddChild(_emptyLabel);
 
             var closeButton = new Button { Name = "CloseButton", Text = "Close" };
-            DockStyle.ConnectPressed(closeButton, OnClosePressed);
+            DockStyle.ConnectPressed(closeButton, this, MethodName.OnClosePressed);
             root.AddChild(closeButton);
         }
 
@@ -130,8 +131,8 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 SizeFlagsHorizontal = Control.SizeFlags.ExpandFill
             };
             DockStyle.ApplyInput(_searchField);
-            // Live (no debounce): every keystroke re-filters.
-            _searchField.TextChanged += DockStyle.KeepAlive<LineEdit.TextChangedEventHandler>(_searchField, _ => RebuildRows());
+            // Live (no debounce): every keystroke re-filters. Object+method Callable (not a delegate +=).
+            _searchField.Connect(LineEdit.SignalName.TextChanged, new Callable(this, MethodName.OnSearchTextChanged));
             bar.AddChild(_searchField);
 
             _statusOption = new OptionButton { Name = "Status" };
@@ -141,7 +142,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _statusOption.AddItem("Disabled", (int)FeatureStatusFilter.Disabled);
             _statusOption.Select((int)FeatureStatusFilter.All);
             DockStyle.ApplyOptionButton(_statusOption);
-            _statusOption.ItemSelected += DockStyle.KeepAlive<OptionButton.ItemSelectedEventHandler>(_statusOption, _ => RebuildRows());
+            _statusOption.Connect(OptionButton.SignalName.ItemSelected, new Callable(this, MethodName.OnStatusItemSelected));
             bar.AddChild(_statusOption);
 
             _statsLabel = new Label
@@ -155,6 +156,12 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
             return bar;
         }
+
+        /// <summary>Search-field <c>text_changed</c> handler (object+method Callable). Re-filters on each keystroke.</summary>
+        public void OnSearchTextChanged(string _) => RebuildRows();
+
+        /// <summary>Status dropdown <c>item_selected</c> handler (object+method Callable). Re-filters on selection.</summary>
+        public void OnStatusItemSelected(long _) => RebuildRows();
 
         /// <summary>Re-read the live item set off the connection, then rebuild the filtered rows.</summary>
         void ReloadItems()
@@ -211,9 +218,12 @@ namespace com.IvanMurzak.Godot.MCP.UI
             DockStyle.ApplyRowTitle(titleLabel);
             headerLine.AddChild(titleLabel);
 
-            var toggle = new CheckButton { Name = "Toggle", ButtonPressed = item.Enabled };
+            var toggle = new DockCheckToggle { Name = "Toggle", ButtonPressed = item.Enabled };
             string itemName = item.Name;
-            toggle.Toggled += DockStyle.KeepAlive<BaseButton.ToggledEventHandler>(toggle, pressed => OnItemToggled(itemName, pressed));
+            // Object+method Callable on the toggle: it stores the per-row action (no delegate Callable enters the
+            // ManagedCallable registry) and invokes it from its own OnToggled instance method.
+            toggle.BindToggled(pressed => OnItemToggled(itemName, pressed));
+            toggle.Connect(BaseButton.SignalName.Toggled, new Callable(toggle, DockCheckToggle.MethodName.OnToggled));
             headerLine.AddChild(toggle);
             content.AddChild(headerLine);
 
@@ -346,7 +356,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             PopupCentered(Size);
         }
 
-        void OnClosePressed()
+        public void OnClosePressed()
         {
             // QueueFree frees the window and all rows next idle frame — no leaks.
             QueueFree();

--- a/addons/godot_mcp/UI/FeatureRow.cs
+++ b/addons/godot_mcp/UI/FeatureRow.cs
@@ -90,9 +90,13 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 SizeFlagsVertical = SizeFlags.ShrinkBegin
             };
             DockStyle.ApplyOpenButton(openButton);
-            DockStyle.ConnectPressed(openButton, () => _onOpen(Kind));
+            // Object+method Callable to this row's own instance method (no captured-lambda delegate connection).
+            DockStyle.ConnectPressed(openButton, this, MethodName.OnOpenPressed);
             AddChild(openButton);
         }
+
+        /// <summary>Open-button <c>pressed</c> handler (object+method Callable): raise the panel's open callback for this kind.</summary>
+        public void OnOpenPressed() => _onOpen(Kind);
 
         /// <summary>Show the "&lt;Title&gt;: enabled / total" counts (+ "~N tokens total" for tools).</summary>
         public void ShowCounts(int enabled, int total, int enabledTokenCount)

--- a/addons/godot_mcp/UI/GodotMcpDock.cs
+++ b/addons/godot_mcp/UI/GodotMcpDock.cs
@@ -62,6 +62,14 @@ namespace com.IvanMurzak.Godot.MCP.UI
         OptionButton? _logLevelSelector;
         Label? _logLevelOverrideNote;
 
+        // The ConnectionPanel.ConfigChanged → AgentConfiguratorsPanel.Refresh bridge, stored in a field (not an
+        // inline lambda) so it can be deterministically removed on teardown. An inline `+= () => ...` was a genuine
+        // delegate leak: it was never stored and never `-=`d, so it stayed rooted on the ConnectionPanel's C# event
+        // across the dock's lifetime and contributed a leftover managed connection at assembly unload. Wired with
+        // the same remove-then-add _EnterTree / -= _ExitTree discipline the connection panels use, so a benign dock
+        // reparent re-arms it and a permanent free drops it.
+        System.Action? _configChangedHandler;
+
         /// <summary>
         /// Construct the dock wired to the live <paramref name="connection"/> so its connection panel can
         /// show status and drive Connect/Disconnect/mode/URL. <see cref="GodotMcpPlugin"/> owns the
@@ -73,6 +81,36 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _connection = connection;
             Name = DockTitle;
             BuildUi();
+        }
+
+        /// <summary>
+        /// (Re)arm the dock's own cross-panel wiring on every tree entry — including the re-attach the editor
+        /// performs during dock-layout restore (which fires <see cref="_ExitTree"/> → <c>_EnterTree</c>). Currently
+        /// just the <see cref="ConnectionPanel.ConfigChanged"/> → <see cref="AgentConfiguratorsPanel.Refresh"/>
+        /// bridge. Remove-then-add so a re-entry never double-subscribes; pairs with <see cref="_ExitTree"/>. The
+        /// per-control signal/button wiring is owned by each panel's own _EnterTree, not here.
+        /// </summary>
+        public override void _EnterTree()
+        {
+            if (_connectionPanel != null && _configChangedHandler != null)
+            {
+                _connectionPanel.ConfigChanged -= _configChangedHandler;
+                _connectionPanel.ConfigChanged += _configChangedHandler;
+            }
+        }
+
+        /// <summary>
+        /// Tear down the dock's own cross-panel wiring on tree exit. Fires both on a benign dock reparent (re-armed
+        /// by <see cref="_EnterTree"/>) and on the permanent plugin-unload free; in both cases removing the stored
+        /// <see cref="_configChangedHandler"/> from the connection panel's event drops the only delegate this dock
+        /// roots directly, so nothing leaks into a C# assembly unload (issue #132). Per-control Godot-signal
+        /// connections are OBJECT+METHOD Callables (not delegates), so they need no managed sweep — they are severed
+        /// when each child's subtree is freed on the unload path.
+        /// </summary>
+        public override void _ExitTree()
+        {
+            if (_connectionPanel != null && _configChangedHandler != null)
+                _connectionPanel.ConfigChanged -= _configChangedHandler;
         }
 
         /// <summary>
@@ -213,8 +251,10 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
                 // When the user changes the server URL / mode / auth / token, re-render the AI-agent section so the
                 // selected agent re-checks its on-disk config and surfaces "Reconfiguration Required" + the Reconfigure
-                // button (mirrors Unity, where each configurator re-evaluates on a settings change).
-                _connectionPanel.ConfigChanged += () => _agentConfiguratorsPanel?.Refresh();
+                // button (mirrors Unity, where each configurator re-evaluates on a settings change). Stored in a field
+                // (see _configChangedHandler) and wired in _EnterTree (remove-then-add) so it is torn down cleanly on
+                // teardown rather than leaking as an un-removable inline lambda.
+                _configChangedHandler = () => _agentConfiguratorsPanel?.Refresh();
 
                 // MCP-features section — tools/prompts/resources counts + per-item enable/disable windows. Placed
                 // AFTER the AI-agent section (Unity order), wired to the live connection's managers.
@@ -253,7 +293,9 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _logLevelSelector = new OptionButton { Name = "LogLevelSelector" };
             foreach (GodotMcpLogLevel level in System.Enum.GetValues(typeof(GodotMcpLogLevel)))
                 _logLevelSelector.AddItem(level.ToString(), (int)level);
-            _logLevelSelector.ItemSelected += DockStyle.KeepAlive(_logLevelSelector, (OptionButton.ItemSelectedEventHandler)OnLogLevelSelected);
+            // Object+method Callable (not delegate +=) so the connection never enters the ManagedCallable
+            // hot-reload registry.
+            _logLevelSelector.Connect(OptionButton.SignalName.ItemSelected, new Callable(this, MethodName.OnLogLevelSelected));
             row.AddChild(_logLevelSelector);
 
             _logLevelOverrideNote = new Label
@@ -273,7 +315,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// logger provider reads the level live on every call. No-op when an env override pins the live level
         /// (the selector is disabled in that case, so this should not fire, but it is guarded defensively).
         /// </summary>
-        void OnLogLevelSelected(long id)
+        public void OnLogLevelSelected(long id)
         {
             if (_connection == null)
                 return;

--- a/addons/godot_mcp/UI/SerializationCheckWindow.cs
+++ b/addons/godot_mcp/UI/SerializationCheckWindow.cs
@@ -39,9 +39,9 @@ namespace com.IvanMurzak.Godot.MCP.UI
     /// <para>
     /// Editor-only (<c>#if TOOLS</c>): it builds live Godot UI <see cref="Node"/>s and reads the editor
     /// selection, so it is verified via the headless Godot smoke (<c>test.md</c> Suite 3), not the plain-xUnit
-    /// host. Every signal connection retains a strong managed reference to its delegate via
-    /// <see cref="DockStyle.KeepAlive{T}"/> / <see cref="DockStyle.ConnectPressed"/> so the "delegate_handle.value
-    /// is null" GC crash cannot occur (mirrors the dock-wide signal-retention discipline).
+    /// host. Every Godot-signal connection is an OBJECT+METHOD <see cref="Callable"/> (<c>new Callable(this,
+    /// MethodName.…)</c>), never a C# delegate — so it is not a ManagedCallable and cannot trigger the
+    /// <c>delegate_handle.value == nullptr</c> Build-Project hot-reload flood (mirrors the dock-wide discipline).
     /// </para>
     /// </summary>
     [Tool]
@@ -68,6 +68,10 @@ namespace com.IvanMurzak.Godot.MCP.UI
         GodotObject? _target;
         string _fullOutputText = string.Empty;
 
+        // The Copy button's label before the transient "Copied!" flash, restored by the timer's object+method
+        // handler (OnCopyFlashTimeout) ~1.5s later. Stored on the instance so the handler needs no captured state.
+        string _copyButtonOriginalText = "Copy";
+
         public SerializationCheckWindow()
         {
             Name = "SerializationCheckWindow";
@@ -76,8 +80,9 @@ namespace com.IvanMurzak.Godot.MCP.UI
             MinSize = new Vector2I(400, 500);
             Unresizable = false;
 
-            // Free the window when the OS/editor close button (the X) is pressed — no leaks.
-            CloseRequested += DockStyle.KeepAlive<Action>(this, OnClosePressed);
+            // Free the window when the OS/editor close button (the X) is pressed — no leaks. Object+method
+            // Callable (not a delegate +=) so it never enters the ManagedCallable hot-reload registry.
+            Connect(Window.SignalName.CloseRequested, new Callable(this, MethodName.OnClosePressed));
 
             BuildUi();
         }
@@ -121,8 +126,8 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 BaseType = nameof(Resource),
                 SizeFlagsHorizontal = Control.SizeFlags.ExpandFill
             };
-            _resourcePicker.ResourceChanged += DockStyle.KeepAlive<EditorResourcePicker.ResourceChangedEventHandler>(
-                _resourcePicker, OnResourcePicked);
+            // Object+method Callable (not a delegate +=) so it never enters the ManagedCallable hot-reload registry.
+            _resourcePicker.Connect(EditorResourcePicker.SignalName.ResourceChanged, new Callable(this, MethodName.OnResourcePicked));
             root.AddChild(_resourcePicker);
 
             var selectionRow = new HBoxContainer { Name = "SelectionRow", SizeFlagsHorizontal = Control.SizeFlags.ExpandFill };
@@ -135,7 +140,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 MouseDefaultCursorShape = Control.CursorShape.PointingHand
             };
             DockStyle.ApplySecondaryButton(useSelectionButton);
-            DockStyle.ConnectPressed(useSelectionButton, OnUseSelectionPressed);
+            DockStyle.ConnectPressed(useSelectionButton, this, MethodName.OnUseSelectionPressed);
             selectionRow.AddChild(useSelectionButton);
 
             _selectionLabel = new Label
@@ -164,7 +169,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 MouseDefaultCursorShape = Control.CursorShape.PointingHand
             };
             DockStyle.ApplyCompactPrimaryButton(serializeButton);
-            DockStyle.ConnectPressed(serializeButton, OnSerializePressed);
+            DockStyle.ConnectPressed(serializeButton, this, MethodName.OnSerializePressed);
             actionRow.AddChild(serializeButton);
             root.AddChild(actionRow);
 
@@ -219,7 +224,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _copyButton.OffsetTop = -34;
             _copyButton.OffsetRight = -8;
             _copyButton.OffsetBottom = -8;
-            DockStyle.ConnectPressed(_copyButton, OnCopyPressed);
+            DockStyle.ConnectPressed(_copyButton, this, MethodName.OnCopyPressed);
             copyAnchor.AddChild(_copyButton);
         }
 
@@ -246,7 +251,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         }
 
         /// <summary>The resource picker changed → make that Resource the target and clear any node selection.</summary>
-        void OnResourcePicked(Resource? resource)
+        public void OnResourcePicked(Resource? resource)
         {
             _target = resource;
             if (resource != null)
@@ -257,7 +262,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// Adopt the first node of the current editor selection as the target. Clears the resource picker so
         /// the two pickers do not silently disagree about which object is "the target".
         /// </summary>
-        void OnUseSelectionPressed()
+        public void OnUseSelectionPressed()
         {
             Node? node = null;
             try
@@ -283,7 +288,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _selectionLabel.Text = $"Node: {node.Name} ({node.GetClass()})";
         }
 
-        void OnSerializePressed()
+        public void OnSerializePressed()
         {
             // The resource picker is the target when no node was explicitly adopted via "Use Editor Selection".
             var target = _target ?? _resourcePicker.EditedResource;
@@ -348,21 +353,29 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _outputText.Text = _fullOutputText;
         }
 
-        void OnCopyPressed()
+        public void OnCopyPressed()
         {
             DisplayServer.ClipboardSet(_fullOutputText);
 
-            var original = _copyButton.Text;
+            _copyButtonOriginalText = _copyButton.Text;
             _copyButton.Text = "Copied!";
 
-            // Flip the label back after ~1.5s. The timer is owned by the button (freed with the window), and
-            // the callback re-checks validity so a window closed mid-flash never touches a freed control.
+            // Flip the label back after ~1.5s via an OBJECT+METHOD Callable to this window's instance handler (no
+            // delegate Callable). The handler re-checks validity so a window closed mid-flash never touches a
+            // freed control. The timer fires once, so a single connection is fine.
             var timer = GetTree().CreateTimer(1.5);
-            timer.Timeout += DockStyle.KeepAlive<Action>(_copyButton, () =>
-            {
-                if (IsInstanceValid(_copyButton))
-                    _copyButton.Text = original;
-            });
+            timer.Connect(SceneTreeTimer.SignalName.Timeout, new Callable(this, MethodName.OnCopyFlashTimeout));
+        }
+
+        /// <summary>
+        /// Restore the Copy button's label after the "Copied!" flash. Connected to the one-shot timer's
+        /// <c>timeout</c> via an object+method <see cref="Callable"/>. Re-checks the button's validity so a window
+        /// closed mid-flash never touches a freed control.
+        /// </summary>
+        public void OnCopyFlashTimeout()
+        {
+            if (IsInstanceValid(_copyButton))
+                _copyButton.Text = _copyButtonOriginalText;
         }
 
         /// <summary>Pop the window up centred and visible. Called by the footer after parenting it into the tree.</summary>
@@ -371,7 +384,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             PopupCentered(Size);
         }
 
-        void OnClosePressed()
+        public void OnClosePressed()
         {
             // QueueFree frees the window and all children next idle frame — no leaks.
             QueueFree();

--- a/addons/godot_mcp/UI/SkillsPanel.cs
+++ b/addons/godot_mcp/UI/SkillsPanel.cs
@@ -47,7 +47,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         readonly GodotMcpConnection _connection;
 
         VBoxContainer? _body;
-        CheckBox? _autoGenerateToggle;
+        DockCheckBox? _autoGenerateToggle;
         Label? _pathLabel;
         Label? _statusLabel;
 
@@ -155,19 +155,21 @@ namespace com.IvanMurzak.Godot.MCP.UI
             toggleLabel.AutowrapMode = TextServer.AutowrapMode.Off;
             controlRow.AddChild(toggleLabel);
 
-            _autoGenerateToggle = new CheckBox
+            _autoGenerateToggle = new DockCheckBox
             {
                 Name = "AutoGenerateToggle",
                 ButtonPressed = _connection.Config.GenerateSkillFiles
             };
-            _autoGenerateToggle.Toggled += DockStyle.KeepAlive(_autoGenerateToggle, (BaseButton.ToggledEventHandler)OnAutoGenerateToggled);
+            // Object+method Callable on the checkbox instance (no delegate += into the ManagedCallable registry).
+            _autoGenerateToggle.BindToggled(OnAutoGenerateToggled);
+            _autoGenerateToggle.Connect(BaseButton.SignalName.Toggled, new Callable(_autoGenerateToggle, DockCheckBox.MethodName.OnToggled));
             controlRow.AddChild(_autoGenerateToggle);
 
             controlRow.AddChild(new Control { Name = "SkillsSpacer", SizeFlagsHorizontal = SizeFlags.ExpandFill });
 
             var generateButton = new Button { Name = "Generate", Text = "Generate" };
             DockStyle.ApplySecondaryButton(generateButton); // compact gray (Unity's .btn-compact), not the big primary
-            DockStyle.ConnectPressed(generateButton, OnGeneratePressed);
+            DockStyle.ConnectPressed(generateButton, this, MethodName.OnGeneratePressed);
             controlRow.AddChild(generateButton);
 
             // --- Last-result status line (muted; turns amber on failure). HIDDEN until there's a result, so the
@@ -200,7 +202,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// destination directory is created if missing. The result is surfaced in the status line; failures never
         /// throw out of the UI handler.
         /// </summary>
-        void OnGeneratePressed()
+        public void OnGeneratePressed()
         {
             var plan = ResolvePlan();
             if (!plan.Supported || string.IsNullOrEmpty(plan.SkillsDir))
@@ -335,6 +337,11 @@ namespace com.IvanMurzak.Godot.MCP.UI
             "macOS" => AgentOs.MacOS,
             _ => AgentOs.Linux,
         };
+
+        // No KeepAlive teardown is needed: every signal here is an OBJECT+METHOD Callable (the auto-generate
+        // checkbox connects to its own instance method; the Generate button connects to this panel's instance
+        // method), which is not a ManagedCallable and never enters the native registry the hot-reload iterates.
+        // The target controls are kept alive by the tree and freed with the panel.
     }
 }
 #endif


### PR DESCRIPTION
## Problem
Clicking **Build Project** in the Godot editor hot-reloads the project's C# assembly and floods the log with dozens of:
```
ERROR: csharp_script.cpp:675 - Condition "managed_callable->delegate_handle.value == nullptr" is true. Continuing.
```
(plus a few `gd_mono.cpp:791 Failed to unload assemblies`, godotengine/godot#78513).

## Root cause (source-verified)
Those `delegate_handle null` errors come from `CSharpLanguage::reload_assemblies` iterating the native `ManagedCallable::instances` registry, which holds **only** Callables created from C# **delegates/lambdas** (`signal += handler` / `Callable.From`). The dock connected every signal that way. Callables created from a **Godot Object + method** (`new Callable(owner, MethodName.X)`) never enter that registry.

## Fix
- Rewrote **every** editor-dock signal connection to object+method Callable form. New `UI/DockControls.cs` hosts small `[Tool]` GodotObject helpers carrying the former closure state as instance fields.
- Removed the now-unnecessary `DockStyle.KeepAlive` / `ConditionalWeakTable` delegate-rooting apparatus.
- Added an `AssemblyLoadContext.Unloading` hook (installed from the existing `[ModuleInitializer]`, because `EditorPlugin._ExitTree` is **not** called on a hot-reload) that best-effort disconnects the MCP connection, unsubscribes `AssemblyLoadContext.Default.Resolving`, frees the dock/dispatcher, and clears statics.
- Pure-managed C# `event` subscriptions are untouched (not Godot signals; never caused the flood).

## Verification
Live in-editor **Build Project** in Godot 4.5.1 (real recompile + hot-reload), connected and disconnected:
- `delegate_handle null`: **64 → 0** ✅
- Build clean (0 err), xUnit green.

## Known remaining (not fixable from the addon)
The residual ~6 `Failed to unload assemblies` (#78513) are inherent to a collectible `AssemblyLoadContext` that registers a Godot logger (no managed remove-logger API) plus Godot's own plugin-context refs. Godot logs "Giving up on assembly reloading" and continues normally. Confirmed unrelated to the MCP connection (persists with a fully-drained, healthy connection).

Closes #132