### PR TITLE
ci(harness): runtime integration harness — live SignalR roundtrip + headless-game runtime-error capture

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,12 +75,30 @@ jobs:
       tag_exists: ${{ steps.tag_exists.outputs.exists }}
       version_changed: ${{ steps.version_changed.outputs.changed }}
       should_release: ${{ steps.gate.outputs.should_release }}
+      server_version: ${{ steps.server_version.outputs.server_version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
+
+      # Single-source the harness server version from the addon's authoritative constant
+      # (GodotMcpServerView.ServerVersion) so the advisory runtime-harness legs download the
+      # server release the addon actually pins — never a stale hardcoded default.
+      - name: Read ServerVersion from the addon constant
+        id: server_version
+        run: |
+          set -euo pipefail
+          src="addons/godot_mcp/Runtime/Connection/GodotMcpServerView.cs"
+          server_version="$(grep -oE 'ServerVersion[[:space:]]*=[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' "$src" \
+            | head -n1 | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/')"
+          if [ -z "${server_version}" ]; then
+            echo "::error::Could not read ServerVersion from ${src}"
+            exit 1
+          fi
+          echo "server_version=${server_version}" >> "$GITHUB_OUTPUT"
+          echo "Addon-pinned server version: ${server_version}"
 
       # plugin.cfg is an INI file, so read its `version="x.y.z"` line directly
       # rather than with npm-get-version-action (which expects a package.json).
@@ -214,12 +232,15 @@ jobs:
   # in-game runtime + error capture, and asserts the live SignalR roundtrip +
   # runtime-error capture (issue #186). Gates the release alongside the addon-load
   # smoke so a transport/capture regression cannot ship in a release.
+  # serverVersion is single-sourced from the addon constant (check-version-tag.server_version),
+  # so these advisory legs download the server release the addon actually pins.
   runtime-harness-4-3:
     needs: [check-version-tag]
     if: needs.check-version-tag.outputs.should_release == 'true'
     uses: ./.github/workflows/test_godot_runtime_harness.yml
     with:
       godotVersion: "4.3.0"
+      serverVersion: ${{ needs.check-version-tag.outputs.server_version }}
 
   runtime-harness-4-4:
     needs: [check-version-tag]
@@ -227,6 +248,7 @@ jobs:
     uses: ./.github/workflows/test_godot_runtime_harness.yml
     with:
       godotVersion: "4.4.0"
+      serverVersion: ${{ needs.check-version-tag.outputs.server_version }}
 
   runtime-harness-4-5:
     needs: [check-version-tag]
@@ -234,6 +256,7 @@ jobs:
     uses: ./.github/workflows/test_godot_runtime_harness.yml
     with:
       godotVersion: "4.5.1"
+      serverVersion: ${{ needs.check-version-tag.outputs.server_version }}
 
   # NOTE: the MCP server is NOT built or released here anymore. The addon consumes the
   # shared GameDev-MCP-Server (https://github.com/IvanMurzak/GameDev-MCP-Server), whose
@@ -250,6 +273,15 @@ jobs:
   # own releases.
   release-addon:
     runs-on: ubuntu-latest
+    # The release gate depends ONLY on the DETERMINISTIC test legs (check-version-tag,
+    # the .NET build+test, the cli node tests, and the addon-LOAD godot smoke). The
+    # runtime-harness-4-{3,4,5} legs are deliberately NOT in this `needs:` array: they are
+    # an end-to-end INTEGRATION harness that downloads an external server release and runs a
+    # live, concurrency-sensitive roundtrip — a transient harness flake or an unavailable
+    # upstream server release must NEVER block a Godot-MCP release. The harness legs still
+    # RUN on the release trigger (in parallel, providing advisory signal against the live
+    # server version); they are just decoupled from the release gate. They remain BLOCKING on
+    # PR CI (test_pull_request.yml), so main is always harness-green before a release is cut.
     needs:
       [
         check-version-tag,
@@ -258,9 +290,6 @@ jobs:
         test-godot-4-3,
         test-godot-4-4,
         test-godot-4-5,
-        runtime-harness-4-3,
-        runtime-harness-4-4,
-        runtime-harness-4-5,
       ]
     if: needs.check-version-tag.outputs.should_release == 'true'
     outputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,6 +209,32 @@ jobs:
     with:
       godotVersion: "4.5.1"
 
+  # godot_mcp runtime INTEGRATION harness across the Godot engine matrix (mono):
+  # downloads the released gamedev-mcp-server, boots a headless game with the
+  # in-game runtime + error capture, and asserts the live SignalR roundtrip +
+  # runtime-error capture (issue #186). Gates the release alongside the addon-load
+  # smoke so a transport/capture regression cannot ship in a release.
+  runtime-harness-4-3:
+    needs: [check-version-tag]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    uses: ./.github/workflows/test_godot_runtime_harness.yml
+    with:
+      godotVersion: "4.3.0"
+
+  runtime-harness-4-4:
+    needs: [check-version-tag]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    uses: ./.github/workflows/test_godot_runtime_harness.yml
+    with:
+      godotVersion: "4.4.0"
+
+  runtime-harness-4-5:
+    needs: [check-version-tag]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    uses: ./.github/workflows/test_godot_runtime_harness.yml
+    with:
+      godotVersion: "4.5.1"
+
   # NOTE: the MCP server is NOT built or released here anymore. The addon consumes the
   # shared GameDev-MCP-Server (https://github.com/IvanMurzak/GameDev-MCP-Server), whose
   # own release workflow publishes the `gamedev-mcp-server-<rid>.zip` assets the addon
@@ -232,6 +258,9 @@ jobs:
         test-godot-4-3,
         test-godot-4-4,
         test-godot-4-5,
+        runtime-harness-4-3,
+        runtime-harness-4-4,
+        runtime-harness-4-5,
       ]
     if: needs.check-version-tag.outputs.should_release == 'true'
     outputs:

--- a/.github/workflows/test_godot_runtime_harness.yml
+++ b/.github/workflows/test_godot_runtime_harness.yml
@@ -1,0 +1,265 @@
+# ┌──────────────────────────────────────────────────────────────────┐
+# │  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+# │  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+# │  Copyright (c) 2026 Ivan Murzak                                  │
+# │  Licensed under the Apache License, Version 2.0.                 │
+# │  See the LICENSE file in the project root for more information.  │
+# └──────────────────────────────────────────────────────────────────┘
+#
+# Reusable workflow: the issue-#186 RUNTIME INTEGRATION harness. Unlike the
+# addon-LOAD smoke (test_godot_plugin.yml, which only boots the editor and greps
+# "[Godot-MCP] plugin loaded"), this boots a HEADLESS GAME of the in-repo
+# Godot-Tests/ project with the in-game Godot-MCP runtime + runtime-error capture
+# enabled, downloads + runs the released gamedev-mcp-server, and asserts the WHOLE
+# end-to-end path that today's CI never exercises (the entire transport is
+# #if TOOLS-excluded from the xUnit suite):
+#
+#   1. the live SignalR transport connects + handshakes (download the released
+#      gamedev-mcp-server, run it Authorization=none on a fixed port, the headless
+#      game connects to it);
+#   2. a live tool roundtrip works (the workflow POSTs `ping` to the server while
+#      the game holds the connection — succeeds ONLY once the game's plugin is
+#      connected, so it proves connect + handshake + dispatch in one call);
+#   3. runtime-errors capture returns, on the 4.5.1 leg, the engine GDScript
+#      runtime error WITH the #163 multi-frame backtrace + push_error/push_warning
+#      + the C# exception with a stack; on the 4.3/4.4 legs it asserts graceful
+#      stub degradation (no engine logger; frames null) while the C# channel still
+#      captures.
+#
+# Called once per matrix version by test_pull_request.yml.
+name: Test Godot Runtime Harness
+
+on:
+  workflow_call:
+    inputs:
+      godotVersion:
+        description: "Godot mono version to install and boot (e.g. 4.3.0, 4.4.0, 4.5.1)."
+        required: true
+        type: string
+      serverVersion:
+        description: "GameDev-MCP-Server release version to download + run (the addon's pinned ServerVersion)."
+        required: false
+        default: "8.0.0"
+        type: string
+
+jobs:
+  runtime-harness:
+    name: runtime harness ${{ inputs.godotVersion }} (mono)
+    runs-on: ubuntu-latest
+    env:
+      TEST_PROJECT: Godot-Tests
+      # Fixed local port the server listens on and the game connects to (loopback, auth=none).
+      SERVER_PORT: "5400"
+      SERVER_VERSION: ${{ inputs.serverVersion }}
+      # The runner is ubuntu-latest x64, so the release asset + extracted binary are fixed.
+      SERVER_ASSET: gamedev-mcp-server-linux-x64.zip
+      SERVER_BIN: gamedev-mcp-server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Setup Godot ${{ inputs.godotVersion }} (mono)
+        uses: chickensoft-games/setup-godot@v2
+        with:
+          version: ${{ inputs.godotVersion }}
+          use-dotnet: true
+          include-templates: false
+
+      - name: Report Godot version
+        shell: bash
+        run: godot --version --headless
+
+      # The engine 4.5+ logger channel (OS.AddLogger / Godot.Logger / ScriptBacktrace) only
+      # compiles in when the build's Godot.NET.Sdk version is >= 4.5 (it defines
+      # GODOT4_5_OR_GREATER). The committed Godot-Tests.csproj pins the addon's engine FLOOR
+      # (Godot.NET.Sdk/4.3.0); the addon-load smoke only needs the floor. For THIS runtime leg
+      # we must build with the SDK matching the matrix Godot version so the engine logger is
+      # present on 4.5+ and absent on 4.3/4.4 — exactly the per-version behavior we assert.
+      # The checkout is disposable, so we rewrite the SDK pin in place per leg.
+      - name: Compute leg expectations + pin build SDK to the matrix version
+        id: leg
+        shell: bash
+        run: |
+          set -euo pipefail
+          GODOT_VERSION="${{ inputs.godotVersion }}"
+          MINOR="$(echo "$GODOT_VERSION" | cut -d. -f2)"
+          if [ "$MINOR" -ge 5 ]; then
+            echo "engine_logger_expected=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "engine_logger_expected=0" >> "$GITHUB_OUTPUT"
+          fi
+          # Pin the testbed build SDK to the matrix Godot version (disposable checkout).
+          sed -i "s#Godot.NET.Sdk/[0-9][0-9.]*#Godot.NET.Sdk/${GODOT_VERSION}#" "${TEST_PROJECT}/${TEST_PROJECT}.csproj"
+          echo "Pinned ${TEST_PROJECT}.csproj SDK:"
+          head -1 "${TEST_PROJECT}/${TEST_PROJECT}.csproj"
+
+      - name: Copy addon into the test project
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf "${TEST_PROJECT}/addons/godot_mcp"
+          mkdir -p "${TEST_PROJECT}/addons"
+          cp -r addons/godot_mcp "${TEST_PROJECT}/addons/godot_mcp"
+          test -f "${TEST_PROJECT}/addons/godot_mcp/plugin.cfg"
+
+      - name: Download the released gamedev-mcp-server
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p server
+          # Pull the EXACT release asset the addon's GodotMcpServerView.DownloadUrl would fetch
+          # (https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/v<ver>/<asset>).
+          gh release download "v${SERVER_VERSION}" \
+            --repo IvanMurzak/GameDev-MCP-Server \
+            --pattern "${SERVER_ASSET}" \
+            --dir server --clobber
+          unzip -o -q "server/${SERVER_ASSET}" -d server/bin
+          chmod +x "server/bin/${SERVER_BIN}"
+          test -x "server/bin/${SERVER_BIN}"
+
+      - name: Start the server (Authorization=none, streamableHttp, fixed port)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Same launch shape as GodotMcpServerView.BuildLaunchArguments:
+          #   port=<p> plugin-timeout=<t> client-transport=streamableHttp authorization=none
+          nohup "server/bin/${SERVER_BIN}" \
+            port="${SERVER_PORT}" \
+            plugin-timeout=10000 \
+            client-transport=streamableHttp \
+            authorization=none \
+            > server.log 2>&1 &
+          echo "$!" > server.pid
+          # Wait-for-ready: poll the /help health endpoint (200 when the HTTP host is up).
+          for i in $(seq 1 60); do
+            code="$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:${SERVER_PORT}/help" || true)"
+            if [ "$code" = "200" ]; then
+              echo "server ready after ${i}s (/help -> 200)."
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::server did not become ready on port ${SERVER_PORT} within 60s."
+          echo "----- server.log -----"; cat server.log || true
+          exit 1
+
+      - name: Import the project (generate .godot layout)
+        shell: bash
+        run: |
+          set -uo pipefail
+          # Cold checkout has no .godot/. Headless import materializes it; benign teardown
+          # warnings/non-zero exits are not fatal (same caveat as test_godot_plugin.yml).
+          godot --headless --path "${TEST_PROJECT}" --import --quit 2>&1 | tee import.log || true
+          echo "Import pass complete."
+
+      - name: Build C# (addon + harness compile into the project assembly)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # dotnet build is deterministic (Godot.NET.Sdk resolves GodotSharp from nuget.org for
+          # the SDK pinned above). The addon's *.cs + Harness/*.cs glob into THIS project
+          # assembly, so a successful build proves the addon AND the harness compile against the
+          # frozen pins at the matrix SDK version.
+          dotnet build "${TEST_PROJECT}/${TEST_PROJECT}.csproj" --configuration Debug 2>&1 | tee build.log
+          if ! ls "${TEST_PROJECT}"/.godot/mono/temp/bin/*/Godot-MCP-Tests.dll >/dev/null 2>&1; then
+            echo "::error::C# build did not produce Godot-MCP-Tests.dll — the addon/harness failed to compile."
+            cat build.log || true
+            exit 1
+          fi
+
+      - name: Run the headless game harness + assert a live tool roundtrip
+        shell: bash
+        env:
+          ENGINE_LOGGER_EXPECTED: ${{ steps.leg.outputs.engine_logger_expected }}
+        run: |
+          set -uo pipefail
+          RESULT="$(pwd)/harness-result.json"
+          rm -f "$RESULT"
+
+          # Boot the headless GAME (NOT --editor): project.godot's run/main_scene is
+          # Harness/Main.tscn, whose RuntimeHarness.cs (gated by GODOT_MCP_HARNESS=1) builds the
+          # in-game runtime, connects to the local server, raises the runtime errors, writes the
+          # structured result, and quits with a pass/fail code. The addon reads host/mode/auth
+          # from its own GODOT_MCP_* env contract.
+          GODOT_MCP_HARNESS=1 \
+          GODOT_MCP_HARNESS_RESULT="$RESULT" \
+          GODOT_MCP_HARNESS_REQUIRE_CONNECT=1 \
+          GODOT_MCP_HARNESS_TIMEOUT_SECONDS=90 \
+          GODOT_MCP_HARNESS_ENGINE_LOGGER_EXPECTED="${ENGINE_LOGGER_EXPECTED}" \
+          GODOT_MCP_CONNECTION_MODE=Custom \
+          GODOT_MCP_HOST="http://localhost:${SERVER_PORT}" \
+          GODOT_MCP_AUTH_OPTION=None \
+            godot --headless --path "${TEST_PROJECT}" > game.log 2>&1 &
+          GAME_PID=$!
+
+          # While the game holds the connection, poll the server's direct tool-call API for a
+          # `ping` roundtrip. It returns the echoed value ONLY once the game's plugin is
+          # connected + handshaken (an unconnected server returns a 500 "Response data is null"),
+          # so a success here proves connect + handshake + live tool dispatch in one call.
+          ROUNDTRIP_OK=0
+          for i in $(seq 1 90); do
+            if ! kill -0 "$GAME_PID" 2>/dev/null; then
+              echo "game exited before the ping roundtrip landed (i=${i})."
+              break
+            fi
+            resp="$(curl -s -X POST "http://localhost:${SERVER_PORT}/api/tools/ping" \
+              -H 'Content-Type: application/json' -d '{"message":"harness-186"}' || true)"
+            if echo "$resp" | grep -q 'harness-186'; then
+              echo "tool roundtrip OK: ping -> ${resp}"
+              ROUNDTRIP_OK=1
+              break
+            fi
+            sleep 1
+          done
+
+          # Wait for the harness game to finish and capture its exit code.
+          GAME_RC=0
+          wait "$GAME_PID" || GAME_RC=$?
+          echo "harness game exit code: ${GAME_RC}"
+          echo "----- game.log (tail) -----"; tail -n 80 game.log || true
+
+          if [ "$ROUNDTRIP_OK" != "1" ]; then
+            echo "::error::the live tool roundtrip (POST /api/tools/ping) never succeeded — the game's plugin did not connect+dispatch."
+            exit 1
+          fi
+
+          # Independent, field-by-field assertion of the structured result (on top of the
+          # harness's own exit code) for a readable per-version diagnosis.
+          python scripts/assert_runtime_harness.py \
+            --result "$RESULT" \
+            --engine-logger-expected "${ENGINE_LOGGER_EXPECTED}" \
+            --require-connect 1
+
+          if [ "$GAME_RC" != "0" ]; then
+            echo "::error::the harness game exited non-zero (${GAME_RC}) — its own pass/fail gate failed."
+            exit 1
+          fi
+
+      - name: Stop the server
+        if: always()
+        shell: bash
+        run: |
+          if [ -f server.pid ]; then
+            kill "$(cat server.pid)" 2>/dev/null || true
+          fi
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-harness-${{ inputs.godotVersion }}-logs
+          path: |
+            import.log
+            build.log
+            game.log
+            server.log
+            harness-result.json
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/test_godot_runtime_harness.yml
+++ b/.github/workflows/test_godot_runtime_harness.yml
@@ -94,7 +94,9 @@ jobs:
             echo "engine_logger_expected=0" >> "$GITHUB_OUTPUT"
           fi
           # Pin the testbed build SDK to the matrix Godot version (disposable checkout).
-          sed -i "s#Godot.NET.Sdk/[0-9][0-9.]*#Godot.NET.Sdk/${GODOT_VERSION}#" "${TEST_PROJECT}/${TEST_PROJECT}.csproj"
+          # Anchor on the Sdk="..." attribute so ONLY the <Project Sdk=...> pin (line 1) is
+          # rewritten — comment mentions of Godot.NET.Sdk/4.3.0 elsewhere in the csproj are left intact.
+          sed -i "s#Sdk=\"Godot.NET.Sdk/[0-9][0-9.]*\"#Sdk=\"Godot.NET.Sdk/${GODOT_VERSION}\"#" "${TEST_PROJECT}/${TEST_PROJECT}.csproj"
           echo "Pinned ${TEST_PROJECT}.csproj SDK:"
           head -1 "${TEST_PROJECT}/${TEST_PROJECT}.csproj"
 
@@ -225,17 +227,27 @@ jobs:
           echo "harness game exit code: ${GAME_RC}"
           echo "----- game.log (tail) -----"; tail -n 80 game.log || true
 
+          # Run the per-field asserter FIRST (non-fatally) so its readable per-version diagnosis
+          # of the structured result prints BEFORE the generic roundtrip hard-fail below — on the
+          # fast-quit race where the roundtrip poll missed but the harness still wrote a result,
+          # the field-level "what was/wasn't captured" diagnosis is the actionable signal.
+          ASSERT_RC=0
+          python scripts/assert_runtime_harness.py \
+            --result "$RESULT" \
+            --engine-logger-expected "${ENGINE_LOGGER_EXPECTED}" \
+            --require-connect 1 || ASSERT_RC=$?
+
           if [ "$ROUNDTRIP_OK" != "1" ]; then
             echo "::error::the live tool roundtrip (POST /api/tools/ping) never succeeded — the game's plugin did not connect+dispatch."
             exit 1
           fi
 
-          # Independent, field-by-field assertion of the structured result (on top of the
-          # harness's own exit code) for a readable per-version diagnosis.
-          python scripts/assert_runtime_harness.py \
-            --result "$RESULT" \
-            --engine-logger-expected "${ENGINE_LOGGER_EXPECTED}" \
-            --require-connect 1
+          # Authoritative gate: the field-by-field assertion must pass (the diagnostic run above
+          # already printed its findings; this re-asserts the exit code as the pass/fail gate).
+          if [ "$ASSERT_RC" != "0" ]; then
+            echo "::error::the structured-result assertion (assert_runtime_harness.py) failed — see the per-field diagnosis above."
+            exit "$ASSERT_RC"
+          fi
 
           if [ "$GAME_RC" != "0" ]; then
             echo "::error::the harness game exited non-zero (${GAME_RC}) — its own pass/fail gate failed."

--- a/.github/workflows/test_godot_runtime_harness.yml
+++ b/.github/workflows/test_godot_runtime_harness.yml
@@ -51,9 +51,14 @@ jobs:
       # Fixed local port the server listens on and the game connects to (loopback, auth=none).
       SERVER_PORT: "5400"
       SERVER_VERSION: ${{ inputs.serverVersion }}
-      # The runner is ubuntu-latest x64, so the release asset + extracted binary are fixed.
+      # The runner is ubuntu-latest x64, so the release asset is fixed. The binary's FILENAME
+      # inside the zip is fixed (gamedev-mcp-server), but its PATH is not: the released zip is a
+      # dotnet-publish-per-RID layout that nests the payload under a <rid>/ subdir
+      # (linux-x64/gamedev-mcp-server, NOT a flat gamedev-mcp-server at the zip root). The
+      # download step resolves the real path with `find` and exports it; downstream steps read
+      # that resolved path — never a hardcoded server/bin/<name>.
       SERVER_ASSET: gamedev-mcp-server-linux-x64.zip
-      SERVER_BIN: gamedev-mcp-server
+      SERVER_BIN_NAME: gamedev-mcp-server
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -110,6 +115,7 @@ jobs:
           test -f "${TEST_PROJECT}/addons/godot_mcp/plugin.cfg"
 
       - name: Download the released gamedev-mcp-server
+        id: server
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -123,16 +129,34 @@ jobs:
             --pattern "${SERVER_ASSET}" \
             --dir server --clobber
           unzip -o -q "server/${SERVER_ASSET}" -d server/bin
-          chmod +x "server/bin/${SERVER_BIN}"
-          test -x "server/bin/${SERVER_BIN}"
+          # The release zip is a dotnet-publish-per-RID layout: the binary is NOT at the zip root,
+          # it lives under a <rid>/ subdir (server/bin/linux-x64/gamedev-mcp-server). Resolve the
+          # real path with `find` so a future layout change (flat vs nested) can't re-break this —
+          # the filename is the stable contract, the directory is not.
+          SERVER_BIN="$(find server/bin -type f -name "${SERVER_BIN_NAME}" | head -n1)"
+          if [ -z "${SERVER_BIN}" ]; then
+            echo "::error::could not locate '${SERVER_BIN_NAME}' under server/bin after extracting ${SERVER_ASSET}."
+            echo "----- server/bin contents -----"; ls -laR server/bin || true
+            exit 1
+          fi
+          chmod +x "${SERVER_BIN}"
+          test -x "${SERVER_BIN}"
+          echo "resolved server binary: ${SERVER_BIN}"
+          # Export the resolved path so the downstream start-server step launches the SAME binary.
+          echo "bin=${SERVER_BIN}" >> "$GITHUB_OUTPUT"
 
       - name: Start the server (Authorization=none, streamableHttp, fixed port)
         shell: bash
+        env:
+          # The path the download step resolved via `find` (nested <rid>/ layout), so this
+          # launches the SAME binary that was chmod'd — never a hardcoded server/bin/<name>.
+          SERVER_BIN: ${{ steps.server.outputs.bin }}
         run: |
           set -euo pipefail
+          test -x "${SERVER_BIN}"
           # Same launch shape as GodotMcpServerView.BuildLaunchArguments:
           #   port=<p> plugin-timeout=<t> client-transport=streamableHttp authorization=none
-          nohup "server/bin/${SERVER_BIN}" \
+          nohup "${SERVER_BIN}" \
             port="${SERVER_PORT}" \
             plugin-timeout=10000 \
             client-transport=streamableHttp \

--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -90,23 +90,57 @@ jobs:
     with:
       godotVersion: "4.5.1"
 
+  # Single-source the server version the harness downloads from the addon's authoritative
+  # constant (GodotMcpServerView.ServerVersion) instead of trusting the reusable workflow's
+  # hardcoded default. This guarantees the harness ALWAYS runs against the server release the
+  # addon actually pins; bumping the addon's ServerVersion automatically bumps the harness.
+  resolve-server-version:
+    runs-on: ubuntu-latest
+    outputs:
+      serverVersion: ${{ steps.read.outputs.serverVersion }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read ServerVersion from the addon constant
+        id: read
+        shell: bash
+        run: |
+          set -euo pipefail
+          src="addons/godot_mcp/Runtime/Connection/GodotMcpServerView.cs"
+          version="$(grep -oE 'ServerVersion[[:space:]]*=[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' "$src" \
+            | head -n1 | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/')"
+          if [ -z "${version}" ]; then
+            echo "::error::Could not read ServerVersion from ${src}"
+            exit 1
+          fi
+          echo "serverVersion=${version}" >> "$GITHUB_OUTPUT"
+          echo "Addon-pinned server version: ${version}"
+
   # (d) the godot_mcp runtime INTEGRATION harness across the Godot engine matrix
   #     (mono). Each leg downloads the released gamedev-mcp-server, boots a
   #     headless game with the in-game runtime + error capture, and asserts the
   #     live SignalR roundtrip + runtime-error capture (issue #186). The 4.5 leg
   #     asserts the engine GDScript backtrace (#163); 4.3/4.4 assert graceful stub
-  #     degradation.
+  #     degradation. The serverVersion is single-sourced from the addon constant
+  #     (resolve-server-version) so the harness tracks the addon's pinned server.
   runtime-harness-4-3:
+    needs: [resolve-server-version]
     uses: ./.github/workflows/test_godot_runtime_harness.yml
     with:
       godotVersion: "4.3.0"
+      serverVersion: ${{ needs.resolve-server-version.outputs.serverVersion }}
 
   runtime-harness-4-4:
+    needs: [resolve-server-version]
     uses: ./.github/workflows/test_godot_runtime_harness.yml
     with:
       godotVersion: "4.4.0"
+      serverVersion: ${{ needs.resolve-server-version.outputs.serverVersion }}
 
   runtime-harness-4-5:
+    needs: [resolve-server-version]
     uses: ./.github/workflows/test_godot_runtime_harness.yml
     with:
       godotVersion: "4.5.1"
+      serverVersion: ${{ needs.resolve-server-version.outputs.serverVersion }}

--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -12,6 +12,12 @@
 #   (b) godot-mcp-cli node tests (20/22) via the reusable test_cli.yml
 #   (c) the godot_mcp addon-load smoke across Godot 4.3 / 4.4 / 4.5 (mono) via
 #       the reusable test_godot_plugin.yml
+#   (d) the runtime INTEGRATION harness across Godot 4.3 / 4.4 / 4.5 (mono) via
+#       the reusable test_godot_runtime_harness.yml — downloads the released
+#       gamedev-mcp-server, boots a HEADLESS GAME with the in-game runtime +
+#       error capture, asserts a live SignalR roundtrip AND runtime-error capture
+#       (issue #186). This is the half the #if TOOLS-excluded xUnit suite cannot
+#       reach (connect/handshake/dispatch + in-game capture).
 #
 # NOTE: ci.yml is intentionally left untouched and still runs on push + PR; its
 # job display name `dotnet build (.NET 8)` remains the canonical required check.
@@ -81,5 +87,26 @@ jobs:
 
   test-godot-4-5:
     uses: ./.github/workflows/test_godot_plugin.yml
+    with:
+      godotVersion: "4.5.1"
+
+  # (d) the godot_mcp runtime INTEGRATION harness across the Godot engine matrix
+  #     (mono). Each leg downloads the released gamedev-mcp-server, boots a
+  #     headless game with the in-game runtime + error capture, and asserts the
+  #     live SignalR roundtrip + runtime-error capture (issue #186). The 4.5 leg
+  #     asserts the engine GDScript backtrace (#163); 4.3/4.4 assert graceful stub
+  #     degradation.
+  runtime-harness-4-3:
+    uses: ./.github/workflows/test_godot_runtime_harness.yml
+    with:
+      godotVersion: "4.3.0"
+
+  runtime-harness-4-4:
+    uses: ./.github/workflows/test_godot_runtime_harness.yml
+    with:
+      godotVersion: "4.4.0"
+
+  runtime-harness-4-5:
+    uses: ./.github/workflows/test_godot_runtime_harness.yml
     with:
       godotVersion: "4.5.1"

--- a/Godot-MCP.csproj
+++ b/Godot-MCP.csproj
@@ -26,9 +26,16 @@
     sources (which reference packages this game assembly does not, e.g. xUnit) get
     compiled into the game assembly and break the build:
       - Godot-MCP.Tests/   — the xUnit unit-test project.
+      - Godot-Tests/       — the headless CI testbed project (owns Godot-Tests.csproj). It holds the
+                             issue-#186 runtime-integration harness (Harness/RuntimeHarness.cs), whose
+                             namespace + test-project assembly identity would leak into the addon assembly
+                             and break the required `dotnet build (.NET 8)` gate (the sibling-project glob
+                             trap — see conventions.md). The harness only ever compiles inside
+                             Godot-Tests.csproj, driven by the Godot editor/CLI in the harness workflow.
   -->
   <ItemGroup>
     <Compile Remove="Godot-MCP.Tests/**/*.cs" />
