### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/addons/godot_mcp/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConnection.cs
@@ -60,7 +60,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// drift if you forget). The live, parsed value in <see cref="PluginVersion"/> is the source of
         /// truth; <see cref="ResolvePluginVersion"/> emits a warning whenever it has to fall back here.
         /// </summary>
-        const string FallbackPluginVersion = "0.6.0";
+        const string FallbackPluginVersion = "0.7.0";
 
         /// <summary>
         /// Plugin version reported to the server in the MCP handshake. Resolved ONCE from

--- a/addons/godot_mcp/plugin.cfg
+++ b/addons/godot_mcp/plugin.cfg
@@ -3,5 +3,5 @@
 name="Godot-MCP"
 description="Model Context Protocol (MCP) integration for the Godot Editor. AI tools in C#, cloud-connected to ai-game.dev."
 author="Ivan Murzak"
-version="0.6.0"
+version="0.7.0"
 script="GodotMcpPlugin.cs"

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "godot-cli",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "godot-cli",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.6.2",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "godot-cli",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Cross-platform CLI tool for Godot-MCP (Skills & MCP). Resolves and launches the Godot editor with MCP connection env vars, runs MCP/system tools over HTTP, probes server health, configures AI agents (Claude Code, Cursor, VS Code, …), and enables/disables the godot_mcp addon. Works with Claude Code, Cursor, Copilot, and any MCP client.",
   "type": "module",
   "main": "dist/lib.js",

--- a/docs/assetlib/SUBMISSION.md
+++ b/docs/assetlib/SUBMISSION.md
@@ -25,11 +25,11 @@ this file is just the field values. Keep it in sync whenever any field changes.
 | **Asset name** | `Godot-MCP` |
 | **Category** | `Tools` (an Addon-side category — categories are split into Addons / Projects, and picking an Addon category is what makes this entry an Addon and surfaces it in the in-editor *AssetLib* tab; there is no separate "Type" field) |
 | **Godot version** | `4.3` (lowest supported; the addon also runs on 4.4 / 4.5 — a single entry cannot carry multiple engine versions, so each version it should advertise needs its own resubmission) |
-| **Version** | `0.6.0` (must match `addons/godot_mcp/plugin.cfg` `version=` and the `v0.6.0` tag) |
+| **Version** | `0.7.0` (must match `addons/godot_mcp/plugin.cfg` `version=` and the `v0.7.0` tag) |
 | **Repository host** | `GitHub` |
 | **Repository URL** | `https://github.com/IvanMurzak/Godot-MCP` |
 | **Issues URL** | `https://github.com/IvanMurzak/Godot-MCP/issues` |
-| **Download Commit** | the commit hash the `v0.6.0` tag points at — get it with `git rev-list -n1 v0.6.0` (a hash, not the tag name) |
+| **Download Commit** | the commit hash the `v0.7.0` tag points at — get it with `git rev-list -n1 v0.7.0` (a hash, not the tag name) |
 | **License** | `Apache-2.0` |
 | **Icon URL** | `https://raw.githubusercontent.com/IvanMurzak/Godot-MCP/main/addons/godot_mcp/icon.png` (square 512×512 PNG; AssetLib requires square PNG/JPG ≥ 128×128 — SVG is not accepted) |
 


### PR DESCRIPTION
## Release 0.7.0

Bumps `plugin.cfg` `version=` 0.6.0 → 0.7.0 (via `scripts/bump-version.mjs`), which opens the `release.yml` gate on merge to `main`: the full test matrix runs, then the GitHub Release (`v0.7.0` + addon zip) is cut, `godot-cli` is published to npm (OIDC), and the Asset Library version edit is submitted.

### Headline since v0.6.0
- **godot#78513** "Failed to unload assemblies" reload-flood fix — ReflectorNet static-cache clear on teardown + opt-in McpPlugin bounded reconnect / connect-timeout so a hot-reload settles cleanly (#137, #140).
- **McpPlugin 6.9.1** pin (carries `WaitForImmediateTeardown` + the opt-in reconnect APIs).
- Accumulated dock / `godot-cli` Unity-parity work already on main.

### Release preconditions (verified)
- `ServerVersion` pin = **8.0.0**; `v8.0.0` exists on GameDev-MCP-Server with all 7 RID zips.
- `v0.7.0` tag does not yet exist → gate will open on merge.

### Files
Only version-bearing files changed (script-synced): `plugin.cfg`, `cli/package.json` + lock, `FallbackPluginVersion`, AssetLib `SUBMISSION.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)