### PR TITLE
fix(runtime): defer runtime-error-capture install so a failed Build() never leaks global hooks

### DIFF
--- a/Godot-MCP.Tests/RuntimeErrorCaptureTests.cs
+++ b/Godot-MCP.Tests/RuntimeErrorCaptureTests.cs
@@ -697,6 +697,112 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Single(builder.ToolTypes, t => t == typeof(Tool_RuntimeErrors));
         }
 
+        // ---- Build leak-guard: a post-install Build() throw must not leak the global hooks (issue #165) ----
+        //
+        // GodotMcpRuntime.Build() opts capture in (RuntimeErrorCapture.Install) and only later constructs the
+        // GodotMcpRuntimeHandle that owns Uninstall(). Before the fix, an exception on the fallible build path
+        // between those two points (the reflector/converter setup, McpPluginBuilder.Build, the WithTools/Prompts/
+        // Resources scans, or the handle construction) escaped with the PROCESS-WIDE engine OS.AddLogger +
+        // AppDomain.UnhandledException + TaskScheduler.UnobservedTaskException hooks still registered for the life
+        // of the game and RuntimeErrorCollector.Current orphaned, with no handle to ever tear them down.
+        //
+        // The fix DEFERS the install to the very end and binds it to the handle construction in the testable
+        // GodotMcpRuntime.InstallCaptureThenBuildHandle, which rolls capture back if the post-install step throws.
+        // These tests drive that helper directly (the full Build() path touches native Godot — Engine.GetMainLoop,
+        // GD.Print, OS.AddLogger — and faults in the binary-less xUnit host). The _installForTests /
+        // _uninstallForTests seams substitute a pure-managed install/uninstall so the REAL RuntimeErrorCapture
+        // static state (IsInstalled / RuntimeErrorCollector.Current) can be asserted without calling GD.Print.
+
+        [Fact]
+        public void InstallCaptureThenBuildHandle_PostInstallThrow_UninstallsCapture_NoLeak()
+        {
+            WithPureManagedCaptureSeams(() =>
+            {
+                Assert.False(RuntimeErrorCapture.IsInstalled); // clean precondition
+                Assert.Null(RuntimeErrorCollector.Current);
+
+                var ex = Record.Exception(() => GodotMcpRuntime.InstallCaptureThenBuildHandle(
+                    captureRequested: true,
+                    buildHandle: captured =>
+                    {
+                        // Capture must already be live by the time the handle factory runs (deferred-install
+                        // contract): the factory is told to wire up Dispose-time uninstall.
+                        Assert.True(captured);
+                        Assert.True(RuntimeErrorCapture.IsInstalled);
+                        Assert.NotNull(RuntimeErrorCollector.Current);
+                        throw new InvalidOperationException("simulated post-install build failure");
+                    }));
+
+                // The original fault propagates...
+                Assert.IsType<InvalidOperationException>(ex);
+                Assert.Equal("simulated post-install build failure", ex!.Message);
+
+                // ...and the global hooks were rolled back — NO leak (the issue #165 acceptance criterion).
+                Assert.False(RuntimeErrorCapture.IsInstalled);
+                Assert.Null(RuntimeErrorCollector.Current);
+            });
+        }
+
+        [Fact]
+        public void InstallCaptureThenBuildHandle_SuccessPath_LeavesCaptureInstalled()
+        {
+            WithPureManagedCaptureSeams(() =>
+            {
+                var sawCaptured = false;
+                GodotMcpRuntime.InstallCaptureThenBuildHandle(
+                    captureRequested: true,
+                    buildHandle: captured =>
+                    {
+                        sawCaptured = captured;
+                        return null!; // a real IMcpPlugin-backed handle is unavailable here; the value is unused.
+                    });
+
+                // Success path: capture stays installed (the handle would uninstall it on Dispose), and the
+                // factory was told capture is owned by this build.
+                Assert.True(sawCaptured);
+                Assert.True(RuntimeErrorCapture.IsInstalled);
+                Assert.NotNull(RuntimeErrorCollector.Current);
+
+                // Cleanup for the next test (the WithPureManagedCaptureSeams finally also restores Current).
+                RuntimeErrorCapture.Uninstall();
+                Assert.False(RuntimeErrorCapture.IsInstalled);
+            });
+        }
+
+        [Fact]
+        public void InstallCaptureThenBuildHandle_NotRequested_NeverInstalls_EvenWhenBuildThrows()
+        {
+            WithPureManagedCaptureSeams(() =>
+            {
+                var uninstallCalled = false;
+                var priorUninstall = GetUninstallSeam();
+                SetUninstallSeam(() => { uninstallCalled = true; });
+                try
+                {
+                    var ex = Record.Exception(() => GodotMcpRuntime.InstallCaptureThenBuildHandle(
+                        captureRequested: false,
+                        buildHandle: captured =>
+                        {
+                            Assert.False(captured);            // capture was never requested
+                            throw new InvalidOperationException("boom");
+                        }));
+
+                    Assert.IsType<InvalidOperationException>(ex);
+                    Assert.False(RuntimeErrorCapture.IsInstalled);  // nothing was ever installed
+                    Assert.Null(RuntimeErrorCollector.Current);
+                    Assert.False(uninstallCalled);                  // no rollback when capture wasn't installed
+                }
+                finally { SetUninstallSeam(priorUninstall); }
+            });
+        }
+
+        [Fact]
+        public void InstallCaptureThenBuildHandle_NullFactory_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                GodotMcpRuntime.InstallCaptureThenBuildHandle(captureRequested: false, buildHandle: null!));
+        }
+
         // ---- helpers: install/teardown the process-wide collector around a test --------------------
 
         static void WithCollector(Action<RuntimeErrorCollector> body)
