### PR TITLE
docs(security): document token-at-rest + runtime-error disclosure; assert DevControl env-gate

### DIFF
--- a/Godot-MCP.Tests/DevControlGateTests.cs
+++ b/Godot-MCP.Tests/DevControlGateTests.cs
@@ -1,0 +1,104 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using com.IvanMurzak.Godot.MCP.Connection.DevControl;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the load-bearing env gate for the DEV-ONLY inject/control bridge (<see cref="DevControlGate"/>).
+    /// The bridge (<c>DevControlServer</c>, <c>#if TOOLS</c> + 127.0.0.1) is UNAUTHENTICATED; its only security
+    /// boundary is that it is constructed/started ONLY when <c>GODOT_MCP_DEV_CONTROL</c> is exactly <c>"1"</c>.
+    /// These tests guarantee that contract is provably load-bearing: the predicate fails closed for every
+    /// non-<c>"1"</c> value, and the construction-site guard throws when the gate is off — so a regression that
+    /// wires DevControl on without the env var fails fast (here in CI, and at runtime construction).
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>), so it runs in the plain-xUnit CI host.
+    /// </summary>
+    public class DevControlGateTests
+    {
+        // --- IsEnabled: only exactly "1" (optionally whitespace-padded) is ON ---
+
+        [Fact]
+        public void IsEnabled_ExactlyOne_IsTrue()
+        {
+            Assert.True(DevControlGate.IsEnabled("1"));
+            Assert.Equal("1", DevControlGate.EnabledValue);
+        }
+
+        [Theory]
+        [InlineData(" 1")]
+        [InlineData("1 ")]
+        [InlineData("\t1\n")]
+        public void IsEnabled_OneWithSurroundingWhitespace_IsTrue(string value)
+        {
+            // The boot site forwards the env/.env value; surrounding whitespace must not flip a real "1" to OFF.
+            Assert.True(DevControlGate.IsEnabled(value));
+        }
+
+        [Theory]
+        [InlineData(null)]       // unset env var → OFF (the default, shipped-addon posture)
+        [InlineData("")]         // empty → OFF
+        [InlineData("0")]        // explicit disable → OFF
+        [InlineData("2")]        // any other number → OFF
+        [InlineData("true")]     // truthy-looking but NOT the contract → OFF (fail closed)
+        [InlineData("TRUE")]
+        [InlineData("yes")]
+        [InlineData("on")]
+        [InlineData("11")]       // must not substring/prefix-match "1"
+        [InlineData("1x")]
+        [InlineData(" 1 0 ")]
+        [InlineData("enabled")]
+        public void IsEnabled_AnythingButOne_IsFalse(string? value)
+        {
+            // Fail closed: every value other than exactly "1" leaves the unauthenticated bridge OFF. This is the
+            // core anti-fail-open guarantee — a stray/garbage env value can never silently enable the surface.
+            Assert.False(DevControlGate.IsEnabled(value));
+        }
+
+        // --- AssertEnabledOrThrow: the construction-site guard ---
+
+        [Fact]
+        public void AssertEnabledOrThrow_WhenEnabled_DoesNotThrow()
+        {
+            // The normal-operation path: gate is on → construction proceeds (no throw).
+            DevControlGate.AssertEnabledOrThrow("1");
+            DevControlGate.AssertEnabledOrThrow(" 1 ");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("0")]
+        [InlineData("true")]
+        [InlineData("yes")]
+        public void AssertEnabledOrThrow_WhenDisabled_ThrowsFailFast(string? value)
+        {
+            // The load-bearing assertion: reaching the DevControlServer construction path with the gate OFF is a
+            // regression and must fail fast rather than open an unauthenticated loopback control surface. This is
+            // what would catch a future refactor that drops/reorders the boot-site early-return.
+            Assert.Throws<InvalidOperationException>(() => DevControlGate.AssertEnabledOrThrow(value));
+        }
+
+        [Fact]
+        public void AssertEnabledOrThrow_IsConsistentWithIsEnabled()
+        {
+            // The guard's throw/no-throw decision is exactly the predicate — one source of truth, no drift.
+            foreach (var value in new string?[] { null, "", "0", "1", " 1 ", "2", "true", "yes", "on", "11" })
+            {
+                if (DevControlGate.IsEnabled(value))
+                    DevControlGate.AssertEnabledOrThrow(value); // must not throw
+                else
+                    Assert.Throws<InvalidOperationException>(() => DevControlGate.AssertEnabledOrThrow(value));
+            }
+        }
+    }
+}

