### PR TITLE
feat(runtime): add GodotMcpRuntime.Initialize() opt-in in-game entry point

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -223,6 +223,21 @@
          target vocabulary. The editor HttpListener transport (DevControlServer.cs) is #if TOOLS and verified
          live (curl the editor), NOT compiled here; the routing/parsing core is unit-tested here. -->
     <Compile Include="..\addons\godot_mcp\Connection\DevControl\DevControlRouter.cs" Link="Source\DevControlRouter.cs" />
+    <!-- Runtime (in-game) entry point — pure-managed builder accumulation + handle wrapper (no #if TOOLS).
+         GodotMcpRuntimeBuilder is fully pure-managed (config-action / tool-type accumulation) and is what
+         these unit tests exercise. GodotMcpRuntime.Build()/GodotMcpRuntimeHandle make native Godot + SignalR
+         calls (Engine.GetMainLoop, McpPluginBuilder.Build) that fault in this binary-less xUnit host, so the
+         tests stop at the builder/config surface — the full Build() + Connect() path is proven by the
+         ExportRelease (TOOLS-undefined) compile + the headless Godot runtime smoke (T3), not here. The two
+         non-builder files are still compiled in so the builder's Build() reference resolves. -->
+    <Compile Include="..\addons\godot_mcp\Runtime\GodotMcpRuntimeBuilder.cs" Link="Source\GodotMcpRuntimeBuilder.cs" />
+    <Compile Include="..\addons\godot_mcp\Runtime\GodotMcpRuntime.cs" Link="Source\GodotMcpRuntime.cs" />
+    <Compile Include="..\addons\godot_mcp\Runtime\GodotMcpRuntimeHandle.cs" Link="Source\GodotMcpRuntimeHandle.cs" />
+    <!-- Main-thread dispatcher pair — GodotMcpRuntime.EnsureMainThreadDispatcher references both. Pure-managed
+         types (MainThreadDispatcher is a Godot Node, but constructing it is a Suite-3 concern; the runtime
+         builder-only tests never instantiate it). Compiled in so the runtime sources resolve their usings. -->
+    <Compile Include="..\addons\godot_mcp\MainThread\MainThreadDispatcher.cs" Link="Source\MainThreadDispatcher.cs" />
+    <Compile Include="..\addons\godot_mcp\MainThread\GodotMainThread.cs" Link="Source\GodotMainThread.cs" />
   </ItemGroup>
 
 </Project>

--- a/Godot-MCP.Tests/GodotMcpRuntimeBuilderTests.cs
+++ b/Godot-MCP.Tests/GodotMcpRuntimeBuilderTests.cs
@@ -1,0 +1,192 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Linq;
+using System.Reflection;
+using com.IvanMurzak.Godot.MCP.Connection;
+using com.IvanMurzak.Godot.MCP.Runtime;
+using com.IvanMurzak.Godot.MCP.Tools;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the pure-managed surface of the runtime (in-game) entry point — the Godot analog of
+    /// Unity-MCP's <c>UnityMcpPluginRuntime</c>:
+    /// <list type="bullet">
+    ///   <item><see cref="GodotMcpRuntime.Initialize"/> returns a configurable builder.</item>
+    ///   <item><b>Zero tools by default</b> — a builder with no <c>WithTools*</c> call registers nothing.</item>
+    ///   <item>Manual tool registration via <see cref="GodotMcpRuntimeBuilder.WithToolsFromAssembly"/> /
+    ///   <see cref="GodotMcpRuntimeBuilder.WithTools"/> accumulates the opted-in set.</item>
+    ///   <item><see cref="GodotMcpRuntimeBuilder.WithConfig"/> mutations compose onto a fresh
+    ///   <see cref="GodotMcpConfig"/> with NO persisted-config auto-load.</item>
+    /// </list>
+    ///
+    /// <para>
+    /// These tests stop at the builder / config layer on purpose. The full <c>.Build()</c> path constructs
+    /// the reused SignalR client and touches native Godot (<c>Engine.GetMainLoop</c>, <c>GD.Print</c>),
+    /// which faults in this binary-less xUnit host (an <c>AccessViolationException</c> would crash the
+    /// runner). That end-to-end "builds an empty-tool-set connection without an editor" proof is the
+    /// ExportRelease (TOOLS-undefined) compile gate plus the headless Godot runtime smoke (T3) — not a unit
+    /// test. Here we verify everything that decides WHAT the build will register, deterministically.
+    /// </para>
+    /// </summary>
+    public class GodotMcpRuntimeBuilderTests
+    {
+        [Fact]
+        public void Initialize_WithNullConfigure_ReturnsBuilder_WithNoTools()
+        {
+            var builder = GodotMcpRuntime.Initialize();
+
+            Assert.NotNull(builder);
+            Assert.True(builder.HasNoTools);
+            Assert.Empty(builder.ToolAssemblies);
+            Assert.Empty(builder.ToolTypes);
+        }
+
+        [Fact]
+        public void Initialize_InvokesConfigureCallback()
+        {
+            var invoked = false;
+            GodotMcpRuntime.Initialize(b =>
+            {
+                invoked = true;
+                Assert.NotNull(b);
+            });
+
+            Assert.True(invoked);
+        }
+
+        [Fact]
+        public void Builder_ByDefault_RegistersZeroTools()
+        {
+            // The core "exactly Unity's model" invariant: nothing opted in → empty tool set.
+            var builder = GodotMcpRuntime.Initialize(b => b.WithConfig(c => c.Host = "http://localhost:9999"));
+
+            Assert.True(builder.HasNoTools);
+        }
+
+        [Fact]
+        public void WithToolsFromAssembly_AccumulatesAndDeduplicates()
+        {
+            var asm = typeof(Tool_Ping).Assembly;
+            var builder = GodotMcpRuntime.Initialize(b =>
+            {
+                b.WithToolsFromAssembly(asm);
+                b.WithToolsFromAssembly(asm); // duplicate — must be de-duplicated
+            });
+
+            Assert.False(builder.HasNoTools);
+            Assert.Single(builder.ToolAssemblies);
+            Assert.Same(asm, builder.ToolAssemblies[0]);
+        }
+
+        [Fact]
+        public void WithTools_AccumulatesTypes_IgnoresNullsAndDuplicates()
+        {
+            var builder = GodotMcpRuntime.Initialize(b =>
+                b.WithTools(typeof(Tool_Ping), typeof(Tool_Ping), null!));
+
+            Assert.False(builder.HasNoTools);
+            Assert.Single(builder.ToolTypes);
+            Assert.Equal(typeof(Tool_Ping), builder.ToolTypes[0]);
+        }
+
+        [Fact]
+        public void WithToolsFromAssembly_Null_Throws()
+        {
+            var builder = GodotMcpRuntime.Initialize();
+            Assert.Throws<ArgumentNullException>(() => builder.WithToolsFromAssembly(null!));
+        }
+
+        [Fact]
+        public void WithConfig_Null_Throws()
+        {
+            var builder = GodotMcpRuntime.Initialize();
+            Assert.Throws<ArgumentNullException>(() => builder.WithConfig(null!));
+        }
+
+        [Fact]
+        public void WithTools_NullArray_IsNoOp()
+        {
+            var builder = GodotMcpRuntime.Initialize(b => b.WithTools(null!));
+            Assert.True(builder.HasNoTools);
+        }
+
+        [Fact]
+        public void ApplyConfig_ComposesMutationsInOrder_OnFreshConfig()
+        {
+            var builder = GodotMcpRuntime.Initialize(b =>
+            {
+                b.WithConfig(c => c.ConnectionMode = GodotMcpConnectionMode.Custom);
+                b.WithConfig(c => c.CustomHost = "http://localhost:8080");
+                b.WithConfig(c =>
+                {
+                    c.AuthOption = GodotMcpAuthOption.Required;
+                    c.CustomToken = "secret-token";
+                });
+            });
+
+            // A fresh config — exactly what GodotMcpRuntime.Build seeds (NO persisted user:// auto-load).
+            var config = new GodotMcpConfig();
+            InvokeApplyConfig(builder, config);
+
+            Assert.Equal(GodotMcpConnectionMode.Custom, config.ConnectionMode);
+            Assert.Equal("http://localhost:8080", config.CustomHost);
+            Assert.Equal(GodotMcpAuthOption.Required, config.AuthOption);
+            Assert.Equal("secret-token", config.CustomToken);
+        }
+
+        [Fact]
+        public void FreshConfig_HasSecureRuntimeDefaults_NoPersistedLoad()
+        {
+            // GodotMcpRuntime.Build starts from `new GodotMcpConfig()` and never reads the persisted
+            // user:// config. A no-WithConfig builder therefore yields the built-in defaults verbatim:
+            // Cloud mode, no custom token, no custom host beyond the default. (The connection still stays
+            // OFF until Connect() — proven structurally by GodotMcpRuntimeHandle, not exercised here.)
+            var builder = GodotMcpRuntime.Initialize();
+            var config = new GodotMcpConfig();
+            InvokeApplyConfig(builder, config);
+
+            Assert.Equal(GodotMcpConnectionMode.Cloud, config.ConnectionMode);
+            Assert.Null(config.CustomToken);
+            Assert.Equal(GodotMcpConfig.DefaultCustomHost, config.CustomHost);
+        }
+
+        [Fact]
+        public void WithoutMainThreadDispatcher_FlipsInstallDispatcherFlag()
+        {
+            // InstallDispatcher is internal; reach it reflectively to pin the opt-out contract.
+            var on = GodotMcpRuntime.Initialize();
+            var off = GodotMcpRuntime.Initialize(b => b.WithoutMainThreadDispatcher());
+
+            Assert.True(ReadInstallDispatcher(on));
+            Assert.False(ReadInstallDispatcher(off));
+        }
+
+        // --- helpers reaching the builder's internal surface (same assembly, but the members are internal
+        //     so the public test stays readable) ----------------------------------------------------------
+
+        static void InvokeApplyConfig(GodotMcpRuntimeBuilder builder, GodotMcpConfig config)
+        {
+            var m = typeof(GodotMcpRuntimeBuilder).GetMethod(
+                "ApplyConfig", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            m.Invoke(builder, new object[] { config });
+        }
+
+        static bool ReadInstallDispatcher(GodotMcpRuntimeBuilder builder)
+        {
+            var p = typeof(GodotMcpRuntimeBuilder).GetProperty(
+                "InstallDispatcher", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            return (bool)p.GetValue(builder)!;
+        }
+    }
+}

--- a/addons/godot_mcp/Runtime/GodotMcpRuntime.cs
+++ b/addons/godot_mcp/Runtime/GodotMcpRuntime.cs
@@ -1,0 +1,221 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Linq;
+using com.IvanMurzak.Godot.MCP.Connection;
+using com.IvanMurzak.Godot.MCP.MainThreadDispatch;
+using com.IvanMurzak.Godot.MCP.Reflection;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet;
+using Godot;
+using McpVersion = com.IvanMurzak.McpPlugin.Common.Version;
+
+namespace com.IvanMurzak.Godot.MCP.Runtime
+{
+    /// <summary>
+    /// Opt-in entry point for using Godot-MCP <b>inside a running / exported game</b> (debug or release),
+    /// outside the editor. The Godot analog of Unity-MCP's <c>UnityMcpPluginRuntime.Initialize()</c>.
+    ///
+    /// <para>
+    /// This type lives OUTSIDE <c>#if TOOLS</c>, so it compiles into an exported game build (where
+    /// <c>TOOLS</c> is undefined and the editor <c>EditorPlugin</c>/dock/editor tool families are dropped).
+    /// It reuses the existing runtime-agnostic stack — <see cref="GodotMcpConfig"/>,
+    /// <see cref="GodotReflectorFactory"/>, <see cref="McpPluginBuilder"/>, <see cref="GodotMcpReflector"/>,
+    /// and the <see cref="MainThreadDispatcher"/>/<see cref="GodotMainThread"/> pair — rather than inventing
+    /// a parallel transport.
+    /// </para>
+    ///
+    /// <para>
+    /// Usage (the game developer writes this, e.g. from an autoload <c>_Ready</c>):
+    /// <code>
+    /// var mcp = GodotMcpRuntime.Initialize(builder =>
+    /// {
+    ///     builder.WithConfig(c =>
+    ///     {
+    ///         c.ConnectionMode = GodotMcpConnectionMode.Custom;
+    ///         c.Host = "http://localhost:8080";
+    ///     });
+    ///     builder.WithToolsFromAssembly(Assembly.GetExecutingAssembly()); // opt in YOUR [AiToolType] tools
+    /// }).Build();
+    ///
+    /// await mcp.Connect();   // explicit — nothing connects until you ask
+    /// // ... later ...
+    /// await mcp.Disconnect();
+    /// </code>
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Security:</b> default OFF (no auto-connect), no persisted-config auto-load in a build (the
+    /// developer supplies host/token in code or via <c>GODOT_MCP_*</c> env / project <c>.env</c>), and
+    /// <b>zero tools by default</b> — only what the developer opts in is registered. Prefer a loopback host
+    /// and a required token when exposing tools.
+    /// </para>
+    /// </summary>
+    public static class GodotMcpRuntime
+    {
+        const string DispatcherNodeName = "GodotMcpRuntimeMainThreadDispatcher";
+
+        /// <summary>
+        /// Begin configuring a runtime MCP connection. Invoke the <paramref name="configure"/> callback to
+        /// register tools and set host/token, then call <see cref="GodotMcpRuntimeBuilder.Build"/> on the
+        /// returned builder to finalize and obtain the (default-OFF) connection handle.
+        /// </summary>
+        /// <param name="configure">
+        /// Configures the connection — <see cref="GodotMcpRuntimeBuilder.WithConfig"/> for host/token/mode,
+        /// <see cref="GodotMcpRuntimeBuilder.WithToolsFromAssembly"/> / <see cref="GodotMcpRuntimeBuilder.WithTools"/>
+        /// to opt tools in. May be <c>null</c> for the zero-tool, env/.env-configured default.
+        /// </param>
+        public static GodotMcpRuntimeBuilder Initialize(Action<GodotMcpRuntimeBuilder>? configure = null)
+        {
+            var builder = new GodotMcpRuntimeBuilder();
+            configure?.Invoke(builder);
+            return builder;
+        }
+
+        /// <summary>
+        /// Finalize a <see cref="GodotMcpRuntimeBuilder"/>: build the reused MCP plugin (reflector +
+        /// opted-in tools + resolved config), bootstrap the main-thread dispatcher, and return the handle.
+        /// Called by <see cref="GodotMcpRuntimeBuilder.Build"/>; not invoked directly.
+        /// </summary>
+        internal static GodotMcpRuntimeHandle Build(GodotMcpRuntimeBuilder builder)
+        {
+            if (builder == null)
+                throw new ArgumentNullException(nameof(builder));
+
+            // 1) Resolve config. Start from a fresh GodotMcpConfig (NO persisted user:// auto-load — that is
+            //    an editor-only convenience; a shipped build must not silently read a saved config). The
+            //    config still reads GODOT_MCP_* process env + project .env LIVE in its getters, so a game can
+            //    be configured out-of-band without code. Then apply the developer's WithConfig mutations on
+            //    top (highest-precedence in-code layer).
+            var config = new GodotMcpConfig();
+            builder.ApplyConfig(config);
+
+            // 2) Guarantee a main-thread dispatcher in the running SceneTree (unless the developer owns one),
+            //    and route ReflectorNet's MainThread.Instance through it, so tool handlers can marshal Godot
+            //    API calls onto the main thread via MainThread.Instance.Run(...). MUST happen before any tool
+            //    runs; doing it at build time keeps the contract simple.
+            if (builder.InstallDispatcher)
+                EnsureMainThreadDispatcher();
+
+            // 3) Build the reflector with the Godot value-type / ref converters and publish it as the ambient
+            //    one so tool handlers share the exact converter set (mirrors GodotMcpConnection.Start). The
+            //    editor ResourceLoader resolver (Tool_Resource.InstallReflectionResolver) is intentionally
+            //    NOT installed — it is #if TOOLS editor-only and absent from a game build.
+            Reflector reflector = GodotReflectorFactory.CreateDefaultReflector();
+            GodotMcpReflector.Current = reflector;
+
+            var version = new McpVersion
+            {
+                Api = com.IvanMurzak.McpPlugin.Common.Consts.ApiVersion,
+                Plugin = ResolvePluginVersion(),
+                Environment = $"Godot {Engine.GetVersionInfo()["string"]} (runtime)"
+            };
+
+            var mcpBuilder = new McpPluginBuilder(version)
+                .SetConfig(config);
+
+            // 4) Register ONLY the developer's opted-in tools. ZERO tools by default: with nothing opted in,
+            //    no WithTools* call is made and the plugin builds with an empty tool set (exactly Unity's
+            //    model). Editor tool families are #if TOOLS and don't compile into a game build, so even a
+            //    WithToolsFromAssembly over the addon assembly can't pull them in.
+            if (builder.ToolAssemblies.Count > 0)
+                mcpBuilder.WithToolsFromAssembly(builder.ToolAssemblies);
+
+            if (builder.ToolTypes.Count > 0)
+                mcpBuilder.WithTools(builder.ToolTypes.ToArray());
+
+            var plugin = mcpBuilder.Build(reflector);
+
+            return new GodotMcpRuntimeHandle(plugin, config);
+        }
+
+        /// <summary>
+        /// Resolve the addon version reported in the MCP handshake from
+        /// <c>res://addons/godot_mcp/plugin.cfg</c> (the single source of truth the release workflow tags),
+        /// via the pure-managed <see cref="GodotMcpServerView.ParsePluginVersion"/> parser, with a safe
+        /// fallback. Mirrors <c>GodotMcpConnection.ResolvePluginVersion</c> but kept local so the runtime
+        /// entry point does not depend on the editor-coupled connection class. Never throws — a read/parse
+        /// failure degrades to <see cref="FallbackPluginVersion"/>.
+        /// </summary>
+        static string ResolvePluginVersion()
+        {
+            try
+            {
+                var path = ProjectSettings.GlobalizePath("res://addons/godot_mcp/plugin.cfg");
+                if (System.IO.File.Exists(path))
+                {
+                    var parsed = GodotMcpServerView.ParsePluginVersion(System.IO.File.ReadAllText(path));
+                    if (!string.IsNullOrEmpty(parsed))
+                        return parsed!;
+                }
+            }
+            catch
+            {
+                // Fall through to the fallback — never let a config read break the runtime build path.
+            }
+
+            return FallbackPluginVersion;
+        }
+
+        /// <summary>
+        /// Version reported when <c>plugin.cfg</c> is unreadable. Bump alongside <c>plugin.cfg</c>'s
+        /// <c>version=</c> (the live parsed value above is the source of truth; this is only the degraded
+        /// fallback). Mirrors <c>GodotMcpConnection.FallbackPluginVersion</c>.
+        /// </summary>
+        const string FallbackPluginVersion = "0.7.0";
+
+        /// <summary>
+        /// Ensure a <see cref="MainThreadDispatcher"/> Node exists in the running game's
+        /// <see cref="SceneTree"/> and that <see cref="GodotMainThread"/> is installed as ReflectorNet's
+        /// <c>MainThread.Instance</c>.
+        ///
+        /// <para>
+        /// In a running game the active <see cref="MainLoop"/> is a <see cref="SceneTree"/>; the dispatcher
+        /// is added under <see cref="SceneTree.Root"/> (the autoload-equivalent injection point) so it
+        /// receives <see cref="Node._Process"/> ticks for the lifetime of the game — no editor-frame
+        /// dependency. Idempotent: a no-op when a dispatcher is already in the tree (e.g. a second
+        /// <c>Initialize().Build()</c>, or a developer-installed autoload dispatcher). Defensive — if the
+        /// SceneTree is not yet available (called too early, before the tree exists) it installs
+        /// <see cref="GodotMainThread"/> anyway and logs a warning; the developer can re-run after the tree
+        /// is up.
+        /// </para>
+        /// </summary>
+        static void EnsureMainThreadDispatcher()
+        {
+            // GodotMainThread.Install() is idempotent and pure-managed — safe to call first.
+            GodotMainThread.Install();
+
+            if (MainThreadDispatcher.Instance != null)
+                return; // already pumped (editor plugin, a prior runtime init, or a developer autoload).
+
+            if (Engine.GetMainLoop() is not SceneTree tree || tree.Root == null)
+            {
+                GD.PushWarning(
+                    "[Godot-MCP] runtime dispatcher bootstrap: no live SceneTree yet — tool handlers cannot " +
+                    "marshal to the main thread until a MainThreadDispatcher is in the tree. Call " +
+                    "GodotMcpRuntime.Initialize(...).Build() once the SceneTree is available (e.g. from an " +
+                    "autoload _Ready), or install your own dispatcher.");
+                return;
+            }
+
+            var dispatcher = new MainThreadDispatcher { Name = DispatcherNodeName };
+
+            // Add under the tree root. Use CallDeferred when off the main thread / mid-tree-iteration so the
+            // add is applied on a safe frame boundary; add directly when already on the main thread at build.
+            if (MainThreadDispatcher.IsMainThread)
+                tree.Root.AddChild(dispatcher);
+            else
+                tree.Root.CallDeferred(Node.MethodName.AddChild, dispatcher);
+
+            GD.Print($"[Godot-MCP] runtime main-thread dispatcher installed ('{DispatcherNodeName}').");
+        }
+    }
+}

--- a/addons/godot_mcp/Runtime/GodotMcpRuntime.cs
+++ b/addons/godot_mcp/Runtime/GodotMcpRuntime.cs
@@ -208,14 +208,14 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
 
             var dispatcher = new MainThreadDispatcher { Name = DispatcherNodeName };
 
-            // Add under the tree root. Use CallDeferred when off the main thread / mid-tree-iteration so the
-            // add is applied on a safe frame boundary; add directly when already on the main thread at build.
-            if (MainThreadDispatcher.IsMainThread)
-                tree.Root.AddChild(dispatcher);
-            else
-                tree.Root.CallDeferred(Node.MethodName.AddChild, dispatcher);
+            // Add under the tree root via CallDeferred so the add lands on a safe frame boundary regardless
+            // of the calling thread or whether we are mid-tree-iteration. (A direct AddChild is never safe to
+            // take here: MainThreadDispatcher.MainThreadId stays -1 until a dispatcher's _EnterTree runs, so
+            // IsMainThread is false on this first-install path even on the engine main thread — and a second
+            // Initialize().Build() already returned at the Instance != null guard above.)
+            tree.Root.CallDeferred(Node.MethodName.AddChild, dispatcher);
 
-            GD.Print($"[Godot-MCP] runtime main-thread dispatcher installed ('{DispatcherNodeName}').");
+            GD.Print($"[Godot-MCP] runtime main-thread dispatcher scheduled ('{DispatcherNodeName}').");
         }
     }
 }

