### PR TITLE
feat: surface deep multi-frame GDScript backtraces in runtime errors (#163)

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -136,6 +136,7 @@
          (GodotScriptErrorLogger.cs) is #if GODOT4_5_OR_GREATER — both verified via the headless Godot runtime
          smoke (test.md Suite 3); the models + collector + factory + tool handlers are unit-tested here. -->
     <Compile Include="..\addons\godot_mcp\Runtime\Data\RuntimeError.cs" Link="Source\RuntimeError.cs" />
+    <Compile Include="..\addons\godot_mcp\Runtime\Data\RuntimeErrorFrame.cs" Link="Source\RuntimeErrorFrame.cs" />
     <Compile Include="..\addons\godot_mcp\Runtime\Data\RuntimeErrorsResult.cs" Link="Source\RuntimeErrorsResult.cs" />
     <Compile Include="..\addons\godot_mcp\Runtime\Tools\RuntimeErrorCollector.cs" Link="Source\RuntimeErrorCollector.cs" />
     <Compile Include="..\addons\godot_mcp\Runtime\Tools\RuntimeErrorFactory.cs" Link="Source\RuntimeErrorFactory.cs" />

--- a/Godot-MCP.Tests/RuntimeErrorCaptureTests.cs
+++ b/Godot-MCP.Tests/RuntimeErrorCaptureTests.cs
@@ -64,6 +64,90 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         }
 
         [Fact]
