### PR TITLE
fix(addon): restore persisted connection config on first load + Cloud-mode UI parity

### DIFF
--- a/Godot-MCP.Tests/DockThemeTests.cs
+++ b/Godot-MCP.Tests/DockThemeTests.cs
@@ -63,7 +63,7 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             // Bumped above Unity's literal px values: Godot's editor renders a smaller glyph at the same px, so
             // the headers/section-titles looked undersized in the dock. See the DockTheme docs for each.
             Assert.Equal(24, DockTheme.FontSizeHeader);
-            Assert.Equal(18, DockTheme.FontSizeSectionTitle);
+            Assert.Equal(20, DockTheme.FontSizeSectionTitle);
             Assert.Equal(13, DockTheme.FontSizeSubLabel);
         }
 
@@ -86,9 +86,9 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         [Fact]
         public void TokenSubLabel_Palette_MatchesBriefReferenceValues()
         {
-            // "~N tokens total" sub-label: gray rgb(150,150,150). Font bumped 11→13 (Godot renders smaller).
+            // "~N tokens total" sub-label: gray rgb(150,150,150). Font bumped 11→15 (Godot renders smaller; operator polish).
             AssertRgb8(DockTheme.ColorTokenSubLabel, 150, 150, 150);
-            Assert.Equal(13, DockTheme.FontSizeTokenSubLabel);
+            Assert.Equal(15, DockTheme.FontSizeTokenSubLabel);
         }
 
         [Fact]
@@ -139,14 +139,15 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             // track bg rgba(255,255,255, 0.05)
             AssertRgba8(DockTheme.SegmentTrackBackground, 255, 255, 255, 0.05f);
             Assert.Equal(6, DockTheme.SegmentTrackCornerRadius);
-            Assert.Equal(2, DockTheme.SegmentTrackPadding);
+            Assert.Equal(1, DockTheme.SegmentTrackPadding);
         }
 
         [Fact]
         public void SegmentSelected_MatchesBriefRgbaAndSizing()
         {
-            // selected highlight rgba(0,0,0, 0.4)
-            AssertRgba8(DockTheme.SegmentSelectedBackground, 0, 0, 0, 0.4f);
+            // selected highlight: solid lighter-gray raised pill Color8(100,100,100) so the active segment is
+            // clearly distinct from the muted track (was a barely-visible translucent darken).
+            AssertRgba8(DockTheme.SegmentSelectedBackground, 100, 100, 100, 1.0f);
             Assert.Equal(4, DockTheme.SegmentSelectedCornerRadius);
         }
 

--- a/addons/godot_mcp/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConnection.cs
@@ -127,6 +127,15 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         Reflector? _publishedReflector;
 
         /// <summary>
+        /// Guards <see cref="ResolveConfig"/> so the persisted + <c>.env</c> layers are applied to
+        /// <see cref="_config"/> exactly once. Set the first time config is resolved (by <see cref="ResolveConfig"/>,
+        /// called from the plugin boot BEFORE the dock UI is built, or lazily from <see cref="Start"/>), so a later
+        /// <see cref="Start"/> / <see cref="Reconnect"/> re-entry does not re-read the files (and would never clobber
+        /// a live UI edit with the on-disk value mid-session).
+        /// </summary>
+        bool _configResolved;
+
+        /// <summary>
         /// Live subscription to the reused client's <see cref="IConnection.ConnectionState"/> +
         /// <see cref="IConnection.KeepConnected"/> reactive properties. Re-created on every
         /// <see cref="Start"/> (a new plugin instance exposes new properties) and disposed on
@@ -235,17 +244,11 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 return;
             }
 
-            // PRECEDENCE: process env > .env file > persisted config > built-in default.
-            // 1) Seed the SERIALIZED-config layer first (lowest layer above the built-in defaults), so the
-            //    .env and live process-env layers below override it — never the other way around.
-            ApplyPersistedConfig();
-
-            // 2) Layer the project-root `.env` BENEATH the live process-env overrides the config already
-            //    applies in its getters. Godot is launched from the GUI (no inherited shell exports), so a
-            //    committed `res://.env` is how a project self-configures its MCP host/token. Process env
-            //    still wins because GodotMcpConfig reads it live on every Host/Token/ActiveMode access —
-            //    see GodotMcpEnvFile's precedence note.
-            ApplyProjectEnvFile();
+            // Resolve the persisted + .env config layers (idempotent). The plugin boot calls ResolveConfig()
+            // BEFORE building the dock UI so the panels render from the SAVED mode/token/agent rather than the
+            // built-in defaults (the first-load "Cloud token empty / Authorize prompted / wrong agent restored"
+            // bug); this lazy call covers a Start() reached without that pre-step. A no-op once already resolved.
+            ResolveConfig();
 
             Reflector reflector = GodotReflectorFactory.CreateDefaultReflector();
 
@@ -817,6 +820,40 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             {
                 GD.PushError($"[Godot-MCP] disconnect failed: {ex.Message}");
             }