+    <Compile Remove="Godot-Tests/**/*.cs" />
   </ItemGroup>
 
 </Project>

--- a/Godot-Tests/Harness/Faulty.gd
+++ b/Godot-Tests/Harness/Faulty.gd
@@ -1,0 +1,44 @@
+# ┌──────────────────────────────────────────────────────────────────┐
+# │  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+# │  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+# │  Copyright (c) 2026 Ivan Murzak                                  │
+# │  Licensed under the Apache License, Version 2.0.                 │
+# │  See the LICENSE file in the project root for more information.  │
+# └──────────────────────────────────────────────────────────────────┘
+#
+# CI runtime-harness fault generator (issue #186). Raises a GENUINE GDScript
+# RUNTIME error from inside a small CALL CHAIN so the engine produces a deep,
+# multi-frame backtrace (issue #163) — NOT a parse error and NOT a push_error.
+# The chain is `raise_runtime_fault -> _level_two -> _level_three`, and the
+# innermost frame calls a NONEXISTENT method on a freshly-constructed object.
+# Calling an undefined method is a real engine runtime fault ("Invalid call.
+# Nonexistent function ..."), surfaced through Godot 4.5's OS.AddLogger error
+# stream WITH a ScriptBacktrace, which the addon's GodotScriptErrorLogger
+# materializes into RuntimeError.Frames. On Godot < 4.5 the engine logger
+# channel is absent, so this same fault is simply not captured (the C# channels
+# still are) — which is exactly the per-version degradation the harness asserts.
+#
+# This is driven from C# (RuntimeHarness.cs) via `call("raise_runtime_fault")`
+# so the harness can sequence it deterministically AFTER capture is installed.
+extends RefCounted
+
+
+# Public entry point the C# harness invokes. Kept as the OUTERMOST frame of the
+# backtrace so the captured stack has a recognizable top function name.
+func raise_runtime_fault() -> void:
+	_level_two()
+
+
+func _level_two() -> void:
+	_level_three()
+
+
+func _level_three() -> void:
+	# A real runtime fault with a multi-frame stack: invoke a method that does
+	# not exist on a live object. The engine raises
+	#   "Invalid call. Nonexistent function 'this_method_does_not_exist' in base 'RefCounted'."
+	# at runtime (this line compiles fine — the call is resolved dynamically),
+	# producing a ScriptBacktrace spanning _level_three -> _level_two ->
+	# raise_runtime_fault.
+	var obj := RefCounted.new()
+	obj.call("this_method_does_not_exist", 1, 2, 3)