--- a/addons/godot_mcp/Runtime/GodotMcpRuntimeBuilder.cs
+++ b/addons/godot_mcp/Runtime/GodotMcpRuntimeBuilder.cs
@@ -1,0 +1,159 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using com.IvanMurzak.Godot.MCP.Connection;
+
+namespace com.IvanMurzak.Godot.MCP.Runtime
+{
+    /// <summary>
+    /// Fluent configuration surface for the runtime (in-game) MCP connection, handed to the game
+    /// developer's <c>configure</c> callback by <see cref="GodotMcpRuntime.Initialize"/>. The Godot analog
+    /// of Unity-MCP's <c>UnityMcpPluginBuilder</c>.
+    ///
+    /// <para>
+    /// <b>Zero tools by default — strictly manual.</b> A freshly-built runtime registers NO MCP tools.
+    /// The developer opts their own <c>[AiToolType]</c>/<c>[AiTool]</c> classes in explicitly via
+    /// <see cref="WithTools(Type[])"/> or <see cref="WithToolsFromAssembly(Assembly)"/>; with none
+    /// registered the connection still builds and connects with an empty tool set (exactly Unity's model).
+    /// The addon's own editor tool families are gated by <c>#if TOOLS</c> and do not compile into an
+    /// exported game build, so they can never leak into a runtime registration even via an
+    /// <see cref="WithToolsFromAssembly(Assembly)"/> over the addon assembly.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Security posture.</b> The builder applies NO persisted-config layer (no <c>user://</c> config
+    /// file is auto-loaded in a build — that is an editor-only convenience). The developer supplies host/
+    /// token either in code via <see cref="WithConfig(Action{GodotMcpConfig})"/> or out-of-band through the
+    /// <c>GODOT_MCP_*</c> process-environment / project <c>.env</c> overrides that <see cref="GodotMcpConfig"/>
+    /// reads live. The connection is <b>default OFF</b> — <see cref="GodotMcpRuntimeHandle.Connect"/> must be
+    /// called explicitly; nothing auto-connects.
+    /// </para>
+    ///
+    /// This builder only accumulates intent; the actual plugin build + dispatcher bootstrap happen in
+    /// <see cref="GodotMcpRuntime.Build"/> when the developer calls <c>.Build()</c> on the returned handle.
+    /// </summary>
+    public sealed class GodotMcpRuntimeBuilder
+    {
+        readonly List<Action<GodotMcpConfig>> _configActions = new();
+        readonly List<Assembly> _toolAssemblies = new();
+        readonly List<Type> _toolTypes = new();
+
+        /// <summary>
+        /// Whether <see cref="GodotMcpRuntime.Initialize"/> should guarantee a
+        /// <see cref="MainThreadDispatch.MainThreadDispatcher"/> Node in the running <c>SceneTree</c> and
+        /// install <see cref="MainThreadDispatch.GodotMainThread"/>. ON by default — tool handlers marshal
+        /// Godot API calls onto the main thread through it. A developer who already owns a dispatcher (e.g.
+        /// installed via an autoload) can turn this off via <see cref="WithoutMainThreadDispatcher"/>.
+        /// </summary>
+        internal bool InstallDispatcher { get; private set; } = true;
+
+        internal GodotMcpRuntimeBuilder() { }
+
+        /// <summary>
+        /// Register a mutation applied to the connection's <see cref="GodotMcpConfig"/> at build time
+        /// (e.g. set <c>Host</c> / <c>Token</c> / <c>ConnectionMode</c>). Multiple calls compose in order.
+        /// Returns <c>this</c> for chaining.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// builder.WithConfig(c =>
+        /// {
+        ///     c.ConnectionMode = GodotMcpConnectionMode.Custom;
+        ///     c.Host = "http://localhost:8080";
+        ///     c.AuthOption = GodotMcpAuthOption.Required;
+        ///     c.Token = "...";
+        /// });
+        /// </code>
+        /// </example>
+        public GodotMcpRuntimeBuilder WithConfig(Action<GodotMcpConfig> configure)
+        {
+            if (configure == null)
+                throw new ArgumentNullException(nameof(configure));
+
+            _configActions.Add(configure);
+            return this;
+        }
+
+        /// <summary>
+        /// Opt every <c>[AiToolType]</c>/<c>[AiTool]</c> class declared in <paramref name="assembly"/> into
+        /// the runtime tool set. The common case is <c>Assembly.GetExecutingAssembly()</c> so a game
+        /// registers its own tools. Multiple calls accumulate; duplicate assemblies are de-duplicated at
+        /// build time. Returns <c>this</c> for chaining.
+        /// </summary>
+        public GodotMcpRuntimeBuilder WithToolsFromAssembly(Assembly assembly)
+        {
+            if (assembly == null)
+                throw new ArgumentNullException(nameof(assembly));
+
+            if (!_toolAssemblies.Contains(assembly))
+                _toolAssemblies.Add(assembly);
+            return this;
+        }
+
+        /// <summary>
+        /// Opt specific <c>[AiToolType]</c> classes into the runtime tool set (when a whole-assembly scan
+        /// is too broad). Null entries are ignored; duplicates are de-duplicated at build time. Returns
+        /// <c>this</c> for chaining.
+        /// </summary>
+        public GodotMcpRuntimeBuilder WithTools(params Type[] toolTypes)
+        {
+            if (toolTypes == null)
+                return this;
+
+            foreach (var type in toolTypes)
+            {
+                if (type != null && !_toolTypes.Contains(type))
+                    _toolTypes.Add(type);
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Skip the automatic <see cref="MainThreadDispatch.MainThreadDispatcher"/> bootstrap. Use this only
+        /// when the game already installs a dispatcher itself (e.g. as a Godot autoload) AND has called
+        /// <see cref="MainThreadDispatch.GodotMainThread.Install"/>. With the bootstrap skipped and no
+        /// dispatcher present, tool handlers that marshal to the main thread will fault — so leave it ON
+        /// (the default) unless you know you have your own. Returns <c>this</c> for chaining.
+        /// </summary>
+        public GodotMcpRuntimeBuilder WithoutMainThreadDispatcher()
+        {
+            InstallDispatcher = false;
+            return this;
+        }
+
+        /// <summary>
+        /// Finalize this configuration: build the reused MCP plugin (reflector + opted-in tools + resolved
+        /// config), bootstrap the main-thread dispatcher in the running <c>SceneTree</c> (unless
+        /// <see cref="WithoutMainThreadDispatcher"/> was called), and return the connection handle. The
+        /// handle is <b>default OFF</b> — call <see cref="GodotMcpRuntimeHandle.Connect"/> to open the
+        /// connection. The Godot analog of Unity-MCP's <c>UnityMcpPluginRuntime.Initialize(...).Build()</c>.
+        /// </summary>
+        public GodotMcpRuntimeHandle Build() => GodotMcpRuntime.Build(this);
+
+        /// <summary>Apply the accumulated <see cref="WithConfig"/> mutations onto <paramref name="config"/>.</summary>
+        internal void ApplyConfig(GodotMcpConfig config)
+        {
+            foreach (var action in _configActions)
+                action(config);
+        }
+
+        /// <summary>The assemblies the developer opted in via <see cref="WithToolsFromAssembly"/>.</summary>
+        internal IReadOnlyList<Assembly> ToolAssemblies => _toolAssemblies;
+
+        /// <summary>The individual tool types the developer opted in via <see cref="WithTools"/>.</summary>
+        internal IReadOnlyList<Type> ToolTypes => _toolTypes;
+
+        /// <summary>True when the developer registered no tools at all (the empty-tool-set default).</summary>
+        internal bool HasNoTools => _toolAssemblies.Count == 0 && _toolTypes.Count == 0;
+    }
+}

--- a/addons/godot_mcp/Runtime/GodotMcpRuntimeHandle.cs
+++ b/addons/godot_mcp/Runtime/GodotMcpRuntimeHandle.cs
@@ -1,0 +1,96 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.Godot.MCP.Connection;
+using com.IvanMurzak.McpPlugin;
+
+namespace com.IvanMurzak.Godot.MCP.Runtime
+{
+    /// <summary>
+    /// The runtime MCP connection handle returned by <see cref="GodotMcpRuntime.Build"/> — the Godot analog
+    /// of the object Unity-MCP's <c>UnityMcpPluginRuntime.Initialize(...).Build()</c> returns. Wraps the
+    /// built reused <see cref="IMcpPlugin"/> (SignalR client) and exposes the minimal in-game surface:
+    /// <see cref="Connect"/> / <see cref="Disconnect"/>.
+    ///
+    /// <para>
+    /// <b>Default OFF.</b> Building a handle does NOT open a connection. The game must call
+    /// <see cref="Connect"/> explicitly — the security-required opt-in. Auto-reconnect/backoff (when the
+    /// resolved <see cref="GodotMcpConfig.KeepConnected"/> is true) is handled inside the reused client, not
+    /// reimplemented here.
+    /// </para>
+    /// </summary>
+    public sealed class GodotMcpRuntimeHandle : IDisposable
+    {
+        readonly IMcpPlugin _plugin;
+        readonly GodotMcpConfig _config;
+        int _disposed;
+
+        internal GodotMcpRuntimeHandle(IMcpPlugin plugin, GodotMcpConfig config)
+        {
+            _plugin = plugin ?? throw new ArgumentNullException(nameof(plugin));
+            _config = config ?? throw new ArgumentNullException(nameof(config));
+        }
+
+        /// <summary>The resolved connection config (host / token / mode) this handle connects with.</summary>
+        public GodotMcpConfig Config => _config;
+
+        /// <summary>The built reused MCP plugin instance (SignalR client + managers).</summary>
+        public IMcpPlugin Plugin => _plugin;
+
+        /// <summary>
+        /// Open the MCP connection to the configured server. Idempotent in the sense the reused client
+        /// guards re-entry; when <see cref="GodotMcpConfig.KeepConnected"/> is true the client also re-arms
+        /// its own auto-reconnect intent here. Returns <c>true</c> when the initial connect succeeded
+        /// (the client keeps retrying afterwards if <c>KeepConnected</c>).
+        /// </summary>
+        public Task<bool> Connect(CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+            return _plugin.Connect(cancellationToken);
+        }
+
+        /// <summary>
+        /// Close the MCP connection and stop auto-reconnect (the reused client flips its own
+        /// <c>KeepConnected</c> to false inside <see cref="IConnection.Disconnect"/>). The handle remains
+        /// reusable — a subsequent <see cref="Connect"/> re-arms the connection.
+        /// </summary>
+        public Task Disconnect(CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+            return _plugin.Disconnect(cancellationToken);
+        }
+
+        /// <summary>
+        /// Tear down the handle: synchronously kill the live connection (immediate disconnect — cancels the
+        /// reconnect loop and fire-and-forgets the transport teardown) and dispose the reused plugin. Safe
+        /// to call multiple times. Call this on game shutdown / when the connection is no longer needed.
+        /// </summary>
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                return;
+
+            try { _plugin.DisconnectImmediate(); }
+            catch { /* best-effort: never throw out of Dispose */ }
+
+            try { _plugin.Dispose(); }
+            catch { /* best-effort: never throw out of Dispose */ }
+        }
+
+        void ThrowIfDisposed()
+        {
+            if (Volatile.Read(ref _disposed) != 0)
+                throw new ObjectDisposedException(nameof(GodotMcpRuntimeHandle));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the runtime (in-game) entry point `GodotMcpRuntime.Initialize(builder => …).Build()` — the Godot analog of Unity-MCP's `UnityMcpPluginRuntime.Initialize()` — so a game developer can start the MCP connection inside a running/exported game and register their own `[AiToolType]` tools manually in code. New `addons/godot_mcp/Runtime/`: `GodotMcpRuntime` (static entry point + dispatcher bootstrap), `GodotMcpRuntimeBuilder` (`WithConfig` / `WithToolsFromAssembly` / `WithTools`), `GodotMcpRuntimeHandle` (`Connect()`/`Disconnect()`). All live OUTSIDE `#if TOOLS`.
- **Zero tools by default** (exactly Unity's model): nothing is registered unless the dev opts in; editor tool families are `#if TOOLS` so they can't leak into a game build. **Security:** default OFF (no auto-connect), no persisted `user://` config auto-load in a build (dev supplies host/token via code or `GODOT_MCP_*` env / `.env`).
- Reuses the existing runtime-agnostic stack (`GodotMcpConfig`, `GodotReflectorFactory`, `McpPluginBuilder`, `GodotMcpReflector`, `MainThreadDispatcher`/`GodotMainThread`) — no parallel transport. The dispatcher is injected under `SceneTree.Root` and pumped by `_Process` (no editor-frame dependency).

## Test plan
- [x] Editor `Debug` (TOOLS-defined) build: 0 errors.
- [x] **`ExportRelease` (TOOLS-undefined) build: 0 errors** — proves the runtime entry point + builder + handle + dispatcher compile into a non-editor game build. Verified runtime types present (`GodotMcpRuntime`/`Builder`/`Handle`) and editor types absent (`GodotMcpPlugin`, `GodotMcpDock`, `Tool_Node`/`Scene`/`Resource`) in the ExportRelease DLL.
- [x] Headless editor smoke (Godot 4.5.1 mono, `Godot-Test-Project`): `[Godot-MCP] plugin loaded`, deps resolved, no `FileNotFoundException`, connect + clean unload — **no editor regression**.
- [x] 11 new xUnit tests (`GodotMcpRuntimeBuilderTests`) pin the zero-tools default, manual-registration accumulation/dedup, and fresh-config no-persisted-load. Suite: 765 passed / 1 failed — the 1 is the pre-existing benign Windows-host `alc-probe` Temp-lock flake (green in Linux CI).

Note: the CI gate is build-only (no Godot binary in CI), so this does NOT claim runtime tools work live on build-green alone — that live (exported-build) proof is T3 (`2026-06-18-godot-mcp-runtime-testbed-verification`).

Closes #147