### PR TITLE
fix(editor): keep GodotLogCollector.Current readable on teardown; make swaps explicit

### DIFF
--- a/Godot-MCP.Tests/GodotLogCollectorTests.cs
+++ b/Godot-MCP.Tests/GodotLogCollectorTests.cs
@@ -130,11 +130,17 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         [Fact]
         public void TeardownLeavesBufferReadable_ReinstallReplaces()
         {
-            // Model the plugin lifecycle: _EnterTree installs a buffer, lines are captured, then teardown
-            // happens. Issue #173: teardown must NOT null Current — the buffer stays readable so
-            // console-get-logs still surfaces the teardown-window diagnostics. (The plugin no longer assigns
-            // null; this test pins the OBSERVABLE contract — a previously-installed buffer remains queryable
-            // and is only displaced by the next install.)
+            // Issue #173 background: teardown must NOT null Current — the buffer stays readable so
+            // console-get-logs still surfaces the teardown-window diagnostics, and only the next _EnterTree
+            // install displaces it.
+            //
+            // SCOPE of this test: it pins the GodotLogCollector.Current PROPERTY contract only —
+            // last-writer-wins, and a previously-installed buffer stays queryable until the next assignment.
+            // It does NOT (and cannot) invoke GodotMcpPlugin.Teardown, which needs a live Godot host, so it
+            // would NOT catch a regression that re-added a `Current = null` to the plugin's teardown body.
+            // That teardown-null regression is guarded by code review + the Suite-3 headless smoke (see the
+            // testbed runbook), NOT by this unit test. The `// ... teardown runs here ...` line below models
+            // the property-level no-op, not an actual plugin teardown call.
             var session1 = new GodotLogCollector();
             GodotLogCollector.Current = session1;
             session1.Append(GodotLogType.Error, "teardown-window failure");
@@ -160,9 +166,16 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             // Reproduce the issue #173 race: a background thread continuously routes log lines through
             // GodotLogCollector.Current?.Append(...) (exactly what RouteFrameworkLog / Log* do off-thread)
             // while the "main thread" repeatedly swaps Current to a freshly installed buffer (the _EnterTree
-            // path). The Volatile read/write contract must guarantee the reader only ever observes a valid,
-            // fully-constructed collector reference (or null between the initial state and the first install)
-            // — never a torn reference — and the loop must complete without an exception.
+            // path).
+            //
+            // NOTE on what this test does and does NOT prove: this is a SMOKE / LIVENESS test, not a
+            // discriminating guard for the Volatile read/write contract. On the x86/x64 arch the CI runs,
+            // reference-sized reads/writes are already atomic AND effectively acquire/release (x86-TSO), so
+            // deleting the Volatile would NOT make this test fail here — the discipline only matters on a
+            // weak memory model (e.g. ARM), which this suite never executes on. So treat a green result as
+            // "the off-thread null-conditional Append path runs to completion under a swap storm without
+            // crashing", NOT as "no torn reference is possible". The torn-read correctness rests on the
+            // Volatile annotations in GodotLogCollector being kept (verified by review), not on this assert.
             const int swaps = 200;
             const int appendThreads = 4;
 

--- a/Godot-MCP.Tests/GodotLogCollectorTests.cs
+++ b/Godot-MCP.Tests/GodotLogCollectorTests.cs
@@ -1,0 +1,250 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.Godot.MCP.Tools;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pure-managed coverage for <see cref="GodotLogCollector"/> (issue #173): the bounded ring buffer
+    /// itself, and — the heart of the issue — the concurrency contract on the process-wide
+    /// <see cref="GodotLogCollector.Current"/> static. In the real plugin the framework log-routing path
+    /// (<c>GodotMcpConnection.RouteFrameworkLog</c> + the plugin <c>Log*</c> helpers) reads
+    /// <c>Current?.Append(...)</c> from ARBITRARY background threads while the editor main thread swaps
+    /// <c>Current</c> at <c>_EnterTree</c> / no longer nulls it at teardown. These tests assert that:
+    /// (1) the swap is published via Volatile so a concurrent reader never sees a torn reference and never
+    /// crashes, and (2) the collector is no longer nulled on teardown, so the buffer stays readable until
+    /// the next install overwrites it.
+    ///
+    /// <para>
+    /// The collector is a plain managed ring buffer (no Godot native types, no <c>#if TOOLS</c>), so it is
+    /// fully unit-testable in this plain xUnit host with no Godot binary. The tests own/restore the
+    /// process-wide <see cref="GodotLogCollector.Current"/> static so they do not leak state into other
+    /// tests (xUnit runs test classes in parallel by default; this class is marked non-parallel via the
+    /// dedicated collection below because it mutates a process-wide static).
+    /// </para>
+    /// </summary>
+    [Collection(GodotLogCollectorCurrentCollection.Name)]
+    public class GodotLogCollectorTests : IDisposable
+    {
+        readonly GodotLogCollector? _savedCurrent;
+
+        public GodotLogCollectorTests()
+        {
+            // Snapshot whatever Current was so the suite is non-destructive even if some other code set it.
+            _savedCurrent = GodotLogCollector.Current;
+            GodotLogCollector.Current = null;
+        }
+
+        public void Dispose()
+        {
+            GodotLogCollector.Current = _savedCurrent;
+        }
+
+        // ---- Ring-buffer basics -------------------------------------------------------------------
+
+        [Fact]
+        public void Append_And_Query_ReturnsNewestFirst()
+        {
+            var collector = new GodotLogCollector();
+            collector.Append(GodotLogType.Log, "first");
+            collector.Append(GodotLogType.Warning, "second");
+            collector.Append(GodotLogType.Error, "third");
+
+            var rows = collector.Query();
+
+            Assert.Equal(3, rows.Length);
+            Assert.Equal("third", rows[0].Message);
+            Assert.Equal("second", rows[1].Message);
+            Assert.Equal("first", rows[2].Message);
+        }
+
+        [Fact]
+        public void Append_EvictsOldest_AtCapacity()
+        {
+            var collector = new GodotLogCollector();
+            for (int i = 0; i < GodotLogCollector.Capacity + 50; i++)
+                collector.Append(GodotLogType.Log, $"line-{i}");
+
+            Assert.Equal(GodotLogCollector.Capacity, collector.Count);
+
+            // Newest is the last appended; the first 50 were evicted (FIFO).
+            var rows = collector.Query(maxEntries: GodotLogCollector.Capacity);
+            Assert.Equal($"line-{GodotLogCollector.Capacity + 49}", rows[0].Message);
+            Assert.Equal($"line-50", rows[GodotLogCollector.Capacity - 1].Message);
+        }
+
+        [Fact]
+        public void Clear_EmptiesBuffer_AndIsHarmlessTwice()
+        {
+            var collector = new GodotLogCollector();
+            collector.Append(GodotLogType.Log, "x");
+            collector.Clear();
+            collector.Clear(); // idempotent
+
+            Assert.Equal(0, collector.Count);
+            Assert.Empty(collector.Query());
+        }
+
+        // ---- Current swap semantics ---------------------------------------------------------------
+
+        [Fact]
+        public void GetOrCreate_InstallsOnce_AndReusesSameInstance()
+        {
+            Assert.Null(GodotLogCollector.Current);
+
+            var a = GodotLogCollector.GetOrCreate();
+            var b = GodotLogCollector.GetOrCreate();
+
+            Assert.Same(a, b);
+            Assert.Same(a, GodotLogCollector.Current);
+        }
+
+        [Fact]
+        public void Current_ReadsBackWhatWasWritten()
+        {
+            var first = new GodotLogCollector();
+            GodotLogCollector.Current = first;
+            Assert.Same(first, GodotLogCollector.Current);
+
+            // A new install (the _EnterTree case) replaces it last-writer-wins.
+            var second = new GodotLogCollector();
+            GodotLogCollector.Current = second;
+            Assert.Same(second, GodotLogCollector.Current);
+        }
+
+        [Fact]
+        public void TeardownLeavesBufferReadable_ReinstallReplaces()
+        {
+            // Model the plugin lifecycle: _EnterTree installs a buffer, lines are captured, then teardown
+            // happens. Issue #173: teardown must NOT null Current — the buffer stays readable so
+            // console-get-logs still surfaces the teardown-window diagnostics. (The plugin no longer assigns
+            // null; this test pins the OBSERVABLE contract — a previously-installed buffer remains queryable
+            // and is only displaced by the next install.)
+            var session1 = new GodotLogCollector();
+            GodotLogCollector.Current = session1;
+            session1.Append(GodotLogType.Error, "teardown-window failure");
+
+            // ... teardown runs here in the real plugin; it deliberately does nothing to Current ...
+
+            Assert.NotNull(GodotLogCollector.Current);
+            Assert.Same(session1, GodotLogCollector.Current);
+            Assert.Equal("teardown-window failure", GodotLogCollector.Current!.Query()[0].Message);
+
+            // Next _EnterTree installs a fresh buffer; only THEN is the old one displaced.
+            var session2 = new GodotLogCollector();
+            GodotLogCollector.Current = session2;
+            Assert.Same(session2, GodotLogCollector.Current);
+            Assert.Empty(GodotLogCollector.Current!.Query());
+        }
+
+        // ---- Concurrency: background Append while main thread swaps Current -------------------------
+
+        [Fact]
+        public async Task BackgroundAppend_WhileMainThreadSwapsCurrent_NoTornReads_NoCrash()
+        {
+            // Reproduce the issue #173 race: a background thread continuously routes log lines through
+            // GodotLogCollector.Current?.Append(...) (exactly what RouteFrameworkLog / Log* do off-thread)
+            // while the "main thread" repeatedly swaps Current to a freshly installed buffer (the _EnterTree
+            // path). The Volatile read/write contract must guarantee the reader only ever observes a valid,
+            // fully-constructed collector reference (or null between the initial state and the first install)
+            // — never a torn reference — and the loop must complete without an exception.
+            const int swaps = 200;
+            const int appendThreads = 4;
+
+            GodotLogCollector.Current = new GodotLogCollector();
+
+            using var cts = new CancellationTokenSource();
+            Exception? readerFault = null;
+            long appendsObserved = 0;
+
+            var readers = Enumerable.Range(0, appendThreads).Select(_ => Task.Run(() =>
+            {
+                try
+                {
+                    var token = cts.Token;
+                    while (!token.IsCancellationRequested)
+                    {
+                        // The exact off-thread shape from RouteFrameworkLog: null-conditional Append on the
+                        // volatile static. A torn read here would surface as an AccessViolation / bad ref.
+                        var current = GodotLogCollector.Current;
+                        current?.Append(GodotLogType.Log, "bg");
+                        if (current != null)
+                            Interlocked.Increment(ref appendsObserved);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Volatile.Write(ref readerFault, ex);
+                }
+            })).ToArray();
+
+            // Main thread: install a fresh collector repeatedly (the _EnterTree swap), interleaved with the
+            // background Append storm.
+            await Task.Run(() =>
+            {
+                for (int i = 0; i < swaps; i++)
+                {
+                    GodotLogCollector.Current = new GodotLogCollector();
+                    Thread.SpinWait(50);
+                }
+            });
+
+            cts.Cancel();
+            await Task.WhenAll(readers);
+
+            Assert.Null(readerFault);                 // no torn read / no crash on any reader thread
+            Assert.True(appendsObserved > 0);         // the readers actually exercised the path
+            Assert.NotNull(GodotLogCollector.Current); // never nulled out from under the readers
+        }
+
+        [Fact]
+        public void ConcurrentAppend_SingleCollector_NoLostWritesPastCapacity()
+        {
+            // The buffer's own lock must serialize concurrent Append so the count never exceeds Capacity and
+            // the structure is never corrupted under parallel producers (the other half of the issue: the
+            // single shared collector is written from many threads).
+            var collector = new GodotLogCollector();
+            const int threads = 8;
+            const int perThread = 500;
+
+            Parallel.For(0, threads, t =>
+            {
+                for (int i = 0; i < perThread; i++)
+                    collector.Append(GodotLogType.Log, $"t{t}-{i}");
+            });
+
+            // Total appended (4000) far exceeds Capacity, so the bounded buffer must be exactly full and
+            // internally consistent (Query does not throw, returns Capacity rows).
+            Assert.Equal(GodotLogCollector.Capacity, collector.Count);
+            var rows = collector.Query(maxEntries: GodotLogCollector.Capacity);
+            Assert.Equal(GodotLogCollector.Capacity, rows.Length);
+            Assert.All(rows, r => Assert.False(string.IsNullOrEmpty(r.Message)));
+        }
+    }
+
+    /// <summary>
+    /// Dedicated xUnit collection so <see cref="GodotLogCollectorTests"/> runs in isolation: it mutates the
+    /// process-wide <see cref="GodotLogCollector.Current"/> static, which would race other test classes if
+    /// run in the default parallel collection.
+    /// </summary>
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public sealed class GodotLogCollectorCurrentCollection
+    {
+        public const string Name = "GodotLogCollector.Current (serial)";
+    }
+}

--- a/addons/godot_mcp/Editor/GodotMcpPlugin.cs
+++ b/addons/godot_mcp/Editor/GodotMcpPlugin.cs
@@ -298,8 +298,11 @@ namespace com.IvanMurzak.Godot.MCP
         ///   if it ever runs off-main-thread the (pure-managed) steps 1–3 still run and the Node frees are
         ///   skipped rather than crashing. We do NOT marshal through <see cref="MainThreadDispatcher"/> — it
         ///   is being torn down and its <c>Enqueue</c> throws once its instance is gone.</item>
-        ///   <item><b>Null the process-wide statics</b> — log collector, error-capture router, and the
-        ///   <see cref="Current"/>/<see cref="GodotMcpAssemblyResolver.ReloadTeardown"/> hook.</item>
+        ///   <item><b>Null the process-wide statics</b> — error-capture router and the
+        ///   <see cref="Current"/>/<see cref="GodotMcpAssemblyResolver.ReloadTeardown"/> hook. The log
+        ///   collector (<see cref="GodotLogCollector.Current"/>) is deliberately NOT nulled — leaving its
+        ///   bounded managed buffer readable preserves teardown/reload-window diagnostics for
+        ///   <c>console-get-logs</c>, and the next <c>_EnterTree</c> replaces it.</item>
         /// </list>
         /// </para>
         /// </summary>
@@ -378,8 +381,15 @@ namespace com.IvanMurzak.Godot.MCP
 
             TryLog("[Godot-MCP] plugin unloaded");
 
-            // 5) Null the process-wide statics so a stale buffer/router/hook does not outlive this instance.
-            try { GodotLogCollector.Current = null; } catch { /* swallow during unload */ }
+            // 5) Null the process-wide statics so a stale router/hook does not outlive this instance.
+            //    NOTE: GodotLogCollector.Current is DELIBERATELY left in place — see below. Nulling the log
+            //    buffer here would wipe exactly the teardown / reload-window diagnostics an operator most
+            //    wants (the background framework log-routing path reads Current?.Append off arbitrary threads;
+            //    a null would silently drop those lines). The buffer is harmless to leave: it is a bounded
+            //    ring of plain managed LogEntry rows, it pins no Godot native object / no collectible-ALC type,
+            //    and the next _EnterTree replaces it (last-writer-wins) so it cannot accumulate across reloads.
+            //    The Current swap itself is Volatile (GodotLogCollector.Current) so the background reader sees
+            //    the install without a torn read.
 
             // Drop the engine error-capture router unconditionally. On 4.5+ the main-thread guard above already
             // called GodotScriptErrorLoggerBridge.Uninstall() (which removes the engine Logger via

--- a/addons/godot_mcp/Editor/GodotMcpPlugin.cs
+++ b/addons/godot_mcp/Editor/GodotMcpPlugin.cs
@@ -300,9 +300,15 @@ namespace com.IvanMurzak.Godot.MCP
         ///   is being torn down and its <c>Enqueue</c> throws once its instance is gone.</item>
         ///   <item><b>Null the process-wide statics</b> — error-capture router and the
         ///   <see cref="Current"/>/<see cref="GodotMcpAssemblyResolver.ReloadTeardown"/> hook. The log
-        ///   collector (<see cref="GodotLogCollector.Current"/>) is deliberately NOT nulled — leaving its
-        ///   bounded managed buffer readable preserves teardown/reload-window diagnostics for
-        ///   <c>console-get-logs</c>, and the next <c>_EnterTree</c> replaces it.</item>
+        ///   collector (<see cref="GodotLogCollector.Current"/>) is the one exception: it is deliberately
+        ///   NOT nulled. Nulling it here would wipe exactly the teardown / reload-window diagnostics an
+        ///   operator most wants — the background framework log-routing path reads <c>Current?.Append</c>
+        ///   off arbitrary threads, so a null would silently drop those lines (issue #173). Leaving it is
+        ///   harmless: it is a bounded ring of plain managed <c>LogEntry</c> rows, it pins no Godot native
+        ///   object and no collectible-ALC type, and the next <c>_EnterTree</c> replaces it
+        ///   (last-writer-wins) so it cannot accumulate across reloads. The swap is published via Volatile
+        ///   (<see cref="GodotLogCollector.Current"/>) so the background reader observes the install without
+        ///   a torn read.</item>
         /// </list>
         /// </para>
         /// </summary>
@@ -382,14 +388,8 @@ namespace com.IvanMurzak.Godot.MCP
             TryLog("[Godot-MCP] plugin unloaded");
 
             // 5) Null the process-wide statics so a stale router/hook does not outlive this instance.
-            //    NOTE: GodotLogCollector.Current is DELIBERATELY left in place — see below. Nulling the log
-            //    buffer here would wipe exactly the teardown / reload-window diagnostics an operator most
-            //    wants (the background framework log-routing path reads Current?.Append off arbitrary threads;
-            //    a null would silently drop those lines). The buffer is harmless to leave: it is a bounded
-            //    ring of plain managed LogEntry rows, it pins no Godot native object / no collectible-ALC type,
-            //    and the next _EnterTree replaces it (last-writer-wins) so it cannot accumulate across reloads.
-            //    The Current swap itself is Volatile (GodotLogCollector.Current) so the background reader sees
-            //    the install without a torn read.
+            //    NOTE: GodotLogCollector.Current is DELIBERATELY left in place (NOT nulled) — see the
+            //    "Null the process-wide statics" item in this method's XML doc for the full rationale (#173).
 
             // Drop the engine error-capture router unconditionally. On 4.5+ the main-thread guard above already
             // called GodotScriptErrorLoggerBridge.Uninstall() (which removes the engine Logger via

--- a/addons/godot_mcp/Runtime/Tools/GodotLogCollector.cs
+++ b/addons/godot_mcp/Runtime/Tools/GodotLogCollector.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using com.IvanMurzak.Godot.MCP.Data;
 
 namespace com.IvanMurzak.Godot.MCP.Tools
@@ -43,16 +44,48 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         readonly object _gate = new();
         readonly Queue<LogEntry> _entries = new(Capacity);
 
+        /// <summary>Backing field for <see cref="Current"/>; accessed only through Volatile read/write.</summary>
+        static GodotLogCollector? _current;
+
         /// <summary>
         /// Process-wide collector used by the plugin's logging path and read by the <c>console-*</c>
-        /// tools. Assigned once at editor boot; tools fall back to a fresh empty collector via
-        /// <see cref="GetOrCreate"/> when the plugin has not booted (e.g. a direct unit call), so the
-        /// tool layer never hard-depends on the editor lifecycle.
+        /// tools. Assigned at editor boot (each <c>_EnterTree</c> installs a fresh buffer) and read by
+        /// the framework log-routing path (<c>GodotMcpConnection.RouteFrameworkLog</c> + the plugin
+        /// <c>Log*</c> helpers), which run on ARBITRARY background threads. The reference swap therefore
+        /// goes through <see cref="Volatile.Write{T}(ref T, T)"/> and reads go through
+        /// <see cref="Volatile.Read{T}(ref T)"/> so the transition is published without torn reads and
+        /// is immediately visible to the background readers — a plain auto-property would expose the
+        /// reader to a stale/torn reference on a weak memory model.
+        ///
+        /// <para>
+        /// Deliberately NOT nulled on teardown: nulling here would wipe the buffer exactly when the
+        /// teardown / reload-window diagnostics matter most (the reader would see <c>null</c> and silently
+        /// drop those lines). Instead the buffer stays readable until the next <c>_EnterTree</c> installs a
+        /// new one (last-writer-wins), so <c>console-get-logs</c> can still surface the most recent session's
+        /// lines after a plugin disable / hot-reload.
+        /// </para>
         /// </summary>
-        public static GodotLogCollector? Current { get; set; }
+        public static GodotLogCollector? Current
+        {
+            get => Volatile.Read(ref _current);
+            set => Volatile.Write(ref _current, value);
+        }
 
-        /// <summary>Return <see cref="Current"/> when set, otherwise a fresh empty collector.</summary>
-        public static GodotLogCollector GetOrCreate() => Current ??= new GodotLogCollector();
+        /// <summary>
+        /// Return <see cref="Current"/> when set, otherwise atomically install a fresh empty collector and
+        /// return it. Uses <see cref="Interlocked.CompareExchange{T}(ref T, T, T)"/> so two concurrent
+        /// callers cannot each publish a different buffer (the loser discards its candidate and adopts the
+        /// winner's), keeping a single process-wide collector even under a race.
+        /// </summary>
+        public static GodotLogCollector GetOrCreate()
+        {
+            var existing = Volatile.Read(ref _current);
+            if (existing != null)
+                return existing;
+
+            var candidate = new GodotLogCollector();
+            return Interlocked.CompareExchange(ref _current, candidate, null) ?? candidate;
+        }
 
         /// <summary>Append a captured line, evicting the oldest when at <see cref="Capacity"/>.</summary>
         public void Append(LogEntry entry)


### PR DESCRIPTION
## Summary
- `console-get-logs` silently dropped teardown / reload-window diagnostics because `GodotLogCollector.Current` was a plain auto-property nulled at `GodotMcpPlugin.Teardown`, while the framework log-routing path reads `Current?.Append(...)` off arbitrary background threads. Stop nulling it on teardown — the buffer (a bounded ring of plain managed `LogEntry` rows, pinning no Godot native object / no collectible-ALC type) stays readable until the next `_EnterTree` replaces it (last-writer-wins).
- Back `Current` with a private field accessed via `Volatile.Read`/`Volatile.Write` so the reference swap is published without torn reads and is immediately visible to the background readers. `GetOrCreate` installs via `Interlocked.CompareExchange` so concurrent first-callers can't publish different buffers.
- No `console-get-logs` / `clear-logs` / enable-disable behavior change. No NuGet pin changes.

## Test plan
- [x] Target-specific local tests passed (see profile test.md): `dotnet build Godot-MCP.sln` 0 errors; `dotnet test` 843 passed / 1 failed (the whitelisted benign Windows-only `GodotAssemblyUtilsTests` temp-DLL `UnauthorizedAccessException` cleanup — green on Linux CI).
- [x] New `GodotLogCollectorTests` (8 tests, all pass): ring-buffer basics, the teardown-leaves-buffer-readable contract, and a background-`Append` storm while the main thread swaps `Current` asserting no torn reads / no crash / never nulled out from under the readers.

Closes #173