@@ -714,6 +820,43 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             RuntimeErrorCollector.Current = null;
             try { body(); }
             finally { RuntimeErrorCollector.Current = prior; }
+        }
+
+        // ---- helpers: drive GodotMcpRuntime's capture seams with a PURE-MANAGED install/uninstall ------------
+        //
+        // GodotMcpRuntime._installForTests / _uninstallForTests are internal static delegates reachable by name
+        // here (the test project Compile-includes GodotMcpRuntime.cs, so it is the same assembly). Pointing them
+        // at RuntimeErrorCapture.InstallForTestsWithoutEngineHooks / Uninstall lets InstallCaptureThenBuildHandle
+        // exercise the REAL RuntimeErrorCapture static lifecycle without calling GD.Print / OS.AddLogger (which
+        // crash the binary-less xUnit host). Always restores the prior seam + Current and force-uninstalls so a
+        // failed assertion can never leak install state into a sibling test.
+
+        static Action? GetUninstallSeam() => GodotMcpRuntime._uninstallForTests;
+        static void SetUninstallSeam(Action? value) => GodotMcpRuntime._uninstallForTests = value;
+
+        static void WithPureManagedCaptureSeams(Action body)
+        {
+            var priorInstall = GodotMcpRuntime._installForTests;
+            var priorUninstall = GodotMcpRuntime._uninstallForTests;
+            var priorCurrent = RuntimeErrorCollector.Current;
+
+            // Make sure no prior install state bleeds in.
+            RuntimeErrorCapture.Uninstall();
+
+            GodotMcpRuntime._installForTests = () => RuntimeErrorCapture.InstallForTestsWithoutEngineHooks();
+            GodotMcpRuntime._uninstallForTests = RuntimeErrorCapture.Uninstall;
+            try
+            {
+                body();
+            }
+            finally
+            {
+                // Force-uninstall regardless of how body() exited, then restore seams + Current.
+                try { RuntimeErrorCapture.Uninstall(); } catch { /* best-effort cleanup */ }
+                GodotMcpRuntime._installForTests = priorInstall;
+                GodotMcpRuntime._uninstallForTests = priorUninstall;
+                RuntimeErrorCollector.Current = priorCurrent;
+            }
         }
     }
 }

