### PR TITLE
feat(runtime): register prompts + resources in the runtime builder

### DIFF
--- a/Godot-MCP.Tests/GodotMcpRuntimeBuilderTests.cs
+++ b/Godot-MCP.Tests/GodotMcpRuntimeBuilderTests.cs
@@ -114,6 +114,144 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Throws<ArgumentNullException>(() => builder.WithConfig(null!));
         }
 
+        // --- Prompts: mirror the tools tests exactly (accumulate + dedup + null-guard + empty-by-default).
+        //     Prompt/resource registration is INDEPENDENTLY optional from tools; a builder can register
+        //     prompts while leaving HasNoTools true. The accumulation logic is type-agnostic, so the
+        //     CI-friendly Tool_Ping plus arbitrary BCL/test types double as distinct Type/Assembly fixtures
+        //     here (the editor-gated tool families are #if TOOLS and not compiled into this xUnit assembly).
+
+        [Fact]
+        public void Builder_ByDefault_RegistersZeroPrompts()
+        {
+            var builder = GodotMcpRuntime.Initialize();
+
+            Assert.Empty(builder.PromptAssemblies);
+            Assert.Empty(builder.PromptTypes);
+        }
+
+        [Fact]
+        public void WithPromptsFromAssembly_AccumulatesAndDeduplicates()
+        {
+            var asm = typeof(Tool_Ping).Assembly;
+            var builder = GodotMcpRuntime.Initialize(b =>
+            {
+                b.WithPromptsFromAssembly(asm);
+                b.WithPromptsFromAssembly(asm); // duplicate — must be de-duplicated
+            });
+
+            Assert.Single(builder.PromptAssemblies);
+            Assert.Same(asm, builder.PromptAssemblies[0]);
+            // Prompts are independent of tools — registering a prompt assembly must NOT flip HasNoTools.
+            Assert.True(builder.HasNoTools);
+        }
+
+        [Fact]
+        public void WithPrompts_AccumulatesTypes_IgnoresNullsAndDuplicates()
+        {
+            var builder = GodotMcpRuntime.Initialize(b =>
+                b.WithPrompts(typeof(Tool_Ping), typeof(Tool_Ping), null!));
+
+            Assert.Single(builder.PromptTypes);
+            Assert.Equal(typeof(Tool_Ping), builder.PromptTypes[0]);
+            Assert.True(builder.HasNoTools);
+        }
+
+        [Fact]
+        public void WithPromptsFromAssembly_Null_Throws()
+        {
+            var builder = GodotMcpRuntime.Initialize();
+            Assert.Throws<ArgumentNullException>(() => builder.WithPromptsFromAssembly(null!));
+        }
+
+        [Fact]
+        public void WithPrompts_NullArray_IsNoOp()
+        {
+            var builder = GodotMcpRuntime.Initialize(b => b.WithPrompts(null!));
+            Assert.Empty(builder.PromptTypes);
+        }
+
+        // --- Resources: mirror the prompts tests exactly.
+
+        [Fact]
+        public void Builder_ByDefault_RegistersZeroResources()
+        {
+            var builder = GodotMcpRuntime.Initialize();
+
+            Assert.Empty(builder.ResourceAssemblies);
+            Assert.Empty(builder.ResourceTypes);
+        }
+
+        [Fact]
+        public void WithResourcesFromAssembly_AccumulatesAndDeduplicates()
+        {
+            var asm = typeof(Tool_Ping).Assembly;
+            var builder = GodotMcpRuntime.Initialize(b =>
+            {
+                b.WithResourcesFromAssembly(asm);
+                b.WithResourcesFromAssembly(asm); // duplicate — must be de-duplicated
+            });
+
+            Assert.Single(builder.ResourceAssemblies);
+            Assert.Same(asm, builder.ResourceAssemblies[0]);
+            Assert.True(builder.HasNoTools);
+        }
+
+        [Fact]
+        public void WithResources_AccumulatesTypes_IgnoresNullsAndDuplicates()
+        {
+            var builder = GodotMcpRuntime.Initialize(b =>
+                b.WithResources(typeof(Tool_Ping), typeof(Tool_Ping), null!));
+
+            Assert.Single(builder.ResourceTypes);
+            Assert.Equal(typeof(Tool_Ping), builder.ResourceTypes[0]);
+            Assert.True(builder.HasNoTools);
+        }
+
+        [Fact]
+        public void WithResourcesFromAssembly_Null_Throws()
+        {
+            var builder = GodotMcpRuntime.Initialize();
+            Assert.Throws<ArgumentNullException>(() => builder.WithResourcesFromAssembly(null!));
+        }
+
+        [Fact]
+        public void WithResources_NullArray_IsNoOp()
+        {
+            var builder = GodotMcpRuntime.Initialize(b => b.WithResources(null!));
+            Assert.Empty(builder.ResourceTypes);
+        }
+
+        // --- Prompts + resources + tools accumulate INDEPENDENTLY in a single builder.
+
+        [Fact]
+        public void Tools_Prompts_Resources_AccumulateIndependently()
+        {
+            // Distinct arbitrary Type fixtures — the accumulation buckets are type-agnostic; only Tool_Ping
+            // is compiled into this xUnit assembly, so use BCL/test types for the prompt/resource slots.
+            var toolType = typeof(Tool_Ping);
+            var promptType = typeof(string);
+            var resourceType = typeof(GodotMcpRuntimeBuilderTests);
+            var asm = toolType.Assembly;
+            var builder = GodotMcpRuntime.Initialize(b =>
+            {
+                b.WithTools(toolType);
+                b.WithPrompts(promptType);
+                b.WithResources(resourceType);
+                b.WithPromptsFromAssembly(asm);
+                b.WithResourcesFromAssembly(asm);
+            });
+
+            Assert.False(builder.HasNoTools);
+            Assert.Single(builder.ToolTypes);
+            Assert.Equal(toolType, builder.ToolTypes[0]);
+            Assert.Single(builder.PromptTypes);
+            Assert.Equal(promptType, builder.PromptTypes[0]);
+            Assert.Single(builder.ResourceTypes);
+            Assert.Equal(resourceType, builder.ResourceTypes[0]);
+            Assert.Single(builder.PromptAssemblies);
+            Assert.Single(builder.ResourceAssemblies);
+        }
+
         [Fact]
         public void WithTools_NullArray_IsNoOp()
         {

--- a/README.md
+++ b/README.md
@@ -472,8 +472,10 @@ Two things make runtime mode different from editor mode, and both are deliberate
 
 - **It never auto-connects.** The editor plugin connects on boot; a game build does **not**. *You* write
   the opt-in code and decide when (if ever) to call `Connect()`.
-- **There are no tools by default — strictly manual.** The runtime ships **zero** MCP tools. You register
-  every `[AiToolType]` tool yourself, in your own code. (The addon's 7 editor tool families are gated by
+- **There are no tools, prompts, or resources by default — strictly manual.** The runtime ships **zero**
+  MCP tools, prompts, **and** resources. You register every `[AiToolType]` tool, `[AiPromptType]` prompt,
+  and `[AiResourceType]` resource yourself, in your own code — and each kind is **independently optional**
+  (register prompts without any tools, or vice versa). (The addon's editor tool families are gated by
   `#if TOOLS` and don't even compile into a game build, so they can never leak in.)
 
 The entry point is `GodotMcpRuntime.Initialize(...)` (namespace `com.IvanMurzak.Godot.MCP.Runtime`).
@@ -502,9 +504,15 @@ public partial class GameMcp : Node
                 config.Token          = "your-secret-token";
             });
 
-            // 2) Opt YOUR tools in. Zero tools by default — this is the only way they get registered.
-            builder.WithToolsFromAssembly(Assembly.GetExecutingAssembly());
-            //   …or register specific families: builder.WithTools(typeof(GameMcpTools));
+            // 2) Opt YOUR tools / prompts / resources in. Zero of each by default — this is the only way
+            //    they get registered, and each kind is independently optional.
+            builder.WithToolsFromAssembly(Assembly.GetExecutingAssembly());     // [AiToolType] classes
+            builder.WithPromptsFromAssembly(Assembly.GetExecutingAssembly());   // [AiPromptType] classes
+            builder.WithResourcesFromAssembly(Assembly.GetExecutingAssembly()); // [AiResourceType] classes
+            //   …or register specific families:
+            //   builder.WithTools(typeof(GameMcpTools));
+            //   builder.WithPrompts(typeof(GameMcpPrompts));
+            //   builder.WithResources(typeof(GameMcpResources));
         }).Build();
 
         // 3) Connect — explicit, the security-required opt-in. Retries in the background while