+        public void RuntimeError_Serializes_DeepFrames_RoundTrip()
+        {
+            // Issue #163: an engine GDScript error on Godot 4.5+ carries the deep multi-frame backtrace.
+            var e = new RuntimeError(
+                source: RuntimeErrorSource.Engine,
+                message: "Invalid get index 'health'",
+                type: "Script",
+                file: "res://scripts/player.gd",
+                line: 42,
+                function: "_take_damage",
+                stackTrace: "GDScript backtrace:\nat _take_damage res://scripts/player.gd:42\n" +
+                            "at _process res://scripts/player.gd:18",
+                frames: new List<RuntimeErrorFrame>
+                {
+                    new RuntimeErrorFrame("_take_damage", "res://scripts/player.gd", 42),
+                    new RuntimeErrorFrame("_process", "res://scripts/player.gd", 18),
+                })
+            { Sequence = 3 };
+
+            var json = JsonSerializer.Serialize(e);
+            Assert.Contains("\"frames\"", json);
+            Assert.Contains("\"_take_damage\"", json);
+            Assert.Contains("\"_process\"", json);
+
+            var restored = JsonSerializer.Deserialize<RuntimeError>(json);
+            Assert.NotNull(restored);
+            Assert.NotNull(restored!.Frames);
+            Assert.Equal(2, restored.Frames!.Count);
+            // Innermost-first ordering is preserved across serialization.
+            Assert.Equal("_take_damage", restored.Frames[0].Function);
+            Assert.Equal("res://scripts/player.gd", restored.Frames[0].File);
+            Assert.Equal(42, restored.Frames[0].Line);
+            Assert.Equal("_process", restored.Frames[1].Function);
+            Assert.Equal(18, restored.Frames[1].Line);
+            Assert.NotNull(restored.StackTrace);
+            Assert.Contains("backtrace", restored.StackTrace!);
+        }
+
+        [Fact]
+        public void RuntimeError_EngineOriginOnly_HasNullFrames_AndNullStackTrace()
+        {
+            // The < 4.5 / no-tracked-backtrace fallback: origin fields only, no deep stack.
+            var e = new RuntimeError(
+                source: RuntimeErrorSource.Engine,
+                message: "boom",
+                type: "Error",
+                file: "res://x.gd",
+                line: 5);
+
+            Assert.Null(e.Frames);
+            Assert.Null(e.StackTrace);
+
+            // An empty frame list normalizes to null (single "no frames" sentinel for consumers).
+            var e2 = new RuntimeError(RuntimeErrorSource.Engine, "boom", "Error",
+                frames: new List<RuntimeErrorFrame>());
+            Assert.Null(e2.Frames);
+        }
+
+        [Fact]
+        public void RuntimeErrorFrame_Serializes_WithExpectedJsonNames()
+        {
+            var f = new RuntimeErrorFrame("_ready", "res://scripts/main.gd", 7);
+
+            var json = JsonSerializer.Serialize(f);
+            foreach (var key in new[] { "function", "file", "line" })
+                Assert.Contains($"\"{key}\"", json);
+
+            var restored = JsonSerializer.Deserialize<RuntimeErrorFrame>(json);
+            Assert.NotNull(restored);
+            Assert.Equal("_ready", restored!.Function);
+            Assert.Equal("res://scripts/main.gd", restored.File);
+            Assert.Equal(7, restored.Line);
+        }
+
+        [Fact]
+        public void RuntimeErrorFrame_ToString_RendersFunctionFileLine()
+        {
+            Assert.Equal("at _ready res://m.gd:7", new RuntimeErrorFrame("_ready", "res://m.gd", 7).ToString());
+            // Unknown line drops the :line suffix; unknown function falls back to <unknown>.
+            Assert.Equal("at _ready res://m.gd", new RuntimeErrorFrame("_ready", "res://m.gd", -1).ToString());
+            Assert.Equal("at <unknown>", new RuntimeErrorFrame(null, null, -1).ToString());
+        }
+
+        [Fact]
         public void RuntimeErrorsResult_Serializes_WithExpectedJsonNames()
         {
             var r = new RuntimeErrorsResult
@@ -216,6 +300,7 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         [Fact]
         public void Factory_FromEngine_MapsOriginFields_NoStackTrace()
         {
+            // The origin-only (< 4.5 / no tracked backtrace) record: the 5-arg ctor leaves frames null.
             var record = new EngineErrorRecord(EngineErrorKind.Script, "res://x.gd", 13, "_ready", "bad index");
             var e = RuntimeErrorFactory.FromEngine(record);
 
@@ -225,7 +310,62 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Equal(13, e.Line);
             Assert.Equal("_ready", e.Function);
             Assert.Equal("bad index", e.Message);
-            Assert.Null(e.StackTrace);                 // engine hook yields origin, not a deep stack
+            Assert.Null(e.StackTrace);                 // no backtrace tracked → origin only
+            Assert.Null(e.Frames);
+        }
+
+        [Fact]
+        public void Factory_FromEngine_MapsDeepBacktrace_FramesAndStackTrace()
+        {
+            // Issue #163: a Godot 4.5+ GDScript error carries the already-materialized deep backtrace. The
+            // factory must copy both the structured frames and the formatted string onto the RuntimeError.
+            var frames = new List<RuntimeErrorFrame>
+            {
+                new RuntimeErrorFrame("_take_damage", "res://scripts/player.gd", 42),
+                new RuntimeErrorFrame("_process", "res://scripts/player.gd", 18),
+            };
+            var record = new EngineErrorRecord(
+                EngineErrorKind.Script, "res://scripts/player.gd", 42, "_take_damage", "Invalid get index",
+                frames: frames,
+                stackTrace: "GDScript backtrace:\nat _take_damage res://scripts/player.gd:42");
+
+            var e = RuntimeErrorFactory.FromEngine(record);
+
+            Assert.Equal(RuntimeErrorSource.Engine, e.Source);
+            Assert.NotNull(e.Frames);
+            Assert.Equal(2, e.Frames!.Count);
+            Assert.Equal("_take_damage", e.Frames[0].Function);    // innermost-first preserved
+            Assert.Equal(42, e.Frames[0].Line);
+            Assert.Equal("_process", e.Frames[1].Function);
+            Assert.NotNull(e.StackTrace);
+            Assert.Contains("GDScript backtrace", e.StackTrace!);
+        }
+
+        [Fact]
+        public void Factory_FromEngine_CopiesFrames_DoesNotAliasRecordList()
+        {
+            // The RuntimeError must own a fresh List<>, not share the record's reference, so later mutation
+            // of the source list cannot corrupt a captured row.
+            var source = new List<RuntimeErrorFrame> { new RuntimeErrorFrame("a", "res://a.gd", 1) };
+            var record = new EngineErrorRecord(EngineErrorKind.Script, "res://a.gd", 1, "a", "msg",
+                frames: source, stackTrace: "trace");
+
+            var e = RuntimeErrorFactory.FromEngine(record);
+            source.Add(new RuntimeErrorFrame("b", "res://b.gd", 2)); // mutate the source after capture
+
+            Assert.NotNull(e.Frames);
+            Assert.Single(e.Frames!);                  // unaffected by the post-capture mutation
+            Assert.Equal("a", e.Frames![0].Function);
+        }
+
+        [Fact]
+        public void EngineErrorRecord_NormalizesEmptyFrames_ToNull()
+        {
+            // The record collapses an empty backtrace to null so consumers have a single "no frames" sentinel.
+            var rec = new EngineErrorRecord(EngineErrorKind.Script, "res://a.gd", 1, "a", "msg",
+                frames: new List<RuntimeErrorFrame>(), stackTrace: "");
+            Assert.Null(rec.Frames);
+            Assert.Null(rec.StackTrace);
         }
 
         [Fact]
@@ -289,6 +429,75 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Equal(5, rec.Line);
             Assert.Equal("_process", rec.Function);
             Assert.Equal("Parse error", rec.Message); // rationale preferred
+        }
+
+        [Fact]
+        public void Route_ForwardsDeepBacktrace_ToErrorSink()
+        {
+            // Issue #163: the deep backtrace materialized by the 4.5 logger flows through Route() untouched
+            // into the structured EngineErrorRecord (Route never reads a live Godot object — only the managed
+            // primitives the logger already copied out).
+            var records = new List<EngineErrorRecord>();
+            var capture = new ScriptErrorCapture { ErrorSink = r => records.Add(r) };
+
+            var frames = new List<RuntimeErrorFrame>
+            {
+                new RuntimeErrorFrame("_inner", "res://p.gd", 9),
+                new RuntimeErrorFrame("_outer", "res://p.gd", 3),
+            };
+            capture.Route(EngineErrorKind.Script, "res://p.gd", 9, "cond", "Boom",
+                function: "_inner", frames: frames, stackTrace: "GDScript backtrace:\n...");
+
+            var rec = Assert.Single(records);
+            Assert.NotNull(rec.Frames);
+            Assert.Equal(2, rec.Frames!.Count);
+            Assert.Equal("_inner", rec.Frames[0].Function);
+            Assert.Equal("_outer", rec.Frames[1].Function);
+            Assert.Equal("GDScript backtrace:\n...", rec.StackTrace);
+        }
+
+        [Fact]
+        public void Route_NoBacktrace_LeavesRecordFramesNull()
+        {
+            // The editor passive-log path (and < 4.5) calls Route without frames — the record stays origin-only.
+            var records = new List<EngineErrorRecord>();
+            var capture = new ScriptErrorCapture { ErrorSink = r => records.Add(r) };
+
+            capture.Route(EngineErrorKind.Error, "res://a.gd", 1, "c", "generic");
+
+            var rec = Assert.Single(records);
+            Assert.Null(rec.Frames);
+            Assert.Null(rec.StackTrace);
+        }
+
+        [Fact]
+        public void Route_To_FromEngine_To_Collector_PreservesDeepBacktrace_EndToEnd()
+        {
+            // Full in-game wiring shape: Route → ErrorSink(FromEngine) → collector, with the deep backtrace
+            // surviving every hop. Mirrors how RuntimeErrorCapture wires the ErrorSink in the running game.
+            var collector = new RuntimeErrorCollector();
+            var capture = new ScriptErrorCapture
+            {
+                ErrorSink = record => collector.Append(RuntimeErrorFactory.FromEngine(record)),
+            };
+
+            var frames = new List<RuntimeErrorFrame>
+            {
+                new RuntimeErrorFrame("_take_damage", "res://player.gd", 42),
+                new RuntimeErrorFrame("_process", "res://player.gd", 18),
+            };
+            capture.Route(EngineErrorKind.Script, "res://player.gd", 42, "cond", "Invalid get index",
+                function: "_take_damage", frames: frames, stackTrace: "GDScript backtrace:\n...");
+
+            var page = collector.QuerySince(0, 100, out _);
+            var captured = Assert.Single(page);
+            Assert.Equal(RuntimeErrorSource.Engine, captured.Source);
+            Assert.Equal("_take_damage", captured.Function);
+            Assert.NotNull(captured.Frames);
+            Assert.Equal(2, captured.Frames!.Count);
+            Assert.Equal("_take_damage", captured.Frames[0].Function);
+            Assert.Equal(42, captured.Frames[0].Line);
+            Assert.NotNull(captured.StackTrace);
         }
 
         [Fact]