--- a/addons/godot_mcp/Runtime/GodotMcpRuntime.cs
+++ b/addons/godot_mcp/Runtime/GodotMcpRuntime.cs
@@ -108,26 +108,6 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
             if (builder.InstallDispatcher)
                 EnsureMainThreadDispatcher();
 
-            // 2b) Install in-game runtime ERROR CAPTURE when opted in (default OFF). Registers the engine 4.5+
-            //     OS.AddLogger hook + the C# unhandled/unobserved-Task exception hooks so errors raised in the
-            //     RUNNING game are captured and surfaced via the runtime-errors-* tool (issue #160). Idempotent
-            //     + best-effort; the handle uninstalls it on Dispose (capturedRuntimeErrors flag below). Done
-            //     before the connection is built so capture is live the moment the game runs — including
-            //     errors raised during the very first frame after Build().
-            var capturedRuntimeErrors = false;
-            if (builder.CaptureRuntimeErrors)
-            {
-                try
-                {
-                    RuntimeErrorCapture.Install();
-                    capturedRuntimeErrors = true;
-                }
-                catch (Exception ex)
-                {
-                    GD.PushWarning($"[Godot-MCP] runtime error capture failed to install: {ex.Message}");
-                }
-            }
-
             // 3) Build the reflector with the Godot value-type / ref converters and publish it as the ambient
             //    one so tool handlers share the exact converter set (mirrors GodotMcpConnection.Start). The
             //    editor ResourceLoader resolver (Tool_Resource.InstallReflectionResolver) is intentionally
@@ -178,8 +158,88 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
 
             var plugin = mcpBuilder.Build(reflector);
 
-            return new GodotMcpRuntimeHandle(plugin, config, uninstallErrorCaptureOnDispose: capturedRuntimeErrors);
+            // 5) Install in-game runtime ERROR CAPTURE last, when opted in (default OFF) — DEFERRED to the very
+            //    end so a failure anywhere on the fallible build path above (reflector/converter setup, the
+            //    McpPluginBuilder.Build reflection scan, the WithTools/Prompts/Resources type scans) never leaves
+            //    the PROCESS-WIDE hooks (engine 4.5+ OS.AddLogger + the C# unhandled / unobserved-Task exception
+            //    handlers) registered for the lifetime of the game with no GodotMcpRuntimeHandle to ever uninstall
+            //    them (issue #165). At this point everything fallible has already succeeded, and the only step
+            //    remaining is constructing the handle that owns Uninstall() — so capture install + handle
+            //    construction are bound together in InstallCaptureThenBuildHandle, which rolls capture back if the
+            //    handle construction (or anything else after install) throws.
+            return InstallCaptureThenBuildHandle(
+                captureRequested: builder.CaptureRuntimeErrors,
+                buildHandle: captured => new GodotMcpRuntimeHandle(
+                    plugin, config, uninstallErrorCaptureOnDispose: captured));
         }