+        }
+
+        /// <summary>
+        /// Apply the config precedence layers — persisted serialized config, then the project-root <c>.env</c> —
+        /// onto <see cref="_config"/>, beneath the live process-env overrides the config getters apply. Idempotent
+        /// and guarded by <see cref="_configResolved"/>: safe to call repeatedly, runs the file reads only once.
+        ///
+        /// <para>
+        /// CRITICAL ORDERING: the plugin boot (<c>GodotMcpPlugin.BootMcp</c>) calls this BEFORE constructing the
+        /// dock so the connection / AI-agent panels read the SAVED connection mode, cloud/custom token, auth
+        /// option, and selected agent at build time — not the built-in defaults. Building the dock first (the old
+        /// order) painted the UI from defaults (Cloud with an EMPTY cloud token → "Authorize" prompt; the
+        /// default <c>claude-code</c> agent instead of the persisted one), and only a later mode-switch — which
+        /// re-reads the by-then-loaded config — "healed" the display. Resolving here first removes that whole
+        /// class of first-load staleness.
+        /// </para>
+        /// </summary>
+        public void ResolveConfig()
+        {
+            if (_configResolved)
+                return;
+            _configResolved = true;
+
+            // PRECEDENCE: process env > .env file > persisted config > built-in default.
+            // 1) Seed the SERIALIZED-config layer first (lowest layer above the built-in defaults), so the
+            //    .env and live process-env layers below override it — never the other way around.
+            ApplyPersistedConfig();
+
+            // 2) Layer the project-root `.env` BENEATH the live process-env overrides the config already
+            //    applies in its getters. Godot is launched from the GUI (no inherited shell exports), so a
+            //    committed `res://.env` is how a project self-configures its MCP host/token. Process env
+            //    still wins because GodotMcpConfig reads it live on every Host/Token/ActiveMode access —
+            //    see GodotMcpEnvFile's precedence note.
+            ApplyProjectEnvFile();
         }
 
         /// <summary>

--- a/addons/godot_mcp/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConnection.cs
@@ -946,13 +946,32 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             try
             {
                 var ok = await plugin.Connect();
+
+                // A Reconnect()/Dispose() may have superseded THIS plugin while its connect was in flight (e.g. a
+                // rapid Custom<->Cloud mode switch). The new plugin drives its own connect — don't report on a
+                // plugin we no longer own.
+                if (!ReferenceEquals(_plugin, plugin))
+                    return;
+
                 if (ok)
                     GD.Print("[Godot-MCP] connected.");
                 else
                     GD.PushWarning("[Godot-MCP] initial connect returned false; client will keep retrying if KeepConnected.");
             }
+            catch (ObjectDisposedException)
+            {
+                // Expected teardown race, NOT a failure: a concurrent Reconnect()/Dispose() disposed this plugin
+                // (and its internal SemaphoreSlim gate) while the connect above was awaiting. The replacement
+                // plugin, if any, runs its own ConnectAsync. Swallow quietly so a fast mode switch does not log a
+                // spurious "connect failed: Cannot access a disposed object." error.
+            }
             catch (Exception ex)
             {
+                // If this plugin was superseded mid-connect, any resulting exception is part of that teardown
+                // race — ignore it; only a failure on the CURRENT plugin is a real connect error.
+                if (!ReferenceEquals(_plugin, plugin))
+                    return;
+
                 GD.PushError($"[Godot-MCP] connect failed: {ex.Message}");
             }
         }