--- a/Godot-MCP.Tests/RuntimeErrorCaptureTests.cs
+++ b/Godot-MCP.Tests/RuntimeErrorCaptureTests.cs
@@ -145,6 +145,10 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             // Unknown line drops the :line suffix; unknown function falls back to <unknown>.
             Assert.Equal("at _ready res://m.gd", new RuntimeErrorFrame("_ready", "res://m.gd", -1).ToString());
             Assert.Equal("at <unknown>", new RuntimeErrorFrame(null, null, -1).ToString());
+            // A line of 0 is NOT treated as "unknown" by the frame itself — only <0 is. This is the contract
+            // that forces GodotScriptErrorLogger.MaterializeBacktrace to normalize Godot's 0 (no line info) to
+            // the -1 sentinel at materialization, rather than letting a bare "res://m.gd:0" reach the agent.
+            Assert.Equal("at _ready res://m.gd:0", new RuntimeErrorFrame("_ready", "res://m.gd", 0).ToString());
         }
 
         [Fact]

--- a/README.md
+++ b/README.md
@@ -588,16 +588,21 @@ An MCP client polls the captured errors with the `runtime-errors-get` tool (and 
 
 | Tool | What it returns / does |
 | ---- | ---------------------- |
-| `runtime-errors-get` | A bounded, newest-kept list of `{ sequence, message, type, source, file, line, function, stackTrace, timestamp }`. Pass the previous result's `highestSequence` as `sinceSequence` to poll only **new** errors — the "did anything break since I last looked?" loop. Returns `available:false` when capture was never enabled (so an empty list is never mistaken for health). |
+| `runtime-errors-get` | A bounded, newest-kept list of `{ sequence, message, type, source, file, line, function, stackTrace, frames, timestamp }`. Pass the previous result's `highestSequence` as `sinceSequence` to poll only **new** errors — the "did anything break since I last looked?" loop. Returns `available:false` when capture was never enabled (so an empty list is never mistaken for health). |
 | `runtime-errors-clear` | Clears the captured buffer (the monotonic `sequence` counter is preserved, so a pre-clear `sinceSequence` poll still behaves). |
 
 > **Stack-trace fidelity (read this).** The two error *sources* differ in depth:
 > - **Engine errors** (`source: Engine`) carry the error's **origin** — `file:line` and the originating
->   `function` — plus the message and a `type` (`Error` / `Warning` / `Script` / `Shader`). They do **not**
->   carry a deep multi-frame GDScript call stack (`OS.AddLogger` yields the origin, not a backtrace), so
->   `stackTrace` is `null` for them.
+>   `function` — plus the message and a `type` (`Error` / `Warning` / `Script` / `Shader`). On **Godot
+>   4.5+**, a GDScript runtime error **also** carries the **deep multi-frame call stack**: `frames` is the
+>   ordered (innermost-first) backtrace — each `{ function, file, line }` — and `stackTrace` is the engine's
+>   formatted rendering of it. On **Godot < 4.5** (or a release build without call-stack tracking) `frames`
+>   is `null` and `stackTrace` is `null` (origin only). The frames are materialized off the engine's
+>   non-thread-safe `ScriptBacktrace` **inside the logger callback on the originating thread** — only plain
+>   managed values ever cross into the collector, never a live engine object.
 > - **C# faults** (`source: UnhandledException` / `UnobservedTaskException`) carry the **full managed stack
->   trace** (inner exceptions inlined) in `stackTrace`, plus the CLR exception type name in `type`.
+>   trace** (inner exceptions inlined) in `stackTrace`, plus the CLR exception type name in `type`. (`frames`
+>   is `null` — the managed stack lives in the `stackTrace` string.)
 
 > **Graceful degradation.** On **Godot < 4.5** there is no `OS.AddLogger` managed hook, so the engine
 > channel is silently unavailable — the C# exception channels still work, and `runtime-errors-get` still

--- a/addons/godot_mcp/Runtime/Data/RuntimeError.cs
+++ b/addons/godot_mcp/Runtime/Data/RuntimeError.cs
@@ -9,6 +9,7 @@
 */
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text.Json.Serialization;
 
@@ -57,12 +58,16 @@ namespace com.IvanMurzak.Godot.MCP.Data
     /// Field availability depends on the <see cref="Source"/>:
     /// <list type="bullet">
     /// <item><b><see cref="RuntimeErrorSource.Engine"/></b> (Godot 4.5+ logger hook): <see cref="File"/>,
-    /// <see cref="Line"/>, <see cref="Function"/> are the error's ORIGIN; <see cref="StackTrace"/> is null
-    /// (the engine hook yields the origin, not a deep GDScript backtrace).</item>
+    /// <see cref="Line"/>, <see cref="Function"/> are the error's ORIGIN. On Godot 4.5+ a GDScript runtime
+    /// error ALSO carries the deep multi-frame call stack (issue #163): <see cref="Frames"/> is the ordered
+    /// (innermost-first) backtrace and <see cref="StackTrace"/> is its formatted rendering. On Godot &lt; 4.5
+    /// (or when no backtrace was tracked) <see cref="Frames"/> is null/empty and <see cref="StackTrace"/> is
+    /// null (origin only).</item>
     /// <item><b><see cref="RuntimeErrorSource.UnhandledException"/> /
     /// <see cref="RuntimeErrorSource.UnobservedTaskException"/></b>: <see cref="StackTrace"/> carries the
     /// full managed stack; <see cref="File"/>/<see cref="Line"/>/<see cref="Function"/> are empty/-1 (the
-    /// origin is inside the stack trace).</item>
+    /// origin is inside the stack trace) and <see cref="Frames"/> is null (the managed stack lives in the
+    /// string).</item>
     /// </list>
     /// </para>
     ///
@@ -107,9 +112,18 @@ namespace com.IvanMurzak.Godot.MCP.Data
         public string Function { get; set; } = string.Empty;
 
         [JsonInclude, JsonPropertyName("stackTrace")]
-        [Description("Full managed stack trace for a C# fault (UnhandledException / UnobservedTaskException); " +
-            "null for engine errors (the 4.5 logger hook yields the origin, not a deep GDScript backtrace).")]
+        [Description("Stack trace string: for a C# fault (UnhandledException / UnobservedTaskException) the " +
+            "full managed stack; for a Godot 4.5+ engine GDScript error the formatted multi-frame backtrace " +
+            "(see 'frames'); null for engine errors with no tracked backtrace (Godot < 4.5 or release builds " +
+            "without call-stack tracking).")]
         public string? StackTrace { get; set; } = null;
+
+        [JsonInclude, JsonPropertyName("frames")]
+        [Description("Structured deep backtrace for a Godot 4.5+ engine GDScript error: ordered stack frames " +
+            "(innermost-first), each with function / file / line. Null for managed C# faults (their stack is " +
+            "in 'stackTrace') and for engine errors with no tracked backtrace (Godot < 4.5 or release builds " +
+            "without call-stack tracking).")]
+        public List<RuntimeErrorFrame>? Frames { get; set; } = null;
 
         [JsonInclude, JsonPropertyName("timestamp")]
         [Description("UTC timestamp when the error was captured.")]
@@ -125,7 +139,8 @@ namespace com.IvanMurzak.Godot.MCP.Data
             int line = -1,
             string? function = null,
             string? stackTrace = null,
-            DateTime? timestamp = null)
+            DateTime? timestamp = null,
+            List<RuntimeErrorFrame>? frames = null)
         {
             Source = source;
             Message = message ?? string.Empty;
@@ -134,6 +149,7 @@ namespace com.IvanMurzak.Godot.MCP.Data
             Line = line;
             Function = function ?? string.Empty;
             StackTrace = string.IsNullOrEmpty(stackTrace) ? null : stackTrace;
+            Frames = frames != null && frames.Count > 0 ? frames : null;
             Timestamp = timestamp ?? DateTime.UtcNow;
         }
 