--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -246,6 +246,11 @@
          target vocabulary. The editor HttpListener transport (DevControlServer.cs) is #if TOOLS and verified
          live (curl the editor), NOT compiled here; the routing/parsing core is unit-tested here. -->
     <Compile Include="..\addons\godot_mcp\Editor\Connection\DevControl\DevControlRouter.cs" Link="Source\DevControlRouter.cs" />
+    <!-- DEV-ONLY inject/control bridge ENV GATE — pure-managed (no Godot native types, no #if TOOLS): the
+         load-bearing "GODOT_MCP_DEV_CONTROL must be exactly 1" predicate + construction-site guard. The bridge
+         (DevControlServer.cs) is unauthenticated and #if TOOLS / loopback-only; this gate is its security
+         boundary, so the predicate + assert are unit-tested here (DevControlGateTests) to keep it load-bearing. -->
+    <Compile Include="..\addons\godot_mcp\Editor\Connection\DevControl\DevControlGate.cs" Link="Source\DevControlGate.cs" />
     <!-- Runtime (in-game) entry point — pure-managed builder accumulation + handle wrapper (no #if TOOLS).
          GodotMcpRuntimeBuilder is fully pure-managed (config-action / tool-type accumulation) and is what
          these unit tests exercise. GodotMcpRuntime.Build()/GodotMcpRuntimeHandle make native Godot + SignalR

--- a/README.md
+++ b/README.md
@@ -615,6 +615,16 @@ An MCP client polls the captured errors with the `runtime-errors-get` tool (and 
 > **strictly opt-in** — without `WithRuntimeErrorCapture()` nothing is hooked and there is no behavior
 > change. Disposing the handle (`handle.Dispose()`) uninstalls the hooks.
 
+> ⚠️ **Security — information disclosure.** Captured errors forward the **full** message and (for C#
+> faults) the **full managed stack trace** to the connected agent through `runtime-errors-get`. Those
+> strings can embed sensitive runtime data — absolute filesystem paths, machine/user names, query
+> strings, or a secret/token that happened to appear in an exception message or argument. That is the
+> intended diagnostic value, but it widens what is exposed over the connection. Enable
+> `WithRuntimeErrorCapture()` **only on a trusted connection**: a loopback host (`http://localhost:…` /
+> `127.0.0.1`) with `AuthOption = GodotMcpAuthOption.Required` and a real token — never an
+> unauthenticated public interface in a release build. See [Security](#security-opt-in-only-default-off)
+> and [`docs/runtime-security.md`](docs/runtime-security.md).
+
 ## Sample: a live game-state tool
 
 A runtime tool is written exactly like an editor tool — a `partial class` decorated `[AiToolType]`, each
@@ -795,6 +805,31 @@ tools can do, a connected MCP client can drive. Godot-MCP's runtime is built so 
   (`http://localhost:…` / `127.0.0.1`) and set `AuthOption = GodotMcpAuthOption.Required` with a real
   `Token`. Avoid exposing the connection on a public interface in a release build unless you have
   explicitly designed and secured that surface.
+- **Runtime-error capture forwards sensitive data.** `WithRuntimeErrorCapture()` is **OFF by default**.
+  When enabled, captured messages and stack traces are sent verbatim to the connected agent via
+  `runtime-errors-get` and may contain absolute paths, machine/user names, or a secret that appeared in
+  an exception — so enable it only on a trusted loopback + token connection (full note under
+  [Capturing in-game runtime errors](#capturing-in-game-runtime-errors)).
+
+### Editor-side security notes (accepted posture)
+
+The points above are about a **game build**. Two editor-side surfaces are documented here for completeness;
+both are **by design** today:
+
+- **Editor token storage is plaintext at rest.** When you connect the editor plugin (Cloud device-auth or
+  a Custom-mode token), the plugin persists your connection config — including the bearer token (`token`)
+  and Cloud token (`cloudToken`) — as **plaintext JSON** in `user://godot-mcp-config.json` (resolved per
+  Godot's `user://` data directory). It is **not** encrypted or stored in an OS keystore. The trust
+  assumption is the **local user account**: anyone with read access to your user data directory can read
+  the token. Treat that file as a secret — don't commit it, sync it, or share it. To rotate, clear the
+  saved token in the dock (or delete the file) and reconnect. (Process-env / `.env` overrides via
+  `GODOT_MCP_TOKEN` always shadow the persisted value and are not written back to this file.)
+- **The dev-control bridge is unauthenticated but gated OFF.** A development-only inject/control HTTP
+  bridge exists for driving the editor dock in tests. It is **unauthenticated**, but its security boundary
+  is threefold: it is editor-only (`#if TOOLS`, never compiled into a game), binds **`127.0.0.1`** only,
+  and starts **only when `GODOT_MCP_DEV_CONTROL=1`** — a shipped addon (and any editor session without the
+  env var) never listens. That env gate is load-bearing and enforced by a unit test + a boot-time
+  assertion, so it can never silently ship enabled.
 
 A short standalone copy of this contract lives in
 [`docs/runtime-security.md`](docs/runtime-security.md).

--- a/addons/godot_mcp/Editor/Connection/DevControl/DevControlGate.cs
+++ b/addons/godot_mcp/Editor/Connection/DevControl/DevControlGate.cs
@@ -1,0 +1,66 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+
+namespace com.IvanMurzak.Godot.MCP.Connection.DevControl
+{
+    /// <summary>
+    /// PURE-MANAGED (no Godot native types, no <c>#if TOOLS</c>) env-gate for the DEV-ONLY inject/control
+    /// HTTP bridge (<see cref="DevControlServer"/>). The bridge is <b>unauthenticated</b> — its ONLY security
+    /// boundary is (a) the <c>127.0.0.1</c> loopback bind, (b) the <c>#if TOOLS</c> editor-only compilation,
+    /// and (c) this env gate: it is constructed/started ONLY when the <c>GODOT_MCP_DEV_CONTROL</c> variable is
+    /// truthy. If that gate ever silently failed open, a shipped/editor session would expose an
+    /// unauthenticated control surface that can drive the live dock. The gate is therefore <b>load-bearing</b>
+    /// and is pinned by a unit test (<c>DevControlGateTests</c>) so a regression that wires DevControl on
+    /// without the env var fails fast — at construction (<see cref="AssertEnabledOrThrow"/>) and in CI.
+    ///
+    /// <para>
+    /// The boot site (<c>GodotMcpPlugin.StartDevControlIfEnabled</c>) resolves the variable with the standard
+    /// precedence (process env &gt; project-root <c>.env</c> &gt; default) and passes the resolved raw string
+    /// here; this class makes no I/O and reads no env itself, so it is CI-unit-testable in the plain-xUnit host
+    /// (mirrors how <see cref="DevControlRouter"/> holds the bridge's pure routing logic).
+    /// </para>
+    /// </summary>
+    public static class DevControlGate
+    {
+        /// <summary>The canonical truthy value of <c>GODOT_MCP_DEV_CONTROL</c> that enables the bridge.</summary>
+        public const string EnabledValue = "1";
+
+        /// <summary>
+        /// The single source of truth for "is the dev-control bridge enabled?". Returns <c>true</c> ONLY when
+        /// <paramref name="devControlValue"/> (the resolved <c>GODOT_MCP_DEV_CONTROL</c> value) is exactly
+        /// <c>"1"</c> after trimming surrounding whitespace — every other value (null, empty, <c>"0"</c>,
+        /// <c>"true"</c>, <c>"yes"</c>, anything else) is OFF. Deliberately strict: "exactly 1" is the documented
+        /// contract (see <see cref="DevControlServer"/> / README) and a strict predicate cannot be tricked into
+        /// failing open by a stray/garbage value. Pure — no env read, no I/O, no Godot types.
+        /// </summary>
+        public static bool IsEnabled(string? devControlValue)
+            => string.Equals(devControlValue?.Trim(), EnabledValue, StringComparison.Ordinal);
+
+        /// <summary>
+        /// Boot-time guard for the <see cref="DevControlServer"/> construction path. Throws
+        /// <see cref="InvalidOperationException"/> when <see cref="IsEnabled"/> is <c>false</c> for
+        /// <paramref name="devControlValue"/>. The boot site already early-returns when the gate is off, so in
+        /// normal operation this never throws; its job is to make the env gate <b>provably load-bearing</b> — a
+        /// future refactor that reorders or drops the early-return and reaches the construction site with the
+        /// gate off trips this assertion immediately (fail-fast) instead of silently opening an unauthenticated
+        /// loopback control surface. Pure — no env read, no I/O, no Godot types.
+        /// </summary>
+        public static void AssertEnabledOrThrow(string? devControlValue)
+        {
+            if (!IsEnabled(devControlValue))
+                throw new InvalidOperationException(
+                    "DevControlServer must never be constructed unless GODOT_MCP_DEV_CONTROL is truthy " +
+                    "(exactly \"1\"). The dev-control bridge is unauthenticated; this env gate is its security " +
+                    "boundary and must stay load-bearing. Reaching this path with the gate off is a regression.");
+        }
+    }
+}

--- a/addons/godot_mcp/Editor/GodotMcpPlugin.cs
+++ b/addons/godot_mcp/Editor/GodotMcpPlugin.cs
@@ -234,7 +234,11 @@ namespace com.IvanMurzak.Godot.MCP
                 return !string.IsNullOrEmpty(fromProcess) ? fromProcess : GodotMcpEnvFile.LookupRaw(envPath, key);
             }
 
-            if (ResolveDevVar(GodotMcpEnv.DevControl) != "1")
+            // The dev-control bridge is UNAUTHENTICATED; this env gate (plus the 127.0.0.1 bind and #if TOOLS)
+            // is its only security boundary. Resolve once and gate through the pure, unit-pinned predicate so the
+            // "exactly 1 enables it" contract lives in one CI-testable place (DevControlGate).
+            var devControlValue = ResolveDevVar(GodotMcpEnv.DevControl);
+            if (!DevControlGate.IsEnabled(devControlValue))
                 return;
 
             if (_dock == null)
@@ -250,6 +254,12 @@ namespace com.IvanMurzak.Godot.MCP
 
             try
             {
+                // Load-bearing assertion: the env gate MUST hold at the construction site. The early-return
+                // above already guarantees it, so this never throws in normal operation — its purpose is to make
+                // the gate provably load-bearing, so any future refactor that reaches here with the gate off
+                // fails fast instead of opening an unauthenticated loopback control surface. (DevControlGateTests
+                // pins this.)
+                DevControlGate.AssertEnabledOrThrow(devControlValue);
                 _devControl = new DevControlServer(_dock, port);
                 _devControl.Start();
             }

--- a/addons/godot_mcp/Runtime/GodotMcpRuntimeBuilder.cs
+++ b/addons/godot_mcp/Runtime/GodotMcpRuntimeBuilder.cs
@@ -231,6 +231,18 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
         /// tool once (the builder de-duplicates) and the runtime installs capture once.
         /// </para>
         ///
+        /// <para>
+        /// <b>SECURITY — information disclosure.</b> Captured errors forward the <em>full</em> exception
+        /// message and (for C# faults) the <em>full managed stack trace</em> to the connected MCP agent via
+        /// <c>runtime-errors-get</c>. Those strings can embed sensitive runtime data — absolute filesystem
+        /// paths, machine/user names, query strings, or a secret/token that happened to appear in an exception
+        /// message or argument. That is the intended diagnostic value, but it means enabling capture widens
+        /// the data exposed over the connection. Enable it <b>only on a trusted connection</b>: prefer a
+        /// loopback host (<c>http://localhost:…</c> / <c>127.0.0.1</c>) with <c>AuthOption =
+        /// GodotMcpAuthOption.Required</c> and a real token — never an unauthenticated public interface in a
+        /// release build. See <c>docs/runtime-security.md</c> and the README "Security: opt-in only" section.
+        /// </para>
+        ///
         /// Returns <c>this</c> for chaining.
         /// </summary>
         public GodotMcpRuntimeBuilder WithRuntimeErrorCapture()

--- a/addons/godot_mcp/Runtime/Tools/Tool_RuntimeErrors.Get.cs
+++ b/addons/godot_mcp/Runtime/Tools/Tool_RuntimeErrors.Get.cs
@@ -43,7 +43,11 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             "[{ sequence, message, type, source, file, line, function, stackTrace, frames, timestamp }] " +
             "oldest-first, counts, 'highestSequence' (poll with it next), and a 'truncated' flag. On Godot " +
             "4.5+ a GDScript runtime error also carries 'frames' (the deep multi-frame call stack, " +
-            "innermost-first, each { function, file, line }) and a formatted 'stackTrace'.")]
+            "innermost-first, each { function, file, line }) and a formatted 'stackTrace'.\n" +
+            "SECURITY: messages and stack traces are forwarded verbatim and may contain sensitive runtime " +
+            "data (absolute filesystem paths, machine/user names, or a secret that appeared in an exception). " +
+            "Capture is OFF by default and the developer must enable it via WithRuntimeErrorCapture(); enable " +
+            "it only on a trusted loopback + token connection.")]
         public RuntimeErrorsResult Get
         (
             [Description("Return only errors with a sequence number greater than this. Pass the previous " +

--- a/docs/runtime-security.md
+++ b/docs/runtime-security.md
@@ -60,6 +60,14 @@ for that mode. Read it before shipping a build that calls `GodotMcpRuntime.Initi
   reviewed decision.
 - **Do not embed long-lived secrets in the shipped binary.** Prefer `GODOT_MCP_TOKEN` from the
   environment over a hard-coded `config.Token` so the token is not extractable from the build.
+- **Enable runtime-error capture only on a trusted connection.** `builder.WithRuntimeErrorCapture()` is
+  **OFF by default**. When enabled, captured errors forward the **full** message and (for C# faults) the
+  **full managed stack trace** to the connected agent via the `runtime-errors-get` tool. Those strings can
+  embed sensitive runtime data — absolute filesystem paths, machine/user names, query strings, or a
+  secret/token that surfaced in an exception message or argument. That is the intended diagnostic value,
+  but it widens the data exposed over the connection. Enable it only on a loopback host with
+  `AuthOption = GodotMcpAuthOption.Required` and a real token — never on an unauthenticated public
+  interface in a release build.
 
 ## Environment variables
 
@@ -74,3 +82,42 @@ The runtime config (`GodotMcpConfig`) reads these `GODOT_MCP_*` variables live (
 | `GODOT_MCP_AUTH_OPTION` | `None` / `Required` | Whether Custom mode sends a bearer token. |
 | `GODOT_MCP_TOKEN` | string | The bearer token (routed to Cloud or Custom by the active mode). |
 | `GODOT_MCP_LOG_LEVEL` | `Trace` / `Debug` / `Info` / `Warning` / `Error` / `None` | Log-verbosity threshold. |
+
+## Editor-side surfaces (accepted posture)
+
+The contract above is for a **game build**. Two editor-side surfaces are documented here for completeness;
+both are **by design** today (no encryption / no shared-secret is implemented yet — those are deferred,
+parity-constrained decisions to coordinate across the Unity / Godot / Unreal siblings).
+
+### Editor token storage is plaintext at rest
+
+When you connect the **editor plugin** (Cloud device-auth, or a Custom-mode token), it persists your
+connection config to **`user://godot-mcp-config.json`** (Godot resolves `user://` to the per-platform user
+data directory via `ProjectSettings.GlobalizePath`). The bearer token (`token`) and Cloud token
+(`cloudToken`) are written as **plaintext JSON** — they are **not** encrypted and **not** stored in an OS
+keystore.
+
+- **Trust assumption: the local user account.** Anyone who can read your user data directory can read the
+  token. Treat `user://godot-mcp-config.json` as a secret — don't commit it, sync it to a shared drive, or
+  paste it.
+- **Rotation.** Clear the saved token in the dock (or delete the file) and reconnect.
+- **Precedence.** A `GODOT_MCP_TOKEN` process-env / `.env` value always shadows the persisted token at
+  resolution time and is **not** written back into this file — so a CI / shared machine can run without
+  ever persisting a token to disk.
+
+### The dev-control bridge is unauthenticated but gated OFF
+
+A development-only inject/control HTTP bridge (`DevControlServer`) exists for driving the editor dock from
+tests / a terminal. It is **unauthenticated**, but its security boundary is threefold:
+
+1. **Editor-only.** It is compiled behind `#if TOOLS`, so it does not exist in an exported game build.
+2. **Loopback-only.** It binds **`127.0.0.1`** exclusively — never a routable interface.
+3. **Env-gated OFF.** It is constructed and started **only when `GODOT_MCP_DEV_CONTROL=1`** (exactly `1`).
+   An unset / any-other value means the bridge never listens — a shipped addon, and any normal editor
+   session, never opens the surface.
+
+That env gate is **load-bearing**: it is the single thing standing between "dev scaffolding" and "an
+unauthenticated control surface on the live dock". It is enforced by a pure-managed predicate
+(`DevControlGate.IsEnabled`) with a unit test (`DevControlGateTests`) **and** a boot-time assertion at the
+construction site (`DevControlGate.AssertEnabledOrThrow`), so a regression that wires the bridge on without
+the env var fails fast in CI and at runtime rather than silently shipping enabled.


### PR DESCRIPTION
## Summary
- Documents three accepted-posture security items (all by-design today): editor token stored as plaintext JSON at rest in `user://godot-mcp-config.json`; runtime-error capture forwarding full messages + stack traces (possible paths/secrets) to the agent via `runtime-errors-get`; and the unauthenticated-but-gated (`#if TOOLS` + `127.0.0.1` + `GODOT_MCP_DEV_CONTROL=1`) dev-control bridge. Surfaces appear in `WithRuntimeErrorCapture` XML docs, the `runtime-errors-get` tool description, README, and `docs/runtime-security.md`.
- Adds the ONE code change: a pure-managed `DevControlGate` (load-bearing `GODOT_MCP_DEV_CONTROL == "1"` predicate + a boot-time `AssertEnabledOrThrow` guard at the `DevControlServer` construction site) so a regression that wires the unauthenticated bridge on without the env var fails fast. Pinned by `DevControlGateTests` (23 cases).
- No behavior change beyond the assert; default-OFF posture unchanged; no NuGet pin changes. Out of scope (deferred): token-at-rest encryption / OS-keystore, DevControl shared-secret.

## Test plan
- [x] Suite 1 — `dotnet build Godot-MCP.sln` 0 errors (only 5 pre-existing CS0649 test-seam warnings)
- [x] Suite 2 — `dotnet test` **867 passed, 0 failed** on Windows (incl. the 23 new `DevControlGateTests`)

Closes #177