--- a/addons/godot_mcp/GodotMcpPlugin.cs
+++ b/addons/godot_mcp/GodotMcpPlugin.cs
@@ -397,10 +397,24 @@ namespace com.IvanMurzak.Godot.MCP
         /// </summary>
         void FreeNodes()
         {
+            // On a FAILED hot-reload (godotengine/godot#78513 — the collectible ALC could not unload), Godot may
+            // have ALREADY disposed the managed wrappers (this EditorPlugin, the dock, the dispatcher) BEFORE this
+            // ALC-unloading teardown runs. Touching a disposed GodotObject throws ObjectDisposedException — which is
+            // benign here (Godot already freed it), so guard every native access with IsInstanceValid and treat an
+            // ObjectDisposedException as "already gone" rather than logging a spurious teardown ERROR. (This became
+            // observable once the connection actually connects on boot — see GodotMcpConnection.ResolveConfig — so
+            // the unload races a live connection's threads.)
             try
             {
                 if (_dock != null)
                 {
+                    // Skip when Godot has already disposed this plugin or the dock — nothing left for us to free.
+                    if (!GodotObject.IsInstanceValid(this) || !GodotObject.IsInstanceValid(_dock))
+                    {
+                        _dock = null;
+                    }
+                    else
+                    {
                     // Remove from the dock slot before freeing so Godot does not hold a dangling control ref.
                     RemoveControlFromDocks(_dock);
 
@@ -417,21 +431,28 @@ namespace com.IvanMurzak.Godot.MCP
                     // SerializationCheckWindow) are parented under the dock, so this frees them too.
                     _dock.Free();
                     _dock = null;
+                    }
                 }
             }
+            catch (System.ObjectDisposedException) { _dock = null; /* Godot already disposed the plugin/dock during the failed unload — benign. */ }
             catch (System.Exception ex) { TryLogTeardownError("dock free", ex); }
 
             try
             {
                 if (_dispatcher != null)
                 {
-                    // Synchronous free for the same reason as the dock: the dispatcher pumps main-thread work
-                    // and holds registered per-tick delegates; freeing it deterministically here ensures no
-                    // dispatcher-rooted managed state survives into the unload.
-                    _dispatcher.Free();
+                    // Skip when Godot has already disposed the dispatcher — nothing left for us to free.
+                    if (GodotObject.IsInstanceValid(_dispatcher))
+                    {
+                        // Synchronous free for the same reason as the dock: the dispatcher pumps main-thread work
+                        // and holds registered per-tick delegates; freeing it deterministically here ensures no
+                        // dispatcher-rooted managed state survives into the unload.
+                        _dispatcher.Free();
+                    }
                     _dispatcher = null;
                 }
             }
+            catch (System.ObjectDisposedException) { _dispatcher = null; /* already disposed by Godot's unload — benign. */ }
             catch (System.Exception ex) { TryLogTeardownError("dispatcher free", ex); }
 
             // No KeepAlive sweep is needed anymore: every dock signal connection is an OBJECT+METHOD Callable

--- a/addons/godot_mcp/GodotMcpPlugin.cs
+++ b/addons/godot_mcp/GodotMcpPlugin.cs
@@ -178,6 +178,15 @@ namespace com.IvanMurzak.Godot.MCP
             try
             {
                 _connection = new GodotMcpConnection();
+
+                // Resolve the persisted + .env config layers BEFORE building the dock UI. The connection /
+                // AI-agent panels read the config at construction time, so the saved connection mode, cloud/
+                // custom token, auth option, and selected agent must already be loaded — otherwise the dock
+                // paints from built-in defaults (Cloud with an EMPTY cloud token → spurious "Authorize" prompt;
+                // the default agent instead of the persisted one) until a later mode-switch heals it. See
+                // GodotMcpConnection.ResolveConfig. Start() re-calls it idempotently (guarded), so this is the
+                // single source of the first-load config; a resolve failure must not block dock/boot.
+                _connection.ResolveConfig();
             }
             catch (System.Exception ex)
             {

--- a/addons/godot_mcp/UI/Agents/AgentConfiguratorsPanel.cs
+++ b/addons/godot_mcp/UI/Agents/AgentConfiguratorsPanel.cs
@@ -201,7 +201,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 headerRow.AddChild(icon);
 
             var headerCol = new VBoxContainer { Name = "AgentHeaderCol", SizeFlagsHorizontal = SizeFlags.ExpandFill };
-            headerCol.AddThemeConstantOverride("separation", 0); // tight: name directly over the Download/Tutorial links
+            headerCol.AddThemeConstantOverride("separation", -3); // pull the Download/Tutorial links up snug under the agent name
             headerRow.AddChild(headerCol);
 
             // Agent name (Unity's `agentName` section-title, 16px). Mirrors Unity, which shows the selected agent's

--- a/addons/godot_mcp/UI/ConnectionPanel.cs
+++ b/addons/godot_mcp/UI/ConnectionPanel.cs
@@ -148,6 +148,14 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// <summary>Re-sync cadence: re-read + re-apply the live connection status this often (seconds).</summary>
         const double ResyncIntervalSeconds = 0.5;
 
+        /// <summary>
+        /// Vertical offset (px) that drops a timeline status dot down so its CENTER lines up with the middle of the
+        /// underlined point label next to it. Derived from the label/dot sizes — roughly
+        /// (underlined-label line height − dot diameter) / 2 — so it tracks <see cref="DockTheme.FontSizeUnderlinedLabel"/>
+        /// (a bigger label needs a larger drop). Tuned live against the dock.
+        /// </summary>
+        const int TimelineCircleTopOffset = 7;
+
         public ConnectionPanel(GodotMcpConnection connection)
         {
             _connection = connection;
@@ -280,7 +288,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             godotContent.AddChild(_godotUnderline);
             godotContent.AddChild(new Control { SizeFlagsHorizontal = SizeFlags.ExpandFill });
             godotContent.AddChild(_connectButton);
-            timeline.AddChild(MakeTimelinePoint(_timelineGodotCircle, godotContent, isLast: false, circleTopOffset: 4));
+            timeline.AddChild(MakeTimelinePoint(_timelineGodotCircle, godotContent, isLast: false, circleTopOffset: TimelineCircleTopOffset));
 
             // Point 2 — MCP server: a frame-group card with the server URL / cloud auth + authorization rows.
             _timelineServerCircle = DockStyle.TimelineCircle("ServerCircle", ConnectionPanelView.TimelinePointState.Disconnected);
@@ -290,7 +298,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             // rectangle, like Unity's frame-mcp-server. The server circle is offset down to line up with it.
             BuildServerCard(serverContent);
             _serverTimelinePoint = MakeTimelinePoint(_timelineServerCircle, serverContent, isLast: false,
-                circleTopOffset: DockTheme.CardMargin + DockTheme.CardContentPadding + 3);
+                circleTopOffset: DockTheme.CardMargin + DockTheme.CardContentPadding + TimelineCircleTopOffset);
             timeline.AddChild(_serverTimelinePoint);
 
             // Point 3 — AI agent: circle + label, LAST point (no connecting line below).
@@ -304,7 +312,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             DockStyle.ApplyDescription(_agentLabel);
             _agentLabel.AutowrapMode = TextServer.AutowrapMode.Off; // single line — never wrap to one char per line in the narrow row
             agentContent.AddChild(_agentLabel);
-            timeline.AddChild(MakeTimelinePoint(_timelineAgentCircle, agentContent, isLast: true, circleTopOffset: 4));
+            timeline.AddChild(MakeTimelinePoint(_timelineAgentCircle, agentContent, isLast: true, circleTopOffset: TimelineCircleTopOffset));
         }
 
         /// <summary>

--- a/addons/godot_mcp/UI/ConnectionPanel.cs
+++ b/addons/godot_mcp/UI/ConnectionPanel.cs
@@ -72,6 +72,12 @@ namespace com.IvanMurzak.Godot.MCP.UI
         Panel _timelineServerCircle = null!;
         Panel _timelineAgentCircle = null!;
 
+        // The MCP-server timeline point (circle + server card), captured so the WHOLE point can be hidden in
+        // Cloud mode. The Unity gold reference shows NO "MCP server" point in Cloud — just the Godot connection
+        // status + the AI-agent point (the cloud token/Authorize row lives above the timeline, under the header).
+        // The MCP-server point (Server URL, Start, Transport, Authorization) is Custom-mode only.
+        HBoxContainer _serverTimelinePoint = null!;
+
         // Godot point: the underlined "Godot" label (now carries the status — "Godot" / "Godot: connecting..." /
         // "Godot: connected") + a single Connect/Stop toggle button.
         PanelContainer _godotUnderline = null!;
@@ -250,6 +256,11 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 () => _connection.Connect());
             AddChild(_connectionRequiredAlert);
 
