### PR TITLE
Rebind the engine logger to the current capture on idempotent re-install (issue #171)

### DIFF
--- a/Godot-MCP.Tests/RuntimeErrorCaptureRebindTests.cs
+++ b/Godot-MCP.Tests/RuntimeErrorCaptureRebindTests.cs
@@ -1,0 +1,270 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.Godot.MCP.Runtime;
+using com.IvanMurzak.Godot.MCP.Tools;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Issue #171 regression coverage: an idempotent <see cref="RuntimeErrorCapture"/> re-install must NOT leave
+    /// the live engine logger forwarding to a STALE capture's sink. Before the fix, the bridge's already-installed
+    /// path returned the existing <see cref="ScriptErrorCapture.Current"/> without rebinding, so after
+    /// "install A → independent engine-logger Uninstall → Install again" engine errors kept routing to the FIRST
+    /// capture's sink — a collector the current handle no longer reads, so <c>runtime-errors-get</c> falls silently
+    /// quiet (the #160 failure this whole feature prevents).
+    ///
+    /// <para>
+    /// The real engine logger registers through native <c>OS.AddLogger</c>, which faults in the binary-less xUnit
+    /// host. So these tests exercise the load-bearing decision two ways, both pure-managed:
+    /// <list type="number">
+    /// <item>directly against <see cref="ScriptErrorCapture.PlanBridgeInstall"/> — the SAME coordinator the real
+    /// Godot 4.5+ bridge calls to choose RegisterNew / Rebind / AlreadyCurrent and republish
+    /// <see cref="ScriptErrorCapture.Current"/>; and</item>
+    /// <item>end-to-end through <see cref="RuntimeErrorCapture.Install"/>/<see cref="RuntimeErrorCapture.Uninstall"/>
+    /// with a PURE-MANAGED fake bridge (driving <see cref="ScriptErrorCapture.PlanBridgeInstall"/> + a single live
+    /// logger) injected via the test seams, so the full re-entrant scenario routes a real engine error and asserts
+    /// it lands in the CURRENT collector.</item>
+    /// </list>
+    /// Both bind to production rebind logic — reverting the fix turns them red.
+    /// </para>
+    ///
+    /// <para>
+    /// These tests touch process-wide statics (<see cref="ScriptErrorCapture.Current"/>,
+    /// <see cref="RuntimeErrorCollector.Current"/>, and <see cref="RuntimeErrorCapture"/>'s install state +
+    /// bridge seams). They run in their own xUnit collection (serialized — no parallel sibling) and every test
+    /// saves + restores that state in a finally, so a failed assertion can never leak into another test.
+    /// </para>
+    /// </summary>
+    [Collection(nameof(RuntimeErrorCaptureRebindTests))]
+    [CollectionDefinition(nameof(RuntimeErrorCaptureRebindTests), DisableParallelization = true)]
+    public class RuntimeErrorCaptureRebindTests
+    {
+        // ── PlanBridgeInstall: the pure-managed decision the real bridge shares ─────────────────────────────
+
+        [Fact]
+        public void PlanBridgeInstall_NoLiveLogger_RegistersNew_AndPublishesIncoming()
+        {
+            WithCleanScriptCaptureCurrent(() =>
+            {
+                var incoming = new ScriptErrorCapture();
+
+                var action = ScriptErrorCapture.PlanBridgeInstall(liveCapture: null, incoming);
+
+                Assert.Equal(BridgeInstallAction.RegisterNew, action);
+                Assert.Same(incoming, ScriptErrorCapture.Current); // published router tracks the live logger
+            });
+        }
+
+        [Fact]
+        public void PlanBridgeInstall_SameCapture_IsAlreadyCurrent_NoChurn()
+        {
+            WithCleanScriptCaptureCurrent(() =>
+            {
+                var live = new ScriptErrorCapture();
+
+                var action = ScriptErrorCapture.PlanBridgeInstall(liveCapture: live, incoming: live);
+
+                Assert.Equal(BridgeInstallAction.AlreadyCurrent, action);
+                Assert.Same(live, ScriptErrorCapture.Current);
+            });
+        }
+
+        [Fact]
+        public void PlanBridgeInstall_DifferentCapture_RequestsRebind_AndRepublishesIncoming()
+        {
+            // The crux of #171: a live logger on capture A asked to install capture B must REBIND (not keep A),
+            // and the published Current must advance to B so it never lags the live logger.
+            WithCleanScriptCaptureCurrent(() =>
+            {
+                var stale = new ScriptErrorCapture();
+                ScriptErrorCapture.Current = stale;
+                var incoming = new ScriptErrorCapture();
+
+                var action = ScriptErrorCapture.PlanBridgeInstall(liveCapture: stale, incoming);
+
+                Assert.Equal(BridgeInstallAction.Rebind, action);
+                Assert.Same(incoming, ScriptErrorCapture.Current); // NOT left on the stale capture
+            });
+        }
+
+        [Fact]
+        public void PlanBridgeInstall_NullIncoming_Throws()
+        {
+            WithCleanScriptCaptureCurrent(() =>
+                Assert.Throws<ArgumentNullException>(() =>
+                    ScriptErrorCapture.PlanBridgeInstall(liveCapture: null, incoming: null!)));
+        }
+
+        // ── End-to-end: RuntimeErrorCapture re-install rebinds the live logger to the current collector ──────
+
+        [Fact]
+        public void Install_WhenBridgeAlreadyLiveOnAnotherCapture_RebindsLiveLoggerToRuntimeCollector_NotStale()
+        {
+            // The exact #171 cross-consumer scenario, end-to-end with a pure-managed fake bridge whose single
+            // live logger SURVIVES across the install (models the editor having registered the bridge first, or a
+            // re-install where the prior logger was never removed):
+            //   1. A logger is ALREADY live, forwarding to a STALE capture (e.g. the editor's log capture).
+            //   2. RuntimeErrorCapture.Install() builds a NEW capture whose ErrorSink feeds the runtime collector B
+            //      and hands it to the bridge. The bridge is already live → it MUST REBIND the live logger to the
+            //      runtime capture (pre-fix it kept the stale one — the bug).
+            //   3. A routed engine error must land in the runtime collector B (the CURRENT one), NOT the stale sink.
+            var fakeBridge = new FakeEngineLoggerBridge();
+            WithFakeBridge(fakeBridge, () =>
+            {
+                // 1) Pre-register a live logger on a STALE capture whose errors land in a collector NOBODY reads
+                //    anymore (the orphaned sink the live handle no longer polls).
+                var staleErrors = new List<EngineErrorRecord>();
+                var staleCapture = new ScriptErrorCapture { ErrorSink = r => staleErrors.Add(r) };
+                fakeBridge.TryInstall(staleCapture);
+                Assert.True(fakeBridge.HasLiveLogger);
+                Assert.Same(staleCapture, fakeBridge.LiveCapture);
+
+                // 2) The runtime opts in — Install builds a fresh capture wired to collector B and hands it to the
+                //    already-live bridge, which must rebind.
+                var collectorB = RuntimeErrorCapture.Install();
+                Assert.Same(collectorB, RuntimeErrorCollector.Current);
+                Assert.NotSame(staleCapture, fakeBridge.LiveCapture); // REBOUND — no longer the stale capture
+
+                // 3) The crux: a freshly-routed engine error lands in the runtime collector B, NOT the stale sink.
+                fakeBridge.RaiseEngineError("res://b.gd", 2, "boom-B");
+
+                Assert.Equal(1, collectorB.Count);          // current collector received it
+                Assert.Empty(staleErrors);                  // the stale sink got NOTHING (pre-fix: it would have)
+                var captured = collectorB.QuerySince(0, 100, out _).Single();
+                Assert.Equal("boom-B", captured.Message);
+                Assert.Equal(RuntimeErrorSource.Engine, captured.Source);
+            });
+        }
+
+        [Fact]
+        public void Reinstall_AfterFullCycle_RoutesEngineErrorsToTheNewCollector()
+        {
+            // install A → full RuntimeErrorCapture.Uninstall (drops the bridge logger) → Install B → route:
+            // the new collector B receives the error and the dropped collector A does not. Complements the
+            // surviving-logger test above with the clean teardown/re-register path.
+            var fakeBridge = new FakeEngineLoggerBridge();
+            WithFakeBridge(fakeBridge, () =>
+            {
+                var collectorA = RuntimeErrorCapture.Install();
+                fakeBridge.RaiseEngineError("res://a.gd", 1, "boom-A");
+                Assert.Equal(1, collectorA.Count);
+
+                RuntimeErrorCapture.Uninstall();
+                Assert.False(fakeBridge.HasLiveLogger);
+
+                var collectorB = RuntimeErrorCapture.Install();
+                Assert.NotSame(collectorA, collectorB);
+
+                fakeBridge.RaiseEngineError("res://b.gd", 2, "boom-B");
+                Assert.Equal(1, collectorB.Count);          // current collector received it
+                Assert.Equal(1, collectorA.Count);          // dropped collector unchanged (still just boom-A)
+            });
+        }
+
+        // ── helpers ─────────────────────────────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// A pure-managed stand-in for <c>GodotScriptErrorLoggerBridge</c> that exercises the REAL decision
+        /// (<see cref="ScriptErrorCapture.PlanBridgeInstall"/>) and models the single live engine logger — without
+        /// touching native <c>OS.AddLogger</c>. <see cref="RaiseEngineError"/> drives an error through the live
+        /// logger exactly as Godot's <c>_LogError</c> callback would, into whatever capture the logger is currently
+        /// bound to — so a missing rebind shows up as the error reaching the stale capture/collector.
+        /// </summary>
+        sealed class FakeEngineLoggerBridge
+        {
+            ScriptErrorCapture? _live; // the one registered logger's current capture (null when none registered)
+
+            public bool HasLiveLogger => _live != null;
+            public ScriptErrorCapture? LiveCapture => _live;
+
+            public ScriptErrorCapture? TryInstall(ScriptErrorCapture capture)
+            {
+                if (capture == null)
+                    return null;
+
+                // SAME production decision the real Godot 4.5+ bridge makes (issue #171).
+                var action = ScriptErrorCapture.PlanBridgeInstall(_live, capture);
+                switch (action)
+                {
+                    case BridgeInstallAction.AlreadyCurrent:
+                        break; // live logger already on this capture — nothing to do
+                    case BridgeInstallAction.Rebind:
+                    case BridgeInstallAction.RegisterNew:
+                    default:
+                        // Both register-new and rebind end with the single live logger forwarding to `capture`.
+                        // (Real bridge: RegisterNew = OS.AddLogger(new logger); Rebind = logger.RebindCapture.)
+                        _live = capture;
+                        break;
+                }
+                return capture;
+            }
+
+            public void Uninstall()
+            {
+                // Models OS.RemoveLogger + clearing the router: the live logger is gone and Current is nulled.
+                _live = null;
+                ScriptErrorCapture.Current = null;
+            }
+
+            /// <summary>Route an engine error through the live logger's CURRENT capture (mirrors _LogError).</summary>
+            public void RaiseEngineError(string file, int line, string message)
+            {
+                Assert.NotNull(_live); // an error can only arrive while a logger is registered
+                _live!.Route(EngineErrorKind.Error, file, line, message: null, rationale: message);
+            }
+        }
+
+        static void WithFakeBridge(FakeEngineLoggerBridge bridge, Action body)
+        {
+            var priorInstall = RuntimeErrorCapture._bridgeInstallForTests;
+            var priorUninstall = RuntimeErrorCapture._bridgeUninstallForTests;
+            var priorLog = RuntimeErrorCapture._logForTests;
+            var priorCollector = RuntimeErrorCollector.Current;
+            var priorScriptCurrent = ScriptErrorCapture.Current;
+
+            // No prior install state may bleed in (the seams are not yet pointed at the fake, so this uses the
+            // stub bridge — a no-op on the 4.3 test pin — which is fine: we only need RuntimeErrorCapture's own
+            // static flags reset).
+            RuntimeErrorCapture.Uninstall();
+
+            RuntimeErrorCapture._bridgeInstallForTests = bridge.TryInstall;
+            RuntimeErrorCapture._bridgeUninstallForTests = bridge.Uninstall;
+            // Substitute the install-summary GD.Print (native — faults in the binary-less host) with a no-op.
+            RuntimeErrorCapture._logForTests = _ => { };
+            try
+            {
+                body();
+            }
+            finally
+            {
+                try { RuntimeErrorCapture.Uninstall(); } catch { /* best-effort cleanup */ }
+                RuntimeErrorCapture._bridgeInstallForTests = priorInstall;
+                RuntimeErrorCapture._bridgeUninstallForTests = priorUninstall;
+                RuntimeErrorCapture._logForTests = priorLog;
+                RuntimeErrorCollector.Current = priorCollector;
+                ScriptErrorCapture.Current = priorScriptCurrent;
+            }
+        }
+
+        static void WithCleanScriptCaptureCurrent(Action body)
+        {
+            var prior = ScriptErrorCapture.Current;
+            ScriptErrorCapture.Current = null;
+            try { body(); }
+            finally { ScriptErrorCapture.Current = prior; }
+        }
+    }
+}