--- a/addons/godot_mcp/Runtime/Data/RuntimeErrorFrame.cs
+++ b/addons/godot_mcp/Runtime/Data/RuntimeErrorFrame.cs
@@ -1,0 +1,66 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.Godot.MCP.Data
+{
+    /// <summary>
+    /// One stack frame of a captured GDScript (or other script-language) backtrace — the structured, deep
+    /// call-stack frame surfaced on a <see cref="RuntimeError"/> (issue #163). It is the pure-managed
+    /// materialization of a single frame of Godot 4.5+'s <c>ScriptBacktrace</c>: the live Godot object is
+    /// NON-thread-safe and is read on the originating (possibly non-main) thread inside the logger callback,
+    /// so its <c>GetFrameFunction</c>/<c>GetFrameFile</c>/<c>GetFrameLine</c> accessors are copied into these
+    /// plain primitives BEFORE the record crosses any thread boundary — no live Godot handle is ever stored
+    /// or forwarded.
+    ///
+    /// <para>
+    /// Pure-managed (no Godot API surface, no <c>#if TOOLS</c>), so it is unit-testable in the plain xUnit
+    /// host and ships into a game build. Frames are ordered innermost-first (frame 0 is where the error was
+    /// raised), mirroring Godot's <c>ScriptBacktrace</c> frame ordering.
+    /// </para>
+    /// </summary>
+    [System.Serializable]
+    [Description("One frame of a captured script-language (e.g. GDScript) backtrace: function, file, line.")]
+    public class RuntimeErrorFrame
+    {
+        [JsonInclude, JsonPropertyName("function")]
+        [Description("The function called at this stack frame (e.g. '_process'); empty when the engine omitted it.")]
+        public string Function { get; set; } = string.Empty;
+
+        [JsonInclude, JsonPropertyName("file")]
+        [Description("The source file of this stack frame's call site (e.g. 'res://scripts/player.gd'); empty " +
+            "when the engine omitted it.")]
+        public string File { get; set; } = string.Empty;
+
+        [JsonInclude, JsonPropertyName("line")]
+        [Description("The 1-based line number of this stack frame's call site, or -1 when unknown.")]
+        public int Line { get; set; } = -1;
+
+        public RuntimeErrorFrame() { }
+
+        public RuntimeErrorFrame(string? function, string? file, int line)
+        {
+            Function = function ?? string.Empty;
+            File = file ?? string.Empty;
+            Line = line;
+        }
+
+        public override string ToString()
+        {
+            var loc = string.IsNullOrEmpty(File)
+                ? string.Empty
+                : (Line >= 0 ? $" {File}:{Line}" : $" {File}");
+            var fn = string.IsNullOrEmpty(Function) ? "<unknown>" : Function;
+            return $"at {fn}{loc}";
+        }
+    }
+}

--- a/addons/godot_mcp/Runtime/Tools/GodotScriptErrorLogger.cs
+++ b/addons/godot_mcp/Runtime/Tools/GodotScriptErrorLogger.cs
@@ -152,10 +152,16 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 var list = new List<RuntimeErrorFrame>(frameCount);
                 for (int i = 0; i < frameCount; i++)
                 {
+                    // Normalize the engine line to RuntimeErrorFrame's "-1 == unknown" sentinel: Godot reports
+                    // 0 (not -1) for a frame with no usable line info (e.g. a function-signature frame, or a
+                    // release export without call-stack line tracking — godotengine/godot#106484). Left raw, a
+                    // 0-line frame would render "res://x.gd:0" and serialize line:0, contradicting the contract
+                    // that ToString()/serialization treat <0 as "no line".
+                    var frameLine = backtrace.GetFrameLine(i);
                     list.Add(new RuntimeErrorFrame(
                         function: backtrace.GetFrameFunction(i),
                         file: backtrace.GetFrameFile(i),
-                        line: backtrace.GetFrameLine(i)));
+                        line: frameLine > 0 ? frameLine : -1));
                 }
 
                 if (list.Count == 0)