+            // --- Cloud-mode auth row (masked token + Revoke/Authorize), DIRECTLY under the header and ABOVE
+            //     the timeline (Unity gold reference). Shown only in Cloud mode; in Cloud the MCP-server
+            //     timeline point is hidden entirely, so this row must NOT live inside the server card. ---
+            BuildCloudAuthRow();
+
             // --- Vertical timeline: Godot -> MCP server -> AI agent ---
             var timeline = new VBoxContainer { Name = "Timeline" };
             timeline.AddThemeConstantOverride("separation", 0);
@@ -278,8 +289,9 @@ namespace com.IvanMurzak.Godot.MCP.UI
             // The "MCP server" label now lives INSIDE the card (see BuildServerCard) so it's framed by the rounded
             // rectangle, like Unity's frame-mcp-server. The server circle is offset down to line up with it.
             BuildServerCard(serverContent);
-            timeline.AddChild(MakeTimelinePoint(_timelineServerCircle, serverContent, isLast: false,
-                circleTopOffset: DockTheme.CardMargin + DockTheme.CardContentPadding + 3));
+            _serverTimelinePoint = MakeTimelinePoint(_timelineServerCircle, serverContent, isLast: false,
+                circleTopOffset: DockTheme.CardMargin + DockTheme.CardContentPadding + 3);
+            timeline.AddChild(_serverTimelinePoint);
 
             // Point 3 — AI agent: circle + label, LAST point (no connecting line below).
             _timelineAgentCircle = DockStyle.TimelineCircle("AgentCircle", ConnectionPanelView.TimelinePointState.Disconnected);
@@ -392,14 +404,34 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
             _localServerRow.AddChild(serverLine);
 
-            // --- Cloud-mode auth section (shown only in Cloud mode): device-code login ---
-            _cloudAuthRow = new VBoxContainer { Name = "CloudAuthRow" };
+            // --- Env/.env override note (shown when a process env / .env value forces mode or host) ---
+            _overrideNote = new Label
+            {
+                Name = "OverrideNote",
+                Text = "Overridden by environment (GODOT_MCP_*) — UI changes won't take effect.",
+                AutowrapMode = TextServer.AutowrapMode.WordSmart
+            };
+            _overrideNote.AddThemeColorOverride("font_color", new Color(0.92f, 0.74f, 0.20f));
+            card.AddChild(_overrideNote);
+
+            // The MCP-server config IS wrapped in the blue frame-group card — this is one of the only two frames
+            // the dock keeps (Unity's `frame-mcp-server`). The Server URL row inside is now inline (label + input).
+            parent.AddChild(DockStyle.Card(card, "Server"));
+        }
+
+        /// <summary>
+        /// Build the Cloud-mode auth row — masked cloud token field + Revoke/Authorize + a status line — and add
+        /// it DIRECTLY to the panel, under the header and above the timeline (Unity gold reference). Shown only in
+        /// Cloud mode (toggled by <see cref="ApplyModeVisibility"/>). It deliberately lives OUTSIDE the MCP-server
+        /// card because in Cloud mode that entire timeline point is hidden — the cloud token UI must survive.
+        /// </summary>
+        void BuildCloudAuthRow()
+        {
+            _cloudAuthRow = new VBoxContainer { Name = "CloudAuthRow", SizeFlagsHorizontal = SizeFlags.ExpandFill };
             _cloudAuthRow.AddThemeConstantOverride("separation", 4);
-            card.AddChild(_cloudAuthRow);
+            AddChild(_cloudAuthRow);
 
-            _cloudAuthRow.AddChild(new Label { Name = "CloudTokenLabel", Text = "Cloud Token" });
-
-            var cloudTokenLine = new HBoxContainer { Name = "CloudTokenLine" };
+            var cloudTokenLine = new HBoxContainer { Name = "CloudTokenLine", SizeFlagsHorizontal = SizeFlags.ExpandFill };
             _cloudAuthRow.AddChild(cloudTokenLine);
 
             _cloudTokenField = new LineEdit
@@ -414,34 +446,33 @@ namespace com.IvanMurzak.Godot.MCP.UI
             };
             cloudTokenLine.AddChild(_cloudTokenField);
 
