### PR TITLE
CLI: advertise the runtime-errors tool family in skills.ts + add a CI cross-check against the addon tool families

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ the `WaitForImmediateTeardown` API + opt-in bounded-reconnect this addon uses fo
 
 Tools live in `addons/godot_mcp/Runtime/Tools/` (pure-managed families) and `addons/godot_mcp/Editor/Tools/` (editor-only families) — one `[AiToolType]` `partial class Tool_<Family>` per family,
 with each tool method (`[AiTool("<name>", ...)]` + `[Description]`) in its own partial-class file. Tool
-names mirror Unity-MCP where sensible. The 10 families:
+names mirror Unity-MCP where sensible. The 11 families:
 
 | Family (class) | Tools | `#if TOOLS`? |
 | --- | --- | --- |
@@ -38,6 +38,7 @@ names mirror Unity-MCP where sensible. The 10 families:
 | `Tool_Editor` | `editor-application-get-state`/`-set-state`, `editor-selection-get`/`-set` | yes (editor) |
 | `Tool_Console` | `console-get-logs`/`-clear-logs` | no (pure-managed collector) |
 | `Tool_Reflection` | `reflection-method-find`/`-call` | no (engine-agnostic ReflectorNet) |
+| `Tool_RuntimeErrors` | `runtime-errors-get`/`-clear` | no (pure-managed; in-game, OFF by default — see `WithRuntimeErrorCapture()`) |
 
 Editor-driving families live behind `#if TOOLS` (they touch `EditorInterface`/live `Node`/`Resource`);
 their pure-managed result models + helpers live OUTSIDE the guard so they are CI-unit-testable. The