--- a/Godot-Tests/Harness/Main.tscn
+++ b/Godot-Tests/Harness/Main.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=3]
+
+; CI runtime-harness main scene (issue #186). Its root node carries RuntimeHarness.cs,
+; which on _Ready (when GODOT_MCP_HARNESS=1) boots the in-game Godot-MCP runtime, connects
+; to a local gamedev-mcp-server, raises representative runtime errors, writes a structured
+; result file, and quits with a pass/fail exit code. When the env flag is absent the script
+; returns immediately, so opening/running this project normally is unaffected.
+
+[ext_resource type="Script" path="res://Harness/RuntimeHarness.cs" id="1_harness"]
+
+[node name="RuntimeHarness" type="Node"]
+script = ExtResource("1_harness")

--- a/Godot-Tests/Harness/RuntimeHarness.cs
+++ b/Godot-Tests/Harness/RuntimeHarness.cs
@@ -1,0 +1,494 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.Godot.MCP.Runtime;
+using com.IvanMurzak.Godot.MCP.Tools;
+using Godot;
+using HubConnectionState = Microsoft.AspNetCore.SignalR.Client.HubConnectionState;
+
+namespace com.IvanMurzak.Godot.MCP.Tests.Project.Harness
+{
+    /// <summary>
+    /// CI runtime-integration harness (issue #186). Boots the in-game Godot-MCP <b>runtime</b> path inside a
+    /// HEADLESS game (NOT the editor), connects it to a LOCAL <c>gamedev-mcp-server</c> over SignalR, raises
+    /// a representative set of runtime errors, reads them back through
+    /// <see cref="RuntimeErrorCollector.Current"/>, and writes a STRUCTURED result file (+ stdout) so a CI
+    /// step can assert:
+    /// <list type="number">
+    ///   <item>the live transport connected (handshake) — proving the <c>#if TOOLS</c>-excluded connect path
+    ///   actually works end-to-end (today CI only does an editor-load smoke);</item>
+    ///   <item>a tool roundtrip works (the CI step POSTs <c>ping</c> to the server while this game holds the
+    ///   connection — exercised CI-side, this harness only proves the connection is up);</item>
+    ///   <item><c>runtime-errors-get</c>'s store shows the engine GDScript runtime error WITH the #163
+    ///   multi-frame backtrace (Godot 4.5+), the <c>push_error</c>/<c>push_warning</c>, and the C# exception
+    ///   with a stack — and on Godot 4.3/4.4 that the engine channel degrades gracefully (frames null).</item>
+    /// </list>
+    ///
+    /// <para>
+    /// <b>Env-guarded.</b> The whole harness only runs when <c>GODOT_MCP_HARNESS=1</c> — a normal editor load
+    /// / a normal game run is unaffected (the autoload returns immediately). Connection is driven by the
+    /// addon's own <c>GODOT_MCP_*</c> env contract (host/mode/auth) set by the CI step; when
+    /// <c>GODOT_MCP_HARNESS_REQUIRE_CONNECT=0</c> the harness still captures + writes the result but does not
+    /// FAIL on a missing connection (used only for a connection-free local capture smoke).
+    /// </para>
+    ///
+    /// <para>
+    /// This file lives under <c>Godot-Tests/</c> (the CI testbed project), NOT under <c>addons/godot_mcp/</c>
+    /// — it is test/CI scaffolding, never shipped in the addon. It compiles into the testbed assembly
+    /// alongside the copied-in addon sources, so it can call the addon's public runtime API directly.
+    /// </para>
+    /// </summary>
+    public partial class RuntimeHarness : Node
+    {
+        // --- Env contract (read once at boot) ---------------------------------------------------------
+
+        /// <summary>Master gate — the harness runs ONLY when this is exactly "1".</summary>
+        const string EnvHarnessEnabled = "GODOT_MCP_HARNESS";
+
+        /// <summary>Absolute path the structured JSON result is written to. Required when the harness runs.</summary>
+        const string EnvResultPath = "GODOT_MCP_HARNESS_RESULT";
+
+        /// <summary>When "0", a missing connection does NOT fail the harness (local capture-only smoke). Default "1".</summary>
+        const string EnvRequireConnect = "GODOT_MCP_HARNESS_REQUIRE_CONNECT";
+
+        /// <summary>Overall wall-clock budget (seconds) for the connect+capture phase before giving up. Default 60.</summary>
+        const string EnvTimeoutSeconds = "GODOT_MCP_HARNESS_TIMEOUT_SECONDS";
+
+        /// <summary>
+        /// Explicit per-leg expectation, set by the CI workflow from the matrix Godot version: "1" when the
+        /// engine 4.5+ logger channel should be present (Godot 4.5+), "0" when it must be absent (4.3 / 4.4 —
+        /// graceful stub degradation). When UNSET the harness falls back to inferring it from the running
+        /// editor version (major==4 && minor>=5). The explicit env is the authoritative signal because the
+        /// REAL determinant is the build's Godot.NET.Sdk version (which defines GODOT4_5_OR_GREATER), and the
+        /// workflow pins the build SDK to the matrix version — so the editor version and this flag always
+        /// agree in CI, but the env makes the contract unambiguous and independently testable.
+        /// </summary>
+        const string EnvEngineLoggerExpected = "GODOT_MCP_HARNESS_ENGINE_LOGGER_EXPECTED";
+
+        // --- State ------------------------------------------------------------------------------------
+
+        GodotMcpRuntimeHandle? _handle;
+        bool _started;
+
+        public override void _Ready()
+        {
+            // Default OFF: a normal editor/game load must be untouched. Only the explicit CI flag runs it.
+            if (OS.GetEnvironment(EnvHarnessEnabled) != "1")
+                return;
+
+            if (_started)
+                return;
+            _started = true;
+
+            // Run the async harness fire-and-forget; it owns its own SceneTree.Quit() with an exit code.
+            _ = RunAsync();
+        }
+
+        async Task RunAsync()
+        {
+            var resultPath = OS.GetEnvironment(EnvResultPath);
+            var requireConnect = OS.GetEnvironment(EnvRequireConnect) != "0"; // default: require
+            var timeoutSeconds = ParseIntOr(OS.GetEnvironment(EnvTimeoutSeconds), 60);
+
+            var report = new HarnessReport
+            {
+                GodotVersion = (string)Engine.GetVersionInfo()["string"],
+                EngineLoggerExpected = ResolveEngineLoggerExpected(),
+                RequireConnect = requireConnect,
+            };
+
+            GD.Print($"[harness] starting (godot={report.GodotVersion}, engineLoggerExpected={report.EngineLoggerExpected}, requireConnect={requireConnect}, timeout={timeoutSeconds}s).");
+
+            try
+            {
+                // 1) Build the in-game runtime: opt the addon's tools in (so the server's tool list — incl.
+                //    ping + runtime-errors-get — is non-empty after connect) and enable runtime error capture
+                //    (installs the engine 4.5+ logger + the C# AppDomain/TaskScheduler hooks). Host/mode/auth
+                //    come from the addon's own GODOT_MCP_* env contract the CI step sets, so we do NOT hard-code
+                //    them here — a WithConfig is unnecessary because GodotMcpConfig reads the env live.
+                _handle = GodotMcpRuntime.Initialize(b =>
+                {
+                    b.WithToolsFromAssembly(typeof(Tool_Ping).Assembly);
+                    b.WithRuntimeErrorCapture();
+                }).Build();
+
+                report.CaptureInstalled = RuntimeErrorCapture.IsInstalled;
+                GD.Print($"[harness] runtime built. captureInstalled={report.CaptureInstalled}.");
+
+                // 2) Let the deferred main-thread dispatcher AddChild land (GodotMcpRuntime schedules it via
+                //    CallDeferred on the tree root), so tool handlers can marshal before we connect.
+                await WaitFramesAsync(3);
+
+                // 3) Connect to the local server (explicit — nothing auto-connects). KeepConnected drives the
+                //    client's own reconnect loop; Connect() returns true on the FIRST successful connect.
+                bool initialConnect = false;
+                try
+                {
+                    initialConnect = await _handle.Connect();
+                }
+                catch (Exception ex)
+                {
+                    report.ConnectError = ex.Message;
+                    GD.PushWarning($"[harness] Connect() threw: {ex.Message}");
+                }
+                report.InitialConnectReturned = initialConnect;
+
+                // 4) Poll for the live SignalR state to reach Connected (robust — NOT a fixed sleep). The
+                //    reused client may report Connected slightly after Connect() returns; poll the plugin's
+                //    ConnectionState reactive property until Connected or the budget expires.
+                report.Connected = await PollConnectedAsync(TimeSpan.FromSeconds(timeoutSeconds));
+                GD.Print($"[harness] connect phase done. initialConnect={initialConnect}, connected={report.Connected}.");
+
+                // 5) Raise the three representative runtime errors.
+                RaiseErrors(report);
+
+                // 6) Poll the collector until all the expected rows have landed (capture is multi-threaded;
+                //    the engine logger + AppDomain/TaskScheduler hooks append from arbitrary threads). Robust
+                //    wait, capped by the same budget.
+                await PollCapturedAsync(report, TimeSpan.FromSeconds(timeoutSeconds));
+
+                // 7) Snapshot the captured rows into the report.
+                Snapshot(report);
+            }
+            catch (Exception ex)
+            {
+                report.FatalError = ex.ToString();
+                GD.PushError($"[harness] FATAL: {ex}");
+            }
+            finally
+            {
+                try { _handle?.Disconnect().Wait(TimeSpan.FromSeconds(5)); } catch { /* best-effort */ }
+            }
+
+            // 8) Decide pass/fail and write the result.
+            var ok = Evaluate(report);
+            report.Ok = ok;
+            WriteResult(resultPath, report);
+
+            GD.Print($"[harness] DONE ok={ok}. summary: connected={report.Connected} engineErr={report.HasEngineRuntimeError} engineFrames={report.EngineRuntimeErrorFrameCount} pushErr={report.HasPushError} pushWarn={report.HasPushWarning} csharpEx={report.HasCSharpException}.");
+
+            // Dispose the handle (uninstalls capture) before quitting.
+            try { _handle?.Dispose(); } catch { /* best-effort */ }
+
+            GetTree().Quit(ok ? 0 : 1);
+        }
+
+        // --- Error generation -------------------------------------------------------------------------
+
+        void RaiseErrors(HarnessReport report)
+        {
+            // (a) A genuine GDScript RUNTIME error with a deep multi-frame backtrace (#163). Load the harness
+            //     .gd, instantiate it, and call its entry point — the innermost frame faults at runtime. On
+            //     Godot 4.5+ the engine logger captures it WITH frames; on < 4.5 the channel is absent.
+            try
+            {
+                var script = GD.Load<GDScript>("res://Harness/Faulty.gd");
+                if (script != null)
+                {
+                    var obj = (GodotObject)script.New();
+                    // A real runtime fault: nonexistent-method call deep in a call chain. Swallow any managed
+                    // surfacing — the point is the ENGINE error stream captures it, not that WE observe it.
+                    try { obj.Call("raise_runtime_fault"); }
+                    catch (Exception ex) { GD.Print($"[harness] gdscript fault surfaced to C# (expected-ish): {ex.Message}"); }
+                    report.RaisedGdScriptFault = true;
+                }
+                else
+                {
+                    GD.PushWarning("[harness] could not load res://Harness/Faulty.gd — GDScript fault not raised.");
+                }
+            }
+            catch (Exception ex)
+            {
+                GD.PushWarning($"[harness] raising the GDScript fault failed: {ex.Message}");
+            }
+
+            // (b) push_error + push_warning — captured by the engine logger on 4.5+ (absent on < 4.5).
+            GD.PushError("[harness] deliberate push_error for runtime-error capture (issue #186).");
+            GD.PushWarning("[harness] deliberate push_warning for runtime-error capture (issue #186).");
+            report.RaisedPushDiagnostics = true;
+
+            // (c) A C# exception via TaskScheduler.UnobservedTaskException: start a Task that throws, drop the
+            //     reference without awaiting, then force GC + finalizers so the unobserved-exception event
+            //     fires (that is exactly when the runtime raises it). Pure-managed channel — works on EVERY
+            //     Godot version, including < 4.5.
+            RaiseUnobservedTaskException();
+            report.RaisedCSharpException = true;
+        }
+
+        static void RaiseUnobservedTaskException()
+        {
+            // Create + abandon a faulted Task inside a non-inlined local so the JIT cannot keep it rooted.
+            FaultAndAbandon();
+            // The unobserved-exception escalation fires from the Task finalizer — force it deterministically.
+            for (var i = 0; i < 4; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            }
+            GC.Collect();
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static void FaultAndAbandon()
+        {
+            // Task.Run schedules work that throws; we never await/observe it, so its exception goes unobserved.
+            _ = Task.Run(() =>
+                throw new InvalidOperationException(
+                    "[harness] deliberate unobserved Task exception for runtime-error capture (issue #186)."));
+        }
+
+        // --- Robust polling (no blind sleeps) ---------------------------------------------------------
+
+        async Task<bool> PollConnectedAsync(TimeSpan budget)
+        {
+            var plugin = _handle?.Plugin;
+            if (plugin == null)
+                return false;
+
+            var deadline = DateTime.UtcNow + budget;
+            while (DateTime.UtcNow < deadline)
+            {
+                if (plugin.ConnectionState.CurrentValue == HubConnectionState.Connected)
+                    return true;
+                await WaitFramesAsync(5);
+            }
+            return plugin.ConnectionState.CurrentValue == HubConnectionState.Connected;
+        }
+
+        async Task PollCapturedAsync(HarnessReport report, TimeSpan budget)
+        {
+            var deadline = DateTime.UtcNow + budget;
+            while (DateTime.UtcNow < deadline)
+            {
+                var collector = RuntimeErrorCollector.Current;
+                if (collector != null)
+                {
+                    var rows = collector.QuerySince(0, RuntimeErrorCollector.Capacity, out _);
+                    // The C# unobserved-Task exception is the version-independent guaranteed row; once it AND
+                    // the push diagnostics are present we have everything the < 4.5 path can produce. On 4.5+
+                    // we additionally wait for the engine GDScript error with frames.
+                    var haveCSharp = rows.Any(IsCSharpException);
+                    var havePushErr = rows.Any(r => IsEnginePushError(r));
+                    var havePushWarn = rows.Any(r => IsEnginePushWarning(r));
+                    var haveEngineRuntime = rows.Any(IsEngineScriptRuntimeError);
+
+                    var enginePartDone = !report.EngineLoggerExpected || (haveEngineRuntime && havePushErr && havePushWarn);
+                    if (haveCSharp && enginePartDone)
+                        return;
+                }
+                await WaitFramesAsync(5);
+            }
+        }
+
+        async Task WaitFramesAsync(int frames)
+        {
+            for (var i = 0; i < frames; i++)
+                await ToSignal(GetTree(), SceneTree.SignalName.ProcessFrame);
+        }
+
+        // --- Snapshot + classification ----------------------------------------------------------------
+
+        void Snapshot(HarnessReport report)
+        {
+            var collector = RuntimeErrorCollector.Current;
+            report.CaptureAvailable = collector != null;
+            if (collector == null)
+                return;
+
+            var rows = collector.QuerySince(0, RuntimeErrorCollector.Capacity, out _);
+            report.TotalCaptured = rows.Length;
+
+            var engineRuntime = rows.FirstOrDefault(IsEngineScriptRuntimeError);
+            if (engineRuntime != null)
+            {
+                report.HasEngineRuntimeError = true;
+                report.EngineRuntimeErrorMessage = engineRuntime.Message;
+                report.EngineRuntimeErrorType = engineRuntime.Type;
+                report.EngineRuntimeErrorFile = engineRuntime.File;
+                report.EngineRuntimeErrorFunction = engineRuntime.Function;
+                report.EngineRuntimeErrorFrameCount = engineRuntime.Frames?.Count ?? 0;
+                report.EngineRuntimeErrorHasStackTrace = !string.IsNullOrEmpty(engineRuntime.StackTrace);
+                report.EngineRuntimeErrorFrameFunctions = engineRuntime.Frames?
+                    .Select(f => f.Function).Where(f => !string.IsNullOrEmpty(f)).ToList() ?? new List<string>();
+            }
+
+            report.HasPushError = rows.Any(IsEnginePushError);
+            report.HasPushWarning = rows.Any(IsEnginePushWarning);
+
+            var csharp = rows.FirstOrDefault(IsCSharpException);
+            if (csharp != null)
+            {
+                report.HasCSharpException = true;
+                report.CSharpExceptionType = csharp.Type;
+                report.CSharpExceptionHasStackTrace = !string.IsNullOrEmpty(csharp.StackTrace);
+            }
+        }
+
+        // A GDScript RUNTIME error is an Engine row of kind Script (or generic Error) that carries an engine
+        // origin and — on 4.5+ — frames. We additionally require it not to be the push_error/push_warning we
+        // raised (those are matched separately by their marker text).
+        static bool IsEngineScriptRuntimeError(RuntimeError r) =>
+            r.Source == RuntimeErrorSource.Engine
+            && (string.Equals(r.Type, nameof(EngineErrorKind.Script), StringComparison.OrdinalIgnoreCase)
+                || string.Equals(r.Type, nameof(EngineErrorKind.Error), StringComparison.OrdinalIgnoreCase))
+            && !r.Message.Contains("deliberate push_error", StringComparison.OrdinalIgnoreCase)
+            && !r.Message.Contains("deliberate push_warning", StringComparison.OrdinalIgnoreCase);
+
+        static bool IsEnginePushError(RuntimeError r) =>
+            r.Source == RuntimeErrorSource.Engine
+            && r.Message.Contains("deliberate push_error", StringComparison.OrdinalIgnoreCase);
+
+        static bool IsEnginePushWarning(RuntimeError r) =>
+            r.Source == RuntimeErrorSource.Engine
+            && r.Message.Contains("deliberate push_warning", StringComparison.OrdinalIgnoreCase);
+
+        static bool IsCSharpException(RuntimeError r) =>
+            r.Source == RuntimeErrorSource.UnobservedTaskException
+            || r.Source == RuntimeErrorSource.UnhandledException;
+
+        // --- Pass/fail evaluation ---------------------------------------------------------------------
+
+        bool Evaluate(HarnessReport report)
+        {
+            if (!string.IsNullOrEmpty(report.FatalError))
+                return false;
+
+            // Capture must have installed and be available regardless of version.
+            if (!report.CaptureInstalled || !report.CaptureAvailable)
+                return false;
+
+            // The C# unobserved-Task exception is the version-independent guaranteed row.
+            if (!report.HasCSharpException || !report.CSharpExceptionHasStackTrace)
+                return false;
+
+            // Connection: required unless explicitly waived (local capture-only smoke).
+            if (report.RequireConnect && !report.Connected)
+                return false;
+
+            if (report.EngineLoggerExpected)
+            {
+                // Godot 4.5+: the engine GDScript runtime error must be captured WITH a multi-frame backtrace
+                // (#163), and the push_error/push_warning must be captured.
+                if (!report.HasEngineRuntimeError) return false;
+                if (report.EngineRuntimeErrorFrameCount < 2) return false; // deep chain => >= 2 frames
+                if (!report.HasPushError) return false;
+                if (!report.HasPushWarning) return false;
+            }
+            else
+            {
+                // Godot < 4.5: the engine logger channel is ABSENT (graceful stub degradation). The engine
+                // rows must NOT appear and no engine frames can exist. The C# channel (asserted above) is the
+                // only one that captures. This is the per-version assertion the issue calls for.
+                if (report.HasEngineRuntimeError) return false;
+                if (report.HasPushError || report.HasPushWarning) return false;
+                if (report.EngineRuntimeErrorFrameCount != 0) return false;
+            }
+
+            return true;
+        }
+
+        // --- Result serialization ---------------------------------------------------------------------
+
+        void WriteResult(string resultPath, HarnessReport report)
+        {
+            var json = JsonSerializer.Serialize(report, new JsonSerializerOptions { WriteIndented = true });
+
+            // Always echo to stdout so the CI log carries it even if the file write fails.
+            GD.Print("[harness-result-begin]");
+            GD.Print(json);
+            GD.Print("[harness-result-end]");
+
+            if (string.IsNullOrEmpty(resultPath))
+            {
+                GD.PushWarning($"[harness] {EnvResultPath} not set — result not written to a file (stdout only).");
+                return;
+            }
+
+            try
+            {
+                System.IO.File.WriteAllText(resultPath, json);
+                GD.Print($"[harness] result written to {resultPath}.");
+            }
+            catch (Exception ex)
+            {
+                GD.PushError($"[harness] failed to write result to {resultPath}: {ex.Message}");
+            }
+        }
+
+        static int ParseIntOr(string? raw, int fallback) =>
+            int.TryParse(raw, out var v) && v > 0 ? v : fallback;
+
+        /// <summary>
+        /// Whether the engine 4.5+ logger channel is expected for THIS leg: the explicit
+        /// <see cref="EnvEngineLoggerExpected"/> env ("1"/"0") when set, else inferred from the running
+        /// editor version (major==4 &amp;&amp; minor&gt;=5). See the env's doc for why the explicit signal is preferred.
+        /// </summary>
+        static bool ResolveEngineLoggerExpected()
+        {
+            var raw = OS.GetEnvironment(EnvEngineLoggerExpected);
+            if (raw == "1") return true;
+            if (raw == "0") return false;
+
+            var info = Engine.GetVersionInfo();
+            return info["major"].AsInt32() == 4 && info["minor"].AsInt32() >= 5;
+        }
+
+        /// <summary>
+        /// The structured harness outcome — serialized to the result file the CI asserter parses, and echoed
+        /// to stdout. Field names are camelCased in JSON to match the addon's data-model convention.
+        /// </summary>
+        sealed class HarnessReport
+        {
+            [JsonPropertyName("ok")] public bool Ok { get; set; }
+            [JsonPropertyName("godotVersion")] public string GodotVersion { get; set; } = string.Empty;
+            [JsonPropertyName("engineLoggerExpected")] public bool EngineLoggerExpected { get; set; }
+            [JsonPropertyName("requireConnect")] public bool RequireConnect { get; set; }
+
+            [JsonPropertyName("captureInstalled")] public bool CaptureInstalled { get; set; }
+            [JsonPropertyName("captureAvailable")] public bool CaptureAvailable { get; set; }
+
+            [JsonPropertyName("initialConnectReturned")] public bool InitialConnectReturned { get; set; }
+            [JsonPropertyName("connected")] public bool Connected { get; set; }
+            [JsonPropertyName("connectError")] public string? ConnectError { get; set; }
+
+            [JsonPropertyName("raisedGdScriptFault")] public bool RaisedGdScriptFault { get; set; }
+            [JsonPropertyName("raisedPushDiagnostics")] public bool RaisedPushDiagnostics { get; set; }
+            [JsonPropertyName("raisedCSharpException")] public bool RaisedCSharpException { get; set; }
+
+            [JsonPropertyName("totalCaptured")] public int TotalCaptured { get; set; }
+
+            [JsonPropertyName("hasEngineRuntimeError")] public bool HasEngineRuntimeError { get; set; }
+            [JsonPropertyName("engineRuntimeErrorMessage")] public string? EngineRuntimeErrorMessage { get; set; }
+            [JsonPropertyName("engineRuntimeErrorType")] public string? EngineRuntimeErrorType { get; set; }
+            [JsonPropertyName("engineRuntimeErrorFile")] public string? EngineRuntimeErrorFile { get; set; }
+            [JsonPropertyName("engineRuntimeErrorFunction")] public string? EngineRuntimeErrorFunction { get; set; }
+            [JsonPropertyName("engineRuntimeErrorFrameCount")] public int EngineRuntimeErrorFrameCount { get; set; }
+            [JsonPropertyName("engineRuntimeErrorHasStackTrace")] public bool EngineRuntimeErrorHasStackTrace { get; set; }
+            [JsonPropertyName("engineRuntimeErrorFrameFunctions")] public List<string> EngineRuntimeErrorFrameFunctions { get; set; } = new();
+
+            [JsonPropertyName("hasPushError")] public bool HasPushError { get; set; }
+            [JsonPropertyName("hasPushWarning")] public bool HasPushWarning { get; set; }
+
+            [JsonPropertyName("hasCSharpException")] public bool HasCSharpException { get; set; }
+            [JsonPropertyName("cSharpExceptionType")] public string? CSharpExceptionType { get; set; }
+            [JsonPropertyName("cSharpExceptionHasStackTrace")] public bool CSharpExceptionHasStackTrace { get; set; }
+
+            [JsonPropertyName("fatalError")] public string? FatalError { get; set; }
+        }
+    }
+}

--- a/Godot-Tests/README.md
+++ b/Godot-Tests/README.md
@@ -39,6 +39,36 @@ alongside the `dotnet build (.NET 8)` + xUnit job and the `godot-mcp-cli` node
 tests. The live matrix only runs in the PR's own GitHub CI run (the runners
 download Godot).
 
+## Runtime integration harness (issue #186)
+
+Beyond the addon-LOAD smoke above, `Harness/` holds a RUNTIME INTEGRATION harness
+that boots a **headless GAME** (not the editor) and exercises the whole end-to-end
+path the `#if TOOLS`-excluded xUnit suite cannot reach — live SignalR connect +
+handshake + tool dispatch, and in-game runtime-error capture:
+
+- `Harness/Main.tscn` — `project.godot`'s `run/main_scene`; its root node carries
+  `RuntimeHarness.cs`.
+- `Harness/RuntimeHarness.cs` — gated by `GODOT_MCP_HARNESS=1` (a normal load/run is
+  untouched). On boot it `GodotMcpRuntime.Initialize(b => b.WithRuntimeErrorCapture())
+  .Build()` + `.Connect()`s to a LOCAL `gamedev-mcp-server`, raises a GDScript runtime
+  fault + `push_error`/`push_warning` + a C# unobserved-Task exception, reads them back
+  via `RuntimeErrorCollector.Current.QuerySince(...)`, writes a structured JSON result
+  (path = `GODOT_MCP_HARNESS_RESULT`), and quits with a pass/fail exit code.
+- `Harness/Faulty.gd` — a small call chain whose innermost frame calls a nonexistent
+  method, producing a genuine engine GDScript runtime error with a deep multi-frame
+  backtrace (issue #163) on Godot 4.5+.
+
+`.github/workflows/test_godot_runtime_harness.yml` (reusable, input `godotVersion`)
+downloads the released `gamedev-mcp-server` (`v<ServerVersion>`), runs it
+`authorization=none` on a fixed port, builds the testbed C# with the SDK matching the
+matrix Godot version (so the engine 4.5+ logger compiles in on 4.5 and is stubbed on
+4.3/4.4), boots the headless harness game, POSTs `ping` to the server while the game
+holds the connection (proving connect + handshake + dispatch), and asserts the result
+via `scripts/assert_runtime_harness.py`. The **4.5.1** leg asserts the engine GDScript
+backtrace + `push_error`/`push_warning`; the **4.3/4.4** legs assert graceful stub
+degradation (no engine logger, frames null) while the C# channel still captures.
+`test_pull_request.yml` and `release.yml` both fan it out across 4.3 / 4.4 / 4.5.
+
 ## Local run
 
 Mirror the CI smoke against the infra testbed instead (it junctions the live

--- a/Godot-Tests/project.godot
+++ b/Godot-Tests/project.godot
@@ -16,6 +16,11 @@ config_version=5
 
 config/name="Godot-MCP-Tests"
 config/description="Minimal headless CI testbed verifying the godot_mcp addon loads across Godot 4.3/4.4/4.5 (mono). No game content."
+; run/main_scene points at the issue-#186 runtime-integration harness so a HEADLESS GAME run
+; (godot --headless --path Godot-Tests, NOT --editor) boots Harness/Main.tscn → RuntimeHarness.cs.
+; The harness only does anything when GODOT_MCP_HARNESS=1, so the existing editor-load smoke
+; (--editor --quit) and a normal run are unaffected.
+run/main_scene="res://Harness/Main.tscn"
 config/features=PackedStringArray("4.3", "C#")
 
 [dotnet]

--- a/scripts/assert_runtime_harness.py
+++ b/scripts/assert_runtime_harness.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# ┌──────────────────────────────────────────────────────────────────┐
+# │  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+# │  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+# │  Copyright (c) 2026 Ivan Murzak                                  │
+# │  Licensed under the Apache License, Version 2.0.                 │
+# │  See the LICENSE file in the project root for more information.  │
+# └──────────────────────────────────────────────────────────────────┘
+"""
+Assert the structured result file produced by the issue-#186 runtime-integration harness
+(Godot-Tests/Harness/RuntimeHarness.cs). The harness ALREADY decides pass/fail and encodes
+it in its process exit code + the result's `ok` field; this asserter re-checks every
+per-version expectation INDEPENDENTLY so CI fails with a readable, field-by-field diagnosis
+(not just a bare non-zero exit) and so a future harness regression that flips `ok` true
+without actually capturing what it claims is still caught here.
+
+Usage:
+    python scripts/assert_runtime_harness.py --result <path> --engine-logger-expected {0|1} \
+        [--require-connect {0|1}] [--require-roundtrip {0|1}]
+
+Per-version contract (the issue's acceptance criteria):
+  * ALWAYS: capture installed + available; the C# unobserved-Task exception captured WITH a
+    stack trace; (when --require-connect=1) the live SignalR transport connected.
+  * --engine-logger-expected 1 (Godot 4.5+): the engine GDScript runtime error captured WITH
+    a multi-frame backtrace (>= 2 frames, issue #163) + push_error + push_warning.
+  * --engine-logger-expected 0 (Godot 4.3 / 4.4): the engine channel is ABSENT (graceful stub
+    degradation) — no engine rows, no engine frames — while the C# channel still captures.
+
+Pure stdlib — runs anywhere Python 3.8+ does. Exit 0 = every assertion held; 1 = a failure
+(each failed assertion is printed); 2 = the result file is missing/unparseable.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _b(value) -> bool:
+    return value is True
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Assert the Godot-MCP runtime-harness result.")
+    ap.add_argument("--result", required=True, help="Path to the harness result JSON.")
+    ap.add_argument("--engine-logger-expected", required=True, choices=["0", "1"],
+                    help="1 when the Godot 4.5+ engine logger channel must be present, 0 for 4.3/4.4.")
+    ap.add_argument("--require-connect", default="1", choices=["0", "1"],
+                    help="1 (default) to require the live SignalR connection.")
+    ap.add_argument("--require-roundtrip", default="0", choices=["0", "1"],
+                    help="1 to require the result to record a successful tool roundtrip (default 0: the "
+                         "roundtrip is asserted by the workflow's own server POST, not by the harness).")
+    args = ap.parse_args()
+
+    result_path = Path(args.result)
+    if not result_path.is_file():
+        print(f"::error::harness result file not found: {result_path}")
+        return 2
+
+    try:
+        data = json.loads(result_path.read_text(encoding="utf-8"))
+    except Exception as ex:  # noqa: BLE001
+        print(f"::error::could not parse harness result {result_path}: {ex}")
+        return 2
+
+    engine_expected = args.engine_logger_expected == "1"
+    require_connect = args.require_connect == "1"
+
+    failures: list[str] = []
+
+    def check(cond: bool, msg: str) -> None:
+        if not cond:
+            failures.append(msg)
+
+    # --- Always-required (version-independent) -----------------------------------------------
+    check(data.get("fatalError") in (None, ""), f"harness reported a fatal error: {data.get('fatalError')!r}")
+    check(_b(data.get("captureInstalled")), "runtime error capture did not install")
+    check(_b(data.get("captureAvailable")), "RuntimeErrorCollector.Current was not available")
+    check(_b(data.get("hasCSharpException")), "the C# (unobserved-Task) exception was not captured")
+    check(_b(data.get("cSharpExceptionHasStackTrace")), "the captured C# exception had no stack trace")
+
+    if require_connect:
+        check(_b(data.get("connected")), "the live SignalR transport did not reach Connected")
+        check(_b(data.get("initialConnectReturned")), "Connect() did not return true (initial connect failed)")
+
+    # --- Per-version engine-channel expectations ---------------------------------------------
+    check(_b(data.get("engineLoggerExpected")) == engine_expected,
+          f"engineLoggerExpected in result ({data.get('engineLoggerExpected')}) != "
+          f"--engine-logger-expected ({engine_expected}) — the leg's SDK build / version are mismatched")
+
+    if engine_expected:
+        # Godot 4.5+: engine GDScript runtime error WITH the #163 multi-frame backtrace + push diagnostics.
+        check(_b(data.get("hasEngineRuntimeError")),
+              "engine GDScript runtime error was NOT captured (4.5+ engine logger expected)")
+        frame_count = data.get("engineRuntimeErrorFrameCount", 0)
+        check(isinstance(frame_count, int) and frame_count >= 2,
+              f"engine GDScript runtime error backtrace was not deep enough "
+              f"(frames={frame_count}, expected >= 2 — issue #163)")
+        check(_b(data.get("engineRuntimeErrorHasStackTrace")),
+              "engine GDScript runtime error carried no formatted stack trace")
+        check(_b(data.get("hasPushError")), "push_error was NOT captured (4.5+ engine logger expected)")
+        check(_b(data.get("hasPushWarning")), "push_warning was NOT captured (4.5+ engine logger expected)")
+    else:
+        # Godot 4.3 / 4.4: the engine channel must degrade gracefully to ABSENT.
+        check(not _b(data.get("hasEngineRuntimeError")),
+              "engine GDScript runtime error was captured on a < 4.5 leg (engine logger should be absent)")
+        check(data.get("engineRuntimeErrorFrameCount", 0) == 0,
+              "engine backtrace frames present on a < 4.5 leg (engine logger should be absent)")
+        check(not _b(data.get("hasPushError")),
+              "push_error was captured on a < 4.5 leg (engine logger should be absent)")
+        check(not _b(data.get("hasPushWarning")),
+              "push_warning was captured on a < 4.5 leg (engine logger should be absent)")
+
+    # --- The harness's own verdict must agree ------------------------------------------------
+    check(_b(data.get("ok")), "the harness's own 'ok' verdict was false")
+
+    print(f"Godot version: {data.get('godotVersion')!r}; engineLoggerExpected={engine_expected}; "
+          f"requireConnect={require_connect}")
+    print(json.dumps(data, indent=2))
+
+    if failures:
+        print(f"::error::runtime harness assertion FAILED ({len(failures)} issue(s)):")
+        for f in failures:
+            print(f"::error::  - {f}")
+        return 1
+
+    print("Runtime harness assertions PASSED.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds a real end-to-end **runtime integration harness** that CI was missing: today CI only does an addon-LOAD smoke (boot the editor, grep `[Godot-MCP] plugin loaded`). The whole transport (`GodotMcpConnection` connect/handshake/dispatch) and the in-game runtime-error capture (`RuntimeErrorCapture` + the 4.5 engine logger + the AppDomain/TaskScheduler hooks) are `#if TOOLS`-excluded from xUnit or never booted, so those regressions pass CI silently.
- New env-guarded (`GODOT_MCP_HARNESS=1`) **headless GAME** harness under `Godot-Tests/Harness/` (`Main.tscn` + `RuntimeHarness.cs` + `Faulty.gd`): builds the in-game runtime with `WithRuntimeErrorCapture()`, `Connect()`s to a LOCAL `gamedev-mcp-server`, raises a GDScript runtime fault (deep multi-frame backtrace, #163) + `push_error`/`push_warning` + a C# unobserved-Task exception, reads them back via `RuntimeErrorCollector.Current`, writes a structured JSON result, and quits with a pass/fail exit code.
- New reusable workflow `test_godot_runtime_harness.yml`: downloads the released `gamedev-mcp-server` (`v8.0.0` — the addon's pinned `GodotMcpServerView.ServerVersion`), runs it `authorization=none` on a fixed port, builds the testbed C# with the SDK matching the matrix Godot version (so the engine 4.5+ logger compiles in on 4.5 and is stubbed on 4.3/4.4), boots the headless harness game, POSTs `ping` to the server while the game holds the connection (proving connect + handshake + dispatch), and asserts the result via `scripts/assert_runtime_harness.py`. The **4.5.1** leg asserts the engine GDScript backtrace + push diagnostics; **4.3/4.4** assert graceful stub degradation (no engine logger, frames null). Logs uploaded on failure.
- Wired across **4.3 / 4.4 / 4.5** into both `test_pull_request.yml` and the `release.yml` gate.
- `Godot-MCP.csproj`: excludes `Godot-Tests/**/*.cs` from the addon glob (the sibling-project glob trap) so the harness never leaks into the addon assembly and breaks the `dotnet build (.NET 8)` gate.
- **No production addon change; no NuGet pin change.**

## Test plan

- [x] Local validation (Godot 4.5.1 mono): downloaded `gamedev-mcp-server` v8.0.0, ran it `authorization=none` on a local port, built the testbed with the 4.5.1 SDK, ran the headless harness game → `connected=true`, `POST /api/tools/ping` returned the echoed value (roundtrip), and `runtime-errors-get`'s store showed the engine GDScript error with a **3-frame backtrace** (`_level_three`→`_level_two`→`raise_runtime_fault`, file `res://Harness/Faulty.gd`, type `Script`) + `push_error`/`push_warning` + the C# `AggregateException` with a stack (`ok=true`).
- [x] 4.3/4.4 degradation simulated locally (build with the 4.3.0-floor SDK + `GODOT_MCP_HARNESS_ENGINE_LOGGER_EXPECTED=0`) → engine channel absent (no engine rows, frames=0), C# channel still captured (`ok=true`).
- [x] `assert_runtime_harness.py` validated against both result JSONs (pass) and a negative cross-check (correctly fails with field-by-field diagnostics).
- [x] Suite 1 `dotnet build Godot-MCP.sln` 0 errors; harness `.cs` confirmed NOT leaked into the addon assembly.
- [x] Suite 2 `dotnet test` — 886/886 passed, 0 failed.
- [x] Runtime/editor boundary guard + YAML lint (all 7 workflows) green.
- [ ] The live CI matrix (4.3/4.4/4.5) runs on this PR's own GitHub run (downloads Godot + the server).

Closes #186