@@ -170,34 +176,34 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         }
 
         /// <summary>
-        /// Render a human-readable stack-trace string for a captured backtrace, prefixing the script-language
-        /// name. Prefers the engine's <see cref="ScriptBacktrace.Format()"/>; falls back to joining the
-        /// already-materialized <paramref name="frames"/> if Format() returns empty.
+        /// Render a human-readable stack-trace string for a captured backtrace. Prefers the engine's
+        /// <see cref="ScriptBacktrace.Format()"/>, which is ALREADY self-heading — it emits its own
+        /// "&lt;language&gt; backtrace (most recent call first):" header — so we return it verbatim and do NOT
+        /// add a second language prefix (which would double-head the output). Only the managed-join fallback
+        /// (used when Format() returns empty) gets a "&lt;language&gt; backtrace:" prefix, since the joined
+        /// frames carry no header of their own.
         /// </summary>
         static string BuildStackTraceString(global::Godot.ScriptBacktrace backtrace, List<RuntimeErrorFrame> frames)
         {
-            string? language = null;
-            try { language = backtrace.GetLanguageName(); } catch { /* best-effort label */ }
-
-            string body;
             string? formatted = null;
             try { formatted = backtrace.Format(); } catch { /* fall back to the managed join below */ }
 
+            // Format() already prepends its own "<language> backtrace (...)" header — return it as-is.
             if (!string.IsNullOrWhiteSpace(formatted))
+                return formatted!;
+
+            // Managed-join fallback: the joined frames have no header, so synthesize one from the language.
+            var sb = new StringBuilder();
+            foreach (var frame in frames)
             {
-                body = formatted!;
+                if (sb.Length > 0)
+                    sb.Append('\n');
+                sb.Append(frame.ToString());
             }
-            else
-            {
-                var sb = new StringBuilder();
-                foreach (var frame in frames)
-                {
-                    if (sb.Length > 0)
-                        sb.Append('\n');
-                    sb.Append(frame.ToString());
-                }
-                body = sb.ToString();
-            }
+            var body = sb.ToString();
+
+            string? language = null;
+            try { language = backtrace.GetLanguageName(); } catch { /* best-effort label */ }
 
             return string.IsNullOrEmpty(language)
                 ? body

--- a/addons/godot_mcp/Runtime/Tools/GodotScriptErrorLogger.cs
+++ b/addons/godot_mcp/Runtime/Tools/GodotScriptErrorLogger.cs
@@ -28,6 +28,8 @@
 #if GODOT4_5_OR_GREATER
 #nullable enable
 using System;
+using System.Collections.Generic;
+using System.Text;
 using com.IvanMurzak.Godot.MCP.Data;
 using Godot;
 
@@ -39,11 +41,18 @@ namespace com.IvanMurzak.Godot.MCP.Tools
     /// registration (via <see cref="OS.AddLogger"/>) that powers BOTH feature deliverables: passive
     /// engine-log capture into <c>console-get-logs</c> AND on-demand <c>script-validate</c> diagnostics
     /// (the router collects <see cref="EngineErrorKind.Script"/> rows while a validation session is open).
+    /// It is ALSO the source of the deep multi-frame GDScript backtrace surfaced by <c>runtime-errors-get</c>
+    /// (issue #163): the engine hands a <see cref="ScriptBacktrace"/> array to <see cref="_LogError"/>, which
+    /// this class materializes into managed primitives before forwarding.
     ///
     /// <para>
     /// Godot calls <see cref="_LogError"/> from the thread the error originated on, so all buffer writes
-    /// happen inside <see cref="ScriptErrorCapture"/> under its lock. We do NOT touch any non-thread-safe
-    /// Godot object here — only forward primitives — so the multi-threaded callback is safe.
+    /// happen inside <see cref="ScriptErrorCapture"/> under its lock. <see cref="ScriptBacktrace"/> is a
+    /// NON-thread-safe Godot object; we read it ONLY here, on the originating thread, copying each frame's
+    /// function/file/line into plain <see cref="RuntimeErrorFrame"/> primitives (and the engine's formatted
+    /// string) BEFORE handing the record to <see cref="ScriptErrorCapture.Route"/>. No live Godot object is
+    /// ever stored or forwarded across the thread boundary — that invariant is what keeps the multi-threaded
+    /// callback safe.
     /// </para>
     /// </summary>
     public sealed partial class GodotScriptErrorLogger : Logger
@@ -57,8 +66,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
 
         // NOTE: the engine's abstract _LogError binds 'errorType' as Int32 (not the Logger.ErrorType enum),
         // so the override MUST use 'int' to match — the enum values (Error=0/Warning=1/Script=2/Shader=3)
-        // are mapped from the int below. The 'scriptBacktraces' parameter is accepted but unused (we forward
-        // primitives only, keeping the multi-threaded callback free of non-thread-safe Godot object access).
+        // are mapped from the int below.
         public override void _LogError(
             string function,
             string file,
@@ -71,6 +79,24 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             // otherwise bind 'Godot.Collections' to 'com.IvanMurzak.Godot.Collections' (CS0234).
             global::Godot.Collections.Array<global::Godot.ScriptBacktrace> scriptBacktraces)
         {
+            // Materialize the deep multi-frame backtrace NOW, on the originating thread, while the
+            // non-thread-safe ScriptBacktrace objects are still valid in this callback's frame. The result is
+            // pure managed primitives — safe to forward across the thread boundary into the collector. Any
+            // fault while reading the engine objects is swallowed to a null backtrace (origin-only) rather
+            // than escaping back into the engine's log path.
+            IReadOnlyList<RuntimeErrorFrame>? frames = null;
+            string? stackTrace = null;
+            try
+            {
+                MaterializeBacktrace(scriptBacktraces, out frames, out stackTrace);
+            }
+            catch
+            {
+                // A backtrace read failure must never abort error capture — degrade to origin-only.
+                frames = null;
+                stackTrace = null;
+            }
+
             _capture.Route(
                 kind: MapKind(errorType),
                 filePath: file,
@@ -80,7 +106,102 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 rationale: rationale,
                 // 'function' is the originating function name — forwarded so the in-game runtime's structured
                 // ErrorSink can populate RuntimeError.Function (the editor passive-log path ignores it).
-                function: function);
+                function: function,
+                // Deep GDScript backtrace (issue #163), already copied to managed primitives above.
+                frames: frames,
+                stackTrace: stackTrace);
+        }
+
+        // ── Backtrace materialization (originating-thread only) ──────────────────────────────────────────
+        //
+        // CRITICAL THREAD-SAFETY INVARIANT: every ScriptBacktrace access below happens synchronously inside
+        // _LogError, on the thread the error originated on. ScriptBacktrace is a RefCounted Godot object and
+        // is NOT thread-safe; we never store or return one — only the plain managed primitives we copy out of
+        // it. The out-params are the ONLY things that cross back to Route() / the collector / another thread.
+
+        /// <summary>
+        /// Copy the engine's per-language <see cref="ScriptBacktrace"/> array into managed primitives:
+        /// <paramref name="frames"/> (innermost-first, function/file/line per frame) and
+        /// <paramref name="stackTrace"/> (the engine's <see cref="ScriptBacktrace.Format()"/> string). Picks
+        /// the FIRST non-empty backtrace in the array — Godot orders them by language and the script language
+        /// that raised the error has the populated stack (GDScript at runtime); a non-empty pick yields the
+        /// real call stack rather than an empty sibling-language entry. Both out-params are null when no
+        /// non-empty backtrace exists (release builds without call-stack tracking, or a pure-engine error),
+        /// preserving the origin-only fallback.
+        /// </summary>
+        static void MaterializeBacktrace(
+            global::Godot.Collections.Array<global::Godot.ScriptBacktrace>? scriptBacktraces,
+            out IReadOnlyList<RuntimeErrorFrame>? frames,
+            out string? stackTrace)
+        {
+            frames = null;
+            stackTrace = null;
+
+            if (scriptBacktraces == null || scriptBacktraces.Count == 0)
+                return;
+
+            foreach (var backtrace in scriptBacktraces)
+            {
+                if (backtrace == null || backtrace.IsEmpty())
+                    continue;
+
+                var frameCount = backtrace.GetFrameCount();
+                if (frameCount <= 0)
+                    continue;
+
+                var list = new List<RuntimeErrorFrame>(frameCount);
+                for (int i = 0; i < frameCount; i++)
+                {
+                    list.Add(new RuntimeErrorFrame(
+                        function: backtrace.GetFrameFunction(i),
+                        file: backtrace.GetFrameFile(i),
+                        line: backtrace.GetFrameLine(i)));
+                }
+
+                if (list.Count == 0)
+                    continue;
+
+                frames = list;
+                // The engine's own formatted rendering is the most faithful human-readable string; fall back
+                // to a managed join only if Format() yields nothing (shouldn't, for a non-empty backtrace).
+                stackTrace = BuildStackTraceString(backtrace, list);
+                return;
+            }
+        }
+
+        /// <summary>
+        /// Render a human-readable stack-trace string for a captured backtrace, prefixing the script-language
+        /// name. Prefers the engine's <see cref="ScriptBacktrace.Format()"/>; falls back to joining the
+        /// already-materialized <paramref name="frames"/> if Format() returns empty.
+        /// </summary>
+        static string BuildStackTraceString(global::Godot.ScriptBacktrace backtrace, List<RuntimeErrorFrame> frames)
+        {
+            string? language = null;
+            try { language = backtrace.GetLanguageName(); } catch { /* best-effort label */ }
+
+            string body;
+            string? formatted = null;
+            try { formatted = backtrace.Format(); } catch { /* fall back to the managed join below */ }
+
+            if (!string.IsNullOrWhiteSpace(formatted))
+            {
+                body = formatted!;
+            }
+            else
+            {
+                var sb = new StringBuilder();
+                foreach (var frame in frames)
+                {
+                    if (sb.Length > 0)
+                        sb.Append('\n');
+                    sb.Append(frame.ToString());
+                }
+                body = sb.ToString();
+            }
+
+            return string.IsNullOrEmpty(language)
+                ? body
+                : $"{language} backtrace:\n{body}";
         }
 
         // We intentionally do NOT override _LogMessage: ordinary print()/stdout traffic is already covered by