-            _authorizeButton = new Button { Name = "AuthorizeButton", Text = ConnectionPanelView.AuthorizeButtonText };
-            DockStyle.ConnectPressed(_authorizeButton, this, MethodName.OnAuthorizeButtonPressed);
-            cloudTokenLine.AddChild(_authorizeButton);
-
             _revokeButton = new Button { Name = "RevokeButton", Text = "Revoke" };
             DockStyle.ConnectPressed(_revokeButton, this, MethodName.OnRevokeButtonPressed);
             cloudTokenLine.AddChild(_revokeButton);
 
+            _authorizeButton = new Button { Name = "AuthorizeButton", Text = ConnectionPanelView.AuthorizeButtonText };
+            DockStyle.ConnectPressed(_authorizeButton, this, MethodName.OnAuthorizeButtonPressed);
+            cloudTokenLine.AddChild(_authorizeButton);
+
             _cloudAuthStatus = new Label
             {
                 Name = "CloudAuthStatus",
-                AutowrapMode = TextServer.AutowrapMode.WordSmart
+                AutowrapMode = TextServer.AutowrapMode.WordSmart,
+                Visible = false // hidden until there's a message — an empty label would otherwise reserve a line and
+                                // open a large gap between the token row and the timeline in Cloud mode.
             };
             _cloudAuthRow.AddChild(_cloudAuthStatus);
+        }
 
-            // --- Env/.env override note (shown when a process env / .env value forces mode or host) ---
-            _overrideNote = new Label
-            {
-                Name = "OverrideNote",
-                Text = "Overridden by environment (GODOT_MCP_*) — UI changes won't take effect.",
-                AutowrapMode = TextServer.AutowrapMode.WordSmart
-            };
-            _overrideNote.AddThemeColorOverride("font_color", new Color(0.92f, 0.74f, 0.20f));
-            card.AddChild(_overrideNote);
-
-            // The MCP-server config IS wrapped in the blue frame-group card — this is one of the only two frames
-            // the dock keeps (Unity's `frame-mcp-server`). The Server URL row inside is now inline (label + input).
-            parent.AddChild(DockStyle.Card(card, "Server"));
+        /// <summary>
+        /// Set the Cloud-auth status line text and collapse the label when the text is empty (so an empty status
+        /// does not reserve a blank line that pushes the timeline down in Cloud mode). Single sink for every
+        /// status update (device-auth flow, revoke, server rejection).
+        /// </summary>
+        void SetCloudAuthStatusText(string text)
+        {
+            _cloudAuthStatus.Text = text;
+            _cloudAuthStatus.Visible = !string.IsNullOrEmpty(text);
         }
 
         /// <summary>
@@ -781,6 +812,10 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 _modeSegmented,
                 SegmentedControlModel.IndexOf(ModeOptions, ModeLabelForMode(persistedMode)));
 
+            // The ENTIRE MCP-server timeline point (circle + Server URL / Start / Transport / Authorization card)
+            // is Custom-mode only. In Cloud mode it is hidden, leaving the timeline as Godot -> AI agent and the
+            // cloud token/Authorize row (above the timeline) as the only server-side UI (Unity gold reference).
+            _serverTimelinePoint.Visible = persistedCustom;
             _customHostRow.Visible = persistedCustom;
             _cloudAuthRow.Visible = !persistedCustom;
 
@@ -901,7 +936,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 return;
 
             // Status line. UserCode is safe to show; the access token never reaches this string.
-            _cloudAuthStatus.Text = ConnectionPanelView.CloudAuthStatusMessage(state, flow.UserCode, flow.ErrorMessage);
+            SetCloudAuthStatusText(ConnectionPanelView.CloudAuthStatusMessage(state, flow.UserCode, flow.ErrorMessage));
             _authorizeButton.Text = ConnectionPanelView.CloudAuthButtonText(state);
 
             // Open the verification URL so the user can approve in the browser.
