### PR TITLE
fix(reload): remove the engine Logger ALC pin on teardown (partial godot#78513)

### DIFF
--- a/addons/godot_mcp/GodotMcpPlugin.cs
+++ b/addons/godot_mcp/GodotMcpPlugin.cs
@@ -358,11 +358,22 @@ namespace com.IvanMurzak.Godot.MCP
             //    always run.
             if (MainThreadDispatcher.IsMainThread)
             {
+                // Remove the engine error Logger (4.5+) registered in _EnterTree via OS.AddLogger. THIS is the
+                // godotengine/godot#78513 fix: the engine holds a strong handle to a GodotObject defined in the
+                // COLLECTIBLE addon assembly, which roots the hot-reload ALC and makes its unload fail with the
+                // ".NET: Failed to unload assemblies" flood. OS.RemoveLogger is an engine call and MUST run on
+                // the main thread (mirroring OS.AddLogger), so it lives inside this main-thread guard. Uninstall
+                // is idempotent + defensive (swallows removal failure) and also clears ScriptErrorCapture.Current.
+                try { GodotScriptErrorLoggerBridge.Uninstall(); }
+                catch (System.Exception ex) { TryLogTeardownError("engine-logger uninstall", ex); }
+
                 FreeNodes();
             }
             else
             {
-                TryLog("[Godot-MCP] teardown ran off the main thread; skipping Node.Free (connection torn down).");
+                // Off-thread teardown skips OS.RemoveLogger (an engine call). Acceptable: the #78513 ALC-unload
+                // path is always main-thread, so the logger is always removed before an unload that matters.
+                TryLog("[Godot-MCP] teardown ran off the main thread; skipping Node.Free + engine-logger remove (connection torn down).");
             }
 
             TryLog("[Godot-MCP] plugin unloaded");
@@ -370,9 +381,11 @@ namespace com.IvanMurzak.Godot.MCP
             // 5) Null the process-wide statics so a stale buffer/router/hook does not outlive this instance.
             try { GodotLogCollector.Current = null; } catch { /* swallow during unload */ }
 
-            // Drop the engine error-capture router. The registered Godot Logger (4.5+) stays in the engine's
-            // logger list (no managed remove API), but clearing Current stops validation sessions leaking
-            // across a reload and lets the router be GC-eligible once the engine drops it.
+            // Drop the engine error-capture router unconditionally. On 4.5+ the main-thread guard above already
+            // called GodotScriptErrorLoggerBridge.Uninstall() (which removes the engine Logger via
+            // OS.RemoveLogger AND nulls Current); this pure-managed re-clear is a belt-and-suspenders that also
+            // covers the off-thread teardown path (where RemoveLogger is skipped) so a stale validation session
+            // never leaks across a reload regardless of which thread tore the plugin down.
             try { ScriptErrorCapture.Current = null; } catch { /* swallow during unload */ }
 
             // Release the static reload hook so a torn-down instance is not reachable from the resolver and

--- a/addons/godot_mcp/Tools/GodotScriptErrorLogger.Stub.cs
+++ b/addons/godot_mcp/Tools/GodotScriptErrorLogger.Stub.cs
@@ -28,6 +28,12 @@ namespace com.IvanMurzak.Godot.MCP.Tools
     {
         /// <summary>No-op on Godot &lt; 4.5; always returns null. (Signature matches the 4.5+ bridge.)</summary>
         public static ScriptErrorCapture? TryInstall(GodotLogCollector collector) => null;
+
+        /// <summary>
+        /// No-op on Godot &lt; 4.5 (nothing was installed, so there is nothing to remove). Matches the 4.5+
+        /// bridge signature so <c>GodotMcpPlugin.Teardown</c> compiles on the SDK floor. Idempotent.
+        /// </summary>
+        public static void Uninstall() { }
     }
 }
 #endif