--- a/addons/godot_mcp/Runtime/Tools/RuntimeErrorCollector.cs
+++ b/addons/godot_mcp/Runtime/Tools/RuntimeErrorCollector.cs
@@ -145,7 +145,9 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         }
 
         /// <summary>Defensive deep-ish copy so a returned row can be serialized/mutated off the lock without
-        /// touching the buffered instance.</summary>
+        /// touching the buffered instance. The deep backtrace (issue #163) is copied into a FRESH frame list so
+        /// the returned row never aliases the buffered row's frames; the frames themselves are immutable-by-use
+        /// plain primitives, so a shallow element copy is sufficient.</summary>
         static RuntimeError Copy(RuntimeError e) => new(
             source: e.Source,
             message: e.Message,
@@ -154,7 +156,8 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             line: e.Line,
             function: e.Function,
             stackTrace: e.StackTrace,
-            timestamp: e.Timestamp)
+            timestamp: e.Timestamp,
+            frames: e.Frames != null ? new List<RuntimeErrorFrame>(e.Frames) : null)
         {
             Sequence = e.Sequence,
         };

--- a/addons/godot_mcp/Runtime/Tools/RuntimeErrorFactory.cs
+++ b/addons/godot_mcp/Runtime/Tools/RuntimeErrorFactory.cs
@@ -9,6 +9,8 @@
 */
 #nullable enable
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using com.IvanMurzak.Godot.MCP.Data;
 
 namespace com.IvanMurzak.Godot.MCP.Tools