@@ -959,7 +994,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         {
             _connection.Config.CloudToken = null;
             _connection.Save();
-            _cloudAuthStatus.Text = "Token revoked.";
+            SetCloudAuthStatusText("Token revoked.");
             ApplyCloudAuthState();
             ApplyAlertVisibility(_connection.ConnectionStatus);
 
@@ -981,7 +1016,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
             _connection.Config.CloudToken = null;
             _connection.Save();
-            _cloudAuthStatus.Text = "Authorization rejected by server — press Authorize.";
+            SetCloudAuthStatusText("Authorization rejected by server — press Authorize.");
             ApplyCloudAuthState();
             ApplyAlertVisibility(_connection.ConnectionStatus);
 

--- a/addons/godot_mcp/UI/ConnectionPanel.cs
+++ b/addons/godot_mcp/UI/ConnectionPanel.cs
@@ -154,7 +154,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// (underlined-label line height − dot diameter) / 2 — so it tracks <see cref="DockTheme.FontSizeUnderlinedLabel"/>
         /// (a bigger label needs a larger drop). Tuned live against the dock.
         /// </summary>
-        const int TimelineCircleTopOffset = 7;
+        const int TimelineCircleTopOffset = 13;
 
         public ConnectionPanel(GodotMcpConnection connection)
         {

--- a/addons/godot_mcp/UI/DockStyle.cs
+++ b/addons/godot_mcp/UI/DockStyle.cs
@@ -324,7 +324,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// </summary>
         static void ApplyCompactButtonBase(Button button, Color normal, Color hover)
         {
-            ApplyButtonBackground(button, normal, hover, DockTheme.ButtonSecondaryCornerRadius, hMargin: 8, vMargin: 2);
+            ApplyButtonBackground(button, normal, hover, DockTheme.ButtonSecondaryCornerRadius, hMargin: 8, vMargin: 1);
             button.AddThemeFontSizeOverride("font_size", DockTheme.FontSizeCompactButton);
             button.CustomMinimumSize = new Vector2(0, DockTheme.ButtonSecondaryHeight);
         }

--- a/addons/godot_mcp/UI/DockStyle.cs
+++ b/addons/godot_mcp/UI/DockStyle.cs
@@ -324,7 +324,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// </summary>
         static void ApplyCompactButtonBase(Button button, Color normal, Color hover)
         {
-            ApplyButtonBackground(button, normal, hover, DockTheme.ButtonSecondaryCornerRadius, hMargin: 8, vMargin: 1);
+            ApplyButtonBackground(button, normal, hover, DockTheme.ButtonSecondaryCornerRadius, hMargin: 8, vMargin: 0);
             button.AddThemeFontSizeOverride("font_size", DockTheme.FontSizeCompactButton);
             button.CustomMinimumSize = new Vector2(0, DockTheme.ButtonSecondaryHeight);
         }
@@ -747,7 +747,10 @@ namespace com.IvanMurzak.Godot.MCP.UI
                     Name = "Segment" + i,
                     Text = options[i],
                     ToggleMode = true,
-                    Flat = true,
+                    // Flat=false so the overridden "normal" stylebox actually DRAWS — a flat button suppresses its
+                    // background, which is why the ACTIVE segment's highlight pill never showed. Unselected segments
+                    // override to a transparent box, so only the selected one paints its pill.
+                    Flat = false,
                     CustomMinimumSize = new Vector2(DockTheme.SegmentMinWidth, 0)
                 };
                 // Carry the per-segment click state on the segment instance (index + the track it reports into +
@@ -825,8 +828,8 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 box.SetCornerRadiusAll(DockTheme.SegmentSelectedCornerRadius);
                 box.ContentMarginLeft = 8;
                 box.ContentMarginRight = 8;
-                box.ContentMarginTop = 2;
-                box.ContentMarginBottom = 2;
+                box.ContentMarginTop = 1;
+                box.ContentMarginBottom = 1;
                 segment.AddThemeStyleboxOverride("normal", box);
                 segment.AddThemeStyleboxOverride("hover", box);
                 segment.AddThemeStyleboxOverride("pressed", box);
@@ -848,8 +851,8 @@ namespace com.IvanMurzak.Godot.MCP.UI
                     box.SetCornerRadiusAll(DockTheme.SegmentSelectedCornerRadius);
                     box.ContentMarginLeft = 8;
                     box.ContentMarginRight = 8;
-                    box.ContentMarginTop = 2;
-                    box.ContentMarginBottom = 2;
+                    box.ContentMarginTop = 1;
+                    box.ContentMarginBottom = 1;
                     return box;
                 }
                 segment.AddThemeStyleboxOverride("normal", Transparent());

--- a/addons/godot_mcp/UI/DockTheme.cs
+++ b/addons/godot_mcp/UI/DockTheme.cs
@@ -56,7 +56,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         public const int FontSizeHeader = 24;
 
         /// <summary>Section-title font size (px) — bold (e.g. "MCP Features", the agent name, extension names).</summary>
-        public const int FontSizeSectionTitle = 18;
+        public const int FontSizeSectionTitle = 20;
 
         /// <summary>Timeline / sub-label font size (px) — bold.</summary>
         public const int FontSizeSubLabel = 13;
@@ -72,21 +72,21 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
         /// <summary>The MCP-features token sub-label font size (px) — the "~N tokens total" line. Bumped above
         /// Unity's literal 11px because Godot's editor renders a larger base font, so 11px looked tiny here.</summary>
-        public const int FontSizeTokenSubLabel = 13;
+        public const int FontSizeTokenSubLabel = 15;
 
         /// <summary>Compact-button font size (px) — Unity's <c>.btn-compact</c> (Configure / Reconfigure / Remove /
         /// Generate). Small so the buttons stay ~20px tall.</summary>
-        public const int FontSizeCompactButton = 12;
+        public const int FontSizeCompactButton = 14;
 
         /// <summary>Underlined section labels (Skills / Model Context Protocol / the connection timeline points
         /// "Godot" / "MCP server" / "AI agent"). Bold; larger than Unity's literal 13px to read well in Godot.</summary>