+
+        /// <summary>
+        /// The issue #165 leak-guard, factored out of <see cref="Build"/> so it is unit-testable without a live
+        /// Godot runtime or a real <c>IMcpPlugin</c>. When <paramref name="captureRequested"/>, install in-game
+        /// runtime error capture (engine 4.5+ <c>OS.AddLogger</c> hook + the C# unhandled / unobserved-Task
+        /// exception hooks, published as <see cref="Tools.RuntimeErrorCollector.Current"/>), then build the handle
+        /// via <paramref name="buildHandle"/> (passed the captured-flag so the handle uninstalls on Dispose). The
+        /// install + handle construction are bound so that if <paramref name="buildHandle"/> throws — or anything
+        /// between install and a returned handle does — the PROCESS-WIDE hooks are uninstalled before the throw
+        /// escapes, instead of leaking for the game's lifetime with no handle to ever tear them down.
+        ///
+        /// <para>Install is best-effort (a failure degrades to a warning, exactly as issue #160 intended); the
+        /// rollback is best-effort + idempotent (<see cref="RuntimeErrorCapture.Uninstall"/> is a no-op when
+        /// nothing is installed) and never masks the original fault. The <c>_installForTests</c> /
+        /// <c>_uninstallForTests</c> seams let a unit test substitute pure-managed install/uninstall that do not
+        /// call into native Godot (<c>GD.Print</c>/<c>OS.AddLogger</c>), which would crash the binary-less xUnit
+        /// host; both are null in production.</para>
+        /// </summary>
+        internal static GodotMcpRuntimeHandle InstallCaptureThenBuildHandle(
+            bool captureRequested, Func<bool, GodotMcpRuntimeHandle> buildHandle)
+        {
+            if (buildHandle == null)
+                throw new ArgumentNullException(nameof(buildHandle));
+
+            var capturedRuntimeErrors = false;
+            if (captureRequested)
+            {
+                try
+                {
+                    (_installForTests ?? RuntimeErrorCaptureInstall)();
+                    capturedRuntimeErrors = true;
+                }
+                catch (Exception ex)
+                {
+                    GD.PushWarning($"[Godot-MCP] runtime error capture failed to install: {ex.Message}");
+                }
+            }
+
+            try
+            {
+                return buildHandle(capturedRuntimeErrors);
+            }
+            catch
+            {
+                // The handle that owns Uninstall() was never returned, so roll the capture install back here
+                // rather than leak the process-wide hooks. Only attempted when THIS call installed capture.
+                if (capturedRuntimeErrors)
+                {
+                    try { (_uninstallForTests ?? RuntimeErrorCapture.Uninstall)(); }
+                    catch { /* swallow: a teardown failure must not mask the original build fault */ }
+                }
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Default capture installer used by <see cref="InstallCaptureThenBuildHandle"/> — the real
+        /// <see cref="RuntimeErrorCapture.Install"/>, discarding the returned collector (it is published as
+        /// <see cref="Tools.RuntimeErrorCollector.Current"/> internally). Indirected through a delegate so a unit
+        /// test can substitute a pure-managed install that does not touch native Godot.
+        /// </summary>
+        static void RuntimeErrorCaptureInstall() => RuntimeErrorCapture.Install();
+
+        /// <summary>Test seam: overrides the capture installer in <see cref="InstallCaptureThenBuildHandle"/>. Null in production.</summary>
+        internal static Action? _installForTests;
+
+        /// <summary>Test seam: overrides the capture uninstaller in <see cref="InstallCaptureThenBuildHandle"/>'s rollback. Null in production.</summary>
+        internal static Action? _uninstallForTests;
 
         /// <summary>
         /// Resolve the addon version reported in the MCP handshake from

--- a/addons/godot_mcp/Runtime/RuntimeErrorCapture.cs
+++ b/addons/godot_mcp/Runtime/RuntimeErrorCapture.cs
@@ -141,6 +141,55 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
         }
 
         /// <summary>
+        /// Test-only installer that wires the PURE-MANAGED channels exactly as <see cref="Install"/> does — the
+        /// AppDomain.UnhandledException + TaskScheduler.UnobservedTaskException hooks — and publishes the backing
+        /// <see cref="RuntimeErrorCollector"/> as <see cref="RuntimeErrorCollector.Current"/>, but SKIPS the engine
+        /// 4.5+ logger registration and the <c>GD.Print</c> summary line. Both of those call into native Godot,
+        /// which faults (<c>AccessViolationException</c>, aborting the runner) in the binary-less xUnit host — so a
+        /// unit test cannot exercise the real <see cref="Install"/>. After this call <see cref="IsInstalled"/> is
+        /// true and <see cref="RuntimeErrorCollector.Current"/> is non-null, and <see cref="Uninstall"/> (which
+        /// touches no native Godot) tears it back down — exactly the install/uninstall lifecycle the issue #165
+        /// leak-guard test needs to assert on the REAL static state. Not part of the production API.
+        /// </summary>
+        internal static RuntimeErrorCollector InstallForTestsWithoutEngineHooks()
+        {
+            lock (_gate)
+            {
+                if (_installed && _collector != null)
+                    return _collector;
+
+                var collector = new RuntimeErrorCollector();
+                RuntimeErrorCollector.Current = collector;
+                _collector = collector;
+                _installed = true;
+
+                _domainHandler = (_, args) =>
+                {
+                    try
+                    {
+                        collector.Append(RuntimeErrorFactory.FromException(
+                            RuntimeErrorSource.UnhandledException, args.ExceptionObject as Exception));
+                    }
+                    catch { /* a fault handler must never throw */ }
+                };
+                AppDomain.CurrentDomain.UnhandledException += _domainHandler;
+
+                _taskHandler = (_, args) =>
+                {
+                    try
+                    {
+                        collector.Append(RuntimeErrorFactory.FromException(
+                            RuntimeErrorSource.UnobservedTaskException, args.Exception));
+                    }
+                    catch { /* a fault handler must never throw */ }
+                };
+                TaskScheduler.UnobservedTaskException += _taskHandler;
+
+                return collector;
+            }
+        }
+
+        /// <summary>
         /// Register the Godot 4.5+ engine-error logger feeding <paramref name="collector"/> via the bridge,
         /// returning true when the engine channel is live. Best-effort: a registration failure (e.g. an
         /// unexpected host) is swallowed to a warning so the C# fault channels still install. Pre-&lt; 4.5 the


### PR DESCRIPTION
## Summary

- `GodotMcpRuntime.Build()` installed the process-wide runtime-error-capture hooks (engine `OS.AddLogger` + `AppDomain.UnhandledException` + `TaskScheduler.UnobservedTaskException`) **before** constructing the `GodotMcpRuntimeHandle` that owns their `Uninstall()`. A throw on the fallible build path in between (reflector setup, `McpPluginBuilder.Build`, the `WithTools`/`Prompts`/`Resources` scans) leaked those hooks for the game's lifetime and orphaned `RuntimeErrorCollector.Current`, with no handle to ever tear them down (issue #165).
- **Fix**: defer the capture install to the very end and bind it to the handle construction in a new testable helper `GodotMcpRuntime.InstallCaptureThenBuildHandle`, which rolls the install back if the post-install step throws. Success-path behavior is unchanged (capture installed, handle owns `Uninstall`, `Dispose` uninstalls); default-OFF/opt-in posture and install idempotency are preserved.
- Add a pure-managed xUnit leak-guard suite that forces a post-install throw and asserts `RuntimeErrorCapture.IsInstalled == false` + `RuntimeErrorCollector.Current == null`, plus success-path / default-OFF / null-factory coverage. It drives the helper through internal install/uninstall seams pointed at a new `RuntimeErrorCapture.InstallForTestsWithoutEngineHooks`, so the REAL static lifecycle is exercised without `GD.Print`/`OS.AddLogger` (which crash the binary-less xUnit host).
- NuGet pins untouched (`ReflectorNet` 5.3.1 / `McpPlugin` 6.10.0); no `.csproj`/`.sln` changes.

## Test plan

- [x] Suite 1 — `dotnet build Godot-MCP.sln --configuration Debug`: 0 errors, 0 warnings.
- [x] Suite 2 — `dotnet test Godot-MCP.Tests`: 818 passed / 1 failed, where the 1 is the documented benign Windows-only `GodotAssemblyUtilsTests` temp-DLL cleanup `UnauthorizedAccessException` (green in Linux CI). The 4 new leak-guard tests + all 30 RuntimeError tests pass.

Closes #165