@@ -80,7 +81,10 @@ AI-agent skill files (a `SKILL.md`-per-tool-family) under the agent's skills pat
 generates the files **locally** from a built-in catalog of the addon's tool families — the Godot server
 exposes no skill-generate HTTP endpoint, so no server or live editor is required. (The addon *additionally*
 auto-generates skills addon-side on plugin boot via `GenerateSkillFilesIfNeeded`; the CLI command is the
-server-less, scriptable path.)
+server-less, scriptable path.) That catalog (`cli/src/utils/skills.ts` § `SKILL_FAMILIES`) is
+hand-maintained, so a CI cross-check (`cli/tests/skills-addon-parity.test.ts`) diffs its family set against
+the addon's actual `[AiToolType] Tool_<Family>` classes and **fails on divergence** — keep the catalog, the
+§ Tool families table above, and the README in lockstep when adding/removing a family.
 
 ```bash
 cd cli

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Godot-MCP is the Godot counterpart of [Unity-MCP](https://github.com/IvanMurzak/
 ## ![Features](https://github.com/IvanMurzak/Godot-MCP/blob/main/docs/img/promo/hazzard-features.svg?raw=true)
 
 - ✔️ **AI agents** — Use the best agents from **Anthropic**, **OpenAI**, **Google**, or any other provider with no vendor lock-in
-- ✔️ **36 built-in Tools** — A wide range of [MCP Tools](#tools-reference) across 10 families for operating the Godot Editor
+- ✔️ **38 built-in Tools** — A wide range of [MCP Tools](#tools-reference) across 11 families for operating the Godot Editor
 - ✔️ **C# & GDScript** — Read, create, and update both `.cs` and `.gd` scripts, and attach them to nodes
 - ✔️ **Scene & Node control** — Build and edit the scene tree, open/save `.tscn` scenes, mutate `.tres`/`.res` resources
 - ✔️ **Visual feedback** — Capture viewport, camera, and isolated-node screenshots the LLM can inspect
@@ -112,10 +112,12 @@ That's it. Ask your AI *"Create 3 cubes in a circle with radius 2"* and watch it
 
 # Tools Reference
 
-Godot-MCP ships **36 built-in tools** grouped into **10 families**. Tool names mirror Unity-MCP where
+Godot-MCP ships **38 built-in tools** grouped into **11 families**. Tool names mirror Unity-MCP where
 sensible (`scene-*`, `node-*`, …). Every tool returns a structured, [ReflectorNet](https://www.nuget.org/packages/com.IvanMurzak.ReflectorNet)-serialized
-result (or a PNG image for screenshots). All tools are available immediately after the addon is enabled —
-no extra configuration required.
+result (or a PNG image for screenshots). All editor tools are available immediately after the addon is
+enabled — no extra configuration required. The **runtime-errors** family is the exception: it surfaces
+errors from the *running game* and is **OFF by default** — opt in with `builder.WithRuntimeErrorCapture()`
+(see [Capturing in-game runtime errors](#capturing-in-game-runtime-errors)).
 
 | Family | Tools | What it does |
 | --- | --- | --- |
@@ -129,9 +131,7 @@ no extra configuration required.
 | **editor** | `editor-application-get-state`, `editor-application-set-state`, `editor-selection-get`, `editor-selection-set` | Read/drive the editor run-and-play lifecycle (Godot launches the game in a separate process) and the current selection. |
 | **console** | `console-get-logs`, `console-clear-logs` | Read and clear the plugin's editor log collector (`GD.Print`/`GD.PushWarning`/`GD.PushError`). |
 | **reflection** | `reflection-method-find`, `reflection-method-call` | Find and call C# methods (static/instance, public/private) across every loaded assembly via ReflectorNet — the engine-agnostic escape hatch. |
-
-<details>
-  <summary>Per-tool descriptions</summary>
+| **runtime-errors** | `runtime-errors-get`, `runtime-errors-clear` | Poll errors raised inside the **running game** (NOT the editor) — GDScript runtime errors, `push_error`/`push_warning`, shader errors, and C# unhandled / unobserved-`Task` exceptions, with multi-frame GDScript backtraces on Godot 4.5+. **OFF by default** — opt in with `builder.WithRuntimeErrorCapture()`. |
 
 **ping**
 
@@ -198,6 +198,11 @@ no extra configuration required.
 
 - `reflection-method-find` — Find C# methods (including private) across every loaded assembly.
 - `reflection-method-call` — Call any C# method with input parameters and get the result.
+
+**runtime-errors** (in-game; **OFF by default** — enable with `builder.WithRuntimeErrorCapture()`)
+
+- `runtime-errors-get` — Read captured in-game runtime errors (oldest-first, newest-kept page); poll only new errors via `sinceSequence`. Returns `available:false` when capture was never enabled, so an empty list is never mistaken for health.
+- `runtime-errors-clear` — Clear the captured in-game runtime-error buffer (a no-op when capture is not enabled); the monotonic sequence counter is preserved.
 
 </details>
 

--- a/cli/src/utils/skills.ts
+++ b/cli/src/utils/skills.ts
@@ -325,13 +325,27 @@ export function addonToolDirs(repoRoot: string): string[] {
  *   names) collapses each multi-file family to ONE entry automatically.
  * - The regex tolerates other attributes/whitespace between `[AiToolType]` and the
  *   class declaration, and an optional access modifier on the class.
+ * - Sub-tool families use a COMPOUND class name (`Tool_Editor_Selection` adds the
+ *   `editor-selection-*` tools to the `editor` family). We capture the whole
+ *   `Tool_<Seg1>[_<Seg2>...]` suffix and attribute it to its FIRST segment
+ *   (`Tool_Editor_Selection` → `Editor`), so a sub-tool class lands in its parent
+ *   family instead of being silently dropped (which would happen if the capture
+ *   stopped at the first `_`). The trailing `Set<string>` dedups the parent family
+ *   when both `Tool_Editor` and `Tool_Editor_Selection` exist.
+ * - The attribute MUST bind to its IMMEDIATELY-following type declaration: the gap
+ *   between `[AiToolType]` and `Tool_<Family>` may contain only other attributes,
+ *   doc comments, and whitespace — never an intervening type keyword. This stops a
+ *   stray `[AiToolType]` on a non-`Tool_` type from being misattributed to a later
+ *   `Tool_` class in the same file.
  */
 export function discoverAddonToolFamilies(repoRoot: string): string[] {
-  // `[AiToolType]` (possibly with args), then any amount of attributes/whitespace,
-  // then `partial class Tool_<Family>`. `[\s\S]*?` is non-greedy so it stops at the
-  // first class declaration after the attribute.
+  // `[AiToolType]` (possibly with args), then ONLY attributes / doc-comments /
+  // whitespace (no intervening `class`/`struct`/`interface`/`enum`/`record`
+  // keyword — `(?:(?!\b(?:class|struct|interface|enum|record)\b)[\s\S])*?` forbids
+  // crossing one), then `partial class Tool_<Family>` where `<Family>` is the full
+  // compound suffix (`Editor`, `Editor_Selection`, ...). First segment = the family.
   const familyRe =
-    /\[AiToolType[^\]]*\][\s\S]*?\bpartial\s+class\s+Tool_([A-Za-z][A-Za-z0-9]*)\b/g;
+    /\[AiToolType[^\]]*\](?:(?!\b(?:class|struct|interface|enum|record)\b)[\s\S])*?\bpartial\s+class\s+Tool_([A-Za-z][A-Za-z0-9]*(?:_[A-Za-z][A-Za-z0-9]*)*)\b/g;
   const found = new Set<string>();
 
   for (const dir of addonToolDirs(repoRoot)) {
@@ -342,7 +356,9 @@ export function discoverAddonToolFamilies(repoRoot: string): string[] {
       let m: RegExpExecArray | null;
       familyRe.lastIndex = 0;
       while ((m = familyRe.exec(src)) !== null) {
-        found.add(m[1]);
+        // Attribute a compound sub-tool class (`Tool_Editor_Selection`) to its
+        // parent family by taking the FIRST `_`-delimited segment (`Editor`).
+        found.add(m[1].split('_')[0]);
       }
     }
   }

--- a/cli/src/utils/skills.ts
+++ b/cli/src/utils/skills.ts
@@ -1,3 +1,6 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
 // Godot-MCP skill catalog + SKILL.md content generation.
 //
 // The Godot analog of Unity-MCP's server-side skill generation. Unlike the
@@ -29,10 +32,17 @@ export interface SkillFamily {
 }
 
 /**
- * The Godot-MCP tool-family catalog. Mirrors the 10 families documented in
+ * The Godot-MCP tool-family catalog. Mirrors the 11 families documented in
  * `Godot-MCP/CLAUDE.md` § Tool families and the `[AiToolType]` classes under
  * `addons/godot_mcp/Runtime/Tools/` and `addons/godot_mcp/Editor/Tools/`. Tool names are the `[AiTool("<name>")]` identifiers
  * an MCP client invokes.
+ *
+ * Each family's `title` is the addon's `Tool_<title>` class-name suffix (e.g.
+ * `FileSystem` → `Tool_FileSystem`, `RuntimeErrors` → `Tool_RuntimeErrors`). That
+ * join key is what the CI cross-check (`discoverAddonToolFamilies`, exercised by
+ * `cli/tests/skills-addon-parity.test.ts`) uses to fail the build if this catalog
+ * ever drifts from the addon's actual `[AiToolType]` classes — so a new addon tool
+ * family cannot ship without a matching catalog entry here.
  */
 export const SKILL_FAMILIES: readonly SkillFamily[] = [
   {
@@ -131,6 +141,24 @@ export const SKILL_FAMILIES: readonly SkillFamily[] = [
     tools: [
       { name: 'reflection-method-find', description: 'Find methods on an engine type by name/signature.' },
       { name: 'reflection-method-call', description: 'Invoke a method reflectively with serialized arguments.' },
+    ],
+  },
+  {
+    id: 'runtime-errors',
+    title: 'RuntimeErrors',
+    summary:
+      'Poll errors raised inside the RUNNING game (NOT the editor) — GDScript runtime errors, push_error/push_warning, shader errors, and C# unhandled/unobserved-Task exceptions, with multi-frame GDScript backtraces on Godot 4.5+.',
+    tools: [
+      {
+        name: 'runtime-errors-get',
+        description:
+          'Read captured in-game runtime errors (oldest-first, newest-kept page). Returns `available:false` when the game never enabled runtime-error capture, so an empty list is never mistaken for health; poll only new errors by passing the previous result\'s `highestSequence` as `sinceSequence`.',
+      },
+      {
+        name: 'runtime-errors-clear',
+        description:
+          'Clear the captured in-game runtime-error buffer (a no-op when capture is not enabled). The monotonic sequence counter is preserved, so a pre-clear `sinceSequence` poll still behaves correctly.',
+      },
     ],
   },
   {
@@ -246,4 +274,78 @@ export function buildSkillFiles(): SkillFile[] {
     files.push(buildFamilySkill(fam));
   }
   return files;
+}
+
+// ---------------------------------------------------------------------------
+// CI cross-check: catalog ⇄ addon tool-family parity
+//
+// `SKILL_FAMILIES` above is hand-maintained, but it must stay in lockstep with
+// the addon's ACTUAL tool families — the `[AiToolType] partial class Tool_<Family>`
+// classes under `addons/godot_mcp/{Runtime,Editor}/Tools/`. When a new family ships
+// in the addon (as `runtime-errors` did in #161/#162) but nobody updates this
+// catalog, the CLI silently stops advertising it. The parity test
+// (`cli/tests/skills-addon-parity.test.ts`) compares the two sets and fails CI on
+// any divergence, so the catalog can never quietly fall behind the addon again.
+//
+// Join key: each catalog family's `title` is exactly the addon class-name suffix
+// (`Tool_<title>`). A naive PascalCase→kebab transform would NOT work — the addon
+// has `Tool_FileSystem` (catalog id `filesystem`, no hyphen) and `Tool_RuntimeErrors`
+// (catalog id `runtime-errors`, hyphenated) — so we match on the class-name suffix,
+// not on a derived slug.
+// ---------------------------------------------------------------------------
+
+/** Catalog (skills.ts) side of the parity check: the `Tool_<title>` suffixes the CLI advertises. */
+export function catalogToolFamilyClassSuffixes(): string[] {
+  return SKILL_FAMILIES.map((f) => f.title).sort();
+}
+
+/**
+ * Resolve the addon's `Tools/` source directories relative to a repo root. The
+ * cross-check passes the Godot-MCP repo root (the directory that contains both
+ * `cli/` and `addons/`); each tool-family base file lives under one of these two
+ * folders (Runtime = pure-managed families, Editor = `#if TOOLS` families).
+ */
+export function addonToolDirs(repoRoot: string): string[] {
+  return [
+    path.join(repoRoot, 'addons', 'godot_mcp', 'Runtime', 'Tools'),
+    path.join(repoRoot, 'addons', 'godot_mcp', 'Editor', 'Tools'),
+  ];
+}
+
+/**
+ * Addon side of the parity check: discover every tool family declared in the addon
+ * by scanning for `[AiToolType] ... partial class Tool_<Family>` in the `.cs` sources
+ * under the addon `Tools/` directories. Returns the sorted set of `<Family>` suffixes
+ * (e.g. `Node`, `FileSystem`, `RuntimeErrors`).
+ *
+ * Robustness notes:
+ * - Tool families are partial classes split across files (`Tool_RuntimeErrors.cs`,
+ *   `Tool_RuntimeErrors.Get.cs`, `Tool_RuntimeErrors.Clear.cs`). Only the base file
+ *   carries the `[AiToolType]` attribute, so keying on `[AiToolType]` (not on file
+ *   names) collapses each multi-file family to ONE entry automatically.
+ * - The regex tolerates other attributes/whitespace between `[AiToolType]` and the
+ *   class declaration, and an optional access modifier on the class.
+ */
+export function discoverAddonToolFamilies(repoRoot: string): string[] {
+  // `[AiToolType]` (possibly with args), then any amount of attributes/whitespace,
+  // then `partial class Tool_<Family>`. `[\s\S]*?` is non-greedy so it stops at the
+  // first class declaration after the attribute.
+  const familyRe =
+    /\[AiToolType[^\]]*\][\s\S]*?\bpartial\s+class\s+Tool_([A-Za-z][A-Za-z0-9]*)\b/g;
+  const found = new Set<string>();
+
+  for (const dir of addonToolDirs(repoRoot)) {
+    if (!fs.existsSync(dir)) continue;
+    for (const entry of fs.readdirSync(dir)) {
+      if (!entry.endsWith('.cs')) continue;
+      const src = fs.readFileSync(path.join(dir, entry), 'utf-8');
+      let m: RegExpExecArray | null;
+      familyRe.lastIndex = 0;
+      while ((m = familyRe.exec(src)) !== null) {
+        found.add(m[1]);
+      }
+    }
+  }
+
+  return [...found].sort();
 }