-        public const int FontSizeUnderlinedLabel = 16;
+        public const int FontSizeUnderlinedLabel = 18;
 
         /// <summary>The right-aligned config/skills PATH font size (px) — smaller than its header so the path is quiet.</summary>
         public const int FontSizeConfigPath = 14;
 
         /// <summary>Inline link font size (px) — the "Download" / "Tutorial" agent links. Smaller than the body.</summary>
-        public const int FontSizeLink = 15;
+        public const int FontSizeLink = 17;
 
         // --- Status dot (Unity _status-indicators.uss) ---------------------------------------------------------
 
@@ -131,8 +131,9 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// <summary>Compact / secondary button corner radius (px).</summary>
         public const int ButtonSecondaryCornerRadius = 4;
 
-        /// <summary>Compact / secondary button height (px).</summary>
-        public const int ButtonSecondaryHeight = 20;
+        /// <summary>Compact / secondary button height (px). Trimmed so the compact action buttons (Configure /
+        /// Reconfigure / Remove / Generate / Stop / Revoke / Authorize) read shorter with the larger compact font.</summary>
+        public const int ButtonSecondaryHeight = 18;
 
         /// <summary>Alert / Remove button background — dark-red <c>Color8(88,44,44)</c> (hover brightens to red).</summary>
         public static readonly (float R, float G, float B) ButtonAlert = (88f / 255f, 44f / 255f, 44f / 255f);

--- a/addons/godot_mcp/UI/DockTheme.cs
+++ b/addons/godot_mcp/UI/DockTheme.cs
@@ -76,11 +76,11 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
         /// <summary>Compact-button font size (px) — Unity's <c>.btn-compact</c> (Configure / Reconfigure / Remove /
         /// Generate). Small so the buttons stay ~20px tall.</summary>
-        public const int FontSizeCompactButton = 14;
+        public const int FontSizeCompactButton = 15;
 
         /// <summary>Underlined section labels (Skills / Model Context Protocol / the connection timeline points
         /// "Godot" / "MCP server" / "AI agent"). Bold; larger than Unity's literal 13px to read well in Godot.</summary>
-        public const int FontSizeUnderlinedLabel = 18;
+        public const int FontSizeUnderlinedLabel = 21;
 
         /// <summary>The right-aligned config/skills PATH font size (px) — smaller than its header so the path is quiet.</summary>
         public const int FontSizeConfigPath = 14;
@@ -133,7 +133,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
         /// <summary>Compact / secondary button height (px). Trimmed so the compact action buttons (Configure /
         /// Reconfigure / Remove / Generate / Stop / Revoke / Authorize) read shorter with the larger compact font.</summary>
-        public const int ButtonSecondaryHeight = 18;
+        public const int ButtonSecondaryHeight = 14;
 
         /// <summary>Alert / Remove button background — dark-red <c>Color8(88,44,44)</c> (hover brightens to red).</summary>
         public static readonly (float R, float G, float B) ButtonAlert = (88f / 255f, 44f / 255f, 44f / 255f);
@@ -253,16 +253,19 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// <summary>Segmented-control track corner radius (px).</summary>
         public const int SegmentTrackCornerRadius = 6;
 
-        /// <summary>Segmented-control track inner padding (px) around the segments.</summary>
-        public const int SegmentTrackPadding = 2;
+        /// <summary>Segmented-control track inner padding (px) around the segments. Tight so the Custom/Cloud
+        /// toggle reads short, not a chunky tall pill.</summary>
+        public const int SegmentTrackPadding = 1;
 
-        /// <summary>SELECTED-segment highlight background — <c>rgba(0,0,0, 0.4)</c> (the dark pill under the active segment).</summary>
-        public static readonly (float R, float G, float B, float A) SegmentSelectedBackground = (0f, 0f, 0f, 0.4f);
+        /// <summary>SELECTED-segment highlight background — a solid lighter-gray raised pill
+        /// <c>Color8(100,100,100)</c> so the ACTIVE segment (Custom / Cloud) is clearly distinct from the muted
+        /// track, not a barely-visible translucent darken.</summary>
+        public static readonly (float R, float G, float B, float A) SegmentSelectedBackground = (100f / 255f, 100f / 255f, 100f / 255f, 1f);
 
         /// <summary>Selected-segment highlight corner radius (px).</summary>
         public const int SegmentSelectedCornerRadius = 4;
 
-        /// <summary>Selected-segment text colour — cyan <c>Color8(175,232,230)</c> (reuses the primary cyan).</summary>
+        /// <summary>Selected-segment text colour — light cyan on the lighter active pill (on-theme "active" accent).</summary>
         public static readonly (float R, float G, float B) SegmentSelectedText = ButtonPrimary;
 
         /// <summary>Unselected-segment text colour — muted gray (reuses the description muted gray).</summary>

--- a/addons/godot_mcp/UI/FeatureRow.cs
+++ b/addons/godot_mcp/UI/FeatureRow.cs
@@ -59,8 +59,9 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 SizeFlagsHorizontal = SizeFlags.ExpandFill,
                 SizeFlagsVertical = SizeFlags.ShrinkBegin
             };