--- a/Godot-MCP.Tests/RuntimeErrorCaptureRebindTests.cs
+++ b/Godot-MCP.Tests/RuntimeErrorCaptureRebindTests.cs
@@ -150,11 +150,50 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         }
 
         [Fact]
+        public void Install_OnSurvivingLogger_RebindsWithoutReRegistering_AndRoutesToNewCollector()
+        {
+            // Pins the load-bearing one-registration invariant (godot#78513): when a logger is ALREADY live and
+            // Install() hands the bridge a fresh capture, the bridge must REBIND the existing registration at the
+            // new capture WITHOUT a second OS.AddLogger. A re-register would re-pin the collectible addon ALC, the
+            // exact churn the rebind exists to avoid. Asserted via the fake's registration counter (incremented
+            // ONLY on the RegisterNew action) — collapsing Rebind into RegisterNew, in the fake OR the prod bridge,
+            // would bump it and fail this test, so it pins that the two actions stay distinct.
+            var fakeBridge = new FakeEngineLoggerBridge();
+            WithFakeBridge(fakeBridge, () =>
+            {
+                // 1) A logger is already live, forwarding to a stale capture nobody reads (models the editor's own
+                //    log capture, or a prior install whose logger was never removed). This is a RegisterNew.
+                var staleErrors = new List<EngineErrorRecord>();
+                var staleCapture = new ScriptErrorCapture { ErrorSink = r => staleErrors.Add(r) };
+                fakeBridge.TryInstall(staleCapture);
+                Assert.Equal(1, fakeBridge.RegistrationCount); // first registration
+
+                // 2) Install() builds a fresh capture wired to collector B and hands it to the already-live bridge,
+                //    which must REBIND (different capture) — repointing the SAME registration, NOT adding a second.
+                var collectorB = RuntimeErrorCapture.Install();
+                Assert.Equal(1, fakeBridge.RegistrationCount); // STILL 1 — rebind reused the registration
+                Assert.NotSame(staleCapture, fakeBridge.LiveCapture); // and the live logger advanced off the stale one
+
+                // 3) A freshly-routed engine error lands in collector B (the rebind took), NOT the stale sink.
+                fakeBridge.RaiseEngineError("res://b.gd", 7, "boom-B");
+                Assert.Equal(1, collectorB.Count);
+                Assert.Empty(staleErrors);
+                Assert.Same(collectorB, RuntimeErrorCollector.Current);
+                Assert.Equal("boom-B", collectorB.QuerySince(0, 100, out _).Single().Message);
+            });
+        }
+
+        [Fact]
         public void Reinstall_AfterFullCycle_RoutesEngineErrorsToTheNewCollector()
         {
             // install A → full RuntimeErrorCapture.Uninstall (drops the bridge logger) → Install B → route:
             // the new collector B receives the error and the dropped collector A does not. Complements the
             // surviving-logger test above with the clean teardown/re-register path.
+            // NOTE: because Uninstall() drops the live logger (the fake's _live goes null), the second Install()
+            // resolves to RegisterNew, NOT Rebind — so this test pins the clean teardown/re-register cycle, it
+            // does NOT exercise the rebind branch. The rebind itself is pinned by
+            // PlanBridgeInstall_DifferentCapture_RequestsRebind_AndRepublishesIncoming and
+            // Install_WhenBridgeAlreadyLiveOnAnotherCapture_RebindsLiveLoggerToRuntimeCollector_NotStale.
             var fakeBridge = new FakeEngineLoggerBridge();
             WithFakeBridge(fakeBridge, () =>
             {
@@ -186,9 +225,18 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         sealed class FakeEngineLoggerBridge
         {
             ScriptErrorCapture? _live; // the one registered logger's current capture (null when none registered)
+            int _registrations;       // how many times a NEW logger was registered (RegisterNew only, never Rebind)
 
             public bool HasLiveLogger => _live != null;
             public ScriptErrorCapture? LiveCapture => _live;
+
+            /// <summary>
+            /// Count of <see cref="BridgeInstallAction.RegisterNew"/> actions — i.e. real <c>OS.AddLogger</c>
+            /// registrations. A Rebind reuses the existing registration and MUST leave this unchanged: re-adding
+            /// the logger would re-pin the collectible addon ALC (godot#78513), the very churn the rebind exists
+            /// to avoid. Pins the one-registration invariant the production bridge guarantees.
+            /// </summary>
+            public int RegistrationCount => _registrations;
 
             public ScriptErrorCapture? TryInstall(ScriptErrorCapture capture)
             {
@@ -201,11 +249,15 @@ namespace com.IvanMurzak.Godot.MCP.Tests
                 {
                     case BridgeInstallAction.AlreadyCurrent:
                         break; // live logger already on this capture — nothing to do
-                    case BridgeInstallAction.Rebind:
                     case BridgeInstallAction.RegisterNew:
+                        // Real bridge: OS.AddLogger(new logger) — a fresh native registration.
+                        _registrations++;
+                        _live = capture;
+                        break;
+                    case BridgeInstallAction.Rebind:
                     default:
-                        // Both register-new and rebind end with the single live logger forwarding to `capture`.
-                        // (Real bridge: RegisterNew = OS.AddLogger(new logger); Rebind = logger.RebindCapture.)
+                        // Real bridge: logger.RebindCapture — repoint the SAME registered logger, NO re-register
+                        // (so _registrations stays put: no OS.RemoveLogger/AddLogger churn, no ALC re-pin).
                         _live = capture;
                         break;
                 }

--- a/addons/godot_mcp/Runtime/RuntimeErrorCapture.cs
+++ b/addons/godot_mcp/Runtime/RuntimeErrorCapture.cs
@@ -60,6 +60,19 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
         static UnhandledExceptionEventHandler? _domainHandler;
         static EventHandler<UnobservedTaskExceptionEventArgs>? _taskHandler;
 
+        // ── Engine-logger bridge + log seams (issue #171) ─────────────────────────────────────────────────
+        //
+        // The real engine logger registers through GodotScriptErrorLoggerBridge.TryInstall / .Uninstall, which
+        // call OS.AddLogger / OS.RemoveLogger — native Godot APIs that FAULT (AccessViolationException) in the
+        // binary-less xUnit host. The install summary also calls GD.Print (native). These delegate seams let a
+        // unit test substitute a PURE-MANAGED fake bridge + log so the re-entrant rebind path (install →
+        // independent bridge teardown → re-install) can be exercised and asserted without a Godot binary. In
+        // production all are null and the real static bridge / GD.Print run. Mirrors the
+        // GodotMcpRuntime._installForTests / _uninstallForTests pattern. Internal: test-only.
+        internal static Func<ScriptErrorCapture, ScriptErrorCapture?>? _bridgeInstallForTests;
+        internal static Action? _bridgeUninstallForTests;
+        internal static Action<string>? _logForTests;
+
         /// <summary>True while capture is installed (an engine logger and/or the C# fault hooks are live).</summary>
         public static bool IsInstalled
         {
@@ -82,8 +95,10 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
                     // Idempotent re-entry. The engine logger lives in the bridge's SEPARATE static
                     // (GodotScriptErrorLoggerBridge._installed), not in our _installed flag, so it could have
                     // been torn down independently (e.g. an editor-side Uninstall) while ours stayed true.
-                    // Re-assert it: the bridge's TryInstall is non-destructive (a no-op when still installed,
-                    // a fresh registration when it was removed), so this never clobbers a live logger.
+                    // Re-assert it via a FRESH capture bound to _collector: if the bridge logger is gone the
+                    // bridge registers anew; if it is still live but on a STALE capture (issue #171), the bridge
+                    // REBINDS it to this fresh capture so engine errors route to _collector — the live collector
+                    // this handle reads — instead of a collector left orphaned by a prior install/uninstall cycle.
                     TryInstallEngineLogger(_collector);
                     return _collector;
                 }
@@ -131,10 +146,14 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
                 };
                 TaskScheduler.UnobservedTaskException += _taskHandler;
 
-                GD.Print(engineInstalled
+                var summary = engineInstalled
                     ? "[Godot-MCP] runtime error capture installed (engine 4.5+ logger + C# exception hooks)."
                     : "[Godot-MCP] runtime error capture installed (C# exception hooks only; engine logger " +
-                      "requires Godot 4.5+).");
+                      "requires Godot 4.5+).";
+                if (_logForTests != null)
+                    _logForTests(summary);
+                else
+                    GD.Print(summary);
 
                 return collector;
             }
@@ -199,11 +218,16 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
         {
             try
             {
+                // Build a FRESH capture each call whose ErrorSink targets the CURRENT collector, then hand it to
+                // the bridge. On a re-entrant install (issue #171) the bridge REBINDS its single live logger to
+                // this new capture (see GodotScriptErrorLoggerBridge.TryInstall), so engine errors always route
+                // to the collector the live handle reads — never a stale one left over from a prior install.
                 var capture = new ScriptErrorCapture
                 {
                     ErrorSink = record => collector.Append(RuntimeErrorFactory.FromEngine(record)),
                 };
-                return GodotScriptErrorLoggerBridge.TryInstall(capture) != null;
+                var install = _bridgeInstallForTests ?? GodotScriptErrorLoggerBridge.TryInstall;
+                return install(capture) != null;
             }
             catch (Exception ex)
             {
@@ -225,7 +249,7 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
                 if (!_installed)
                     return;
 
-                try { GodotScriptErrorLoggerBridge.Uninstall(); }
+                try { (_bridgeUninstallForTests ?? GodotScriptErrorLoggerBridge.Uninstall)(); }
                 catch { /* swallow: a logger-removal failure must not break teardown */ }
 
                 if (_domainHandler != null)

--- a/addons/godot_mcp/Runtime/Tools/GodotScriptErrorLogger.cs
+++ b/addons/godot_mcp/Runtime/Tools/GodotScriptErrorLogger.cs
@@ -57,9 +57,36 @@ namespace com.IvanMurzak.Godot.MCP.Tools
     /// </summary>
     public sealed partial class GodotScriptErrorLogger : Logger
     {
-        readonly ScriptErrorCapture _capture;
+        // The router the live logger forwards every engine callback into. NOT readonly: a re-entrant
+        // install (issue #171) must be able to REBIND this to a fresh capture without removing+re-adding the
+        // engine Logger (OS.RemoveLogger/AddLogger), so the single registered logger always feeds whichever
+        // ScriptErrorCapture is current. Volatile so the rebind written on the main (install) thread is visible
+        // to the engine's multi-threaded _LogError callback without a lock on the hot error path.
+        volatile ScriptErrorCapture _capture;
 
         public GodotScriptErrorLogger(ScriptErrorCapture capture)
+        {
+            _capture = capture ?? throw new ArgumentNullException(nameof(capture));
+        }
+
+        /// <summary>
+        /// The router this live logger currently forwards into. Exposed so the bridge can detect a
+        /// sink-identity mismatch on a re-entrant install (issue #171) and rebind rather than silently keep
+        /// routing engine errors to a stale capture (whose sink feeds a collector the current handle no longer
+        /// reads — the #160 silent-quiet failure).
+        /// </summary>
+        public ScriptErrorCapture Capture => _capture;
+
+        /// <summary>
+        /// Repoint this already-registered logger at a NEW <paramref name="capture"/> WITHOUT touching
+        /// <see cref="OS.AddLogger"/>/<see cref="OS.RemoveLogger"/>. Used by the bridge's re-entrant install
+        /// path (issue #171): an independent engine-logger teardown + a re-install would otherwise leave the
+        /// single live logger forwarding to the FIRST capture's sink (routing errors to an orphaned collector),
+        /// because the engine still holds the original Logger instance. Rebinding the field keeps the single
+        /// registration but makes the new capture authoritative. The write is volatile, so the engine's
+        /// off-thread <see cref="_LogError"/> sees the new router immediately.
+        /// </summary>
+        public void RebindCapture(ScriptErrorCapture capture)
         {
             _capture = capture ?? throw new ArgumentNullException(nameof(capture));
         }
@@ -280,22 +307,38 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             if (capture == null)
                 return null;
 
-            // Non-destructive when ALREADY installed: do NOT tear down a live registration to replace it. In
-            // the normal paired install/uninstall lifecycle _installed is null here, but a stray double-install
-            // must not OS.RemoveLogger/Dispose the engine's current logger out from under it (which would both
-            // re-pin the collectible ALC — the exact godot#78513 unload failure this bridge removes — and orphan
-            // the prior registration beyond Uninstall's reach). Treat the already-installed case as a no-op and
-            // return the live router. (Editor and in-game runtime are separate OS processes — see the _installed
-            // field note — so this guard only ever fires for an in-process re-init, never cross-context.)
-            if (_installed != null)
-                return ScriptErrorCapture.Current;
+            // Decide RegisterNew / Rebind / AlreadyCurrent via the pure-managed coordinator so this native path
+            // and the unit tests share ONE decision (issue #171). PlanBridgeInstall also republishes
+            // ScriptErrorCapture.Current = capture, so the published router never lags the live logger.
+            var action = ScriptErrorCapture.PlanBridgeInstall(_installed?.Capture, capture);
+            switch (action)
+            {
+                case BridgeInstallAction.AlreadyCurrent:
+                    // Benign idempotent re-assert (RuntimeErrorCapture.Install's re-entry with the same capture).
+                    return capture;
 
-            var logger = new GodotScriptErrorLogger(capture);
-            OS.AddLogger(logger); // static API in GodotSharp 4.5
+                case BridgeInstallAction.Rebind:
+                    // ALREADY installed on a DIFFERENT capture — issue #171. REBIND the single live logger to the
+                    // new capture rather than (a) OS.RemoveLogger/AddLogger churn (which re-pins the collectible
+                    // ALC — the godot#78513 unload failure this bridge removes) or (b) silently keeping the OLD
+                    // capture (the bug: the live logger would keep forwarding to the FIRST capture's sink, so
+                    // engine errors land in a collector the current handle no longer reads → runtime-errors-get
+                    // falls silently quiet, the #160 failure this feature prevents). Surface the rebind so a
+                    // stale-sink regression is never silent again.
+                    GD.PushWarning(
+                        "[Godot-MCP] engine error-logger re-installed with a new capture; rebinding the live " +
+                        "logger to it so runtime errors route to the current collector (issue #171).");
+                    _installed!.RebindCapture(capture);
+                    return capture;
 
-            _installed = logger; // retain so Uninstall() can remove the exact same instance
-            ScriptErrorCapture.Current = capture;
-            return capture;
+                case BridgeInstallAction.RegisterNew:
+                default:
+                    var logger = new GodotScriptErrorLogger(capture);
+                    OS.AddLogger(logger); // static API in GodotSharp 4.5
+
+                    _installed = logger; // retain so Uninstall() can remove the exact same instance
+                    return capture;
+            }
         }
 
         /// <summary>

--- a/addons/godot_mcp/Runtime/Tools/ScriptErrorCapture.cs
+++ b/addons/godot_mcp/Runtime/Tools/ScriptErrorCapture.cs
@@ -311,5 +311,58 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 : (line >= 0 ? $" {filePath}:{line}" : $" {filePath}");
             return $"[{kind}]{loc} — {text}";
         }
+
+        /// <summary>
+        /// Pure-managed install/rebind coordinator shared by the engine-logger bridge (issue #171). Decides what
+        /// the bridge does when asked to install <paramref name="incoming"/>, given whether a logger is already
+        /// live (<paramref name="liveCapture"/> is the capture that logger currently forwards into, or null when
+        /// nothing is registered). This logic is the load-bearing fix and is decoupled from the native
+        /// <c>OS.AddLogger</c> path so it is unit-testable in the binary-less xUnit host: the real Godot 4.5+
+        /// bridge calls this to make the SAME decision, then performs the native side effect the result names.
+        /// <list type="bullet">
+        /// <item><see cref="BridgeInstallAction.RegisterNew"/> — nothing was live; register a new logger.</item>
+        /// <item><see cref="BridgeInstallAction.Rebind"/> — a logger is live on a DIFFERENT capture; repoint it
+        /// at <paramref name="incoming"/> WITHOUT re-registering (no OS.RemoveLogger/AddLogger churn). This is
+        /// the path that closes #171: it stops engine errors routing to a stale capture's collector.</item>
+        /// <item><see cref="BridgeInstallAction.AlreadyCurrent"/> — a logger is live on the SAME capture; a
+        /// benign idempotent re-assert (RuntimeErrorCapture.Install's re-entry path). No side effect needed.</item>
+        /// </list>
+        /// In all non-null-incoming cases <see cref="Current"/> ends up equal to <paramref name="incoming"/> so
+        /// the published router never lags the live logger. Returns the action the caller must apply.
+        /// </summary>
+        public static BridgeInstallAction PlanBridgeInstall(ScriptErrorCapture? liveCapture, ScriptErrorCapture incoming)
+        {
+            if (incoming == null)
+                throw new ArgumentNullException(nameof(incoming));
+
+            BridgeInstallAction action;
+            if (liveCapture == null)
+                action = BridgeInstallAction.RegisterNew;
+            else if (ReferenceEquals(liveCapture, incoming))
+                action = BridgeInstallAction.AlreadyCurrent;
+            else
+                action = BridgeInstallAction.Rebind;
+
+            // The published router must always track the capture the live logger ends up forwarding into — set it
+            // here so neither the RegisterNew nor the Rebind caller can forget and leave Current pointing at a
+            // stale capture (the very desync #171 is about).
+            Current = incoming;
+            return action;
+        }
+    }
+
+    /// <summary>
+    /// What the engine-logger bridge must do for a given install request — the outcome of
+    /// <see cref="ScriptErrorCapture.PlanBridgeInstall"/>. Pure-managed so the decision is unit-testable apart
+    /// from the native <c>OS.AddLogger</c> side effect each value names (issue #171).
+    /// </summary>
+    public enum BridgeInstallAction
+    {
+        /// <summary>No logger was live; register a new one via <c>OS.AddLogger</c>.</summary>
+        RegisterNew = 0,
+        /// <summary>A logger is live on a DIFFERENT capture; repoint it at the incoming one (no re-register).</summary>
+        Rebind = 1,
+        /// <summary>A logger is live on the SAME capture; benign idempotent re-assert — no side effect.</summary>
+        AlreadyCurrent = 2,
     }
 }


### PR DESCRIPTION
## Summary

- An idempotent `RuntimeErrorCapture` re-install left the single live engine logger forwarding to the **first** capture's sink. After `install A → independent engine-logger Uninstall (editor teardown / hot-reload) → Install again`, the bridge's already-installed branch returned the existing `ScriptErrorCapture.Current` without rebinding, so engine errors kept routing to a collector the current handle no longer reads — `runtime-errors-get` falls silently quiet (the #160 failure this feature prevents).
- Fix: the bridge's re-entrant `TryInstall(ScriptErrorCapture)` now **rebinds** the single registered logger to the new capture (no `OS.RemoveLogger`/`AddLogger` churn → the collectible ALC is never re-pinned, so godot#78513 stays fixed). The `RegisterNew` / `Rebind` / `AlreadyCurrent` decision is factored into the pure-managed `ScriptErrorCapture.PlanBridgeInstall`, which also republishes `ScriptErrorCapture.Current` so the published router never lags the live logger, and logs a warning on a sink-identity mismatch so a mis-wire is observable.
- Idempotency, default-OFF/opt-in, and thread-safety preserved (`GodotScriptErrorLogger._capture` is now `volatile`). No NuGet pin / csproj / sln changes.

## Test plan

- [x] `dotnet build Godot-MCP.sln` — 0 errors.
- [x] `dotnet test Godot-MCP.Tests` — 834 passed / 1 failed, the 1 being the documented benign Windows-only `GodotAssemblyUtilsTests` temp-DLL cleanup (green in Linux CI).
- [x] New `RuntimeErrorCaptureRebindTests` (6 tests): drives `PlanBridgeInstall` directly + the full re-install path end-to-end through a pure-managed fake bridge. **Fail-pre-fix proven** — reverting the rebind turns 3 of the 6 red, including the crux end-to-end case.
- [x] `scripts/check-runtime-boundary.py` — 0 violations (all edits are in `Runtime/`).

Closes #171