--- a/cli/tests/skills-addon-parity.test.ts
+++ b/cli/tests/skills-addon-parity.test.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+// CI cross-check: the CLI skill catalog (`src/utils/skills.ts` § SKILL_FAMILIES)
+// MUST advertise exactly the tool families the addon actually ships. The addon's
+// families are the `[AiToolType] partial class Tool_<Family>` classes under
+// `addons/godot_mcp/{Runtime,Editor}/Tools/`. If a new family ships in the addon
+// but nobody adds a catalog entry here (the `runtime-errors` regression this test
+// was added to prevent — shipped in #161/#162, never advertised by the CLI), this
+// test fails — so the CLI catalog can never silently fall behind the addon again.
+//
+// This runs in the existing `test-cli` CI leg (Node 20 & 22) — no Godot binary,
+// no .NET build — because it only reads the addon's `.cs` SOURCE text.
+
+import { describe, it, expect } from 'vitest';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  catalogToolFamilyClassSuffixes,
+  discoverAddonToolFamilies,
+  addonToolDirs,
+} from '../src/utils/skills.js';
+import * as fs from 'fs';
+
+// cli/tests/ -> cli/ -> <repo root> (the dir that holds both `cli/` and `addons/`).
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+describe('skills.ts ⇄ addon tool-family parity (CI cross-check)', () => {
+  it('addon Tools/ source directories exist (guards against a moved/renamed addon layout)', () => {
+    // If the addon layout moves, discovery would silently return an empty set and
+    // the parity assert below could pass vacuously — assert the dirs are real first.
+    const dirs = addonToolDirs(REPO_ROOT);
+    for (const dir of dirs) {
+      expect(fs.existsSync(dir), `expected addon Tools dir to exist: ${dir}`).toBe(true);
+    }
+  });
+
+  it('discovers a non-empty set of addon tool families', () => {
+    // Guard against a discovery regex regression that matches nothing (which would
+    // make the parity assert pass vacuously when the catalog is also empty).
+    const addonFamilies = discoverAddonToolFamilies(REPO_ROOT);
+    expect(addonFamilies.length).toBeGreaterThan(5);
+  });
+
+  it('the addon ships the runtime-errors family (regression anchor for #167)', () => {
+    // The specific family whose absence from the catalog motivated this test.
+    const addonFamilies = discoverAddonToolFamilies(REPO_ROOT);
+    expect(addonFamilies).toContain('RuntimeErrors');
+  });
+
+  it('catalog families exactly match the addon `Tool_<Family>` classes (no drift)', () => {
+    const catalog = catalogToolFamilyClassSuffixes(); // skills.ts titles, sorted
+    const addon = discoverAddonToolFamilies(REPO_ROOT); // Tool_<Family> suffixes, sorted
+
+    const inAddonNotInCatalog = addon.filter((f) => !catalog.includes(f));
+    const inCatalogNotInAddon = catalog.filter((f) => !addon.includes(f));
+
+    // Build human-readable diagnostics so a failure tells the maintainer exactly
+    // what to add/remove (and where).
+    expect(
+      inAddonNotInCatalog,
+      `Addon tool families with NO entry in cli/src/utils/skills.ts § SKILL_FAMILIES: ` +
+        `[${inAddonNotInCatalog.join(', ')}]. Add a SkillFamily whose \`title\` is the ` +
+        `\`Tool_<Family>\` suffix (and update CLAUDE.md + README family count).`,
+    ).toEqual([]);
+
+    expect(
+      inCatalogNotInAddon,
+      `skills.ts catalog families with NO backing \`[AiToolType] Tool_<Family>\` addon class: ` +
+        `[${inCatalogNotInAddon.join(', ')}]. Remove the stale catalog entry or fix its \`title\`.`,
+    ).toEqual([]);
+
+    // Belt-and-suspenders: the full sets are equal.
+    expect(catalog).toEqual(addon);
+  });
+});

