### PR TITLE
refactor(connection): un-gate the runtime-agnostic MCP core for non-editor builds

### DIFF
--- a/addons/godot_mcp/Connection/FeatureManagerAdapters.cs
+++ b/addons/godot_mcp/Connection/FeatureManagerAdapters.cs
@@ -7,7 +7,6 @@
 │  See the LICENSE file in the project root for more information.  │
 └──────────────────────────────────────────────────────────────────┘
 */
-#if TOOLS
 #nullable enable
 using System.Collections.Generic;
 using System.Linq;
@@ -21,8 +20,11 @@ namespace com.IvanMurzak.Godot.MCP.Connection
     /// <see cref="IPromptManager"/> / <see cref="IResourceManager"/>). The three managers expose the same
     /// shape (enumerate / count / is-enabled / set-enabled) under different method names; this collapses them
     /// to one surface so <see cref="GodotMcpConnection"/> and the dock's features UI can address any kind
-    /// generically via <see cref="GodotMcpFeatureKind"/>. Editor-only (<c>#if TOOLS</c>): it depends on the
-    /// reused client types, which are only present once the connection assembly is loaded. The map merge/
+    /// generically via <see cref="GodotMcpFeatureKind"/>. Pure-managed and runtime-agnostic (outside
+    /// <c>#if TOOLS</c>): it depends only on the reused McpPlugin client types — present in both the editor
+    /// and an exported game build once the connection is up — and on the pure-managed
+    /// <see cref="FeatureRowItem"/> view-model, never on a Godot editor API. It rides outside the guard
+    /// alongside <see cref="GodotMcpConnection"/>, whose <c>FeatureManager(...)</c> binds it. The map merge/
     /// capture decisions stay pure-managed in <see cref="GodotMcpFeatureStateMerge"/> and the filter/row
     /// view-model shaping in <see cref="FeatureFilter"/> / <see cref="FeatureRowItem"/>; this adapter is the
     /// thin live-manager binding that maps each live descriptor into a pure-managed <see cref="FeatureRowItem"/>
@@ -129,4 +131,3 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         public void SetEnabled(string name, bool enabled) => _manager.SetResourceEnabled(name, enabled);
     }
 }
-#endif

--- a/addons/godot_mcp/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Connection/GodotMcpConnection.cs
@@ -7,7 +7,6 @@
 │  See the LICENSE file in the project root for more information.  │
 └──────────────────────────────────────────────────────────────────┘
 */
-#if TOOLS
 #nullable enable
 using System;
 using System.Collections.Generic;
@@ -48,8 +47,14 @@ namespace com.IvanMurzak.Godot.MCP.Connection
     /// </list>
     /// </para>
     ///
-    /// This type is editor-only (<c>#if TOOLS</c>): it instantiates the SignalR client and is driven
-    /// by <see cref="GodotMcpPlugin"/>'s tree lifecycle.
+    /// This type is runtime-agnostic (it lives OUTSIDE <c>#if TOOLS</c> so it also compiles into an
+    /// exported, non-editor game build): it instantiates the reused SignalR client and owns the
+    /// connection lifecycle, depending only on pure-managed config / view-model / reflector helpers and
+    /// the Godot <i>runtime</i> API (<see cref="Godot.Node"/>, <see cref="GD"/>, <c>ProjectSettings</c>),
+    /// never on a Godot editor API. In the editor it is driven by <see cref="GodotMcpPlugin"/>'s tree
+    /// lifecycle; the sole editor-only coupling — installing the editor <c>ResourceLoader</c> resolver
+    /// into the (pure-managed) Resource reflection converter — is guarded by <c>#if TOOLS</c> at its one
+    /// call site in <see cref="Start"/>, so the exported build wires up the reflector without it.
     /// </summary>
     public sealed class GodotMcpConnection : IDisposable
     {
@@ -293,7 +298,15 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             // Wire the editor-side ResourceLoader.Load resolution into the (pure-managed) Resource
             // reflection converter so node-modify can assign a Resource-typed property by ref (res:// path /
             // instance id). The converter lives outside #if TOOLS; this installs the native resolver.
+            //
+            // EDITOR-ONLY COUPLING (the single one in the connect path): Tool_Resource — and the editor
+            // ResourceLoader/EditorInterface wiring it depends on — is itself gated by #if TOOLS, so it does
+            // NOT compile into an exported game build. Guard the call so the runtime-agnostic connection
+            // compiles with TOOLS undefined; in a non-editor build the Resource converter simply has no
+            // native resolver installed here (a runtime entry point can inject its own resolver later — T2).
+#if TOOLS
             Tools.Tool_Resource.InstallReflectionResolver();
+#endif
 
             // Publish the connection's reflector as the ambient one so tool handlers (e.g. node-modify)
             // share the exact converter set registered here instead of building their own.
@@ -1225,4 +1238,3 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         }
     }
 }