@@ -529,6 +537,10 @@ Builder surface (all fluent / chainable):
 | `builder.WithConfig(Action<GodotMcpConfig>)` | Set `Host` / `Token` / `ConnectionMode` / `AuthOption` in code. Multiple calls compose in order. |
 | `builder.WithToolsFromAssembly(Assembly)` | Register every `[AiToolType]` class in an assembly (usually `Assembly.GetExecutingAssembly()`). |
 | `builder.WithTools(params Type[])` | Register specific `[AiToolType]` classes when a whole-assembly scan is too broad. |
+| `builder.WithPromptsFromAssembly(Assembly)` | Register every `[AiPromptType]` class in an assembly. Independent of tools/resources. |
+| `builder.WithPrompts(params Type[])` | Register specific `[AiPromptType]` classes. |
+| `builder.WithResourcesFromAssembly(Assembly)` | Register every `[AiResourceType]` class in an assembly. Independent of tools/prompts. |
+| `builder.WithResources(params Type[])` | Register specific `[AiResourceType]` classes. |
 | `builder.WithoutMainThreadDispatcher()` | Skip the automatic main-thread-dispatcher bootstrap (only if you install your own autoload dispatcher). |
 | `builder.Build()` | Finalize; returns a **default-OFF** `GodotMcpRuntimeHandle`. |
 | `handle.Connect()` / `handle.Disconnect()` | Open / close the connection. `handle.Dispose()` tears it down on shutdown. |