--- a/cli/tests/skills-addon-parity.test.ts
+++ b/cli/tests/skills-addon-parity.test.ts
@@ -12,8 +12,9 @@
 // This runs in the existing `test-cli` CI leg (Node 20 & 22) — no Godot binary,
 // no .NET build — because it only reads the addon's `.cs` SOURCE text.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import * as path from 'path';
+import * as os from 'os';
 import { fileURLToPath } from 'url';
 import {
   catalogToolFamilyClassSuffixes,
@@ -47,6 +48,57 @@ describe('skills.ts ⇄ addon tool-family parity (CI cross-check)', () => {
     // The specific family whose absence from the catalog motivated this test.
     const addonFamilies = discoverAddonToolFamilies(REPO_ROOT);
     expect(addonFamilies).toContain('RuntimeErrors');
+  });
+
+  it('attributes the compound Tool_Editor_Selection sub-tool class to the Editor family (not dropped)', () => {
+    // The addon ships `[AiToolType] partial class Tool_Editor_Selection` — a compound
+    // sub-tool class whose `editor-selection-*` tools belong to the `editor` family.
+    // A discovery regex that stopped capturing at the first `_` would SILENTLY DROP it
+    // (parity then passes 11==11 only by accident). It must instead resolve to the
+    // first-segment family `Editor`, where it dedups against the base `Tool_Editor`.
+    const addonFamilies = discoverAddonToolFamilies(REPO_ROOT);
+    expect(addonFamilies).toContain('Editor');
+    // Discovery still equals the catalog at exactly 11 families — the compound class
+    // collapses INTO `Editor` rather than adding a phantom 12th family.
+    expect(addonFamilies).toEqual(catalogToolFamilyClassSuffixes());
+    expect(addonFamilies).toHaveLength(11);
+  });
+
+  describe('discovery robustness against compound + misattributed [AiToolType] classes', () => {
+    let tmpRoot: string | undefined;
+
+    afterEach(() => {
+      if (tmpRoot && fs.existsSync(tmpRoot)) fs.rmSync(tmpRoot, { recursive: true, force: true });
+      tmpRoot = undefined;
+    });
+
+    // Write a synthetic addon tree under a temp repo root so we can probe discovery on
+    // hand-crafted edge cases without depending on the real addon source.
+    function writeSyntheticAddon(fileName: string, contents: string): string {
+      tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-mcp-parity-'));
+      const runtimeDir = addonToolDirs(tmpRoot)[0]; // .../Runtime/Tools
+      fs.mkdirSync(runtimeDir, { recursive: true });
+      fs.writeFileSync(path.join(runtimeDir, fileName), contents, 'utf-8');
+      return tmpRoot;
+    }
+
+    it('maps a compound Tool_<Seg1>_<Seg2> class to its first segment', () => {
+      const root = writeSyntheticAddon(
+        'Tool_Foo.Bar.cs',
+        '[AiToolType]\n    public partial class Tool_Foo_Bar\n    {\n    }\n',
+      );
+      expect(discoverAddonToolFamilies(root)).toEqual(['Foo']);
+    });
+
+    it('does not misattribute a stray [AiToolType] on a non-Tool_ type to a later Tool_ class', () => {
+      // The `[AiToolType]` here sits on a helper type; the unattributed `Tool_Bridged`
+      // class below it must NOT be bridged to that attribute (cross-match guard).
+      const root = writeSyntheticAddon(
+        'Helper.cs',
+        '[AiToolType]\n    public class HelperType { }\n\n    public partial class Tool_Bridged { }\n',
+      );
+      expect(discoverAddonToolFamilies(root)).toEqual([]);
+    });
   });
 
   it('catalog families exactly match the addon `Tool_<Family>` classes (no drift)', () => {


### PR DESCRIPTION
## Summary

- Add the `runtime-errors` family (`runtime-errors-get` / `runtime-errors-clear`) to the CLI skill catalog (`cli/src/utils/skills.ts` § `SKILL_FAMILIES`). It shipped in #161/#162 (backtraces in #163) but the CLI never advertised it, so an agent driving via `godot-cli` was never told these tools exist.
- Add a durable CI cross-check (`cli/tests/skills-addon-parity.test.ts`) that discovers the addon's `[AiToolType] Tool_<Family>` classes under `addons/godot_mcp/{Runtime,Editor}/Tools/` and asserts the catalog's family set matches exactly — failing CI on any future drift. It runs in the existing `test-cli` leg (Node 20 & 22), reads only addon `.cs` source (no Godot binary / no .NET build), **fails pre-fix** (`[RuntimeErrors]` missing) and **passes post-fix**.
- Update addon `CLAUDE.md` (10 → 11 families, `Tool_RuntimeErrors` row, cross-check note) and `README.md` (38 tools / 11 families, family table + per-tool docs). The `runtime-errors` family is documented as in-game and **OFF by default** (`builder.WithRuntimeErrorCapture()`).

## How the cross-check maps classes → catalog ids

Each catalog family's `title` is exactly the addon class-name suffix (`Tool_<title>`), so the parity test joins on the suffix — not a derived slug. A naive PascalCase→kebab transform would not work (`Tool_FileSystem` → id `filesystem` with no hyphen; `Tool_RuntimeErrors` → id `runtime-errors` hyphenated). Discovery keys on the `[AiToolType]` attribute (only the base partial-class file carries it), so a multi-file family (`Tool_RuntimeErrors.cs` / `.Get.cs` / `.Clear.cs`) collapses to one entry.

## Test plan
- [x] `cli/`: `npm ci && npm run build && npm test` — 22 files / 261 tests pass (incl. the new parity test).
- [x] Verified the cross-check would FAIL pre-fix by temporarily removing the catalog entry: parity test reports `Addon tool families with NO entry in cli/src/utils/skills.ts § SKILL_FAMILIES: [RuntimeErrors]`, then restored.
- [x] No NuGet pin changes; no `dist/`/`bin/`/`obj/` staged; `package-lock.json` unchanged (no new deps).

Closes #167