@@ -28,12 +30,23 @@ namespace com.IvanMurzak.Godot.MCP.Tools
     {
         /// <summary>
         /// Build a <see cref="RuntimeError"/> from an engine error-stream callback. The engine yields the
-        /// ORIGIN (file / line / function) + message + kind, but NOT a deep GDScript call stack, so
-        /// <see cref="RuntimeError.StackTrace"/> stays null (documented fidelity limit). The engine kind is
-        /// rendered as the <see cref="RuntimeError.Type"/> string (Error / Warning / Script / Shader).
+        /// ORIGIN (file / line / function) + message + kind. On Godot 4.5+ a GDScript runtime error ALSO
+        /// carries the deep multi-frame call stack (issue #163): the record's already-materialized
+        /// <see cref="EngineErrorRecord.Frames"/> become <see cref="RuntimeError.Frames"/> and its
+        /// <see cref="EngineErrorRecord.StackTrace"/> becomes <see cref="RuntimeError.StackTrace"/>. On Godot
+        /// &lt; 4.5 (or for an engine error with no tracked backtrace) both stay null/empty — the documented
+        /// origin-only fallback. The engine kind is rendered as the <see cref="RuntimeError.Type"/> string
+        /// (Error / Warning / Script / Shader).
         /// </summary>
         public static RuntimeError FromEngine(EngineErrorRecord record)
         {
+            // Copy the record's frames into a fresh List<> the RuntimeError owns — the record's IReadOnlyList
+            // is already plain managed primitives (materialized off the non-thread-safe ScriptBacktrace inside
+            // the logger callback), so this is a pure managed copy with no Godot object involved.
+            List<RuntimeErrorFrame>? frames = record.Frames != null && record.Frames.Count > 0
+                ? record.Frames.ToList()
+                : null;
+
             return new RuntimeError(
                 source: RuntimeErrorSource.Engine,
                 message: record.Message ?? string.Empty,
@@ -41,7 +54,8 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 file: record.FilePath,
                 line: record.Line,
                 function: record.Function,
-                stackTrace: null);
+                stackTrace: record.StackTrace,
+                frames: frames);
         }
 
         /// <summary>

--- a/addons/godot_mcp/Runtime/Tools/ScriptErrorCapture.cs
+++ b/addons/godot_mcp/Runtime/Tools/ScriptErrorCapture.cs
@@ -37,6 +37,16 @@ namespace com.IvanMurzak.Godot.MCP.Tools
     /// full origin (kind + file + line + function + already-resolved human message), distinct from the
     /// flattened single-line form <see cref="ScriptErrorCapture.LogSink"/> receives. Consumed by the in-game
     /// runtime to build <see cref="Data.RuntimeError"/> rows that preserve file/line/function. Pure-managed.
+    ///
+    /// <para>
+    /// On Godot 4.5+, an engine SCRIPT error also carries the deep multi-frame GDScript call stack (issue
+    /// #163): <see cref="Frames"/> is the ALREADY-MATERIALIZED list of managed frame primitives, and
+    /// <see cref="StackTrace"/> is the engine's formatted backtrace string. Both are copied off the live
+    /// non-thread-safe <c>ScriptBacktrace</c> inside the logger callback on the originating thread — this
+    /// record only ever holds plain managed values, never a live Godot handle, so it is safe to forward
+    /// across the thread boundary into the collector. On &lt; 4.5 (or for non-script engine errors) both are
+    /// null/empty, preserving the origin-only behavior.
+    /// </para>
     /// </summary>
     public readonly struct EngineErrorRecord
     {
@@ -51,13 +61,37 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         /// <summary>The resolved human-readable error text (rationale preferred, else the C++ condition).</summary>
         public string Message { get; }
 
+        /// <summary>
+        /// The deep multi-frame backtrace, innermost-first, materialized off Godot 4.5+'s
+        /// <c>ScriptBacktrace</c> (issue #163). Null/empty when no backtrace was available (Godot &lt; 4.5,
+        /// release builds without call-stack tracking, or a non-script error). Always plain managed values —
+        /// never a live Godot object.
+        /// </summary>
+        public IReadOnlyList<RuntimeErrorFrame>? Frames { get; }
+
+        /// <summary>
+        /// The engine's formatted backtrace string (from <c>ScriptBacktrace.Format()</c>), or null when no
+        /// backtrace was available. A human-readable multi-line rendering of <see cref="Frames"/>, surfaced as
+        /// <see cref="Data.RuntimeError.StackTrace"/>.
+        /// </summary>
+        public string? StackTrace { get; }
+
         public EngineErrorRecord(EngineErrorKind kind, string? filePath, int line, string? function, string message)
+            : this(kind, filePath, line, function, message, frames: null, stackTrace: null)
+        {
+        }
+
+        public EngineErrorRecord(EngineErrorKind kind, string? filePath, int line, string? function, string message,
+            IReadOnlyList<RuntimeErrorFrame>? frames, string? stackTrace)
         {
             Kind = kind;
             FilePath = filePath;
             Line = line;
             Function = function;
             Message = message;
+            // Normalize an empty backtrace to null so consumers have a single "no frames" sentinel.
+            Frames = frames != null && frames.Count > 0 ? frames : null;
+            StackTrace = string.IsNullOrEmpty(stackTrace) ? null : stackTrace;
         }
     }
 
@@ -165,9 +199,16 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         /// diagnostic. <paramref name="line"/> may be -1 when unknown; <paramref name="filePath"/> is the engine
         /// source path (kept as-is; it may be a <c>res://</c> or absolute path); <paramref name="function"/> is
         /// the originating function name (may be null/empty when the engine omits it). Thread-safe.