--- a/addons/godot_mcp/Tools/GodotScriptErrorLogger.cs
+++ b/addons/godot_mcp/Tools/GodotScriptErrorLogger.cs
@@ -89,6 +89,14 @@ namespace com.IvanMurzak.Godot.MCP.Tools
     /// </summary>
     public static class GodotScriptErrorLoggerBridge
     {
+        // The Logger we registered with OS.AddLogger, retained so Uninstall can hand the SAME instance to
+        // OS.RemoveLogger on teardown. The engine holds a strong native+managed handle to this object; that
+        // handle is what roots the collectible AssemblyLoadContext (the logger type is DEFINED in the
+        // collectible addon assembly), so leaving it registered makes the hot-reload ALC unload fail with the
+        // godotengine/godot#78513 ".NET: Failed to unload assemblies" flood. Static field => one registration
+        // per loaded assembly, which matches the single boot-time TryInstall.
+        static GodotScriptErrorLogger? _installed;
+
         /// <summary>
         /// Install the engine-error logger and return the router it feeds. The router's <see cref="ScriptErrorCapture.LogSink"/>
         /// is wired to <paramref name="collector"/> so passive engine errors land in <c>console-get-logs</c>.
@@ -108,8 +116,64 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             var logger = new GodotScriptErrorLogger(capture);
             OS.AddLogger(logger); // static API in GodotSharp 4.5
 
+            _installed = logger; // retain so Uninstall() can remove the exact same instance
             ScriptErrorCapture.Current = capture;
             return capture;
+        }
+
+        /// <summary>
+        /// Reverse <see cref="TryInstall"/>: remove the registered <see cref="Logger"/> from the engine via
+        /// <see cref="OS.RemoveLogger(Logger)"/> (a public static API in GodotSharp 4.5+ — see
+        /// <c>GodotSharp.xml</c> "Remove a custom logger added by OS.AddLogger"), then free the logger's native
+        /// counterpart and clear the router. This drops the engine's strong handle to a GodotObject defined in
+        /// the collectible addon assembly, which is what lets the hot-reload ALC actually unload (closing the
+        /// godotengine/godot#78513 ".NET: Failed to unload assemblies" flood on Alt+B rebuild).
+        ///
+        /// <para>
+        /// MAIN-THREAD ONLY: <see cref="OS.RemoveLogger"/> is an engine call and mirrors the
+        /// <see cref="OS.AddLogger"/> in <c>GodotMcpPlugin._EnterTree</c>; the caller must invoke this from the
+        /// editor main thread (the #78513 ALC-unload path always is). Idempotent (safe to call when nothing is
+        /// installed, and safe to call twice) and defensive (a removal failure is swallowed — teardown must not
+        /// crash).
+        /// </para>
+        /// </summary>
+        public static void Uninstall()
+        {
+            var logger = _installed;
+            _installed = null;
+
+            if (logger != null)
+            {
+                // RemoveLogger drops the engine's reference; Free() then releases the native counterpart so its
+                // native handle cannot keep re-pinning the collectible ALC. Both are best-effort — a throw here
+                // must not abort the rest of teardown (the connection/dock are already being torn down).
+                try
+                {
+                    OS.RemoveLogger(logger); // static API in GodotSharp 4.5+
+                }
+                catch (Exception)
+                {
+                    // Swallow: removal failing must not crash teardown. Worst case the logger stays registered
+                    // and the #78513 flood persists — no worse than the pre-fix behavior.
+                }
+
+                try
+                {
+                    // The Logger is a GodotObject with a native object behind it. After the engine drops its
+                    // reference, free that native object so its handle does not re-root the ALC. IsInstanceValid
+                    // guards against a double-free if Godot already disposed it on a failed reload.
+                    if (GodotObject.IsInstanceValid(logger))
+                        logger.Free();
+                }
+                catch (Exception)
+                {
+                    // Swallow: a disposed/already-freed logger throwing here is benign during unload.
+                }
+            }
+
+            // Always clear the router so a stale capture/validation session never leaks across a reload, even if
+            // nothing was installed (e.g. collector was null at boot). Pure-managed — cannot fault on the engine.
+            try { ScriptErrorCapture.Current = null; } catch { /* swallow during unload */ }
         }
     }
 }

