### PR TITLE
test: de-flake GodotAssemblyUtilsTests temp-DLL cleanup on Windows

### DIFF
--- a/Godot-MCP.Tests/GodotAssemblyUtilsTests.cs
+++ b/Godot-MCP.Tests/GodotAssemblyUtilsTests.cs
@@ -34,16 +34,27 @@ namespace com.IvanMurzak.Godot.MCP.Tests
     /// <see cref="AppDomain.GetAssemblies"/>. Pure-BCL, CI-friendly (no Godot binary needed).
     /// </para>
     /// </summary>
-    public class GodotAssemblyUtilsTests
+    public class GodotAssemblyUtilsTests : IClassFixture<GodotAssemblyUtilsTests.AlcProbeTempDir>
     {
+        private readonly AlcProbeTempDir _tempDir;
+
+        public GodotAssemblyUtilsTests(AlcProbeTempDir tempDir)
+        {
+            _tempDir = tempDir;
+        }
+
         [Fact]
         public void AllAssemblies_IncludesAssemblyLoadedInNonDefaultContext()
         {
             // Simulate Godot's plugin context: load a copy of this test assembly into a fresh
             // collectible ALC (a copy, so the path differs and the load is not deduplicated into
             // an already-loaded assembly identity).
+            //
+            // The copy lands in a per-run temp SUBDIRECTORY (not bare %TEMP%), so that any DLL the
+            // OS still has memory-mapped after alc.Unload() is reaped wholesale at class teardown
+            // (AlcProbeTempDir.Dispose) and %TEMP% never accumulates orphaned alc-probe-*.dll.
             var sourcePath = typeof(GodotAssemblyUtilsTests).Assembly.Location;
-            var copyPath = Path.Combine(Path.GetTempPath(), $"alc-probe-{Guid.NewGuid():N}.dll");
+            var copyPath = Path.Combine(_tempDir.Path, $"alc-probe-{Guid.NewGuid():N}.dll");
             File.Copy(sourcePath, copyPath);
 
             var alc = new AssemblyLoadContext($"test-plugin-context-{Guid.NewGuid():N}", isCollectible: true);
@@ -57,7 +68,76 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             finally
             {
                 alc.Unload();
-                try { File.Delete(copyPath); } catch (IOException) { /* still mapped; temp cleanup */ }
+                BestEffortDeleteAfterUnload(copyPath);
+            }
+        }
+
+        /// <summary>
+        /// Best-effort delete of the ALC-loaded probe DLL after <see cref="AssemblyLoadContext.Unload"/>.
+        /// <para>
+        /// <c>alc.Unload()</c> is ASYNCHRONOUS — the collectible context is only torn down once the GC
+        /// reclaims it, so immediately after the call the copied DLL is typically still memory-mapped.
+        /// On Windows a delete of a mapped file throws <see cref="UnauthorizedAccessException"/> (a SIBLING
+        /// of <see cref="IOException"/>, NOT a subclass — so the original <c>catch (IOException)</c> let it
+        /// escape and fail the test). We force the collection that frees the ALC, then retry the delete a
+        /// few times, and swallow BOTH exception types: cleanup is best-effort and must NEVER fail the test.
+        /// Whatever survives here is reaped at class teardown by <see cref="AlcProbeTempDir.Dispose"/>.
+        /// </para>
+        /// </summary>
+        private static void BestEffortDeleteAfterUnload(string copyPath)
+        {
+            // Force the GC pass that actually frees the collectible ALC and unmaps the DLL.
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            for (var attempt = 0; attempt < 5; attempt++)
+            {
+                try
+                {
+                    File.Delete(copyPath);
+                    return;
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+                {
+                    // Still mapped (Windows: UnauthorizedAccessException after an async Unload). Retry;
+                    // if it never unmaps in-process, the temp-dir teardown reaps it on a later run.
+                    System.Threading.Thread.Sleep(20);
+                }
+            }
+        }
+
+        /// <summary>
+        /// xUnit class fixture: owns a per-run temp subdirectory for the ALC probe DLLs and best-effort
+        /// deletes the WHOLE directory at class teardown. A DLL the OS still has memory-mapped when the
+        /// individual delete in <see cref="BestEffortDeleteAfterUnload"/> gave up is reaped here (or, if
+        /// still locked, on the next run that recreates the dir) — so %TEMP% never grows alc-probe-*.dll.
+        /// </summary>
+        public sealed class AlcProbeTempDir : IDisposable
+        {
+            public string Path { get; }
+
+            public AlcProbeTempDir()
+            {
+                Path = System.IO.Path.Combine(
+                    System.IO.Path.GetTempPath(), $"godot-mcp-alc-probe-{Guid.NewGuid():N}");
+                Directory.CreateDirectory(Path);
+            }
+
+            public void Dispose()
+            {
+                // Best-effort: a still-mapped DLL must not throw out of teardown.
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+                try
+                {
+                    Directory.Delete(Path, recursive: true);
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+                {
+                    // Leave it for the next run / OS temp cleaner; never fail the suite on teardown.
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- `AllAssemblies_IncludesAssemblyLoadedInNonDefaultContext` previously deleted the ALC-loaded probe DLL inside `catch (IOException)` only. Because `alc.Unload()` is asynchronous, on Windows the still-mapped DLL throws `UnauthorizedAccessException` (a sibling of `IOException`, not a subclass), which escaped the catch and failed the test; even the happy path leaked `alc-probe-*.dll` into `%TEMP%`. This was the single whitelisted "benign Windows-only" failure.
- Cleanup-robustness fix only — the assertion under test is unchanged: copy the probe DLL into a per-run temp subdirectory (`IClassFixture`); after `alc.Unload()` force `GC.Collect()`/`WaitForPendingFinalizers()`/`Collect()` then delete in a short retry loop swallowing both `IOException` and `UnauthorizedAccessException`; best-effort-delete the whole temp dir at class teardown so a still-mapped file is reaped on a later run and `%TEMP%` never accumulates.
- No NuGet pin changes.

## Test plan
- [x] `dotnet build` 0 errors (Suite 1).
- [x] `dotnet test` full suite: 844/844 pass, 0 failures (was 843 pass / 1 fail — this test was the whitelisted benign Windows failure, now green).
- [x] 10x local Windows runs of `GodotAssemblyUtilsTests`: zero failures, zero `%TEMP%`/per-run-dir growth on every run (bare `%TEMP%` flat, per-run subdir reaped at teardown).

Closes #175