+        /// <para>
+        /// <paramref name="frames"/> / <paramref name="stackTrace"/> carry the deep multi-frame GDScript
+        /// backtrace (issue #163), already materialized off Godot 4.5+'s non-thread-safe
+        /// <c>ScriptBacktrace</c> INSIDE the logger callback (on the originating thread) by the caller — this
+        /// router only ever receives plain managed values, never a live Godot object, so the thread-safety
+        /// invariant is preserved. Both are null/empty for the editor passive-log path and on Godot &lt; 4.5.
+        /// </para>
         /// </summary>
         public void Route(EngineErrorKind kind, string? filePath, int line, string? message, string? rationale,
-            string? function = null)
+            string? function = null, IReadOnlyList<RuntimeErrorFrame>? frames = null, string? stackTrace = null)
         {
             // Build the human line: prefer the engine "rationale" (the actual error text) and fall back to
             // the C++ assertion "message" (the failed condition) when no rationale is present.
@@ -180,11 +221,12 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             // Passive capture: surface a path:line prefix so console-get-logs is self-describing.
             LogSink?.Invoke(logType, FormatLogLine(kind, filePath, line, text));
 
-            // Structured capture (in-game runtime): forward the full origin so runtime-errors-get can return
-            // file/line/function/type, not just a flattened line. Always fires (errors are not session-gated).
-            // Wrapped for parity with the in-game C# fault handlers: this runs on the engine's (multi-threaded)
-            // log callback, so a throwing sink must never escape back into the engine.
-            try { ErrorSink?.Invoke(new EngineErrorRecord(kind, filePath, line, function, text)); }
+            // Structured capture (in-game runtime): forward the full origin + deep backtrace so
+            // runtime-errors-get can return file/line/function/type AND the multi-frame stack, not just a
+            // flattened line. Always fires (errors are not session-gated). Wrapped for parity with the in-game
+            // C# fault handlers: this runs on the engine's (multi-threaded) log callback, so a throwing sink
+            // must never escape back into the engine.
+            try { ErrorSink?.Invoke(new EngineErrorRecord(kind, filePath, line, function, text, frames, stackTrace)); }
             catch { /* a captured engine-error sink must never throw back into the engine callback */ }
 
             // Validation capture: only script errors, only while a session is open.

--- a/addons/godot_mcp/Runtime/Tools/Tool_RuntimeErrors.Get.cs
+++ b/addons/godot_mcp/Runtime/Tools/Tool_RuntimeErrors.Get.cs
@@ -40,8 +40,10 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             "  - 'maxEntries' (default 100, min 1): cap the returned page (newest kept; 'truncated' flags a cap).\n" +
             "Result (RuntimeErrorsResult): 'available' (false when the game did not enable runtime error " +
             "capture — then an empty list proves nothing), 'ok' (no error-severity entries), the 'errors' " +
-            "[{ sequence, message, type, source, file, line, function, stackTrace, timestamp }] oldest-first, " +
-            "counts, 'highestSequence' (poll with it next), and a 'truncated' flag.")]
+            "[{ sequence, message, type, source, file, line, function, stackTrace, frames, timestamp }] " +
+            "oldest-first, counts, 'highestSequence' (poll with it next), and a 'truncated' flag. On Godot " +
+            "4.5+ a GDScript runtime error also carries 'frames' (the deep multi-frame call stack, " +
+            "innermost-first, each { function, file, line }) and a formatted 'stackTrace'.")]
         public RuntimeErrorsResult Get
         (
             [Description("Return only errors with a sequence number greater than this. Pass the previous " +


### PR DESCRIPTION
## Summary
- Surface the **deep multi-frame GDScript call stack** in captured in-game runtime errors (Godot 4.5+). The engine already hands `GodotScriptErrorLogger._LogError` a populated `Godot.Collections.Array<ScriptBacktrace>` — it was being dropped. Now it is materialized into a structured `frames` field + a formatted `stackTrace` on each `RuntimeError`, surfaced via `runtime-errors-get`.
- All `ScriptBacktrace` access happens **inside the logger callback on the originating thread** — frames are copied into plain managed primitives before crossing the thread boundary; no live, non-thread-safe Godot object ever reaches `Route`/the collector (the invariant the existing comment protected is preserved).
- Gated behind `#if GODOT4_5_OR_GREATER` + the existing opt-in capture: Godot < 4.5 and the stub keep the current null-`StackTrace` behavior; default-OFF posture unchanged.

### Key files
- `Runtime/Data/RuntimeErrorFrame.cs` (new) — pure-managed `{ function, file, line }` frame row.
- `Runtime/Data/RuntimeError.cs` — new `Frames` field; `StackTrace` now carries the 4.5+ formatted backtrace.
- `Runtime/Tools/GodotScriptErrorLogger.cs` — materializes `ScriptBacktrace` → managed frames + formatted string on the originating thread.
- `Runtime/Tools/ScriptErrorCapture.cs` — `EngineErrorRecord` + `Route` carry the frames/stack (defaulted; editor passive-log path unaffected).
- `Runtime/Tools/RuntimeErrorFactory.cs` — `FromEngine` copies frames + stack onto the row.
- `Runtime/Tools/RuntimeErrorCollector.cs` — `Copy` now propagates `Frames` (was silently dropping it).
- `Runtime/Tools/Tool_RuntimeErrors.Get.cs` + `README.md` — document the new `frames` field.

## Test plan
- [x] `dotnet build Godot-MCP.sln` — 0 errors / 0 warnings (Debug + ExportRelease).
- [x] `dotnet test Godot-MCP.Tests` — 814 passed (10 new), 1 failed = the known benign Windows-only `GodotAssemblyUtilsTests` temp-DLL cleanup (green on Linux CI).
- [x] Runtime/editor boundary guard: 0 violations.
- [x] **Live Godot 4.5.1 headless smoke**: a 3-deep GDScript runtime error (`outer → middle → inner`, nil index) surfaces via `runtime-errors-get` with `available=True`, `type=Script`, and a **3-frame** innermost-first backtrace (`inner:22`, `middle:16`, `outer:13`) plus a formatted `stackTrace`.

Out of scope: break-on-error stepping / locals-at-arbitrary-frame (separate item).

Closes #163