### PR TITLE
feat(runtime): capture in-game runtime errors and surface them to the agent

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -127,6 +127,28 @@
     <Compile Include="..\addons\godot_mcp\Runtime\Data\ScriptDiagnostic.cs" Link="Source\ScriptDiagnostic.cs" />
     <Compile Include="..\addons\godot_mcp\Runtime\Data\ScriptDiagnosticsResult.cs" Link="Source\ScriptDiagnosticsResult.cs" />
     <Compile Include="..\addons\godot_mcp\Runtime\Tools\ScriptErrorCapture.cs" Link="Source\ScriptErrorCapture.cs" />
+    <!-- In-game runtime ERROR CAPTURE (issue #160) — pure-managed pieces only (no Godot native types, no
+         #if TOOLS): the RuntimeError row + source enum, the RuntimeErrorsResult model, the bounded ring-buffer
+         RuntimeErrorCollector (monotonic sequence + since-marker poll), the RuntimeErrorFactory (engine-record
+         + C#-exception → RuntimeError mapping), and the runtime-errors-* tool handlers (read the collector).
+         The capture INSTALLER (RuntimeErrorCapture.cs) touches OS.AddLogger/GD.Print + the static AppDomain/
+         TaskScheduler events (faults in this binary-less host) and the engine Logger subclass
+         (GodotScriptErrorLogger.cs) is #if GODOT4_5_OR_GREATER — both verified via the headless Godot runtime
+         smoke (test.md Suite 3); the models + collector + factory + tool handlers are unit-tested here. -->
+    <Compile Include="..\addons\godot_mcp\Runtime\Data\RuntimeError.cs" Link="Source\RuntimeError.cs" />
+    <Compile Include="..\addons\godot_mcp\Runtime\Data\RuntimeErrorsResult.cs" Link="Source\RuntimeErrorsResult.cs" />
+    <Compile Include="..\addons\godot_mcp\Runtime\Tools\RuntimeErrorCollector.cs" Link="Source\RuntimeErrorCollector.cs" />
+    <Compile Include="..\addons\godot_mcp\Runtime\Tools\RuntimeErrorFactory.cs" Link="Source\RuntimeErrorFactory.cs" />
+    <Compile Include="..\addons\godot_mcp\Runtime\Tools\Tool_RuntimeErrors.cs" Link="Source\Tool_RuntimeErrors.cs" />
+    <Compile Include="..\addons\godot_mcp\Runtime\Tools\Tool_RuntimeErrors.Get.cs" Link="Source\Tool_RuntimeErrors.Get.cs" />
+    <Compile Include="..\addons\godot_mcp\Runtime\Tools\Tool_RuntimeErrors.Clear.cs" Link="Source\Tool_RuntimeErrors.Clear.cs" />
+    <!-- Engine-error logger bridge — RuntimeErrorCapture references GodotScriptErrorLoggerBridge. The real
+         bridge (GodotScriptErrorLogger.cs) is #if GODOT4_5_OR_GREATER (compiled OUT at the 4.3.0 test pin), so
+         only the no-op stub (#if !GODOT4_5_OR_GREATER) compiles in here — matching what the addon's 4.3 floor
+         build (and the < 4.5 export) sees. Both are included so the resolution is identical to the addon; the
+         4.5+ Logger subclass + OS.AddLogger path is exercised by the headless Godot 4.5 smoke (test.md Suite 3). -->
+    <Compile Include="..\addons\godot_mcp\Runtime\Tools\GodotScriptErrorLogger.cs" Link="Source\GodotScriptErrorLogger.cs" />
+    <Compile Include="..\addons\godot_mcp\Runtime\Tools\GodotScriptErrorLogger.Stub.cs" Link="Source\GodotScriptErrorLogger.Stub.cs" />
     <!-- Screenshot tool family — pure-managed pieces only (no Godot native types, no #if TOOLS): the
          size-cap clamping, framing trig, view-direction table, and hex-color parse. The editor-driving
          handlers (Tool_Screenshot.*.cs) are #if TOOLS and encode a real Godot Image, so they are verified
@@ -233,6 +255,13 @@
     <Compile Include="..\addons\godot_mcp\Runtime\GodotMcpRuntimeBuilder.cs" Link="Source\GodotMcpRuntimeBuilder.cs" />
     <Compile Include="..\addons\godot_mcp\Runtime\GodotMcpRuntime.cs" Link="Source\GodotMcpRuntime.cs" />
     <Compile Include="..\addons\godot_mcp\Runtime\GodotMcpRuntimeHandle.cs" Link="Source\GodotMcpRuntimeHandle.cs" />
+    <!-- Runtime error-capture INSTALLER — referenced by GodotMcpRuntime.Build()/Handle.Dispose(), so it must
+         compile in for those to resolve. It references GD.Print/GD.PushWarning + the AppDomain/TaskScheduler
+         static events (all present at the 4.3.0 test pin; the 4.5-only OS.AddLogger is reached only through
+         the #if-guarded bridge, which is the stub here). The builder-only runtime tests never call Install()
+         (it would touch the live engine and fault in this binary-less host), so it stays compiled-but-uncalled,
+         exactly like GodotMcpRuntime.Build(). Its pure-managed mapping is unit-tested via RuntimeErrorFactory. -->
+    <Compile Include="..\addons\godot_mcp\Runtime\RuntimeErrorCapture.cs" Link="Source\RuntimeErrorCapture.cs" />
     <!-- Main-thread dispatcher pair — GodotMcpRuntime.EnsureMainThreadDispatcher references both. Pure-managed
          types (MainThreadDispatcher is a Godot Node, but constructing it is a Suite-3 concern; the runtime
          builder-only tests never instantiate it). Compiled in so the runtime sources resolve their usings. -->

--- a/Godot-MCP.Tests/RuntimeErrorCaptureTests.cs
+++ b/Godot-MCP.Tests/RuntimeErrorCaptureTests.cs
@@ -1,0 +1,506 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.Godot.MCP.Runtime;
+using com.IvanMurzak.Godot.MCP.Tools;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pure-managed coverage for the in-game runtime error-capture feature (issue #160): the
+    /// <see cref="RuntimeError"/> / <see cref="RuntimeErrorsResult"/> models, the bounded ring-buffer
+    /// <see cref="RuntimeErrorCollector"/> (monotonic sequence + since-marker poll + eviction), the
+    /// <see cref="RuntimeErrorFactory"/> (engine-record + C#-exception → row mapping), the
+    /// <c>runtime-errors-*</c> tool handlers, the structured <see cref="ScriptErrorCapture.ErrorSink"/>
+    /// forwarding, and the builder opt-in. None touch a live Godot runtime, so they run in the plain xUnit
+    /// host with no Godot binary. The capture INSTALLER (<c>RuntimeErrorCapture.Install</c>, which registers
+    /// the engine logger via <c>OS.AddLogger</c> + the AppDomain/TaskScheduler hooks) and the 4.5 engine
+    /// Logger subclass are verified by the headless Godot runtime smoke (test.md Suite 3).
+    /// </summary>
+    public class RuntimeErrorCaptureTests
+    {
+        // ---- RuntimeError / RuntimeErrorsResult serialization ------------------------------------
+
+        [Fact]
+        public void RuntimeError_Serializes_WithExpectedJsonNames()
+        {
+            var e = new RuntimeError(
+                source: RuntimeErrorSource.Engine,
+                message: "Invalid get index 'x'",
+                type: "Script",
+                file: "res://scripts/player.gd",
+                line: 42,
+                function: "_process")
+            { Sequence = 7 };
+
+            var json = JsonSerializer.Serialize(e);
+            foreach (var key in new[] { "sequence", "message", "type", "source", "file", "line",
+                "function", "stackTrace", "timestamp" })
+                Assert.Contains($"\"{key}\"", json);
+
+            var restored = JsonSerializer.Deserialize<RuntimeError>(json);
+            Assert.NotNull(restored);
+            Assert.Equal(7, restored!.Sequence);
+            Assert.Equal("Invalid get index 'x'", restored.Message);
+            Assert.Equal("Script", restored.Type);
+            Assert.Equal(RuntimeErrorSource.Engine, restored.Source);
+            Assert.Equal("res://scripts/player.gd", restored.File);
+            Assert.Equal(42, restored.Line);
+            Assert.Equal("_process", restored.Function);
+        }
+
+        [Fact]
+        public void RuntimeErrorsResult_Serializes_WithExpectedJsonNames()
+        {
+            var r = new RuntimeErrorsResult
+            {
+                Available = true,
+                Ok = false,
+                Count = 1,
+                ErrorCount = 1,
+                HighestSequence = 9,
+                Errors = { new RuntimeError(RuntimeErrorSource.UnhandledException, "boom", "System.Exception") },
+                Note = "1 runtime error.",
+            };
+
+            var json = JsonSerializer.Serialize(r);
+            foreach (var key in new[] { "available", "ok", "count", "errorCount", "warningCount",
+                "highestSequence", "truncated", "errors", "note" })
+                Assert.Contains($"\"{key}\"", json);
+
+            var restored = JsonSerializer.Deserialize<RuntimeErrorsResult>(json);
+            Assert.NotNull(restored);
+            Assert.True(restored!.Available);
+            Assert.False(restored.Ok);
+            Assert.Equal(9, restored.HighestSequence);
+            Assert.Single(restored.Errors);
+        }
+
+        // ---- RuntimeErrorCollector: sequence + buffer --------------------------------------------
+
+        [Fact]
+        public void Collector_Append_AssignsMonotonicSequence_AndAdvancesHighest()
+        {
+            var c = new RuntimeErrorCollector();
+            Assert.Equal(0, c.HighestSequence);
+
+            var s1 = c.Append(new RuntimeError(RuntimeErrorSource.Engine, "a", "Error"));
+            var s2 = c.Append(new RuntimeError(RuntimeErrorSource.Engine, "b", "Error"));
+
+            Assert.Equal(1, s1);
+            Assert.Equal(2, s2);
+            Assert.Equal(2, c.HighestSequence);
+            Assert.Equal(2, c.Count);
+        }
+
+        [Fact]
+        public void Collector_Append_NullIsIgnored_ReturnsZero()
+        {
+            var c = new RuntimeErrorCollector();
+            Assert.Equal(0, c.Append(null!));
+            Assert.Equal(0, c.Count);
+        }
+
+        [Fact]
+        public void Collector_QuerySince_ReturnsOnlyNewerErrors_OldestFirst()
+        {
+            var c = new RuntimeErrorCollector();
+            for (int i = 0; i < 5; i++)
+                c.Append(new RuntimeError(RuntimeErrorSource.Engine, $"e{i}", "Error"));
+
+            var page = c.QuerySince(sinceSequence: 2, maxEntries: 100, out var truncated);
+
+            Assert.False(truncated);
+            Assert.Equal(3, page.Length);                       // sequences 3,4,5
+            Assert.Equal(new long[] { 3, 4, 5 }, page.Select(e => e.Sequence)); // oldest-first
+        }
+
+        [Fact]
+        public void Collector_QuerySince_Zero_ReturnsAllRetained()
+        {
+            var c = new RuntimeErrorCollector();
+            c.Append(new RuntimeError(RuntimeErrorSource.Engine, "a", "Error"));
+            c.Append(new RuntimeError(RuntimeErrorSource.Engine, "b", "Error"));
+
+            var page = c.QuerySince(0, 100, out _);
+            Assert.Equal(2, page.Length);
+        }
+
+        [Fact]
+        public void Collector_QuerySince_CapsToMaxEntries_KeepingNewest_AndFlagsTruncation()
+        {
+            var c = new RuntimeErrorCollector();
+            for (int i = 0; i < 10; i++)
+                c.Append(new RuntimeError(RuntimeErrorSource.Engine, $"e{i}", "Error"));
+
+            var page = c.QuerySince(0, maxEntries: 3, out var truncated);
+
+            Assert.True(truncated);
+            Assert.Equal(3, page.Length);
+            // The NEWEST 3 (sequences 8,9,10) are kept — never the oldest.
+            Assert.Equal(new long[] { 8, 9, 10 }, page.Select(e => e.Sequence));
+        }
+
+        [Fact]
+        public void Collector_EvictsOldest_AtCapacity_ButHighestSequenceKeepsAdvancing()
+        {
+            var c = new RuntimeErrorCollector();
+            int total = RuntimeErrorCollector.Capacity + 50;
+            for (int i = 0; i < total; i++)
+                c.Append(new RuntimeError(RuntimeErrorSource.Engine, $"e{i}", "Error"));
+
+            Assert.Equal(RuntimeErrorCollector.Capacity, c.Count);   // bounded
+            Assert.Equal(total, c.HighestSequence);                  // sequence still advanced past eviction
+
+            // The earliest sequences were evicted; a since-poll for the very first ones returns only what
+            // survived (capacity worth), capped — proving eviction does not corrupt the since semantics.
+            var page = c.QuerySince(0, int.MaxValue, out _);
+            Assert.Equal(RuntimeErrorCollector.Capacity, page.Length);
+            Assert.Equal(51, page.First().Sequence);  // first surviving = total-Capacity+1 = 50+1
+            Assert.Equal(total, page.Last().Sequence);
+        }
+
+        [Fact]
+        public void Collector_Clear_DropsEntries_ButNotTheSequenceCounter()
+        {
+            var c = new RuntimeErrorCollector();
+            c.Append(new RuntimeError(RuntimeErrorSource.Engine, "a", "Error")); // seq 1
+            c.Append(new RuntimeError(RuntimeErrorSource.Engine, "b", "Error")); // seq 2
+            c.Clear();
+
+            Assert.Equal(0, c.Count);
+            Assert.Equal(2, c.HighestSequence); // retained across clear
+
+            var s3 = c.Append(new RuntimeError(RuntimeErrorSource.Engine, "c", "Error"));
+            Assert.Equal(3, s3); // counter did NOT reset — no sequence reuse after a clear
+        }
+
+        [Fact]
+        public void Collector_Append_IsThreadSafe_AllSequencesUniqueAndContiguous()
+        {
+            var c = new RuntimeErrorCollector();
+            const int perThread = 200;
+            const int threadCount = 8;
+            var threads = new List<Thread>();
+            for (int t = 0; t < threadCount; t++)
+            {
+                var thread = new Thread(() =>
+                {
+                    for (int i = 0; i < perThread; i++)
+                        c.Append(new RuntimeError(RuntimeErrorSource.Engine, "x", "Error"));
+                });
+                threads.Add(thread);
+                thread.Start();
+            }
+            foreach (var thread in threads) thread.Join();
+
+            Assert.Equal(threadCount * perThread, c.HighestSequence); // no lost/duplicated sequences
+        }
+
+        // ---- RuntimeErrorFactory: engine + exception mapping -------------------------------------
+
+        [Fact]
+        public void Factory_FromEngine_MapsOriginFields_NoStackTrace()
+        {
+            var record = new EngineErrorRecord(EngineErrorKind.Script, "res://x.gd", 13, "_ready", "bad index");
+            var e = RuntimeErrorFactory.FromEngine(record);
+
+            Assert.Equal(RuntimeErrorSource.Engine, e.Source);
+            Assert.Equal("Script", e.Type);            // EngineErrorKind name
+            Assert.Equal("res://x.gd", e.File);
+            Assert.Equal(13, e.Line);
+            Assert.Equal("_ready", e.Function);
+            Assert.Equal("bad index", e.Message);
+            Assert.Null(e.StackTrace);                 // engine hook yields origin, not a deep stack
+        }
+
+        [Fact]
+        public void Factory_FromException_MapsTypeMessageAndFullStackTrace()
+        {
+            Exception caught;
+            try { throw new InvalidOperationException("kaboom"); }
+            catch (Exception ex) { caught = ex; }
+
+            var e = RuntimeErrorFactory.FromException(RuntimeErrorSource.UnhandledException, caught);
+
+            Assert.Equal(RuntimeErrorSource.UnhandledException, e.Source);
+            Assert.Equal("System.InvalidOperationException", e.Type);
+            Assert.Equal("kaboom", e.Message);
+            Assert.NotNull(e.StackTrace);
+            Assert.Contains("InvalidOperationException", e.StackTrace);
+            Assert.Contains("kaboom", e.StackTrace);
+        }
+
+        [Fact]
+        public void Factory_FromException_FlattensInnerException_InStackTrace()
+        {
+            Exception caught;
+            try
+            {
+                try { throw new ArgumentNullException("inner-arg"); }
+                catch (Exception inner) { throw new InvalidOperationException("outer", inner); }
+            }
+            catch (Exception ex) { caught = ex; }
+
+            var e = RuntimeErrorFactory.FromException(RuntimeErrorSource.UnobservedTaskException, caught);
+
+            Assert.Equal(RuntimeErrorSource.UnobservedTaskException, e.Source);
+            Assert.Equal("System.InvalidOperationException", e.Type); // OUTER type/message stay discrete
+            Assert.Equal("outer", e.Message);
+            Assert.NotNull(e.StackTrace);
+            Assert.Contains("ArgumentNullException", e.StackTrace!); // inner is inlined by Exception.ToString()
+        }
+
+        [Fact]
+        public void Factory_FromException_NullIsSafe_YieldsPlaceholderRow()
+        {
+            var e = RuntimeErrorFactory.FromException(RuntimeErrorSource.UnhandledException, null);
+            Assert.Equal(RuntimeErrorSource.UnhandledException, e.Source);
+            Assert.Contains("null", e.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        // ---- ScriptErrorCapture.ErrorSink: structured forwarding ---------------------------------
+
+        [Fact]
+        public void Route_ForwardsStructuredRecordToErrorSink_WithFunction()
+        {
+            var records = new List<EngineErrorRecord>();
+            var capture = new ScriptErrorCapture { ErrorSink = r => records.Add(r) };
+
+            capture.Route(EngineErrorKind.Script, "res://p.gd", 5, "cond", "Parse error", function: "_process");
+
+            var rec = Assert.Single(records);
+            Assert.Equal(EngineErrorKind.Script, rec.Kind);
+            Assert.Equal("res://p.gd", rec.FilePath);
+            Assert.Equal(5, rec.Line);
+            Assert.Equal("_process", rec.Function);
+            Assert.Equal("Parse error", rec.Message); // rationale preferred
+        }
+
+        [Fact]
+        public void Route_ErrorSink_FiresIndependentlyOfValidationSession()
+        {
+            var records = new List<EngineErrorRecord>();
+            var capture = new ScriptErrorCapture { ErrorSink = r => records.Add(r) };
+
+            // No BeginSession — the validation path is silent, but the structured ErrorSink still fires (the
+            // runtime captures every engine error, not just script errors during a validation window).
+            capture.Route(EngineErrorKind.Error, "res://a.gd", 1, "c", "generic");
+            capture.Route(EngineErrorKind.Warning, "res://b.gd", 2, "c", "warn");
+
+            Assert.Equal(2, records.Count);
+            Assert.Empty(capture.EndSession()); // confirms no validation session was implicitly opened
+        }
+
+        [Fact]
+        public void Route_BothSinks_CanCoexist()
+        {
+            var logs = new List<(GodotLogType, string)>();
+            var records = new List<EngineErrorRecord>();
+            var capture = new ScriptErrorCapture
+            {
+                LogSink = (t, m) => logs.Add((t, m)),
+                ErrorSink = r => records.Add(r),
+            };
+
+            capture.Route(EngineErrorKind.Script, "res://p.gd", 5, "c", "boom");
+
+            Assert.Single(logs);
+            Assert.Single(records);
+        }
+
+        // ---- Tool_RuntimeErrors.Get / Clear ------------------------------------------------------
+
+        [Fact]
+        public void Tool_Get_ReportsUnavailable_WhenNoCollectorInstalled()
+        {
+            WithNoCollector(() =>
+            {
+                var result = new Tool_RuntimeErrors().Get();
+                Assert.False(result.Available);
+                Assert.True(result.Ok); // ok defaults true so an unavailable result is not read as a failure
+                Assert.Empty(result.Errors);
+                Assert.Contains("not enabled", result.Note, StringComparison.OrdinalIgnoreCase);
+            });
+        }
+
+        [Fact]
+        public void Tool_Get_ReturnsErrors_AndComputesCounts_WhenAvailable()
+        {
+            WithCollector(c =>
+            {
+                c.Append(new RuntimeError(RuntimeErrorSource.Engine, "warn", nameof(EngineErrorKind.Warning)));
+                c.Append(new RuntimeError(RuntimeErrorSource.Engine, "err", nameof(EngineErrorKind.Error)));
+                c.Append(new RuntimeError(RuntimeErrorSource.UnhandledException, "boom", "System.Exception"));
+
+                var result = new Tool_RuntimeErrors().Get();
+
+                Assert.True(result.Available);
+                Assert.False(result.Ok);                 // has error-severity rows
+                Assert.Equal(3, result.Count);
+                Assert.Equal(2, result.ErrorCount);      // engine Error + managed fault
+                Assert.Equal(1, result.WarningCount);    // engine Warning only
+                Assert.Equal(3, result.HighestSequence);
+            });
+        }
+
+        [Fact]
+        public void Tool_Get_OkTrue_WhenOnlyWarnings()
+        {
+            WithCollector(c =>
+            {
+                c.Append(new RuntimeError(RuntimeErrorSource.Engine, "w1", nameof(EngineErrorKind.Warning)));
+                c.Append(new RuntimeError(RuntimeErrorSource.Engine, "w2", nameof(EngineErrorKind.Warning)));
+
+                var result = new Tool_RuntimeErrors().Get();
+                Assert.True(result.Available);
+                Assert.True(result.Ok);                  // warnings do not flip ok
+                Assert.Equal(0, result.ErrorCount);
+                Assert.Equal(2, result.WarningCount);
+            });
+        }
+
+        [Fact]
+        public void Tool_Get_SinceSequence_ReturnsOnlyNewer()
+        {
+            WithCollector(c =>
+            {
+                for (int i = 0; i < 4; i++)
+                    c.Append(new RuntimeError(RuntimeErrorSource.Engine, $"e{i}", nameof(EngineErrorKind.Error)));
+
+                var result = new Tool_RuntimeErrors().Get(sinceSequence: 2);
+                Assert.Equal(2, result.Count);          // sequences 3,4
+                Assert.All(result.Errors, e => Assert.True(e.Sequence > 2));
+                Assert.Equal(4, result.HighestSequence); // still reflects ALL captured, for the next poll
+            });
+        }
+
+        [Fact]
+        public void Tool_Get_MaxEntries_TruncatesKeepingNewest()
+        {
+            WithCollector(c =>
+            {
+                for (int i = 0; i < 6; i++)
+                    c.Append(new RuntimeError(RuntimeErrorSource.Engine, $"e{i}", nameof(EngineErrorKind.Error)));
+
+                var result = new Tool_RuntimeErrors().Get(maxEntries: 2);
+                Assert.Equal(2, result.Count);
+                Assert.True(result.Truncated);
+                Assert.Equal(new long[] { 5, 6 }, result.Errors.Select(e => e.Sequence));
+            });
+        }
+
+        [Fact]
+        public void Tool_Get_RejectsNonPositiveMaxEntries()
+        {
+            WithCollector(_ =>
+                Assert.Throws<ArgumentException>(() => new Tool_RuntimeErrors().Get(maxEntries: 0)));
+        }
+
+        [Fact]
+        public void Tool_Clear_EmptiesBuffer_WhenAvailable()
+        {
+            WithCollector(c =>
+            {
+                c.Append(new RuntimeError(RuntimeErrorSource.Engine, "e", nameof(EngineErrorKind.Error)));
+                Assert.Equal(1, c.Count);
+
+                new Tool_RuntimeErrors().Clear();
+                Assert.Equal(0, c.Count);
+
+                // available stays true after clear (capture still wired); the get just sees an empty buffer.
+                var result = new Tool_RuntimeErrors().Get();
+                Assert.True(result.Available);
+                Assert.True(result.Ok);
+                Assert.Empty(result.Errors);
+            });
+        }
+
+        [Fact]
+        public void Tool_Clear_IsNoOp_WhenUnavailable()
+        {
+            WithNoCollector(() =>
+            {
+                var ex = Record.Exception(() => new Tool_RuntimeErrors().Clear());
+                Assert.Null(ex); // must not throw when capture was never enabled
+            });
+        }
+
+        // ---- Builder opt-in ----------------------------------------------------------------------
+
+        [Fact]
+        public void Builder_WithRuntimeErrorCapture_SetsFlag_AndRegistersTool()
+        {
+            var builder = GodotMcpRuntime.Initialize(b => b.WithRuntimeErrorCapture());
+
+            // The flag is internal — reach it reflectively (same assembly).
+            var flag = (bool)typeof(GodotMcpRuntimeBuilder)
+                .GetProperty("CaptureRuntimeErrors",
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+                .GetValue(builder)!;
+            Assert.True(flag);
+
+            // The runtime-errors tool is auto-registered so the captured errors are reachable.
+            Assert.False(builder.HasNoTools);
+            Assert.Contains(typeof(Tool_RuntimeErrors), builder.ToolTypes);
+        }
+
+        [Fact]
+        public void Builder_WithoutOptIn_DoesNotEnableCapture_OrRegisterTool()
+        {
+            var builder = GodotMcpRuntime.Initialize();
+
+            var flag = (bool)typeof(GodotMcpRuntimeBuilder)
+                .GetProperty("CaptureRuntimeErrors",
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+                .GetValue(builder)!;
+            Assert.False(flag);                              // default OFF
+            Assert.True(builder.HasNoTools);
+            Assert.DoesNotContain(typeof(Tool_RuntimeErrors), builder.ToolTypes);
+        }
+
+        [Fact]
+        public void Builder_WithRuntimeErrorCapture_IsIdempotent_RegistersToolOnce()
+        {
+            var builder = GodotMcpRuntime.Initialize(b => b
+                .WithRuntimeErrorCapture()
+                .WithRuntimeErrorCapture()
+                .WithTools(typeof(Tool_RuntimeErrors))); // explicit dup too
+
+            Assert.Single(builder.ToolTypes, t => t == typeof(Tool_RuntimeErrors));
+        }
+
+        // ---- helpers: install/teardown the process-wide collector around a test --------------------
+
+        static void WithCollector(Action<RuntimeErrorCollector> body)
+        {
+            var prior = RuntimeErrorCollector.Current;
+            var c = new RuntimeErrorCollector();
+            RuntimeErrorCollector.Current = c;
+            try { body(c); }
+            finally { RuntimeErrorCollector.Current = prior; }
+        }
+
+        static void WithNoCollector(Action body)
+        {
+            var prior = RuntimeErrorCollector.Current;
+            RuntimeErrorCollector.Current = null;
+            try { body(); }
+            finally { RuntimeErrorCollector.Current = prior; }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ That's it. Ask your AI *"Create 3 cubes in a circle with radius 2"* and watch it
   - [Build & run the server manually (advanced)](#build--run-the-server-manually-advanced)
 - [Customize Tools](#customize-tools)
 - [Runtime usage (in-game)](#runtime-usage-in-game)
+  - [Capturing in-game runtime errors](#capturing-in-game-runtime-errors)
   - [Sample: a live game-state tool](#sample-a-live-game-state-tool)
   - [Where the server URL and token come from](#where-the-server-url-and-token-come-from)
   - [Security: opt-in only, default OFF](#security-opt-in-only-default-off)
@@ -542,12 +543,67 @@ Builder surface (all fluent / chainable):
 | `builder.WithResourcesFromAssembly(Assembly)` | Register every `[AiResourceType]` class in an assembly. Independent of tools/prompts. |
 | `builder.WithResources(params Type[])` | Register specific `[AiResourceType]` classes. |
 | `builder.WithoutMainThreadDispatcher()` | Skip the automatic main-thread-dispatcher bootstrap (only if you install your own autoload dispatcher). |
+| `builder.WithRuntimeErrorCapture()` | Capture errors raised in the **running game** (GDScript runtime errors, `push_error`/`push_warning`, shader errors via the Godot 4.5+ engine hook; C# unhandled / unobserved-`Task` exceptions with full stack traces) and register the `runtime-errors-*` tool so an agent can poll them. **OFF by default.** See ["Capturing in-game runtime errors"](#capturing-in-game-runtime-errors) below. |
 | `builder.Build()` | Finalize; returns a **default-OFF** `GodotMcpRuntimeHandle`. |
 | `handle.Connect()` / `handle.Disconnect()` | Open / close the connection. `handle.Dispose()` tears it down on shutdown. |
 
 > `Initialize().Build()` also guarantees a main-thread dispatcher `Node` in the running `SceneTree` (so
 > tool handlers can marshal Godot API calls onto the engine main thread), unless you opt out with
 > `WithoutMainThreadDispatcher()`. Call it once a `SceneTree` is live (e.g. from an autoload `_Ready`).
+
+## Capturing in-game runtime errors
+
+In editor mode, `console-get-logs` and `script-validate` surface the plugin's own logs and GDScript
+*parse* errors. But errors raised inside a **running game** — a GDScript *runtime* error (a null
+dereference, a bad index), a `push_error`/`push_warning`, a shader error, or a C# unhandled exception —
+are not visible to an agent through those editor tools. Without this, an agent can launch the game, poll
+for logs, see silence, and wrongly conclude the game is healthy. This is the gap that blocks an unattended
+"keep fixing until no errors" loop for real gameplay/runtime bugs.
+
+Opt in with **`WithRuntimeErrorCapture()`**:
+
+```csharp
+_mcp = GodotMcpRuntime.Initialize(builder =>
+{
+    builder.WithConfig(cfg => { /* host / token … */ });
+    builder.WithRuntimeErrorCapture();   // capture in-game runtime errors + expose the runtime-errors-* tool
+}).Build();
+
+await _mcp.Connect();
+```
+
+That single call installs three best-effort capture channels and registers the `runtime-errors-*` tool:
+
+1. **Engine error stream (Godot 4.5+)** — registers a `Godot.Logger` via `OS.AddLogger`, so GDScript
+   runtime errors, `push_error`/`push_warning`, and shader errors raised in the running game are captured
+   with their **origin** (`file` / `line` / `function`).
+2. **C# unhandled exceptions** — `AppDomain.CurrentDomain.UnhandledException`, with the **full managed
+   stack trace**.
+3. **C# unobserved `Task` exceptions** — `TaskScheduler.UnobservedTaskException`, with the **full managed
+   stack trace**. (It only observes for logging — it does **not** call `SetObserved()`, so your game's own
+   escalation behavior is unchanged.)
+
+An MCP client polls the captured errors with the `runtime-errors-get` tool (and clears the buffer with
+`runtime-errors-clear`):
+
+| Tool | What it returns / does |
+| ---- | ---------------------- |
+| `runtime-errors-get` | A bounded, newest-kept list of `{ sequence, message, type, source, file, line, function, stackTrace, timestamp }`. Pass the previous result's `highestSequence` as `sinceSequence` to poll only **new** errors — the "did anything break since I last looked?" loop. Returns `available:false` when capture was never enabled (so an empty list is never mistaken for health). |
+| `runtime-errors-clear` | Clears the captured buffer (the monotonic `sequence` counter is preserved, so a pre-clear `sinceSequence` poll still behaves). |
+
+> **Stack-trace fidelity (read this).** The two error *sources* differ in depth:
+> - **Engine errors** (`source: Engine`) carry the error's **origin** — `file:line` and the originating
+>   `function` — plus the message and a `type` (`Error` / `Warning` / `Script` / `Shader`). They do **not**
+>   carry a deep multi-frame GDScript call stack (`OS.AddLogger` yields the origin, not a backtrace), so
+>   `stackTrace` is `null` for them.
+> - **C# faults** (`source: UnhandledException` / `UnobservedTaskException`) carry the **full managed stack
+>   trace** (inner exceptions inlined) in `stackTrace`, plus the CLR exception type name in `type`.
+
+> **Graceful degradation.** On **Godot < 4.5** there is no `OS.AddLogger` managed hook, so the engine
+> channel is silently unavailable — the C# exception channels still work, and `runtime-errors-get` still
+> functions (it just won't see GDScript runtime errors). And like the rest of runtime mode, capture is
+> **strictly opt-in** — without `WithRuntimeErrorCapture()` nothing is hooked and there is no behavior
+> change. Disposing the handle (`handle.Dispose()`) uninstalls the hooks.
 
 ## Sample: a live game-state tool
 

--- a/addons/godot_mcp/Runtime/Data/RuntimeError.cs
+++ b/addons/godot_mcp/Runtime/Data/RuntimeError.cs
@@ -1,0 +1,149 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.Godot.MCP.Data
+{
+    /// <summary>
+    /// Where a captured <see cref="RuntimeError"/> originated. Lets the agent tell an engine-side error
+    /// (a GDScript runtime error, <c>push_error</c>, shader error — captured via Godot 4.5's
+    /// <c>OS.AddLogger</c> hook) apart from a managed C# fault (an unhandled exception or an unobserved
+    /// faulted <see cref="System.Threading.Tasks.Task"/>), which carry a full managed stack trace.
+    /// </summary>
+    [Description("Origin of a captured in-game runtime error.")]
+    public enum RuntimeErrorSource
+    {
+        /// <summary>
+        /// The Godot engine's error/warning stream (GDScript runtime error, <c>push_error</c>,
+        /// <c>push_warning</c>, shader error, generic engine error) — captured via the 4.5+
+        /// <c>OS.AddLogger</c> hook. Carries file / line / function but NOT a deep call stack.
+        /// </summary>
+        [Description("Godot engine error stream (GDScript runtime / push_error / push_warning / shader).")]
+        Engine = 0,
+
+        /// <summary>
+        /// A managed <see cref="System.AppDomain.UnhandledException"/> — a C# exception that escaped to the
+        /// top of a thread. Carries the exception type, message, and full managed stack trace.
+        /// </summary>
+        [Description("C# unhandled exception (AppDomain.CurrentDomain.UnhandledException) with full stack trace.")]
+        UnhandledException = 1,
+
+        /// <summary>
+        /// A managed <see cref="System.Threading.Tasks.TaskScheduler.UnobservedTaskException"/> — a faulted
+        /// <see cref="System.Threading.Tasks.Task"/> whose exception was never awaited/observed. Carries the
+        /// exception type, message, and full managed stack trace.
+        /// </summary>
+        [Description("C# unobserved faulted-Task exception (TaskScheduler.UnobservedTaskException) with full stack trace.")]
+        UnobservedTaskException = 2,
+    }
+
+    /// <summary>
+    /// One captured in-game runtime error — the structured row returned by the <c>runtime-errors-get</c>
+    /// MCP tool. Closes the gap (issue #160) where errors raised inside a RUNNING game (not just editor-side
+    /// script errors) were invisible to the agent: an agent could launch the game, poll for logs, see
+    /// silence, and wrongly conclude the game was healthy.
+    ///
+    /// <para>
+    /// Field availability depends on the <see cref="Source"/>:
+    /// <list type="bullet">
+    /// <item><b><see cref="RuntimeErrorSource.Engine"/></b> (Godot 4.5+ logger hook): <see cref="File"/>,
+    /// <see cref="Line"/>, <see cref="Function"/> are the error's ORIGIN; <see cref="StackTrace"/> is null
+    /// (the engine hook yields the origin, not a deep GDScript backtrace).</item>
+    /// <item><b><see cref="RuntimeErrorSource.UnhandledException"/> /
+    /// <see cref="RuntimeErrorSource.UnobservedTaskException"/></b>: <see cref="StackTrace"/> carries the
+    /// full managed stack; <see cref="File"/>/<see cref="Line"/>/<see cref="Function"/> are empty/-1 (the
+    /// origin is inside the stack trace).</item>
+    /// </list>
+    /// </para>
+    ///
+    /// Pure-managed (no Godot API surface, no <c>#if TOOLS</c>), so it is unit-testable in the plain xUnit
+    /// host and ships into a game build.
+    /// </summary>
+    [System.Serializable]
+    [Description("A single captured in-game runtime error: message, type, origin (file/line/function), " +
+        "source, an optional managed stack trace, a monotonic sequence number, and a UTC timestamp.")]
+    public class RuntimeError
+    {
+        [JsonInclude, JsonPropertyName("sequence")]
+        [Description("Monotonic 1-based sequence number assigned when captured. Pass the largest you have " +
+            "seen as 'sinceSequence' to 'runtime-errors-get' to poll only NEWER errors.")]
+        public long Sequence { get; set; } = 0;
+
+        [JsonInclude, JsonPropertyName("message")]
+        [Description("The error message text.")]
+        public string Message { get; set; } = string.Empty;
+
+        [JsonInclude, JsonPropertyName("type")]
+        [Description("The error type/severity: for engine errors one of Error / Warning / Script / Shader; " +
+            "for managed faults the CLR exception type name (e.g. 'System.NullReferenceException').")]
+        public string Type { get; set; } = string.Empty;
+
+        [JsonInclude, JsonPropertyName("source")]
+        [Description("Where the error came from: Engine (Godot error stream) / UnhandledException / " +
+            "UnobservedTaskException (managed C# faults with a full stack trace).")]
+        public RuntimeErrorSource Source { get; set; } = RuntimeErrorSource.Engine;
+
+        [JsonInclude, JsonPropertyName("file")]
+        [Description("Origin file of an engine error (e.g. 'res://scripts/player.gd'); empty for managed " +
+            "faults (the origin is in the stack trace instead).")]
+        public string File { get; set; } = string.Empty;
+
+        [JsonInclude, JsonPropertyName("line")]
+        [Description("1-based origin line of an engine error, or -1 when unknown / for managed faults.")]
+        public int Line { get; set; } = -1;
+
+        [JsonInclude, JsonPropertyName("function")]
+        [Description("Origin function of an engine error; empty when unknown / for managed faults.")]
+        public string Function { get; set; } = string.Empty;
+
+        [JsonInclude, JsonPropertyName("stackTrace")]
+        [Description("Full managed stack trace for a C# fault (UnhandledException / UnobservedTaskException); " +
+            "null for engine errors (the 4.5 logger hook yields the origin, not a deep GDScript backtrace).")]
+        public string? StackTrace { get; set; } = null;
+
+        [JsonInclude, JsonPropertyName("timestamp")]
+        [Description("UTC timestamp when the error was captured.")]
+        public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+
+        public RuntimeError() { }
+
+        public RuntimeError(
+            RuntimeErrorSource source,
+            string message,
+            string type,
+            string? file = null,
+            int line = -1,
+            string? function = null,
+            string? stackTrace = null,
+            DateTime? timestamp = null)
+        {
+            Source = source;
+            Message = message ?? string.Empty;
+            Type = type ?? string.Empty;
+            File = file ?? string.Empty;
+            Line = line;
+            Function = function ?? string.Empty;
+            StackTrace = string.IsNullOrEmpty(stackTrace) ? null : stackTrace;
+            Timestamp = timestamp ?? DateTime.UtcNow;
+        }
+
+        public override string ToString()
+        {
+            var loc = string.IsNullOrEmpty(File)
+                ? string.Empty
+                : (Line >= 0 ? $" {File}:{Line}" : $" {File}");
+            var fn = string.IsNullOrEmpty(Function) ? string.Empty : $" ({Function})";
+            return $"#{Sequence} [{Source}/{Type}]{loc}{fn} — {Message}";
+        }
+    }
+}

--- a/addons/godot_mcp/Runtime/Data/RuntimeErrorsResult.cs
+++ b/addons/godot_mcp/Runtime/Data/RuntimeErrorsResult.cs
@@ -1,0 +1,87 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.Godot.MCP.Data
+{
+    /// <summary>
+    /// Structured result of the <c>runtime-errors-get</c> tool — the answer to "did the RUNNING game raise
+    /// any new errors since I last looked?". The cornerstone of an unattended "keep fixing until no errors"
+    /// loop for real gameplay/runtime bugs: poll with the largest <see cref="RuntimeError.Sequence"/> seen
+    /// so far and only NEWER errors come back.
+    ///
+    /// <para>
+    /// <see cref="Available"/> reports whether in-game runtime error capture is actually wired up — it is
+    /// false when the in-game runtime was never initialized with capture enabled (the default-OFF posture),
+    /// so an agent can distinguish "capture is on and the game is clean" (<c>available:true, count:0</c>)
+    /// from "capture was never enabled, so absence of errors proves nothing" (<c>available:false</c>).
+    /// </para>
+    ///
+    /// Pure-managed (no Godot API surface, no <c>#if TOOLS</c>), so it is unit-testable in the plain xUnit
+    /// host and ships into a game build.
+    /// </summary>
+    [System.Serializable]
+    [Description("Result of 'runtime-errors-get': whether capture is available, the captured runtime errors " +
+        "newer than the requested sequence, counts, and the highest sequence seen (poll with it next time).")]
+    public class RuntimeErrorsResult
+    {
+        [JsonInclude, JsonPropertyName("available")]
+        [Description("True when in-game runtime error capture is wired up (the runtime was initialized with " +
+            "capture enabled). When false, the runtime was never started with capture, so an empty 'errors' " +
+            "list proves nothing — enable capture via GodotMcpRuntime's WithRuntimeErrorCapture().")]
+        public bool Available { get; set; } = false;
+
+        [JsonInclude, JsonPropertyName("ok")]
+        [Description("True when no error-severity runtime errors are present in 'errors' (warnings do not " +
+            "flip this to false). Always true when capture is unavailable or the buffer is empty.")]
+        public bool Ok { get; set; } = true;
+
+        [JsonInclude, JsonPropertyName("count")]
+        [Description("Number of runtime errors returned in 'errors' (after the 'sinceSequence' filter and the " +
+            "'maxEntries' cap).")]
+        public int Count { get; set; } = 0;
+
+        [JsonInclude, JsonPropertyName("errorCount")]
+        [Description("Number of error-severity entries in 'errors' (managed faults + engine Error/Script/Shader).")]
+        public int ErrorCount { get; set; } = 0;
+
+        [JsonInclude, JsonPropertyName("warningCount")]
+        [Description("Number of warning-severity entries in 'errors' (engine Warning).")]
+        public int WarningCount { get; set; } = 0;
+
+        [JsonInclude, JsonPropertyName("highestSequence")]
+        [Description("The highest sequence number across ALL captured runtime errors (not just the returned " +
+            "page). Pass this as 'sinceSequence' on the next call to poll only newer errors. 0 when none " +
+            "have ever been captured.")]
+        public long HighestSequence { get; set; } = 0;
+
+        [JsonInclude, JsonPropertyName("truncated")]
+        [Description("True when more matching errors existed than the 'maxEntries' cap returned. The NEWEST " +
+            "are kept; call again (the buffer is bounded, so very old errors may already have been evicted).")]
+        public bool Truncated { get; set; } = false;
+
+        [JsonInclude, JsonPropertyName("errors")]
+        [Description("The captured runtime errors newer than 'sinceSequence', oldest-first within the page so " +
+            "they read in chronological order. Empty when 'ok' is true / capture is unavailable.")]
+        public List<RuntimeError> Errors { get; set; } = new();
+
+        [JsonInclude, JsonPropertyName("note")]
+        [Description("Human-readable summary, e.g. 'No new runtime errors (capture active).' or '2 runtime " +
+            "error(s) since sequence 5.' or 'Runtime error capture is not enabled in this game.'.")]
+        public string Note { get; set; } = string.Empty;
+
+        public RuntimeErrorsResult() { }
+
+        public override string ToString() => Note;
+    }
+}

--- a/addons/godot_mcp/Runtime/GodotMcpRuntime.cs
+++ b/addons/godot_mcp/Runtime/GodotMcpRuntime.cs
@@ -108,6 +108,26 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
             if (builder.InstallDispatcher)
                 EnsureMainThreadDispatcher();
 
+            // 2b) Install in-game runtime ERROR CAPTURE when opted in (default OFF). Registers the engine 4.5+
+            //     OS.AddLogger hook + the C# unhandled/unobserved-Task exception hooks so errors raised in the
+            //     RUNNING game are captured and surfaced via the runtime-errors-* tool (issue #160). Idempotent
+            //     + best-effort; the handle uninstalls it on Dispose (capturedRuntimeErrors flag below). Done
+            //     before the connection is built so capture is live the moment the game runs — including
+            //     errors raised during the very first frame after Build().
+            var capturedRuntimeErrors = false;
+            if (builder.CaptureRuntimeErrors)
+            {
+                try
+                {
+                    RuntimeErrorCapture.Install();
+                    capturedRuntimeErrors = true;
+                }
+                catch (Exception ex)
+                {
+                    GD.PushWarning($"[Godot-MCP] runtime error capture failed to install: {ex.Message}");
+                }
+            }
+
             // 3) Build the reflector with the Godot value-type / ref converters and publish it as the ambient
             //    one so tool handlers share the exact converter set (mirrors GodotMcpConnection.Start). The
             //    editor ResourceLoader resolver (Tool_Resource.InstallReflectionResolver) is intentionally
@@ -158,7 +178,7 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
 
             var plugin = mcpBuilder.Build(reflector);
 
-            return new GodotMcpRuntimeHandle(plugin, config);
+            return new GodotMcpRuntimeHandle(plugin, config, uninstallErrorCaptureOnDispose: capturedRuntimeErrors);
         }
 
         /// <summary>

--- a/addons/godot_mcp/Runtime/GodotMcpRuntimeBuilder.cs
+++ b/addons/godot_mcp/Runtime/GodotMcpRuntimeBuilder.cs
@@ -61,6 +61,15 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
         /// </summary>
         internal bool InstallDispatcher { get; private set; } = true;
 
+        /// <summary>
+        /// Whether <see cref="GodotMcpRuntime.Build"/> should install in-game runtime error capture (the
+        /// engine 4.5+ <c>OS.AddLogger</c> hook + C# unhandled / unobserved-Task exception hooks) and register
+        /// the <c>runtime-errors-*</c> tool so captured errors are retrievable. OFF by default — the
+        /// security/secure-by-default posture: nothing is captured and no hooks are installed unless the
+        /// developer opts in via <see cref="WithRuntimeErrorCapture"/>. See <c>RuntimeErrorCapture</c>.
+        /// </summary>
+        internal bool CaptureRuntimeErrors { get; private set; } = false;
+
         internal GodotMcpRuntimeBuilder() { }
 
         /// <summary>
@@ -202,6 +211,34 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
         public GodotMcpRuntimeBuilder WithoutMainThreadDispatcher()
         {
             InstallDispatcher = false;
+            return this;
+        }
+
+        /// <summary>
+        /// Enable in-game runtime ERROR CAPTURE: at <see cref="Build"/> the runtime installs the engine 4.5+
+        /// <c>OS.AddLogger</c> hook (capturing GDScript runtime errors, <c>push_error</c>/<c>push_warning</c>,
+        /// and shader errors raised in the RUNNING game) plus the C# <c>AppDomain.UnhandledException</c> /
+        /// <c>TaskScheduler.UnobservedTaskException</c> hooks (capturing unhandled managed exceptions with full
+        /// stack traces), and registers the <c>runtime-errors-*</c> tool so the agent can poll the captured
+        /// errors. This is the in-game answer to "did the running game raise any error?" — closing the gap
+        /// (issue #160) where only editor-side script errors were visible.
+        ///
+        /// <para>
+        /// <b>OFF by default</b> (the secure/opt-in posture): without this call nothing is captured and no
+        /// fault hooks are installed. On Godot &lt; 4.5 the engine logger channel is unavailable (documented
+        /// graceful degradation), but the C# exception channels still work. Disposing the
+        /// <see cref="GodotMcpRuntimeHandle"/> uninstalls the hooks. Idempotent — calling twice registers the
+        /// tool once (the builder de-duplicates) and the runtime installs capture once.
+        /// </para>
+        ///
+        /// Returns <c>this</c> for chaining.
+        /// </summary>
+        public GodotMcpRuntimeBuilder WithRuntimeErrorCapture()
+        {
+            CaptureRuntimeErrors = true;
+            // Auto-register the runtime-errors tool so the captured errors are actually reachable by the agent.
+            // De-duplicated by WithTools, so this is safe to compose with an explicit registration.
+            WithTools(typeof(com.IvanMurzak.Godot.MCP.Tools.Tool_RuntimeErrors));
             return this;
         }
 

--- a/addons/godot_mcp/Runtime/GodotMcpRuntimeHandle.cs
+++ b/addons/godot_mcp/Runtime/GodotMcpRuntimeHandle.cs
@@ -33,12 +33,15 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
     {
         readonly IMcpPlugin _plugin;
         readonly GodotMcpConfig _config;
+        readonly bool _uninstallErrorCaptureOnDispose;
         int _disposed;
 
-        internal GodotMcpRuntimeHandle(IMcpPlugin plugin, GodotMcpConfig config)
+        internal GodotMcpRuntimeHandle(IMcpPlugin plugin, GodotMcpConfig config,
+            bool uninstallErrorCaptureOnDispose = false)
         {
             _plugin = plugin ?? throw new ArgumentNullException(nameof(plugin));
             _config = config ?? throw new ArgumentNullException(nameof(config));
+            _uninstallErrorCaptureOnDispose = uninstallErrorCaptureOnDispose;
         }
 
         /// <summary>The resolved connection config (host / token / mode) this handle connects with.</summary>
@@ -85,6 +88,15 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
 
             try { _plugin.Dispose(); }
             catch { /* best-effort: never throw out of Dispose */ }
+
+            // Uninstall in-game runtime error capture IFF this handle's Build installed it (opt-in via
+            // WithRuntimeErrorCapture). Removes the engine logger + the AppDomain/TaskScheduler fault hooks and
+            // clears RuntimeErrorCollector.Current. Idempotent + defensive in RuntimeErrorCapture.Uninstall.
+            if (_uninstallErrorCaptureOnDispose)
+            {
+                try { RuntimeErrorCapture.Uninstall(); }
+                catch { /* best-effort: never throw out of Dispose */ }
+            }
         }
 
         void ThrowIfDisposed()

--- a/addons/godot_mcp/Runtime/RuntimeErrorCapture.cs
+++ b/addons/godot_mcp/Runtime/RuntimeErrorCapture.cs
@@ -78,28 +78,33 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
             lock (_gate)
             {
                 if (_installed && _collector != null)
+                {
+                    // Idempotent re-entry. The engine logger lives in the bridge's SEPARATE static
+                    // (GodotScriptErrorLoggerBridge._installed), not in our _installed flag, so it could have
+                    // been torn down independently (e.g. an editor-side Uninstall) while ours stayed true.
+                    // Re-assert it: the bridge's TryInstall is non-destructive (a no-op when still installed,
+                    // a fresh registration when it was removed), so this never clobbers a live logger.
+                    TryInstallEngineLogger(_collector);
                     return _collector;
+                }
 
                 var collector = new RuntimeErrorCollector();
+
+                // Publish state BEFORE wiring the fault hooks so a throw mid-subscribe still leaves the capture
+                // discoverable AND uninstallable: Uninstall() keys on _installed, and unsubscribes only the
+                // handlers it finds assigned — so a partially-installed pass never leaks a handler for the
+                // process lifetime.
+                RuntimeErrorCollector.Current = collector;
+                _collector = collector;
+                _installed = true;
 
                 // 1) Engine error stream (Godot 4.5+). Wire a structured ErrorSink so engine errors land as
                 //    full RuntimeError rows (file/line/function/type). On < 4.5 the bridge stub returns null —
                 //    this channel is absent; the C# channels below still capture managed faults.
-                var engineInstalled = false;
-                try
-                {
-                    var capture = new ScriptErrorCapture
-                    {
-                        ErrorSink = record => collector.Append(RuntimeErrorFactory.FromEngine(record)),
-                    };
-                    engineInstalled = GodotScriptErrorLoggerBridge.TryInstall(capture) != null;
-                }
-                catch (Exception ex)
-                {
-                    GD.PushWarning($"[Godot-MCP] runtime engine-error capture not installed: {ex.Message}");
-                }
+                var engineInstalled = TryInstallEngineLogger(collector);
 
-                // 2) C# unhandled exceptions — full managed stack trace.
+                // 2) C# unhandled exceptions — full managed stack trace. Field assigned first, then subscribed,
+                //    so even a throw between the two leaves Uninstall() with a handler reference to detach.
                 _domainHandler = (_, args) =>
                 {
                     try
@@ -126,16 +131,35 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
                 };
                 TaskScheduler.UnobservedTaskException += _taskHandler;
 
-                RuntimeErrorCollector.Current = collector;
-                _collector = collector;
-                _installed = true;
-
                 GD.Print(engineInstalled
                     ? "[Godot-MCP] runtime error capture installed (engine 4.5+ logger + C# exception hooks)."
                     : "[Godot-MCP] runtime error capture installed (C# exception hooks only; engine logger " +
                       "requires Godot 4.5+).");
 
                 return collector;
+            }
+        }
+
+        /// <summary>
+        /// Register the Godot 4.5+ engine-error logger feeding <paramref name="collector"/> via the bridge,
+        /// returning true when the engine channel is live. Best-effort: a registration failure (e.g. an
+        /// unexpected host) is swallowed to a warning so the C# fault channels still install. Pre-&lt; 4.5 the
+        /// bridge stub returns null and this returns false (documented degradation). Call under <c>_gate</c>.
+        /// </summary>
+        static bool TryInstallEngineLogger(RuntimeErrorCollector collector)
+        {
+            try
+            {
+                var capture = new ScriptErrorCapture
+                {
+                    ErrorSink = record => collector.Append(RuntimeErrorFactory.FromEngine(record)),
+                };
+                return GodotScriptErrorLoggerBridge.TryInstall(capture) != null;
+            }
+            catch (Exception ex)
+            {
+                GD.PushWarning($"[Godot-MCP] runtime engine-error capture not installed: {ex.Message}");
+                return false;
             }
         }
 

--- a/addons/godot_mcp/Runtime/RuntimeErrorCapture.cs
+++ b/addons/godot_mcp/Runtime/RuntimeErrorCapture.cs
@@ -1,0 +1,178 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.Godot.MCP.Tools;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Runtime
+{
+    /// <summary>
+    /// Installs in-game runtime error capture so errors raised inside a RUNNING game (not just editor-side
+    /// script errors) are captured in-process and surfaced to the agent over the existing MCP/SignalR channel
+    /// via the <c>runtime-errors-get</c> tool. Closes issue #160: previously an agent could launch the game,
+    /// poll for logs, see silence, and wrongly conclude the game was healthy.
+    ///
+    /// <para>
+    /// Three independent capture channels, each best-effort and gracefully degrading:
+    /// <list type="number">
+    /// <item><b>Engine error stream (Godot 4.5+)</b> — registers a <c>Godot.Logger</c> via
+    /// <c>OS.AddLogger</c> (through <see cref="GodotScriptErrorLoggerBridge"/>) so GDScript runtime errors,
+    /// <c>push_error</c>/<c>push_warning</c>, and shader errors are captured with their origin
+    /// (file/line/function). On Godot &lt; 4.5 the bridge is a no-op stub — this channel is simply absent
+    /// (documented degradation), and the C# channels below still work.</item>
+    /// <item><b>C# unhandled exceptions</b> — <c>AppDomain.CurrentDomain.UnhandledException</c>, with the
+    /// full managed stack trace.</item>
+    /// <item><b>C# unobserved Task exceptions</b> — <c>TaskScheduler.UnobservedTaskException</c>, with the
+    /// full managed stack trace.</item>
+    /// </list>
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Default OFF / opt-in.</b> Nothing here runs unless the game explicitly enables it via
+    /// <c>GodotMcpRuntime.Initialize(b =&gt; b.WithRuntimeErrorCapture())</c> (or by passing
+    /// <c>captureRuntimeErrors: true</c>). No behavior change for a game that does not opt in. Idempotent:
+    /// a second <see cref="Install"/> is a no-op; <see cref="Uninstall"/> is safe to call when nothing is
+    /// installed and is invoked on handle dispose.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Main-thread note.</b> <c>OS.AddLogger</c> is an engine call; the editor parallel registers it on the
+    /// main thread. <see cref="Install"/> is called from <c>GodotMcpRuntime.Build()</c>, which the developer
+    /// invokes from game code (typically an autoload <c>_Ready</c>, i.e. the main thread). The AppDomain /
+    /// TaskScheduler subscriptions are pure-managed and thread-agnostic.
+    /// </para>
+    /// </summary>
+    public static class RuntimeErrorCapture
+    {
+        static readonly object _gate = new();
+        static bool _installed;
+        static RuntimeErrorCollector? _collector;
+        static UnhandledExceptionEventHandler? _domainHandler;
+        static EventHandler<UnobservedTaskExceptionEventArgs>? _taskHandler;
+
+        /// <summary>True while capture is installed (an engine logger and/or the C# fault hooks are live).</summary>
+        public static bool IsInstalled
+        {
+            get { lock (_gate) { return _installed; } }
+        }
+
+        /// <summary>
+        /// Install all available capture channels and publish the backing <see cref="RuntimeErrorCollector"/>
+        /// as <see cref="RuntimeErrorCollector.Current"/> so <c>runtime-errors-get</c> can read it. Idempotent
+        /// (a second call while installed is a no-op and returns the live collector). Each channel is wired
+        /// defensively — a failure to register one (e.g. the engine logger on an unexpected host) does not
+        /// abort the others. Returns the collector capturing runtime errors.
+        /// </summary>
+        public static RuntimeErrorCollector Install()
+        {
+            lock (_gate)
+            {
+                if (_installed && _collector != null)
+                    return _collector;
+
+                var collector = new RuntimeErrorCollector();
+
+                // 1) Engine error stream (Godot 4.5+). Wire a structured ErrorSink so engine errors land as
+                //    full RuntimeError rows (file/line/function/type). On < 4.5 the bridge stub returns null —
+                //    this channel is absent; the C# channels below still capture managed faults.
+                var engineInstalled = false;
+                try
+                {
+                    var capture = new ScriptErrorCapture
+                    {
+                        ErrorSink = record => collector.Append(RuntimeErrorFactory.FromEngine(record)),
+                    };
+                    engineInstalled = GodotScriptErrorLoggerBridge.TryInstall(capture) != null;
+                }
+                catch (Exception ex)
+                {
+                    GD.PushWarning($"[Godot-MCP] runtime engine-error capture not installed: {ex.Message}");
+                }
+
+                // 2) C# unhandled exceptions — full managed stack trace.
+                _domainHandler = (_, args) =>
+                {
+                    try
+                    {
+                        collector.Append(RuntimeErrorFactory.FromException(
+                            RuntimeErrorSource.UnhandledException, args.ExceptionObject as Exception));
+                    }
+                    catch { /* a fault handler must never throw */ }
+                };
+                AppDomain.CurrentDomain.UnhandledException += _domainHandler;
+
+                // 3) C# unobserved faulted-Task exceptions — full managed stack trace. We intentionally do NOT
+                //    call args.SetObserved(): that would change the game's behavior (suppressing the escalation
+                //    a game may rely on), violating the "no behavior change unless opted in beyond capture"
+                //    posture. We only OBSERVE-FOR-LOGGING here, leaving the runtime's own handling intact.
+                _taskHandler = (_, args) =>
+                {
+                    try
+                    {
+                        collector.Append(RuntimeErrorFactory.FromException(
+                            RuntimeErrorSource.UnobservedTaskException, args.Exception));
+                    }
+                    catch { /* a fault handler must never throw */ }
+                };
+                TaskScheduler.UnobservedTaskException += _taskHandler;
+
+                RuntimeErrorCollector.Current = collector;
+                _collector = collector;
+                _installed = true;
+
+                GD.Print(engineInstalled
+                    ? "[Godot-MCP] runtime error capture installed (engine 4.5+ logger + C# exception hooks)."
+                    : "[Godot-MCP] runtime error capture installed (C# exception hooks only; engine logger " +
+                      "requires Godot 4.5+).");
+
+                return collector;
+            }
+        }
+
+        /// <summary>
+        /// Reverse <see cref="Install"/>: remove the engine logger (via the bridge — a no-op on &lt; 4.5),
+        /// unsubscribe the AppDomain / TaskScheduler fault hooks, and clear
+        /// <see cref="RuntimeErrorCollector.Current"/>. Idempotent and defensive (each step swallows its own
+        /// failure) so it is safe on game shutdown / handle dispose, even mid-teardown.
+        /// </summary>
+        public static void Uninstall()
+        {
+            lock (_gate)
+            {
+                if (!_installed)
+                    return;
+
+                try { GodotScriptErrorLoggerBridge.Uninstall(); }
+                catch { /* swallow: a logger-removal failure must not break teardown */ }
+
+                if (_domainHandler != null)
+                {
+                    try { AppDomain.CurrentDomain.UnhandledException -= _domainHandler; }
+                    catch { /* swallow */ }
+                    _domainHandler = null;
+                }
+
+                if (_taskHandler != null)
+                {
+                    try { TaskScheduler.UnobservedTaskException -= _taskHandler; }
+                    catch { /* swallow */ }
+                    _taskHandler = null;
+                }
+
+                try { RuntimeErrorCollector.Current = null; } catch { /* swallow */ }
+                _collector = null;
+                _installed = false;
+            }
+        }
+    }
+}

--- a/addons/godot_mcp/Runtime/Tools/GodotScriptErrorLogger.Stub.cs
+++ b/addons/godot_mcp/Runtime/Tools/GodotScriptErrorLogger.Stub.cs
@@ -13,7 +13,12 @@
 // is compiled IN. TryInstall is a no-op that installs nothing, so ScriptErrorCapture.Current stays null:
 // passive engine-log capture is unavailable and script-validate falls back to the per-file Reload()
 // error-code probe (Coarse fidelity).
-#if TOOLS && !GODOT4_5_OR_GREATER
+//
+// Like its 4.5+ counterpart this stub lives under Runtime/ and is NOT gated by #if TOOLS — it ships into a
+// game build so the in-game runtime error-capture (Runtime/RuntimeErrorCapture.cs) compiles and degrades
+// gracefully on a < 4.5 export (TryInstall returns null → no engine-error capture, but the C# unhandled-
+// exception hooks still work; see issue #160).
+#if !GODOT4_5_OR_GREATER
 #nullable enable
 
 namespace com.IvanMurzak.Godot.MCP.Tools
@@ -26,8 +31,14 @@ namespace com.IvanMurzak.Godot.MCP.Tools
     /// </summary>
     public static class GodotScriptErrorLoggerBridge
     {
-        /// <summary>No-op on Godot &lt; 4.5; always returns null. (Signature matches the 4.5+ bridge.)</summary>
+        /// <summary>No-op on Godot &lt; 4.5; always returns null. (Signature matches the 4.5+ bridge — the
+        /// editor passive-log path.)</summary>
         public static ScriptErrorCapture? TryInstall(GodotLogCollector collector) => null;
+
+        /// <summary>No-op on Godot &lt; 4.5; always returns null. (Signature matches the 4.5+ bridge — the
+        /// in-game runtime structured-capture path. On the floor there is no engine error stream to hook, so
+        /// the runtime degrades to C#-exception capture only; see RuntimeErrorCapture.)</summary>
+        public static ScriptErrorCapture? TryInstall(ScriptErrorCapture capture) => null;
 
         /// <summary>
         /// No-op on Godot &lt; 4.5 (nothing was installed, so there is nothing to remove). Matches the 4.5+

--- a/addons/godot_mcp/Runtime/Tools/GodotScriptErrorLogger.cs
+++ b/addons/godot_mcp/Runtime/Tools/GodotScriptErrorLogger.cs
@@ -7,13 +7,25 @@
 │  See the LICENSE file in the project root for more information.  │
 └──────────────────────────────────────────────────────────────────┘
 */
-// GODOT 4.5+ ONLY. Godot.Logger / OS.AddLogger do NOT exist in the addon's SDK floor (Godot.NET.Sdk/4.3.0),
-// so referencing them outside this guard would break the required `dotnet build (.NET 8)` CI gate (which
-// pins 4.3.0) with CS0246. The Godot.NET.Sdk defines GODOT4_5_OR_GREATER only when building against the
-// 4.5+ SDK (e.g. the infra testbed pins 4.5.1), so this whole file compiles in on 4.5+ and out on 4.3/4.4.
-// On the floor, GodotScriptErrorLoggerBridge.TryInstall is a no-op stub (see the #else partial below) and
-// script-validate falls back to the per-file Reload() error-code probe (Tool_Script.Validate.cs).
-#if TOOLS && GODOT4_5_OR_GREATER
+// GODOT 4.5+ ONLY (NOT editor-only). Godot.Logger / OS.AddLogger do NOT exist in the addon's SDK floor
+// (Godot.NET.Sdk/4.3.0), so referencing them outside this guard would break the required
+// `dotnet build (.NET 8)` CI gate (which pins 4.3.0) with CS0246. The Godot.NET.Sdk defines
+// GODOT4_5_OR_GREATER only when building against the 4.5+ SDK (e.g. the infra testbed pins 4.5.1), so this
+// whole file compiles in on 4.5+ and out on 4.3/4.4. On the floor, GodotScriptErrorLoggerBridge.TryInstall
+// is a no-op stub (see GodotScriptErrorLogger.Stub.cs) and script-validate falls back to the per-file
+// Reload() error-code probe (Tool_Script.Validate.cs).
+//
+// This file lives under Runtime/ and is NOT gated by #if TOOLS: OS.AddLogger / Godot.Logger are ENGINE
+// (runtime) APIs, not editor APIs — available inside a running / exported game as well as the editor. Two
+// consumers install the SAME bridge:
+//   * the editor boot (Editor/GodotMcpPlugin.cs) captures engine script errors raised IN-EDITOR, and
+//   * the in-game runtime (Runtime/RuntimeErrorCapture.cs) captures engine errors raised in the RUNNING
+//     GAME (GDScript runtime errors, push_error/push_warning, shader errors) — closing the gap where in-game
+//     runtime errors were invisible to the agent (issue #160).
+// The runtime/editor boundary guard (scripts/check-runtime-boundary.py) passes this file because it
+// references no editor-only API (EditorInterface / EditorPlugin / EditorFileSystem / EditorScript) — only
+// the engine OS singleton + Godot.Logger.
+#if GODOT4_5_OR_GREATER
 #nullable enable
 using System;
 using com.IvanMurzak.Godot.MCP.Data;
@@ -65,7 +77,10 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 line: line,
                 // 'code' is the failed C++ condition string; 'rationale' is the human error text.
                 message: code,
-                rationale: rationale);
+                rationale: rationale,
+                // 'function' is the originating function name — forwarded so the in-game runtime's structured
+                // ErrorSink can populate RuntimeError.Function (the editor passive-log path ignores it).
+                function: function);
         }
 
         // We intentionally do NOT override _LogMessage: ordinary print()/stdout traffic is already covered by
@@ -101,26 +116,43 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         /// Install the engine-error logger and return the router it feeds. The router's <see cref="ScriptErrorCapture.LogSink"/>
         /// is wired to <paramref name="collector"/> so passive engine errors land in <c>console-get-logs</c>.
         /// Returns null only if <paramref name="collector"/> is null (nothing to wire) — callers treat null as
-        /// "unavailable". Idempotent-friendly: the caller installs once at boot.
+        /// "unavailable". Idempotent-friendly: the caller installs once at boot. This is the EDITOR path
+        /// (Editor/GodotMcpPlugin.cs); the in-game runtime uses the <see cref="TryInstall(ScriptErrorCapture)"/>
+        /// overload to wire a structured <see cref="ScriptErrorCapture.ErrorSink"/> instead.
         /// </summary>
         public static ScriptErrorCapture? TryInstall(GodotLogCollector collector)
         {
             if (collector == null)
                 return null;
 
-            // Symmetric with Uninstall: tear down any prior registration FIRST. In the normal paired
-            // _EnterTree/_ExitTree lifecycle _installed is already null here, but a stray double-install
-            // (two _EnterTree without an intervening Teardown) would otherwise overwrite _installed without
-            // OS.RemoveLogger/Free()-ing the previous logger — leaking it registered in the engine, which
-            // re-pins the collectible ALC (the exact godot#78513 unload failure this bridge removes) AND
-            // orphans it beyond Uninstall's reach. Uninstall is idempotent, so this is a safe no-op when
-            // nothing is installed.
-            Uninstall();
-
             var capture = new ScriptErrorCapture
             {
                 LogSink = (logType, message) => collector.Append(logType, message),
             };
+
+            return TryInstall(capture);
+        }
+
+        /// <summary>
+        /// Install the engine-error logger feeding a caller-supplied <paramref name="capture"/> router and
+        /// publish it as <see cref="ScriptErrorCapture.Current"/>. The IN-GAME RUNTIME path
+        /// (Runtime/RuntimeErrorCapture.cs): the caller pre-wires <paramref name="capture"/>'s
+        /// <see cref="ScriptErrorCapture.ErrorSink"/> so engine errors raised in the running game are captured
+        /// as structured <see cref="Data.RuntimeError"/> rows. Returns the same <paramref name="capture"/> on
+        /// success, or null if it was null. Main-thread only (mirrors <see cref="OS.AddLogger"/>).
+        /// </summary>
+        public static ScriptErrorCapture? TryInstall(ScriptErrorCapture capture)
+        {
+            if (capture == null)
+                return null;
+
+            // Symmetric with Uninstall: tear down any prior registration FIRST. In the normal paired
+            // install/uninstall lifecycle _installed is already null here, but a stray double-install would
+            // otherwise overwrite _installed without OS.RemoveLogger/Free()-ing the previous logger — leaking
+            // it registered in the engine, which re-pins the collectible ALC (the exact godot#78513 unload
+            // failure this bridge removes) AND orphans it beyond Uninstall's reach. Uninstall is idempotent,
+            // so this is a safe no-op when nothing is installed.
+            Uninstall();
 
             var logger = new GodotScriptErrorLogger(capture);
             OS.AddLogger(logger); // static API in GodotSharp 4.5

--- a/addons/godot_mcp/Runtime/Tools/GodotScriptErrorLogger.cs
+++ b/addons/godot_mcp/Runtime/Tools/GodotScriptErrorLogger.cs
@@ -110,6 +110,13 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         // collectible addon assembly), so leaving it registered makes the hot-reload ALC unload fail with the
         // godotengine/godot#78513 ".NET: Failed to unload assemblies" flood. Static field => one registration
         // per loaded assembly, which matches the single boot-time TryInstall.
+        //
+        // Separate-process safety: the editor (Editor/GodotMcpPlugin.cs) and the in-game runtime
+        // (Runtime/RuntimeErrorCapture.cs) BOTH register through this bridge, but Godot launches the running
+        // game (F5 / "Play") as a SEPARATE OS PROCESS — the editor and the game never share an address space,
+        // so each process owns its own copy of this static and one cannot tear down or clobber the other's
+        // registration. The non-destructive guard in TryInstall below additionally protects against a stray
+        // in-process double-install (e.g. a re-init) so it never silently leaks the prior logger.
         static GodotScriptErrorLogger? _installed;
 
         /// <summary>
@@ -146,13 +153,15 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             if (capture == null)
                 return null;
 
-            // Symmetric with Uninstall: tear down any prior registration FIRST. In the normal paired
-            // install/uninstall lifecycle _installed is already null here, but a stray double-install would
-            // otherwise overwrite _installed without OS.RemoveLogger/Free()-ing the previous logger — leaking
-            // it registered in the engine, which re-pins the collectible ALC (the exact godot#78513 unload
-            // failure this bridge removes) AND orphans it beyond Uninstall's reach. Uninstall is idempotent,
-            // so this is a safe no-op when nothing is installed.
-            Uninstall();
+            // Non-destructive when ALREADY installed: do NOT tear down a live registration to replace it. In
+            // the normal paired install/uninstall lifecycle _installed is null here, but a stray double-install
+            // must not OS.RemoveLogger/Dispose the engine's current logger out from under it (which would both
+            // re-pin the collectible ALC — the exact godot#78513 unload failure this bridge removes — and orphan
+            // the prior registration beyond Uninstall's reach). Treat the already-installed case as a no-op and
+            // return the live router. (Editor and in-game runtime are separate OS processes — see the _installed
+            // field note — so this guard only ever fires for an in-process re-init, never cross-context.)
+            if (_installed != null)
+                return ScriptErrorCapture.Current;
 
             var logger = new GodotScriptErrorLogger(capture);
             OS.AddLogger(logger); // static API in GodotSharp 4.5

--- a/addons/godot_mcp/Runtime/Tools/RuntimeErrorCollector.cs
+++ b/addons/godot_mcp/Runtime/Tools/RuntimeErrorCollector.cs
@@ -1,0 +1,155 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using com.IvanMurzak.Godot.MCP.Data;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// In-memory, bounded ring-buffer of <see cref="RuntimeError"/> rows captured inside a RUNNING game —
+    /// the in-game analog of <see cref="GodotLogCollector"/>, but holding the richer structured runtime-error
+    /// shape (source / type / file / line / function / stack trace) rather than plain log lines. It is the
+    /// store the <c>runtime-errors-get</c> tool reads.
+    ///
+    /// <para>
+    /// <b>Monotonic sequence + since-marker poll.</b> Every appended error is stamped with a process-wide
+    /// monotonically-increasing <see cref="RuntimeError.Sequence"/> (never reused, even after eviction or
+    /// <see cref="Clear"/>). <see cref="QuerySince"/> returns only errors NEWER than a caller-supplied
+    /// sequence, so an agent driving a "launch the game, keep fixing until no new errors" loop can poll with
+    /// the largest sequence it has seen and get exactly the deltas — the cornerstone use-case from issue #160.
+    /// </para>
+    ///
+    /// <para>
+    /// Thread-safe (a single lock guards the buffer): <see cref="Append"/> is called from arbitrary threads
+    /// (Godot's logger callback is multi-threaded; <c>AppDomain.UnhandledException</c> /
+    /// <c>TaskScheduler.UnobservedTaskException</c> fire on whatever thread faulted), while
+    /// <see cref="QuerySince"/> reads from the tool dispatch thread. Bounded by <see cref="Capacity"/> — once
+    /// full the oldest error is evicted (FIFO), so memory never grows without bound during a long play
+    /// session. <see cref="HighestSequence"/> is retained across eviction so a since-poll still advances even
+    /// if the matching errors were evicted before the agent read them (the result then flags truncation).
+    /// </para>
+    ///
+    /// Pure-managed (no Godot API surface, no <c>#if TOOLS</c>), so it is unit-testable in the plain xUnit
+    /// host and ships into a game build.
+    /// </summary>
+    public sealed class RuntimeErrorCollector
+    {
+        /// <summary>Maximum number of retained runtime errors before the oldest is evicted (FIFO).</summary>
+        public const int Capacity = 1000;
+
+        readonly object _gate = new();
+        readonly Queue<RuntimeError> _entries = new(Capacity);
+        long _nextSequence = 1;
+        long _highestSequence = 0;
+
+        /// <summary>
+        /// Process-wide collector for the running game, set by <c>RuntimeErrorCapture.Install</c> when the
+        /// in-game runtime is started with error capture enabled, and read by <c>runtime-errors-get</c>.
+        /// Null when capture was never enabled (the default-OFF posture) — the tool reports
+        /// <c>available:false</c> in that case so the agent does not read silence as health.
+        /// </summary>
+        public static RuntimeErrorCollector? Current { get; set; }
+
+        /// <summary>
+        /// Append a captured runtime error, stamping it with the next monotonic
+        /// <see cref="RuntimeError.Sequence"/> and evicting the oldest when at <see cref="Capacity"/>.
+        /// Returns the assigned sequence. Thread-safe. A null <paramref name="error"/> is ignored (returns 0).
+        /// </summary>
+        public long Append(RuntimeError error)
+        {
+            if (error == null)
+                return 0;
+
+            lock (_gate)
+            {
+                var seq = _nextSequence++;
+                error.Sequence = seq;
+                _highestSequence = seq;
+
+                if (_entries.Count >= Capacity)
+                    _entries.Dequeue();
+                _entries.Enqueue(error);
+                return seq;
+            }
+        }
+
+        /// <summary>Drop all retained runtime errors. The monotonic sequence counter is NOT reset, so a
+        /// post-clear since-poll with a pre-clear sequence still behaves (no duplicate/old rows reappear).</summary>
+        public void Clear()
+        {
+            lock (_gate)
+            {
+                _entries.Clear();
+            }
+        }
+
+        /// <summary>Current number of retained runtime errors.</summary>
+        public int Count
+        {
+            get { lock (_gate) { return _entries.Count; } }
+        }
+
+        /// <summary>
+        /// The highest sequence number ever assigned (retained across eviction and <see cref="Clear"/>). An
+        /// agent passes this back as <c>sinceSequence</c> to poll only newer errors. 0 before any append.
+        /// </summary>
+        public long HighestSequence
+        {
+            get { lock (_gate) { return _highestSequence; } }
+        }
+
+        /// <summary>
+        /// Return retained errors whose <see cref="RuntimeError.Sequence"/> is strictly greater than
+        /// <paramref name="sinceSequence"/>, oldest-first (chronological), capped at <paramref name="maxEntries"/>.
+        /// Pass <c>sinceSequence = 0</c> (the default) for every retained error. When more matching errors
+        /// exist than the cap, the NEWEST are kept and <paramref name="truncated"/> is set true — so an agent
+        /// reading deltas never silently misses the most recent fault. Returns fresh copies so the caller can
+        /// serialize off the lock.
+        /// </summary>
+        public RuntimeError[] QuerySince(long sinceSequence, int maxEntries, out bool truncated)
+        {
+            if (maxEntries < 1)
+                maxEntries = 1;
+
+            lock (_gate)
+            {
+                // Newer-than-marker, in stored (chronological) order.
+                var matching = _entries.Where(e => e.Sequence > sinceSequence).ToList();
+                truncated = matching.Count > maxEntries;
+
+                // Keep the NEWEST page when capping: take the last `maxEntries` of the chronological list, so
+                // the most-recent faults are never dropped in favor of older ones.
+                IEnumerable<RuntimeError> page = truncated
+                    ? matching.Skip(matching.Count - maxEntries)
+                    : matching;
+
+                return page.Select(Copy).ToArray();
+            }
+        }
+
+        /// <summary>Defensive deep-ish copy so a returned row can be serialized/mutated off the lock without
+        /// touching the buffered instance.</summary>
+        static RuntimeError Copy(RuntimeError e) => new(
+            source: e.Source,
+            message: e.Message,
+            type: e.Type,
+            file: e.File,
+            line: e.Line,
+            function: e.Function,
+            stackTrace: e.StackTrace,
+            timestamp: e.Timestamp)
+        {
+            Sequence = e.Sequence,
+        };
+    }
+}

--- a/addons/godot_mcp/Runtime/Tools/RuntimeErrorCollector.cs
+++ b/addons/godot_mcp/Runtime/Tools/RuntimeErrorCollector.cs
@@ -115,11 +115,18 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         /// exist than the cap, the NEWEST are kept and <paramref name="truncated"/> is set true — so an agent
         /// reading deltas never silently misses the most recent fault. Returns fresh copies so the caller can
         /// serialize off the lock.
+        /// <para>
+        /// <paramref name="maxEntries"/> has a hard floor of 1: a value &lt; 1 is clamped up to 1 (this is the
+        /// reusable buffer's defensive contract — it never returns an empty page for a non-positive cap). The
+        /// <c>runtime-errors-get</c> tool surface is stricter and rejects <c>maxEntries &lt; 1</c> with an
+        /// <see cref="ArgumentException"/> before reaching here, so the clamp is the inner-layer safety net for
+        /// direct callers, not the validated tool path.
+        /// </para>
         /// </summary>
         public RuntimeError[] QuerySince(long sinceSequence, int maxEntries, out bool truncated)
         {
             if (maxEntries < 1)
-                maxEntries = 1;
+                maxEntries = 1; // floor; the tool layer rejects < 1 upstream — see the doc remark above.
 
             lock (_gate)
             {

--- a/addons/godot_mcp/Runtime/Tools/RuntimeErrorFactory.cs
+++ b/addons/godot_mcp/Runtime/Tools/RuntimeErrorFactory.cs
@@ -1,0 +1,75 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using com.IvanMurzak.Godot.MCP.Data;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// Pure-managed factory that maps the two in-game error sources into <see cref="RuntimeError"/> rows:
+    /// the engine error stream (<see cref="EngineErrorRecord"/>, via the 4.5 <c>OS.AddLogger</c> hook) and
+    /// managed C# faults (<see cref="System.Exception"/>, via the <c>AppDomain.UnhandledException</c> /
+    /// <c>TaskScheduler.UnobservedTaskException</c> hooks). Split out of <see cref="RuntimeErrorCapture"/> so
+    /// the mapping/formatting is unit-testable in the plain xUnit host with NO Godot binary and NO live
+    /// runtime — the install/hook wiring (which touches <c>OS.AddLogger</c> / static AppDomain events) is the
+    /// Godot/runtime-coupled part verified by the headless smoke.
+    ///
+    /// No Godot API surface, no <c>#if TOOLS</c> — ships into a game build.
+    /// </summary>
+    public static class RuntimeErrorFactory
+    {
+        /// <summary>
+        /// Build a <see cref="RuntimeError"/> from an engine error-stream callback. The engine yields the
+        /// ORIGIN (file / line / function) + message + kind, but NOT a deep GDScript call stack, so
+        /// <see cref="RuntimeError.StackTrace"/> stays null (documented fidelity limit). The engine kind is
+        /// rendered as the <see cref="RuntimeError.Type"/> string (Error / Warning / Script / Shader).
+        /// </summary>
+        public static RuntimeError FromEngine(EngineErrorRecord record)
+        {
+            return new RuntimeError(
+                source: RuntimeErrorSource.Engine,
+                message: record.Message ?? string.Empty,
+                type: record.Kind.ToString(),
+                file: record.FilePath,
+                line: record.Line,
+                function: record.Function,
+                stackTrace: null);
+        }
+
+        /// <summary>
+        /// Build a <see cref="RuntimeError"/> from a managed C# fault. <paramref name="source"/> distinguishes
+        /// an <c>AppDomain.UnhandledException</c> from a <c>TaskScheduler.UnobservedTaskException</c>. The
+        /// exception's runtime type name becomes <see cref="RuntimeError.Type"/>, its message becomes
+        /// <see cref="RuntimeError.Message"/>, and the FULL stack trace (flattened across inner exceptions)
+        /// becomes <see cref="RuntimeError.StackTrace"/> — the deep managed stack the engine hook cannot give.
+        /// Null-safe: a null exception yields a placeholder row rather than throwing inside a fault handler.
+        /// </summary>
+        public static RuntimeError FromException(RuntimeErrorSource source, Exception? exception)
+        {
+            if (exception == null)
+            {
+                return new RuntimeError(
+                    source: source,
+                    message: "(null exception)",
+                    type: "System.Exception");
+            }
+
+            // ToString() on an Exception already renders "Type: Message\n   at frame...\n --- inner ---" with
+            // every inner exception inlined — exactly the full-fidelity stack the issue asks for. We still set
+            // Message/Type to the OUTER exception's discrete fields so the structured row stays queryable.
+            return new RuntimeError(
+                source: source,
+                message: exception.Message ?? string.Empty,
+                type: exception.GetType().FullName ?? exception.GetType().Name,
+                stackTrace: exception.ToString());
+        }
+    }
+}

--- a/addons/godot_mcp/Runtime/Tools/ScriptErrorCapture.cs
+++ b/addons/godot_mcp/Runtime/Tools/ScriptErrorCapture.cs
@@ -182,7 +182,10 @@ namespace com.IvanMurzak.Godot.MCP.Tools
 
             // Structured capture (in-game runtime): forward the full origin so runtime-errors-get can return
             // file/line/function/type, not just a flattened line. Always fires (errors are not session-gated).
-            ErrorSink?.Invoke(new EngineErrorRecord(kind, filePath, line, function, text));
+            // Wrapped for parity with the in-game C# fault handlers: this runs on the engine's (multi-threaded)
+            // log callback, so a throwing sink must never escape back into the engine.
+            try { ErrorSink?.Invoke(new EngineErrorRecord(kind, filePath, line, function, text)); }
+            catch { /* a captured engine-error sink must never throw back into the engine callback */ }
 
             // Validation capture: only script errors, only while a session is open.
             if (kind != EngineErrorKind.Script)

--- a/addons/godot_mcp/Runtime/Tools/ScriptErrorCapture.cs
+++ b/addons/godot_mcp/Runtime/Tools/ScriptErrorCapture.cs
@@ -33,6 +33,35 @@ namespace com.IvanMurzak.Godot.MCP.Tools
     }
 
     /// <summary>
+    /// One structured engine-error callback forwarded to <see cref="ScriptErrorCapture.ErrorSink"/> — the
+    /// full origin (kind + file + line + function + already-resolved human message), distinct from the
+    /// flattened single-line form <see cref="ScriptErrorCapture.LogSink"/> receives. Consumed by the in-game
+    /// runtime to build <see cref="Data.RuntimeError"/> rows that preserve file/line/function. Pure-managed.
+    /// </summary>
+    public readonly struct EngineErrorRecord
+    {
+        /// <summary>The engine error category (Error / Warning / Script / Shader).</summary>
+        public EngineErrorKind Kind { get; }
+        /// <summary>Origin source path (res:// or absolute), or null/empty when the engine omitted it.</summary>
+        public string? FilePath { get; }
+        /// <summary>1-based origin line, or -1 when unknown.</summary>
+        public int Line { get; }
+        /// <summary>Origin function name, or null/empty when the engine omitted it.</summary>
+        public string? Function { get; }
+        /// <summary>The resolved human-readable error text (rationale preferred, else the C++ condition).</summary>
+        public string Message { get; }
+
+        public EngineErrorRecord(EngineErrorKind kind, string? filePath, int line, string? function, string message)
+        {
+            Kind = kind;
+            FilePath = filePath;
+            Line = line;
+            Function = function;
+            Message = message;
+        }
+    }
+
+    /// <summary>
     /// Pure-managed router for engine log/error callbacks captured via Godot 4.5's <c>OS.AddLogger</c> hook.
     /// It does TWO independent jobs from a single engine callback, decoupled from the Godot type so both are
     /// unit-testable:
@@ -72,6 +101,17 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         /// real collector; unit tests inject a fake). May be null (capture-session-only mode).
         /// </summary>
         public Action<GodotLogType, string>? LogSink { get; set; }
+
+        /// <summary>
+        /// Optional STRUCTURED sink for full engine-error records (kind + file + line + function + message),
+        /// distinct from the flattened-string <see cref="LogSink"/>. The in-game runtime
+        /// (<c>RuntimeErrorCapture</c>) wires this so engine errors raised in a running game are captured as
+        /// structured <see cref="Data.RuntimeError"/> rows for the <c>runtime-errors-get</c> tool — preserving
+        /// the origin fields the formatted log line collapses. Invoked on every engine callback regardless of
+        /// validation-session state (errors fire whether or not a <see cref="BeginSession"/> is open). May be
+        /// null (the editor passive-log path leaves it unset and uses <see cref="LogSink"/> only).
+        /// </summary>
+        public Action<EngineErrorRecord>? ErrorSink { get; set; }
 
         /// <summary>True while a validation capture session is open (see <see cref="BeginSession"/>).</summary>
         public bool SessionActive
@@ -118,13 +158,16 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         }
 
         /// <summary>
-        /// Route one engine callback. Appends to <see cref="LogSink"/> (passive capture, always) and — when a
-        /// session is open and the callback is a <see cref="EngineErrorKind.Script"/> error whose file matches
-        /// the session target (see <see cref="BeginSession"/>) — records a structured diagnostic.
-        /// <paramref name="line"/> may be -1 when unknown; <paramref name="filePath"/> is the engine source
-        /// path (kept as-is; it may be a <c>res://</c> or absolute path). Thread-safe.
+        /// Route one engine callback. Appends to <see cref="LogSink"/> (passive flattened capture, always),
+        /// forwards a structured record to <see cref="ErrorSink"/> (always, when wired — the in-game runtime's
+        /// path), and — when a session is open and the callback is a <see cref="EngineErrorKind.Script"/> error
+        /// whose file matches the session target (see <see cref="BeginSession"/>) — records a structured
+        /// diagnostic. <paramref name="line"/> may be -1 when unknown; <paramref name="filePath"/> is the engine
+        /// source path (kept as-is; it may be a <c>res://</c> or absolute path); <paramref name="function"/> is
+        /// the originating function name (may be null/empty when the engine omits it). Thread-safe.
         /// </summary>
-        public void Route(EngineErrorKind kind, string? filePath, int line, string? message, string? rationale)
+        public void Route(EngineErrorKind kind, string? filePath, int line, string? message, string? rationale,
+            string? function = null)
         {
             // Build the human line: prefer the engine "rationale" (the actual error text) and fall back to
             // the C++ assertion "message" (the failed condition) when no rationale is present.
@@ -136,6 +179,10 @@ namespace com.IvanMurzak.Godot.MCP.Tools
 
             // Passive capture: surface a path:line prefix so console-get-logs is self-describing.
             LogSink?.Invoke(logType, FormatLogLine(kind, filePath, line, text));
+
+            // Structured capture (in-game runtime): forward the full origin so runtime-errors-get can return
+            // file/line/function/type, not just a flattened line. Always fires (errors are not session-gated).
+            ErrorSink?.Invoke(new EngineErrorRecord(kind, filePath, line, function, text));
 
             // Validation capture: only script errors, only while a session is open.
             if (kind != EngineErrorKind.Script)

--- a/addons/godot_mcp/Runtime/Tools/Tool_RuntimeErrors.Clear.cs
+++ b/addons/godot_mcp/Runtime/Tools/Tool_RuntimeErrors.Clear.cs
@@ -1,0 +1,36 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.ComponentModel;
+using com.IvanMurzak.McpPlugin;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_RuntimeErrors
+    {
+        public const string RuntimeErrorsClearToolId = "runtime-errors-clear";
+
+        [AiTool
+        (
+            RuntimeErrorsClearToolId,
+            Title = "Runtime Errors / Clear",
+            DestructiveHint = true,
+            IdempotentHint = true
+        )]
+        [Description("Clear the captured in-game runtime-error buffer (read by 'runtime-errors-get'). Useful " +
+            "for isolating errors to a specific in-game action by clearing the slate first, then performing " +
+            "the action, then polling 'runtime-errors-get'. NOTE: the monotonic sequence counter is NOT reset, " +
+            "so a 'sinceSequence' poll from before the clear still behaves correctly (no old rows reappear). " +
+            "A no-op when runtime error capture is not enabled in this game.")]
+        public void Clear(string? nothing = null)
+        {
+            RuntimeErrorCollector.Current?.Clear();
+        }
+    }
+}

--- a/addons/godot_mcp/Runtime/Tools/Tool_RuntimeErrors.Clear.cs
+++ b/addons/godot_mcp/Runtime/Tools/Tool_RuntimeErrors.Clear.cs
@@ -28,6 +28,9 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             "the action, then polling 'runtime-errors-get'. NOTE: the monotonic sequence counter is NOT reset, " +
             "so a 'sinceSequence' poll from before the clear still behaves correctly (no old rows reappear). " +
             "A no-op when runtime error capture is not enabled in this game.")]
+        // The unused 'nothing' parameter is the repo-wide idiom for a zero-input [AiTool] method (mirrors
+        // Tool_Console.ClearLogs / Tool_Editor.GetState / Tool_Scene.ListOpened): the tool-schema generator
+        // expects at least one parameter, so an optional defaulted no-op stands in for "takes no input".
         public void Clear(string? nothing = null)
         {
             RuntimeErrorCollector.Current?.Clear();

--- a/addons/godot_mcp/Runtime/Tools/Tool_RuntimeErrors.Get.cs
+++ b/addons/godot_mcp/Runtime/Tools/Tool_RuntimeErrors.Get.cs
@@ -1,0 +1,128 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.ComponentModel;
+using System.Linq;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.McpPlugin;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    public partial class Tool_RuntimeErrors
+    {
+        public const string RuntimeErrorsGetToolId = "runtime-errors-get";
+
+        [AiTool
+        (
+            RuntimeErrorsGetToolId,
+            Title = "Runtime Errors / Get",
+            ReadOnlyHint = true,
+            IdempotentHint = true,
+            OpenWorldHint = false
+        )]
+        [Description("Retrieve errors raised inside the RUNNING game — GDScript runtime errors, " +
+            "push_error/push_warning, shader errors (Godot 4.5+ engine hook), and C# unhandled / unobserved-" +
+            "Task exceptions (with full managed stack traces). This is the in-game counterpart to " +
+            "'console-get-logs' / 'script-validate' (which are editor-side): it lets an agent driving a live " +
+            "game detect real gameplay/runtime bugs instead of assuming the game is healthy because the editor " +
+            "console is quiet.\n" +
+            "Poll loop: pass the 'highestSequence' from the previous call as 'sinceSequence' to get ONLY newer " +
+            "errors. Start with sinceSequence=0 (default) for everything captured so far.\n" +
+            "Inputs:\n" +
+            "  - 'sinceSequence' (default 0): return only errors with a sequence number greater than this.\n" +
+            "  - 'maxEntries' (default 100, min 1): cap the returned page (newest kept; 'truncated' flags a cap).\n" +
+            "Result (RuntimeErrorsResult): 'available' (false when the game did not enable runtime error " +
+            "capture — then an empty list proves nothing), 'ok' (no error-severity entries), the 'errors' " +
+            "[{ sequence, message, type, source, file, line, function, stackTrace, timestamp }] oldest-first, " +
+            "counts, 'highestSequence' (poll with it next), and a 'truncated' flag.")]
+        public RuntimeErrorsResult Get
+        (
+            [Description("Return only errors with a sequence number greater than this. Pass the previous " +
+                "result's 'highestSequence' to poll only new errors. Default 0 (all captured).")]
+            long sinceSequence = 0,
+            [Description("Maximum number of errors to return. Minimum 1, default 100. Newest kept when capped.")]
+            int maxEntries = 100
+        )
+        {
+            if (maxEntries < 1)
+                throw new ArgumentException($"maxEntries must be >= 1; got {maxEntries}.", nameof(maxEntries));
+
+            var collector = RuntimeErrorCollector.Current;
+            if (collector == null)
+            {
+                return new RuntimeErrorsResult
+                {
+                    Available = false,
+                    Ok = true,
+                    Note = "Runtime error capture is not enabled in this game. Initialize the in-game runtime " +
+                           "with GodotMcpRuntime.Initialize(b => b.WithRuntimeErrorCapture()) to capture in-game " +
+                           "runtime errors. (Absence of errors here does NOT mean the game is error-free.)",
+                };
+            }
+
+            var errors = collector.QuerySince(sinceSequence, maxEntries, out var truncated);
+
+            var errorCount = errors.Count(e => IsErrorSeverity(e));
+            var warningCount = errors.Length - errorCount;
+
+            var result = new RuntimeErrorsResult
+            {
+                Available = true,
+                Count = errors.Length,
+                ErrorCount = errorCount,
+                WarningCount = warningCount,
+                HighestSequence = collector.HighestSequence,
+                Truncated = truncated,
+                Errors = errors.ToList(),
+                Ok = errorCount == 0,
+            };
+            result.Note = BuildNote(result, sinceSequence);
+            return result;
+        }
+
+        /// <summary>
+        /// Error-vs-warning classification for the result counts. Engine WARNING entries (and only those) are
+        /// warnings; everything else — engine Error/Script/Shader and BOTH managed-fault sources — is an
+        /// error (a C# unhandled / unobserved-Task exception is always error-severity).
+        /// </summary>
+        static bool IsErrorSeverity(RuntimeError e)
+        {
+            if (e.Source != RuntimeErrorSource.Engine)
+                return true; // managed faults are always errors
+            // Engine 'Type' carries the EngineErrorKind name; only "Warning" is non-error.
+            return !string.Equals(e.Type, nameof(EngineErrorKind.Warning), StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>Compose the human-readable summary note.</summary>
+        static string BuildNote(RuntimeErrorsResult result, long sinceSequence)
+        {
+            var scope = sinceSequence > 0 ? $" since sequence {sinceSequence}" : string.Empty;
+
+            string note;
+            if (result.Count == 0)
+            {
+                note = $"No new runtime errors{scope} (capture active).";
+            }
+            else
+            {
+                var noun = result.ErrorCount == 1 ? "error" : "errors";
+                note = $"{result.ErrorCount} runtime {noun}{scope}.";
+                if (result.WarningCount > 0)
+                    note += $" {result.WarningCount} warning(s).";
+            }
+
+            if (result.Truncated)
+                note += $" NOTE: more than {result.Count} matched — only the newest {result.Count} were " +
+                        "returned; poll again with 'sinceSequence' = 'highestSequence'.";
+
+            return note;
+        }
+    }
+}

--- a/addons/godot_mcp/Runtime/Tools/Tool_RuntimeErrors.cs
+++ b/addons/godot_mcp/Runtime/Tools/Tool_RuntimeErrors.cs
@@ -1,0 +1,37 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using com.IvanMurzak.McpPlugin;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// In-game runtime-error tool family (<c>runtime-errors-*</c>) — surfaces errors raised inside a RUNNING
+    /// game (GDScript runtime errors, <c>push_error</c>/<c>push_warning</c>, shader errors, and C# unhandled /
+    /// unobserved-Task exceptions) to the agent, closing the gap (issue #160) where in-game runtime errors
+    /// were invisible (only editor-side script errors were captured).
+    ///
+    /// <para>
+    /// Each tool method lives in its own partial-class file (Get / Clear) and reads/clears the process-wide
+    /// <see cref="RuntimeErrorCollector"/> that <c>RuntimeErrorCapture</c> feeds. When the in-game runtime was
+    /// NOT started with error capture enabled (the default-OFF posture), the collector is null and
+    /// <c>runtime-errors-get</c> returns <c>available:false</c> so the agent does not read silence as health.
+    /// </para>
+    ///
+    /// This family is engine-runtime logic with no Godot editor-API surface (it only touches the pure-managed
+    /// collector), so it lives OUTSIDE <c>#if TOOLS</c> — it ships into a game build, is discovered by the
+    /// McpPlugin assembly scanner, and is unit-testable in the plain xUnit host. Unlike the editor tool
+    /// families it is opt-in for the running game: a developer registers it via
+    /// <c>GodotMcpRuntime.Initialize(b =&gt; b.WithRuntimeErrorTool())</c> (or the whole addon assembly).
+    /// </summary>
+    [AiToolType]
+    public partial class Tool_RuntimeErrors
+    {
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,8 +42,9 @@ addons/godot_mcp/
 ├── Icons/                     # dock icons (res:// loaded; editor-only assets)
 ├── Runtime/                   # un-gated — COMPILES INTO A GAME BUILD
 │   ├── GodotMcpRuntime.cs            # in-game entry point: GodotMcpRuntime.Initialize(...)
-│   ├── GodotMcpRuntimeBuilder.cs     # fluent builder (WithConfig / WithTools / …)
+│   ├── GodotMcpRuntimeBuilder.cs     # fluent builder (WithConfig / WithTools / WithRuntimeErrorCapture / …)
 │   ├── GodotMcpRuntimeHandle.cs      # disposable handle over a running connection
+│   ├── RuntimeErrorCapture.cs        # installs in-game error capture (OS.AddLogger 4.5+ + C# fault hooks)
 │   ├── GodotMcpEnv.cs
 │   ├── Connection/                   # connection core, config, env/store, logger, resolver,
 │   │                                 #   token gen, server-view (version parse), STJ cache
@@ -51,8 +52,11 @@ addons/godot_mcp/
 │   ├── Reflection/                   # reflector factory + Godot value-type converters + GodotAssemblyUtils
 │   ├── Data/                         # pure-managed result/ref models (NodeRef, ResourceRef, …)
 │   ├── Extensions/                   # extension registry/installer planning logic (pure-managed)
-│   └── Tools/                        # RUNTIME-SAFE tools: Tool_Ping, Tool_Console*, Tool_Reflection*
-│                                     #   + pure helpers (NodePathNormalizer, ResPathNormalizer, …)
+│   └── Tools/                        # RUNTIME-SAFE tools: Tool_Ping, Tool_Console*, Tool_Reflection*,
+│                                     #   Tool_RuntimeErrors* (in-game runtime-error capture, opt-in)
+│                                     #   + the engine-error logger bridge (GodotScriptErrorLogger*, 4.5+,
+│                                     #   shared by the editor AND the in-game runtime) + pure helpers
+│                                     #   (NodePathNormalizer, ResPathNormalizer, RuntimeErrorCollector, …)
 └── Editor/                    # #if TOOLS — STRIPPED FROM A GAME BUILD (editor-only)
     ├── GodotMcpPlugin.cs             # the [Tool] EditorPlugin entry (boots the dock + connection)
     ├── Connection/                   # editor server lifecycle (GodotMcpServerManager), device-auth
@@ -119,9 +123,31 @@ var handle = GodotMcpRuntime
 Everything this path needs lives under `Runtime/` and compiles into the game build: the
 entry point + builder + handle, the connection core, the main-thread dispatcher, the
 reflector, the assembly resolver, and the runtime-safe tools (`ping`, `console-*`,
-`reflection-*`). The editor tool families are **not** available here — they are `#if TOOLS`
-and don't exist in the game build by design (they require `EditorInterface` and a live
-editor).
+`reflection-*`, and the opt-in `runtime-errors-*`). The editor tool families are **not**
+available here — they are `#if TOOLS` and don't exist in the game build by design (they
+require `EditorInterface` and a live editor).
+
+#### In-game runtime error capture (issue #160)
+
+A subtlety worth calling out: the engine-error logger bridge
+(`Runtime/Tools/GodotScriptErrorLogger.cs`) is gated by `#if GODOT4_5_OR_GREATER` **but not**
+by `#if TOOLS` — because `OS.AddLogger` / `Godot.Logger` are **engine (runtime) APIs**, not
+editor APIs. That is what lets the *same* bridge serve two callers:
+
+- the **editor** (`Editor/GodotMcpPlugin.cs`) installs it to capture engine script errors
+  raised in-editor (feeding `console-get-logs` / `script-validate`), and
+- the **in-game runtime** (`Runtime/RuntimeErrorCapture.cs`, opt-in via
+  `GodotMcpRuntime.Initialize(b => b.WithRuntimeErrorCapture())`) installs it to capture
+  errors raised in the **running game** — GDScript runtime errors, `push_error`/`push_warning`,
+  shader errors — plus C# unhandled / unobserved-`Task` exceptions (with full managed stack
+  traces) via `AppDomain.UnhandledException` / `TaskScheduler.UnobservedTaskException`. The
+  captured rows are ring-buffered (`RuntimeErrorCollector`) and surfaced via the
+  `runtime-errors-*` tool with monotonic-sequence since-poll / clear semantics.
+
+This is why those files live under `Runtime/` and pass the boundary guard: they reference no
+editor-only API (only `OS` + `Godot.Logger`), so they ship into a game build. On Godot < 4.5
+the bridge's `#else` stub compiles in (no `OS.AddLogger`), so the engine channel degrades
+gracefully to a no-op while the C# fault channels still work.
 
 ## The Editor → Runtime dependency rule
 


### PR DESCRIPTION
## Summary

- Capture errors raised inside a **running game** — not just editor-side script errors — and surface them to the agent via a new `runtime-errors-*` MCP tool, closing the gap where an agent could launch the game, see a quiet console, and wrongly conclude the game was healthy.
- Lift the engine-error logger bridge (`GodotScriptErrorLogger` + Stub) out of `Editor/#if TOOLS` into `Runtime/` (gated by `#if GODOT4_5_OR_GREATER` only) so the **same** `OS.AddLogger` bridge serves both the editor and the in-game runtime; add a structured `ErrorSink` to `ScriptErrorCapture` that preserves the error origin (file/line/function).
- New opt-in `GodotMcpRuntime.Initialize(b => b.WithRuntimeErrorCapture())` installs three best-effort, gracefully-degrading channels: the engine error stream (Godot 4.5+ `OS.AddLogger`: GDScript runtime errors, `push_error`/`push_warning`, shader errors), `AppDomain.UnhandledException`, and `TaskScheduler.UnobservedTaskException` (the two C# channels carry full managed stack traces). Default-OFF; the handle uninstalls on `Dispose`.
- `runtime-errors-get` returns a ring-buffered, structured `{ sequence, message, type, source, file, line, function, stackTrace, timestamp }` list with monotonic-sequence since-poll + `runtime-errors-clear` semantics; reports `available:false` when capture was never enabled so silence is never read as health.
- Docs: README "Capturing in-game runtime errors" + ARCHITECTURE.md, including the stack-trace fidelity nuance (engine errors = origin only; C# faults = full stack).

## Test plan
- [x] `dotnet build Godot-MCP.sln` — 0 errors / 0 warnings.
- [x] `dotnet test Godot-MCP.Tests` — 804 passed / 1 failed (the documented benign Windows-only `GodotAssemblyUtilsTests` temp-DLL cleanup; green in Linux CI). 30 new xUnit cases cover the collector, factory, tool, `ErrorSink`, and builder opt-in.
- [x] Runtime/editor boundary guard holds (74 Runtime/ files, 0 violations).
- [x] **ExportRelease (TOOLS-undefined) compiles** — the relocated bridge + new runtime files ship into a game build.
- [x] **Live headless Godot 4.5.1 game smoke**: `WithRuntimeErrorCapture()` captured a real GDScript runtime error (`Invalid call... in base 'Nil'`) + `push_error` + `push_warning` through `runtime-errors-get` (`available=True, count=3, errorCount=2, warningCount=1`, origins/functions populated).

Closes #160