--- a/addons/godot_mcp/Tools/GodotScriptErrorLogger.cs
+++ b/addons/godot_mcp/Tools/GodotScriptErrorLogger.cs
@@ -153,9 +153,9 @@ namespace com.IvanMurzak.Godot.MCP.Tools
 
             if (logger != null)
             {
-                // RemoveLogger drops the engine's reference; Free() then releases the native counterpart so its
-                // native handle cannot keep re-pinning the collectible ALC. Both are best-effort — a throw here
-                // must not abort the rest of teardown (the connection/dock are already being torn down).
+                // RemoveLogger drops the engine's reference; Dispose() then deterministically releases the
+                // managed↔native binding. Both are best-effort — a throw here must not abort the rest of
+                // teardown (the connection/dock are already being torn down).
                 try
                 {
                     OS.RemoveLogger(logger); // static API in GodotSharp 4.5+
@@ -168,11 +168,13 @@ namespace com.IvanMurzak.Godot.MCP.Tools
 
                 try
                 {
-                    // The Logger is a GodotObject with a native object behind it. After the engine drops its
-                    // reference, free that native object so its handle does not re-root the ALC. IsInstanceValid
-                    // guards against a double-free if Godot already disposed it on a failed reload.
-                    if (GodotObject.IsInstanceValid(logger))
-                        logger.Free();
+                    // Godot.Logger is RefCounted-derived, so it has NO `free()` builtin — calling Free() throws
+                    // "Invalid call. Nonexistent function 'free'". Dispose() is the correct, valid release: it
+                    // breaks the native object's strong GCHandle back to this managed wrapper SYNCHRONOUSLY here.
+                    // That matters — the wrapper type lives in the collectible addon ALC, so leaving the cycle
+                    // for the finalizer is exactly the timing fragility that makes the engine give up on the ALC
+                    // unload (#78513). Dispose() is idempotent, so a double-call / already-disposed logger is safe.
+                    logger.Dispose();
                 }
                 catch (Exception)
                 {

--- a/addons/godot_mcp/Tools/GodotScriptErrorLogger.cs
+++ b/addons/godot_mcp/Tools/GodotScriptErrorLogger.cs
@@ -108,6 +108,15 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             if (collector == null)
                 return null;
 
+            // Symmetric with Uninstall: tear down any prior registration FIRST. In the normal paired
+            // _EnterTree/_ExitTree lifecycle _installed is already null here, but a stray double-install
+            // (two _EnterTree without an intervening Teardown) would otherwise overwrite _installed without
+            // OS.RemoveLogger/Free()-ing the previous logger — leaking it registered in the engine, which
+            // re-pins the collectible ALC (the exact godot#78513 unload failure this bridge removes) AND
+            // orphans it beyond Uninstall's reach. Uninstall is idempotent, so this is a safe no-op when
+            // nothing is installed.
+            Uninstall();
+
             var capture = new ScriptErrorCapture
             {
                 LogSink = (logType, message) => collector.Append(logType, message),


### PR DESCRIPTION
## Summary
`GodotMcpPlugin.Teardown` now removes the engine error `Logger` (a `Godot.Logger` subclass defined in the **collectible** addon assembly) that `_EnterTree` registered via `OS.AddLogger`. The engine's strong handle to that managed object is one of the roots that pins the hot-reload `AssemblyLoadContext` (godotengine/godot#78513 ".NET: Failed to unload assemblies").

- Added idempotent + defensive `GodotScriptErrorLoggerBridge.Uninstall()` (4.5+): retains the registered logger, calls `OS.RemoveLogger(logger)` (a real public static API in GodotSharp 4.5.1 — the old "no managed remove API" comment was wrong), `Dispose()`s the logger to break the native↔managed binding synchronously, and clears `ScriptErrorCapture.Current`. A matching no-op `Uninstall()` keeps the `Godot.NET.Sdk/4.3.0` floor compiling.
- `Uninstall()` runs **inside** Teardown's main-thread guard (`OS.RemoveLogger` is an engine call mirroring `OS.AddLogger`'s main-thread registration).
- **`Dispose()`, not `Free()`** — `Godot.Logger` is `RefCounted`-derived and has no `free()` builtin; the initial cut called `Free()` and threw `Invalid call. Nonexistent function 'free'` on every teardown. Caught + fixed via the live-editor smoke (commit `95d996f`).

## Scope — this is a PARTIAL step toward #78513, NOT a full fix
Live-editor measurement (`Godot-Test-Project`, 4× Alt+B reloads) showed the ".NET: Failed to unload assemblies" flood **persists (~6/reload)** with this change. #78513 is **multi-root**: our teardown runs cleanly (0 `free` errors, 0 teardown-step errors, 0 null delegate_handle), but the ALC stays pinned by **other roots — the dominant one in testing being the SignalR connection's running async tasks** (`TaskCanceledException` from `HttpClient` inside `ConnectionManager.AttemptConnection` negotiating an unreachable endpoint), which the runtime names as "Strong GC handles, running threads."

This PR is **necessary-but-not-sufficient**: it removes one real engine→managed pin and fixes a latent teardown crash. The remaining connection-thread root is tracked as a follow-up.

## Test plan
- [x] `dotnet build Godot-MCP.sln` — 0 errors / 0 warnings (CI parity).
- [x] `dotnet test Godot-MCP.Tests` — 802 passed / 1 benign Windows-host-only `alc-probe` flake (green in Linux CI).
- [x] Live-editor smoke (`Godot-Test-Project`): plugin loads + unloads cleanly, **0** `free` errors, **0** teardown errors. (#78513 flood itself is multi-root and not resolved by this change alone — see Scope.)

Closes #136