-            // Tight: the "~N tokens total" sub-label hugs the count header directly above it (no gap).
-            leftColumn.AddThemeConstantOverride("separation", 0);
+            // Pull the "~N tokens total" sub-label up tight under the count header (negative separation halves the
+            // intrinsic line gap between the 24px header and the 15px sub-label).
+            leftColumn.AddThemeConstantOverride("separation", -4);
             AddChild(leftColumn);
 
             _countLabel = new Label

--- a/addons/godot_mcp/UI/FeatureRow.cs
+++ b/addons/godot_mcp/UI/FeatureRow.cs
@@ -59,7 +59,8 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 SizeFlagsHorizontal = SizeFlags.ExpandFill,
                 SizeFlagsVertical = SizeFlags.ShrinkBegin
             };
-            leftColumn.AddThemeConstantOverride("separation", 2);
+            // Tight: the "~N tokens total" sub-label hugs the count header directly above it (no gap).
+            leftColumn.AddThemeConstantOverride("separation", 0);
             AddChild(leftColumn);
 
             _countLabel = new Label

--- a/addons/godot_mcp/UI/GodotMcpDock.cs
+++ b/addons/godot_mcp/UI/GodotMcpDock.cs
@@ -232,7 +232,9 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 Name = "Body",
                 SizeFlagsHorizontal = SizeFlags.ExpandFill
             };
-            Body.AddThemeConstantOverride("separation", 8);
+            // Wider separation so the dark 1px section dividers (Connection / AI agent / MCP features / …) get
+            // visible breathing room above and below — the sections read as distinct bands, not a dense stack.
+            Body.AddThemeConstantOverride("separation", 14);
             content.AddChild(Body);
 
             // Connection + AI-agent + MCP-features sections — only when a live connection was threaded in.

--- a/addons/godot_mcp/UI/SupportFooter.cs
+++ b/addons/godot_mcp/UI/SupportFooter.cs
@@ -35,8 +35,9 @@ namespace com.IvanMurzak.Godot.MCP.UI
     [Tool]
     public partial class SupportFooter : VBoxContainer
     {
-        // Footer text size — the "Found an issue?" prompt, the thanks paragraph, and the sign-off.
-        const int FooterFontSize = 16;
+        // Footer text size — the "Found an issue?" prompt, the thanks paragraph, and the sign-off. Normal body
+        // size (was an undersized 16) so the footer reads at the same scale as the rest of the dock.
+        const int FooterFontSize = 18;
 
         public SupportFooter()
         {
@@ -90,6 +91,9 @@ namespace com.IvanMurzak.Godot.MCP.UI
             };
             thanks.AddThemeFontSizeOverride("normal_font_size", FooterFontSize);
             thanks.AddThemeFontSizeOverride("bold_font_size", FooterFontSize);
+            // Strip the editor theme's default RichTextLabel panel background so the thanks paragraph blends with
+            // the dock instead of sitting in a custom-coloured text box.
+            thanks.AddThemeStyleboxOverride("normal", new StyleBoxEmpty());
             AddChild(thanks);
 
             // --- Sign-off + Gold "GitHub Star" on ONE row: "Sincerely, Ivan Murzak" on the LEFT and the star


### PR DESCRIPTION
## Problem (reported by operator)
1. Switching Custom↔Cloud appeared to do nothing — Cloud still used the Custom/localhost URL.
2. The AI-agent section did not refresh on a connection-type switch.
3. On first open: Cloud shown but cloud token EMPTY (spurious Authorize prompt), wrong AI agent restored.

## Root cause
`GodotMcpPlugin.BootMcp()` built the dock (which reads `GodotMcpConfig` at construction) BEFORE
`GodotMcpConnection.Start()` loaded the persisted config + `.env` into that same object. The dock
painted from built-in DEFAULTS; only a later mode-switch re-read the loaded config and "healed" it.

## Fix
- **Boot ordering** — extract `GodotMcpConnection.ResolveConfig()` (idempotent/guarded) and call it
  BEFORE `RegisterDock()`, so panels render from the saved mode/token/agent. The existing
  `ConfigChanged → AgentConfiguratorsPanel.Refresh()` wiring then works against the correct panel.
- **Cloud-mode UI parity** — hide the entire "MCP server" timeline point in Cloud mode (Unity gold
  reference: Cloud shows only Godot status + AI agent, with the cloud token/Authorize row under the
  header). The server point is Custom-only. Cloud-auth status collapses when empty.
- **Typography & spacing polish** — first pass (sizes still under operator review).

## Verification (live, via dev-control bridge)
- Fresh boot restores Cloud + cloud token + GitHub Copilot CLI and connects to ai-game.dev — no
  Authorize prompt.
- Custom↔Cloud switch re-points the connection AND refreshes the AI-agent section (status flips
  Configured ↔ Not configured, Reconfiguration Required alert appears/clears).
- Cloud/Custom layout matches the gold reference screenshots.
- `dev_control_smoke.py`: **57 passed, 0 failed**. xUnit: **791 passed** (1 unrelated pre-existing
  ALC temp-file-lock flake in `GodotAssemblyUtilsTests`).

> Note: typography/spacing amounts are being iterated with the operator; follow-up commits may nudge
> sizes before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)