### PR TITLE
fix(dispatcher): async continuations + bounded teardown drain

### DIFF
--- a/Godot-MCP.Tests/MainThreadDispatcherTests.cs
+++ b/Godot-MCP.Tests/MainThreadDispatcherTests.cs
@@ -44,6 +44,7 @@ namespace com.IvanMurzak.Godot.MCP.Tests
     /// </para>
     /// </summary>
     [Collection(nameof(MainThreadDispatcherTests))]
+    [CollectionDefinition(nameof(MainThreadDispatcherTests), DisableParallelization = true)]
     public class MainThreadDispatcherTests : IDisposable
     {
         public MainThreadDispatcherTests() => ResetState();

--- a/Godot-MCP.Tests/MainThreadDispatcherTests.cs
+++ b/Godot-MCP.Tests/MainThreadDispatcherTests.cs
@@ -228,5 +228,119 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.True(task.IsCompletedSuccessfully);
             Assert.Equal(42, await task); // already completed — await just unwraps it without blocking
         }
+
+        // ---- Bounded teardown drain (#179: terminate against re-enqueueing bodies) --------------------------
+
+        [Fact]
+        public void TeardownDrain_IsBounded_TerminatesWhenDrainedBodyReEnqueues()
+        {
+            // Boot, then queue an action whose body re-enqueues a fresh action every time it runs. On the
+            // PRE-FIX code _ExitTree used the unbounded DrainQueue (while (TryDequeue)), so this body would
+            // re-feed the loop forever and teardown would hang. The bounded teardown drain snapshots the
+            // current count first, so it runs only the items present at entry and the re-enqueued item is
+            // left in the queue — the drain terminates.
+            MainThreadDispatcher.SimulateInstanceEnteredForTests();
+
+            var runs = 0;
+            void ReEnqueueingBody()
+            {
+                runs++;
+                if (runs < 1_000_000) // would loop a million times under the unbounded drain; bounded runs once
+                    MainThreadDispatcher.Enqueue(ReEnqueueingBody);
+            }
+            MainThreadDispatcher.Enqueue(ReEnqueueingBody);
+            Assert.Equal(1, MainThreadDispatcher.PendingActionCountForTests);
+
+            // Bounded teardown drain: snapshot is 1, so the body runs exactly once. It re-enqueues one item,
+            // which is NOT pulled into this same pass. Termination is the assertion — no hang/no overflow.
+            MainThreadDispatcher.DrainBoundedForTests();
+
+            Assert.Equal(1, runs); // ran exactly the one snapshotted item, not the re-enqueued follow-on
+            Assert.Equal(1, MainThreadDispatcher.PendingActionCountForTests); // the re-enqueue is left queued
+        }
+
+        [Fact]
+        public void TeardownViaExit_DrainsPendingOnce_ThenFailsFast()
+        {
+            // The bounded drain through the real teardown seam (SimulateInstanceExited → DrainQueueBounded).
+            // Two non-re-enqueueing bodies are pending at teardown; the bounded drain runs BOTH (the snapshot
+            // is 2) and terminates, and once torn down a later Enqueue fails fast so a pending awaiter cannot
+            // hang on a queue nothing will drain.
+            //
+            // NOTE: this test deliberately does NOT re-enqueue from a drained body. During the real teardown
+            // seam _instancePresentForTests is already false, so a body that re-enqueued would take Enqueue's
+            // post-teardown throw branch; that InvalidOperationException would be caught by the drain's
+            // InvokeDrained and routed to GD.PushError, which P/Invokes into the (absent) Godot native binary
+            // and faults the binary-less xUnit host. That throw→GD.PushError path is correct in a real editor;
+            // the snapshot-and-bound TERMINATION guarantee against a re-enqueueing body is asserted separately
+            // by TeardownDrain_IsBounded_TerminatesWhenDrainedBodyReEnqueues (which keeps the instance present
+            // so the re-enqueue succeeds and never reaches GD.PushError).
+            MainThreadDispatcher.SimulateInstanceEnteredForTests();
+
+            var runs = 0;
+            MainThreadDispatcher.Enqueue(() => runs++);
+            MainThreadDispatcher.Enqueue(() => runs++);
+            Assert.Equal(2, MainThreadDispatcher.PendingActionCountForTests);
+
+            MainThreadDispatcher.SimulateInstanceExitedForTests(); // bounded teardown drain — must terminate
+
+            Assert.Equal(2, runs);
+            Assert.Equal(0, MainThreadDispatcher.PendingActionCountForTests);
+            Assert.Throws<InvalidOperationException>(() => MainThreadDispatcher.Enqueue(() => { }));
+        }
+
+        // ---- Continuations don't run inline on the pump/drain thread (#179) ---------------------------------
+
+        [Fact]
+        public async Task GodotMainThread_Dispatch_ContinuationDoesNotRunInlineOnDrainThread()
+        {
+            // GodotMainThread.Dispatch builds its TaskCompletionSource with RunContinuationsAsynchronously, so
+            // an awaiter's continuation is posted to the thread pool — NOT executed inline on whatever thread
+            // completes the TCS. The completing thread here is the drain thread (DrainForTests below = the
+            // _Process / _ExitTree pump in production). On the PRE-FIX default-ctor TCS, SetResult from the
+            // drain thread would run the continuation synchronously ON the drain thread, which mid-teardown is
+            // the SceneTree-touch / re-entrancy hazard #179 fixes.
+            GodotMainThread.Install();
+            var mt = com.IvanMurzak.ReflectorNet.Utils.MainThread.Instance;
+
+            // Dispatch from a background thread (so it is not the captured main thread and takes the Dispatch
+            // → Enqueue path), leaving a pending task buffered until we drain.
+            Task<int>? task = null;
+            var bg = new Thread(() => { task = mt.RunAsync(() => 7); });
+            bg.Start();
+            bg.Join();
+            Assert.NotNull(task);
+            Assert.False(task!.IsCompleted);
+
+            // Attach a continuation that records WHICH thread it runs on. ExecuteSynchronously asks the runtime
+            // to run it inline on the completing thread IF the TCS allows synchronous continuations — which is
+            // exactly what RunContinuationsAsynchronously forbids. So with the fix this continuation can never
+            // observe the drain thread.
+            var continuationThreadId = 0;
+            var continuationRan = new ManualResetEventSlim(false);
+            var cont = task.ContinueWith(_ =>
+                {
+                    continuationThreadId = Thread.CurrentThread.ManagedThreadId;
+                    continuationRan.Set();
+                },
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+
+            // Drain on THIS thread — models the main-thread pump completing the buffered body.
+            var drainThreadId = Thread.CurrentThread.ManagedThreadId;
+            MainThreadDispatcher.DrainForTests();
+
+            // The body completed the task, but with RunContinuationsAsynchronously the continuation was posted
+            // off-thread; it must NOT have run inline during the drain on this thread.
+            Assert.True(task.IsCompletedSuccessfully);
+            Assert.False(continuationRan.IsSet); // not run inline on the drain thread
+
+            // It does still run — just asynchronously, on a thread that is NOT the drain thread.
+            Assert.True(continuationRan.Wait(TimeSpan.FromSeconds(5)), "continuation never ran asynchronously");
+            Assert.NotEqual(drainThreadId, continuationThreadId);
+            Assert.Equal(7, await task);
+            await cont;
+        }
     }
 }