-#endif

--- a/addons/godot_mcp/MainThread/GodotMainThread.cs
+++ b/addons/godot_mcp/MainThread/GodotMainThread.cs
@@ -7,7 +7,6 @@
 │  See the LICENSE file in the project root for more information.  │
 └──────────────────────────────────────────────────────────────────┘
 */
-#if TOOLS
 #nullable enable
 using System;
 using System.Threading.Tasks;
@@ -103,4 +102,3 @@ namespace com.IvanMurzak.Godot.MCP.MainThreadDispatch
         }
     }
 }
-#endif

--- a/addons/godot_mcp/MainThread/MainThreadDispatcher.cs
+++ b/addons/godot_mcp/MainThread/MainThreadDispatcher.cs
@@ -7,7 +7,6 @@
 │  See the LICENSE file in the project root for more information.  │
 └──────────────────────────────────────────────────────────────────┘
 */
-#if TOOLS
 #nullable enable
 using System;
 using System.Collections.Concurrent;
@@ -165,4 +164,3 @@ namespace com.IvanMurzak.Godot.MCP.MainThreadDispatch
         }
     }
 }
-#endif


### PR DESCRIPTION
## Summary
- Move the engine-runtime-agnostic MCP core (`GodotMcpConnection`, `GodotMainThread` + `MainThreadDispatcher`, `FeatureManagerAdapters`) **out of `#if TOOLS`** so it compiles into an exported (non-editor) Godot game build — the Godot analog of Unity-MCP's Runtime-vs-Editor assembly split.
- Keep the editor surface gated (`#if TOOLS`): `GodotMcpPlugin : EditorPlugin`, all `UI/`, and the 7 editor tool families. Guard the single editor coupling — `Tool_Resource.InstallReflectionResolver()` in `GodotMcpConnection.Start()` — with `#if TOOLS` at its one call site.
- **Zero editor behaviour change** — a pure compile-time re-gating. No runtime entry point, no new tools, no connection-on-by-default (those are later tasks).
- `GodotMcpAssemblyResolver`'s `[ModuleInitializer]` + `AssemblyLoadContext.Default.Resolving` hook is **confirmed harmless** when `TOOLS` is undefined: in an exported game the .NET runtime loads bundled DLLs normally so the resolver never fires, and the ALC-unloading hook is a no-op in the non-collectible runtime context (already documented for the CI/xUnit host) — no change needed.

## Test plan
- [x] Editor build green: `dotnet build Debug` (TOOLS defined) — 0 errors / 0 warnings.
- [x] **Runtime compile proven**: `dotnet build ExportRelease` (TOOLS **undefined**) green; the emitted `Godot-MCP.dll` *contains* the un-gated core (`GodotMcpConnection`, both dispatchers, the 3 feature adapters, the pure tools, reflector factory, assembly resolver, log collector) and *excludes* `GodotMcpPlugin` + all 7 editor tool families + the UI dock/panels.
- [x] **Grep gate**: no `EditorInterface` / `EditorFileSystem` / `EditorPlugin` type or API reachable from TOOLS-undefined code (the only `EditorInterface` strings in the ExportRelease DLL are `[Description]` text in the pure-managed `EditorStateData` model, not type references).
- [x] xUnit suite: 754 passed / 1 failed — the single failure is the documented benign Windows-host-only `GodotAssemblyUtilsTests` temp-DLL cleanup flake (green on Linux CI), unrelated to this change.
- [x] Headless editor smoke (Godot 4.5.1 mono testbed): `[Godot-MCP] plugin loaded`, deps resolved, config + `.env` applied, `connecting (mode=Custom)` — clean load/unload, exit 0. Editor behaviour unchanged.

Closes #145