### PR TITLE
docs(readme): add Docker Image badge (no size) after the Stars badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![release](https://github.com/IvanMurzak/Godot-MCP/workflows/release/badge.svg 'release')](https://github.com/IvanMurzak/Godot-MCP/actions/workflows/release.yml)</br>
 [![Discord](https://img.shields.io/badge/Discord-Join-7289da?logo=discord&logoColor=white&labelColor=333A41 'Join')](https://discord.gg/cfbdMZX99G)
 [![Stars](https://img.shields.io/github/stars/IvanMurzak/Godot-MCP 'Stars')](https://github.com/IvanMurzak/Godot-MCP/stargazers)
+[![Docker Image](https://img.shields.io/badge/Docker-Image-2496ED?style=flat&logo=docker&logoColor=white&labelColor=333A41 'Docker Image')](https://hub.docker.com/r/aigamedeveloper/mcp-server)
 [![License](https://img.shields.io/github/license/IvanMurzak/Godot-MCP?label=License&labelColor=333A41)](https://github.com/IvanMurzak/Godot-MCP/blob/main/LICENSE)
 [![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://stand-with-ukraine.pp.ua)
 


### PR DESCRIPTION
Adds a Docker Image badge to the second badge row, right after the Stars badge —
mirroring Unity-MCP, but **without** the image-size value.

It's a static badge (Docker logo + "Docker | Image") linking to the shared
[`aigamedeveloper/mcp-server`](https://hub.docker.com/r/aigamedeveloper/mcp-server)
image on Docker Hub — the same GameDev-MCP-Server image Unity-MCP and Unreal-MCP use.

Docs-only; opened as a PR because `main` is a protected branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)