@@ -607,6 +619,69 @@ game controller on the main thread, plus a `chess-get-board` tool returning a st
 > Same `[AiToolType]`/`[AiTool]`/`MainThread.Instance.Run(...)` contract as the editor [Customize
 > Tools](#customize-tools) section — the only difference is that in a game build *you* register the tools
 > and *you* call `Connect()`.
+
+## Sample: a prompt and a resource
+
+Tools are not the only thing you can expose — MCP also has **prompts** (reusable instruction templates an
+LLM can request by name) and **resources** (addressable, read-only content the LLM can fetch by URI). They
+register exactly like tools: a `partial class` decorated `[AiPromptType]` / `[AiResourceType]`, with each
+member decorated `[AiPrompt(...)]` / `[AiResource(...)]` and a `[Description]`. Register your prompt and
+resource classes the same way you register tools — `WithPromptsFromAssembly(...)` /
+`WithResourcesFromAssembly(...)` (or the by-type `WithPrompts(...)` / `WithResources(...)`) from the
+`Initialize(...)` block above. **Each kind is independently optional** — a game can expose prompts and/or
+resources with no tools at all.
+
+```csharp
+using System.ComponentModel;
+using com.IvanMurzak.McpPlugin;               // [AiPromptType], [AiPrompt], [AiResourceType], [AiResource]
+using com.IvanMurzak.McpPlugin.Common.Model;  // Role, ResponseResourceContent
+using com.IvanMurzak.ReflectorNet.Utils;      // MainThread
+using Godot;
+
+// A PROMPT — a named, reusable instruction the LLM can request. Returns the prompt text; Role marks who
+// the message is from. Set Enabled = false to ship a prompt registered-but-off until you flip it on.
+[AiPromptType]
+public partial class GameMcpPrompts
+{
+    [AiPrompt(Name = "explain-game-state", Role = Role.User)]
+    [Description("Ask the assistant to summarize the current game state for the player.")]
+    public string ExplainGameState()
+    {
+        return "Read the live SceneTree via the game tools and explain the current game state in one paragraph.";
+    }
+}
+
+// A RESOURCE — addressable read-only content fetched by URI. Route is the URI template; the method
+// returns ResponseResourceContent[]. Any Godot API access marshals onto the main thread, exactly like a tool.
+[AiResourceType]
+public partial class GameMcpResources
+{
+    [AiResource(
+        Name = "Live SceneTree node names",
+        Route = "game://scene-tree/nodes",
+        MimeType = "application/json",
+        Description = "The root child node names of the live running game's SceneTree.")]
+    public ResponseResourceContent[] SceneTreeNodes(string uri)
+    {
+        return MainThread.Instance.Run(() =>
+        {
+            var names = new System.Collections.Generic.List<string>();
+            if (Engine.GetMainLoop() is SceneTree tree && tree.Root != null)
+            {
+                foreach (var child in tree.Root.GetChildren())
+                    names.Add(child.Name);
+            }
+
+            var json = System.Text.Json.JsonSerializer.Serialize(names);
+            return new[] { ResponseResourceContent.CreateText(uri, json, "application/json") };
+        });
+    }
+}
+```
+
+> Same independently-optional, manual-registration contract as tools. The `[AiPrompt]`/`[AiResource]`
+> attribute names, `Role` enum, and `ResponseResourceContent` helper all come from the reused
+> `com.IvanMurzak.McpPlugin` package the editor path already uses — nothing Godot-specific to learn.
 
 ## Where the server URL and token come from
 

--- a/addons/godot_mcp/Runtime/GodotMcpRuntime.cs
+++ b/addons/godot_mcp/Runtime/GodotMcpRuntime.cs
@@ -71,7 +71,10 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
         /// <param name="configure">
         /// Configures the connection — <see cref="GodotMcpRuntimeBuilder.WithConfig"/> for host/token/mode,
         /// <see cref="GodotMcpRuntimeBuilder.WithToolsFromAssembly"/> / <see cref="GodotMcpRuntimeBuilder.WithTools"/>
-        /// to opt tools in. May be <c>null</c> for the zero-tool, env/.env-configured default.
+        /// to opt tools in, and the analogous <see cref="GodotMcpRuntimeBuilder.WithPromptsFromAssembly"/> /
+        /// <see cref="GodotMcpRuntimeBuilder.WithPrompts"/> + <see cref="GodotMcpRuntimeBuilder.WithResourcesFromAssembly"/> /
+        /// <see cref="GodotMcpRuntimeBuilder.WithResources"/> to opt prompts and resources in (each
+        /// independently optional). May be <c>null</c> for the zero-tool/prompt/resource, env/.env-configured default.
         /// </param>
         public static GodotMcpRuntimeBuilder Initialize(Action<GodotMcpRuntimeBuilder>? configure = null)
         {
@@ -131,6 +134,27 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
 
             if (builder.ToolTypes.Count > 0)
                 mcpBuilder.WithTools(builder.ToolTypes.ToArray());
+
+            // 4b) Register the developer's opted-in prompts + resources. ZERO of each by default and
+            //     INDEPENDENTLY optional from tools (a game may register prompts and/or resources without
+            //     any tools, or vice versa). Mirrors the tools conditionals above 1:1 and the editor path's
+            //     WithPromptsFromAssembly/WithResourcesFromAssembly calls (GodotMcpConnection.Start). The
+            //     by-type WithPrompts/WithResources(params Type[]) overloads exist on McpPluginBuilder
+            //     alongside the FromAssembly(IEnumerable<Assembly>) variants, so this matches Build()'s tools
+            //     shape exactly. Editor prompt/resource families (if any) are #if TOOLS and don't compile
+            //     into a game build, so a WithPromptsFromAssembly/WithResourcesFromAssembly over the addon
+            //     assembly can't pull them in.
+            if (builder.PromptAssemblies.Count > 0)
+                mcpBuilder.WithPromptsFromAssembly(builder.PromptAssemblies);
+
+            if (builder.PromptTypes.Count > 0)
+                mcpBuilder.WithPrompts(builder.PromptTypes.ToArray());
+
+            if (builder.ResourceAssemblies.Count > 0)
+                mcpBuilder.WithResourcesFromAssembly(builder.ResourceAssemblies);
+
+            if (builder.ResourceTypes.Count > 0)
+                mcpBuilder.WithResources(builder.ResourceTypes.ToArray());
 
             var plugin = mcpBuilder.Build(reflector);
 

--- a/addons/godot_mcp/Runtime/GodotMcpRuntimeBuilder.cs
+++ b/addons/godot_mcp/Runtime/GodotMcpRuntimeBuilder.cs
@@ -47,6 +47,10 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
         readonly List<Action<GodotMcpConfig>> _configActions = new();
         readonly List<Assembly> _toolAssemblies = new();
         readonly List<Type> _toolTypes = new();
+        readonly List<Assembly> _promptAssemblies = new();
+        readonly List<Type> _promptTypes = new();
+        readonly List<Assembly> _resourceAssemblies = new();
+        readonly List<Type> _resourceTypes = new();
 
         /// <summary>
         /// Whether <see cref="GodotMcpRuntime.Initialize"/> should guarantee a
@@ -119,6 +123,76 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
         }
 
         /// <summary>
+        /// Opt every <c>[AiPromptType]</c>/<c>[AiPrompt]</c> class declared in <paramref name="assembly"/> into
+        /// the runtime prompt set. The common case is <c>Assembly.GetExecutingAssembly()</c> so a game
+        /// registers its own prompts. Multiple calls accumulate; duplicate assemblies are de-duplicated at
+        /// build time. Returns <c>this</c> for chaining. <b>Independently optional from tools/resources</b> —
+        /// a game can register prompts without registering any tools (zero prompts by default).
+        /// </summary>
+        public GodotMcpRuntimeBuilder WithPromptsFromAssembly(Assembly assembly)
+        {
+            if (assembly == null)
+                throw new ArgumentNullException(nameof(assembly));
+
+            if (!_promptAssemblies.Contains(assembly))
+                _promptAssemblies.Add(assembly);
+            return this;
+        }
+
+        /// <summary>
+        /// Opt specific <c>[AiPromptType]</c> classes into the runtime prompt set (when a whole-assembly scan
+        /// is too broad). Null entries are ignored; duplicates are de-duplicated at build time. Returns
+        /// <c>this</c> for chaining.
+        /// </summary>
+        public GodotMcpRuntimeBuilder WithPrompts(params Type[] promptTypes)
+        {
+            if (promptTypes == null)
+                return this;
+
+            foreach (var type in promptTypes)
+            {
+                if (type != null && !_promptTypes.Contains(type))
+                    _promptTypes.Add(type);
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Opt every <c>[AiResourceType]</c>/<c>[AiResource]</c> class declared in <paramref name="assembly"/>
+        /// into the runtime resource set. The common case is <c>Assembly.GetExecutingAssembly()</c> so a game
+        /// registers its own resources. Multiple calls accumulate; duplicate assemblies are de-duplicated at
+        /// build time. Returns <c>this</c> for chaining. <b>Independently optional from tools/prompts</b> —
+        /// a game can register resources without registering any tools (zero resources by default).
+        /// </summary>
+        public GodotMcpRuntimeBuilder WithResourcesFromAssembly(Assembly assembly)
+        {
+            if (assembly == null)
+                throw new ArgumentNullException(nameof(assembly));
+
+            if (!_resourceAssemblies.Contains(assembly))
+                _resourceAssemblies.Add(assembly);
+            return this;
+        }
+
+        /// <summary>
+        /// Opt specific <c>[AiResourceType]</c> classes into the runtime resource set (when a whole-assembly
+        /// scan is too broad). Null entries are ignored; duplicates are de-duplicated at build time. Returns
+        /// <c>this</c> for chaining.
+        /// </summary>
+        public GodotMcpRuntimeBuilder WithResources(params Type[] resourceTypes)
+        {
+            if (resourceTypes == null)
+                return this;
+
+            foreach (var type in resourceTypes)
+            {
+                if (type != null && !_resourceTypes.Contains(type))
+                    _resourceTypes.Add(type);
+            }
+            return this;
+        }
+
+        /// <summary>
         /// Skip the automatic <see cref="MainThreadDispatch.MainThreadDispatcher"/> bootstrap. Use this only
         /// when the game already installs a dispatcher itself (e.g. as a Godot autoload) AND has called
         /// <see cref="MainThreadDispatch.GodotMainThread.Install"/>. With the bootstrap skipped and no
@@ -152,6 +226,18 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
 
         /// <summary>The individual tool types the developer opted in via <see cref="WithTools"/>.</summary>
         internal IReadOnlyList<Type> ToolTypes => _toolTypes;
+
+        /// <summary>The assemblies the developer opted in via <see cref="WithPromptsFromAssembly"/>.</summary>
+        internal IReadOnlyList<Assembly> PromptAssemblies => _promptAssemblies;
+
+        /// <summary>The individual prompt types the developer opted in via <see cref="WithPrompts"/>.</summary>
+        internal IReadOnlyList<Type> PromptTypes => _promptTypes;
+
+        /// <summary>The assemblies the developer opted in via <see cref="WithResourcesFromAssembly"/>.</summary>
+        internal IReadOnlyList<Assembly> ResourceAssemblies => _resourceAssemblies;
+
+        /// <summary>The individual resource types the developer opted in via <see cref="WithResources"/>.</summary>
+        internal IReadOnlyList<Type> ResourceTypes => _resourceTypes;
 
         /// <summary>True when the developer registered no tools at all (the empty-tool-set default).</summary>
         internal bool HasNoTools => _toolAssemblies.Count == 0 && _toolTypes.Count == 0;


### PR DESCRIPTION
## Summary
- Extend `GodotMcpRuntimeBuilder` with prompt + resource registration mirroring the tools surface 1:1 (`WithPromptsFromAssembly`/`WithPrompts` + `WithResourcesFromAssembly`/`WithResources`, null-guarded, deduped, fluent; internal accessors). Each kind is independently optional and zero-by-default.
- Wire `GodotMcpRuntime.Build()` to pass them into `McpPluginBuilder` via the same conditional shape as tools (verified the `WithPrompts`/`WithResources(params Type[])` + `FromAssembly(IEnumerable<Assembly>)` overloads exist on McpPlugin 6.10.0; editor path unchanged).
- Document registering tools + prompts + resources in the README "Runtime usage (in-game)" with author-your-own `[AiPromptType]`/`[AiResourceType]` snippets (attribute names, `Role` enum, `ResponseResourceContent.CreateText` signature grep-verified against shipped source).
- 12 new accumulate/dedup/null-guard/empty-by-default unit tests.

## Test plan
- [x] Suite 1 `dotnet build Godot-MCP.sln` (Debug, TOOLS-on) — 0 errors.
- [x] ExportRelease (TOOLS-undefined) addon build — 0 errors, proving the new surface compiles into a game build.
- [x] Suite 2 `dotnet test Godot-MCP.Tests` — 776 passed; the single failure is the known-benign Windows-host-only `alc-probe` cleanup flake (green in Linux CI, untouched by this change).

Closes #152