--- a/addons/godot_mcp/Runtime/MainThread/GodotMainThread.cs
+++ b/addons/godot_mcp/Runtime/MainThread/GodotMainThread.cs
@@ -81,10 +81,21 @@ namespace com.IvanMurzak.Godot.MCP.MainThreadDispatch
         /// Enqueue <paramref name="body"/> on the dispatcher and return a task that completes with the
         /// body's result, or faults with its exception. Mirrors the TaskCompletionSource pattern in
         /// Unity-MCP's <c>UnityMainThread.Dispatch</c>.
+        /// <para>
+        /// The TCS is created with <see cref="TaskCreationOptions.RunContinuationsAsynchronously"/> (the same
+        /// option <c>DevControlServer.RunOnMainThread</c> already uses) so the awaiter's continuation is posted
+        /// to the thread pool instead of running INLINE on whatever thread completes the TCS. The body is
+        /// completed from <see cref="MainThreadDispatcher.DrainQueue"/>, which runs on the editor main thread —
+        /// including during <c>MainThreadDispatcher._ExitTree</c> teardown. Without this option a continuation
+        /// (e.g. more <c>await MainThread.Instance.Run(...)</c> work that touches the SceneTree) would execute
+        /// synchronously on the pump thread mid-teardown, a re-entrancy / SceneTree-touch hazard; it would also
+        /// let a re-enqueueing continuation extend the drain inline. Posting continuations off-thread keeps the
+        /// pump tick (and the bounded teardown drain) free of caller-supplied continuation bodies.
+        /// </para>
         /// </summary>
         static Task<T> Dispatch<T>(Func<T> body)
         {
-            var tcs = new TaskCompletionSource<T>();
+            var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             MainThreadDispatcher.Enqueue(() =>
             {

--- a/addons/godot_mcp/Runtime/MainThread/MainThreadDispatcher.cs
+++ b/addons/godot_mcp/Runtime/MainThread/MainThreadDispatcher.cs
@@ -188,11 +188,17 @@ namespace com.IvanMurzak.Godot.MCP.MainThreadDispatch
             if (ReferenceEquals(_instance, this))
                 _instance = null;
 
-            // Drain anything left so pending awaiters do not hang forever. NOTE: this runs each
-            // queued action's FULL body during teardown — those bodies may touch the SceneTree
-            // while the editor is tearing the dispatcher down. Callers must not assume the tree is
-            // fully alive in work that could still be pending at _ExitTree time.
-            DrainQueue();
+            // Drain anything left so pending awaiters do not hang forever, but BOUND the drain to the
+            // items already queued at this moment (see DrainQueueBounded). The unbounded DrainQueue used
+            // on the normal _Process tick keeps draining until the queue empties; at teardown that is a
+            // liveness hazard, because an action body (or, before GodotMainThread switched to
+            // RunContinuationsAsynchronously, an awaiter continuation) that re-enqueues could make the
+            // loop run forever while the editor is mid-teardown. Snapshotting the count first means a body
+            // that re-enqueues lands its work in the queue but does NOT extend this drain — the teardown
+            // terminates deterministically. (NOTE: a drained body still runs its FULL body here and may
+            // touch the SceneTree while the editor tears the dispatcher down; callers must not assume the
+            // tree is fully alive in work that could still be pending at _ExitTree time.)
+            DrainQueueBounded();
         }
 
         public override void _Process(double delta)
@@ -219,17 +225,45 @@ namespace com.IvanMurzak.Godot.MCP.MainThreadDispatch
         {
             while (_actions.TryDequeue(out var action))
             {
-                try
-                {
-                    action.Invoke();
-                }
-                catch (Exception ex)
-                {
-                    // The action is responsible for routing its own exceptions back to its awaiter
-                    // (GodotMainThread wraps the body in a try/catch). A throw here would only mean a
-                    // bug in the action wrapper itself; surface it without killing the pump loop.
-                    GD.PushError($"[Godot-MCP] MainThreadDispatcher action threw: {ex}");
-                }
+                InvokeDrained(action);
+            }
+        }
+
+        /// <summary>
+        /// Drain only the actions already queued at the moment this is called — at most a snapshot of the
+        /// current <see cref="ConcurrentQueue{T}.Count"/> — so a drained body that re-enqueues cannot make
+        /// the loop run unboundedly. Used at <see cref="_ExitTree"/> teardown, where the unbounded
+        /// <see cref="DrainQueue"/> would be a liveness hazard against re-enqueueing work while the editor is
+        /// tearing the dispatcher down. Re-enqueued items are simply left in the queue (no live dispatcher
+        /// will drain them afterward; <see cref="Enqueue"/> then fails fast for any later caller because
+        /// <see cref="_hasEverEntered"/> is set). FIFO order of the snapshot is preserved.
+        /// </summary>
+        static void DrainQueueBounded()
+        {
+            // Snapshot the bound BEFORE dequeuing. ConcurrentQueue.Count is a point-in-time read; capturing it
+            // first caps the iteration at the items present now, so any item a drained body re-enqueues is not
+            // pulled into this same drain pass.
+            var budget = _actions.Count;
+            for (var i = 0; i < budget && _actions.TryDequeue(out var action); i++)
+            {
+                InvokeDrained(action);
+            }
+        }
+
+        /// <summary>
+        /// Invoke one drained action, swallowing and surfacing any throw without killing the pump loop. The
+        /// action is responsible for routing its own exceptions back to its awaiter (GodotMainThread wraps the
+        /// body in a try/catch). A throw here would only mean a bug in the action wrapper itself.
+        /// </summary>
+        static void InvokeDrained(Action action)
+        {
+            try
+            {
+                action.Invoke();
+            }
+            catch (Exception ex)
+            {
+                GD.PushError($"[Godot-MCP] MainThreadDispatcher action threw: {ex}");
             }
         }
 
@@ -265,17 +299,25 @@ namespace com.IvanMurzak.Godot.MCP.MainThreadDispatch
 
         /// <summary>
         /// Test-only: model the dispatcher leaving the tree (teardown). Mirrors <see cref="_ExitTree"/>'s
-        /// pure-managed effects — mark no instance present and drain anything still pending — so that a
+        /// pure-managed effects — mark no instance present and drain anything still pending via the SAME
+        /// bounded drain teardown uses — so that the unit tests exercise the real termination guarantee and a
         /// subsequent <see cref="Enqueue"/> takes the post-teardown fail-fast branch.
         /// </summary>
         internal static void SimulateInstanceExitedForTests()
         {
             _instancePresentForTests = false;
-            DrainQueue();
+            DrainQueueBounded();
         }
 
         /// <summary>Test-only: drain the buffered actions on the calling thread (no Node, no tick).</summary>
         internal static void DrainForTests() => DrainQueue();
+
+        /// <summary>
+        /// Test-only: model the bounded teardown drain (<see cref="_ExitTree"/>) directly, WITHOUT also
+        /// flipping the instance-present flag. Lets a test assert the snapshot-and-bound termination guarantee
+        /// against a re-enqueueing body in isolation from the fail-fast lifecycle transition.
+        /// </summary>
+        internal static void DrainBoundedForTests() => DrainQueueBounded();
 
         /// <summary>
         /// Test-only: reset ALL static lifecycle state to its pre-boot defaults. Static state outlives a


### PR DESCRIPTION
## Summary

- `GodotMainThread.Dispatch` now builds its `TaskCompletionSource` with `TaskCreationOptions.RunContinuationsAsynchronously` (the same option `DevControlServer.RunOnMainThread` already uses), so an awaiter's continuation is posted to the thread pool instead of running INLINE on the editor pump thread that completes the TCS — including during `_ExitTree` teardown (the SceneTree-touch / re-entrancy hazard).
- `MainThreadDispatcher._ExitTree` now drains via a new `DrainQueueBounded()` that snapshots the current queue count first, so a drained body that re-enqueues cannot make the teardown drain loop unboundedly; the drain terminates deterministically. The normal `_EnterTree` / `_Process` drain stays the unbounded `DrainQueue` (re-enqueues land on the next per-frame tick). Composes with #170's buffer/drain + `volatile` and #169's early-boot buffering / `_hasEverEntered` semantics — none regressed.

## Test plan
- [x] Target-specific local tests passed (see profile test.md): `dotnet build Godot-MCP.sln` 0 errors; `dotnet test Godot-MCP.Tests` **870 passed / 0 failed** (Windows host).
- [x] Two new tests each verified to FAIL on the pre-fix code: `TeardownDrain_IsBounded_TerminatesWhenDrainedBodyReEnqueues` (unbounded drain ran the re-enqueueing body >1×) and `GodotMainThread_Dispatch_ContinuationDoesNotRunInlineOnDrainThread` (default-ctor TCS ran the continuation inline on the drain thread). Companion `TeardownViaExit_DrainsPendingOnce_ThenFailsFast` added.

Closes #179