### PR TITLE
feat(connection): warn when DisconnectAndDrain bounded wait times out

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -100,6 +100,12 @@
     <!-- Editor-runtime NuGet-dependency resolver. Pure-BCL (System.Runtime.Loader), no #if TOOLS,
          no Godot native types — so it is unit-testable in this plain-xUnit host. -->
     <Compile Include="..\addons\godot_mcp\Runtime\Connection\GodotMcpAssemblyResolver.cs" Link="Source\GodotMcpAssemblyResolver.cs" />
+    <!-- Bounded-teardown drain diagnostics — pure-BCL (no Godot native types, no #if TOOLS): the
+         timeout->warning DECISION for DisconnectAndDrain's WaitForImmediateTeardown bounded wait (issue #189).
+         Routes the single warning through an injectable Action&lt;string&gt; sink (the GD.PushWarning wiring lives in
+         GodotMcpConnection.cs, which is editor/runtime-coupled and verified via the headless Godot smoke); the
+         drained->no-warning / timeout->warning decision + message shape are unit-tested here. -->
+    <Compile Include="..\addons\godot_mcp\Runtime\Connection\GodotMcpDrainDiagnostics.cs" Link="Source\GodotMcpDrainDiagnostics.cs" />
     <Compile Include="..\addons\godot_mcp\Runtime\Tools\Tool_Ping.cs" Link="Source\Tool_Ping.cs" />
     <!-- Scene/Node tool family — pure-managed pieces only (no Godot native types, no #if TOOLS):
          structured result models, the property-patch model, the path normalizer, and the ambient

--- a/Godot-MCP.Tests/GodotMcpDrainDiagnosticsTests.cs
+++ b/Godot-MCP.Tests/GodotMcpDrainDiagnosticsTests.cs
@@ -1,0 +1,121 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using com.IvanMurzak.Godot.MCP.Connection;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Regression tests for <see cref="GodotMcpDrainDiagnostics"/> — the pure-managed seam that decides whether
+    /// <see cref="GodotMcpConnection.DisconnectAndDrain(TimeSpan)"/> emits a diagnostic warning when its bounded
+    /// <c>WaitForImmediateTeardown</c> drain TIMES OUT (silently re-introducing godot#78513) vs COMPLETES.
+    ///
+    /// <para>
+    /// The bool fed to <see cref="GodotMcpDrainDiagnostics.ReportDrainResult"/> is exactly what the reused
+    /// client's <c>IConnection.WaitForImmediateTeardown(TimeSpan)</c> returns (verified against McpPlugin 6.10.0:
+    /// <c>true</c> = drained within the bound / nothing pending / already disposed; <c>false</c> = the bounded
+    /// <c>Task.Wait(timeout)</c> timed out or faulted). The editor/runtime-coupled <see cref="GodotMcpConnection"/>
+    /// that calls into the live SignalR client is verified via the headless Godot smoke (test.md Suite 3); the
+    /// timeout->warn / completion->no-warn DECISION, the single-warning guarantee, the never-throws contract, and
+    /// the message shape are pinned here in the plain-xUnit host with a capturing sink (no Godot binary needed).
+    /// </para>
+    /// </summary>
+    public class GodotMcpDrainDiagnosticsTests : IDisposable
+    {
+        readonly Action<string>? _savedWarn;
+
+        public GodotMcpDrainDiagnosticsTests()
+        {
+            // Snapshot the production sink (wired by GodotMcpConnection's static ctor when the type is touched)
+            // so each test can install a capturing sink and restore the original in Dispose — the seam's Warn is
+            // process-wide static state.
+            _savedWarn = GodotMcpDrainDiagnostics.Warn;
+        }
+
+        public void Dispose()
+        {
+            GodotMcpDrainDiagnostics.Warn = _savedWarn;
+        }
+
+        [Fact]
+        public void Timeout_EmitsExactlyOneWarning_AndReportsTrue()
+        {
+            // THE TIMEOUT BRANCH: WaitForImmediateTeardown returned false (bounded wait did not drain) -> the
+            // godot#78513 reintroduction must be surfaced as exactly ONE warning, and the call reports it warned.
+            var captured = new List<string>();
+            GodotMcpDrainDiagnostics.Warn = captured.Add;
+
+            bool warned = GodotMcpDrainDiagnostics.ReportDrainResult(drained: false, timeout: TimeSpan.FromSeconds(2));
+
+            Assert.True(warned);
+            Assert.Single(captured);
+            // The warning is informative and clearly a WARNING (proceed-anyway), referencing the godot#78513 root.
+            Assert.Contains("godot#78513", captured[0]);
+            Assert.Contains("did not drain", captured[0]);
+        }
+
+        [Fact]
+        public void Completion_EmitsNoWarning_AndReportsFalse()
+        {
+            // THE COMPLETION BRANCH: WaitForImmediateTeardown returned true (drained within the bound, or nothing
+            // pending / already disposed) -> NO warning, and the call reports it did not warn.
+            var captured = new List<string>();
+            GodotMcpDrainDiagnostics.Warn = captured.Add;
+
+            bool warned = GodotMcpDrainDiagnostics.ReportDrainResult(drained: true, timeout: TimeSpan.FromSeconds(2));
+
+            Assert.False(warned);
+            Assert.Empty(captured);
+        }
+
+        [Fact]
+        public void Timeout_WithNoSink_StillReportsTrue_AndDoesNotThrow()
+        {
+            // The sink is optional (null on a non-editor game build before any wiring). A timeout must still be
+            // detected (reports true) and must NEVER throw — the seam runs on the ALC-unload teardown path.
+            GodotMcpDrainDiagnostics.Warn = null;
+
+            bool warned = false;
+            var ex = Record.Exception(() =>
+            {
+                warned = GodotMcpDrainDiagnostics.ReportDrainResult(drained: false, timeout: TimeSpan.FromSeconds(1));
+            });
+
+            Assert.Null(ex);
+            Assert.True(warned);
+        }
+
+        [Fact]
+        public void Timeout_WithFaultingSink_DoesNotThrow()
+        {
+            // SAFETY CONTRACT: the warning runs inside the ALC-unloading teardown path, so a faulting sink (e.g.
+            // GD unavailable mid editor-reload) must be swallowed — ReportDrainResult must never throw.
+            GodotMcpDrainDiagnostics.Warn = _ => throw new InvalidOperationException("sink boom");
+
+            var ex = Record.Exception(() =>
+                GodotMcpDrainDiagnostics.ReportDrainResult(drained: false, timeout: TimeSpan.FromSeconds(1)));
+
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void FormatTimeoutWarning_IncludesTheTimeout()
+        {
+            // The message names the bound that was applied (the timeout value is unchanged — observability only).
+            string msg = GodotMcpDrainDiagnostics.FormatTimeoutWarning(TimeSpan.FromSeconds(3));
+
+            Assert.Contains("00:00:03", msg);
+            Assert.Contains("[Godot-MCP]", msg);
+        }
+    }
+}

--- a/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
@@ -269,6 +269,29 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// </summary>
         public event Action? AgentsUpdated;
 
+        /// <summary>
+        /// Wire the pure-managed <see cref="GodotMcpDrainDiagnostics"/> seam's warning sink to a defensively
+        /// wrapped <see cref="GD.PushWarning(string)"/> exactly once, when this type is first touched (which is
+        /// guaranteed before any <see cref="DisconnectAndDrain"/> call). The seam stays Godot-free + unit-testable;
+        /// the actual editor/runtime warning is emitted through this swallow-on-fault wrapper so a timeout report
+        /// never throws into the ALC-unloading teardown path even if GD is unavailable mid editor-reload.
+        /// </summary>
+        static GodotMcpConnection()
+        {
+            GodotMcpDrainDiagnostics.Warn = PushWarningSafe;
+        }
+
+        /// <summary>
+        /// Emit a warning via <see cref="GD.PushWarning(string)"/>, swallowing any failure (GD may be unavailable
+        /// mid editor-reload). Same defensive discipline as the inline <c>try { GD.Push* } catch { }</c> call sites
+        /// in <see cref="DisconnectAndDrain"/> — diagnostics must never break the boot/unload path.
+        /// </summary>
+        static void PushWarningSafe(string message)
+        {
+            try { GD.PushWarning(message); }
+            catch { /* GD may be unavailable mid-reload; swallow */ }
+        }
+
         public GodotMcpConnection(GodotMcpConfig? config = null)
         {
             _config = config ?? new GodotMcpConfig();
@@ -1159,12 +1182,25 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             //      abandon the task) and before the ALC unload — so the SignalR transport's running threads /
             //      GC handles are actually released, not just signalled. Non-blocking-on-async (thread-pool
             //      task), so no deadlock on the editor main = unload thread. THE connection root of godot#78513.
-            try { plugin.WaitForImmediateTeardown(timeout); }
+            //
+            //      WaitForImmediateTeardown returns a bool: true = drained within the bound (or nothing pending /
+            //      already disposed); false = the bounded wait TIMED OUT (a black-holed host that never finished
+            //      the dispatched teardown) or faulted. On a timeout we still proceed with Dispose + the ALC
+            //      unload (the correct bounded behaviour — the timeout value + proceed-anyway semantics are
+            //      UNCHANGED), but proceeding silently re-introduces the godot#78513 symptom (live transport
+            //      threads/handles may briefly outlive the reload). Surface that as exactly ONE diagnostic
+            //      WARNING (not an error — proceeding is still correct) via the pure-managed, unit-testable
+            //      GodotMcpDrainDiagnostics seam; the completion path emits nothing. The warning itself is
+            //      defensively wrapped (the seam swallows a faulting sink) so it never throws into the unload.
+            bool drained = true;
+            try { drained = plugin.WaitForImmediateTeardown(timeout); }
             catch (Exception ex)
             {
+                drained = false; // treat a fault like a timeout — the teardown did not provably drain.
                 try { GD.PushError($"[Godot-MCP] wait-for-immediate-teardown (drain) failed: {ex.Message}"); }
                 catch { /* GD may be unavailable mid-reload; swallow */ }
             }
+            GodotMcpDrainDiagnostics.ReportDrainResult(drained, timeout);
 
             // 2) Final plugin Dispose (idempotent): releases the R3 subscriptions + the manager.
             try { plugin.Dispose(); }

--- a/addons/godot_mcp/Runtime/Connection/GodotMcpDrainDiagnostics.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotMcpDrainDiagnostics.cs
@@ -1,0 +1,93 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// Pure-managed diagnostic seam for the bounded teardown drain in
+    /// <see cref="GodotMcpConnection.DisconnectAndDrain(TimeSpan)"/>.
+    ///
+    /// <para>
+    /// <b>Why.</b> <c>DisconnectAndDrain</c> bounded-JOINs the dispatched SignalR teardown via the reused
+    /// client's <c>IConnection.WaitForImmediateTeardown(TimeSpan)</c> — the connection root of the
+    /// godot#78513 reload fix. That call returns a <see cref="bool"/>: <c>true</c> when the dispatched
+    /// teardown actually DRAINED within the bound (or there was nothing pending / the client was already
+    /// disposed — i.e. the transport's threads/handles are released before the collectible ALC unloads),
+    /// and <c>false</c> when the bounded wait TIMED OUT or faulted (a black-holed host that never finished
+    /// the dispatched teardown). On the <c>false</c> path the method still proceeds with <c>Dispose</c> + the
+    /// ALC unload — which is the correct bounded behaviour — but doing so SILENTLY re-introduces the
+    /// godot#78513 symptom (live transport threads/GC handles may briefly outlive the reload). This seam
+    /// surfaces that timeout as exactly ONE warning so the silent reintroduction is at least visible in the
+    /// editor log / runtime; the completion path emits nothing.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Seam discipline.</b> Pure-BCL (no Godot native types), so the timeout→warning DECISION is
+    /// CI-unit-testable without a Godot binary (the editor-only <c>GodotMcpConnection</c> instantiates the
+    /// SignalR client and is verified via the headless Godot smoke instead). The warning is routed through an
+    /// injectable <see cref="Warn"/> sink that defaults to <c>null</c> (no-op); the production caller wires it
+    /// to a defensively-wrapped <c>GD.PushWarning</c>. This mirrors the existing
+    /// <see cref="GodotMcpAssemblyResolver.Log"/> / <see cref="GodotMcpStjReflectionCache.Log"/> static-sink
+    /// pattern. <see cref="ReportDrainResult"/> NEVER throws (a faulting sink is swallowed), preserving the
+    /// "never throw into the ALC-unloading handler" contract.
+    /// </para>
+    /// </summary>
+    public static class GodotMcpDrainDiagnostics
+    {
+        /// <summary>
+        /// Optional warning sink (e.g. a defensively-wrapped <c>GD.PushWarning</c>). Stays pure-BCL by taking
+        /// a delegate; defaults to <c>null</c> (no-op) so unit tests can assert the timeout→warning DECISION
+        /// via the <see cref="ReportDrainResult"/> return value alone, and can also inject a capturing sink to
+        /// assert the message text. Never invoked on the completion path.
+        /// </summary>
+        public static Action<string>? Warn { get; set; }
+
+        /// <summary>
+        /// Build the single diagnostic message emitted when the bounded teardown wait times out. Pure function
+        /// (exposed for the unit test to pin the message shape without coupling to the sink).
+        /// </summary>
+        public static string FormatTimeoutWarning(TimeSpan timeout) =>
+            $"[Godot-MCP] connection teardown did not drain within {timeout} (host may be unreachable); " +
+            "proceeding with unload anyway — transport threads may briefly outlive the reload (godot#78513).";
+
+        /// <summary>
+        /// Report the result of the bounded <c>WaitForImmediateTeardown</c> drain. When <paramref name="drained"/>
+        /// is <c>false</c> (timed out / faulted), emit exactly ONE warning via <see cref="Warn"/> (if set) and
+        /// return <c>true</c>. When <paramref name="drained"/> is <c>true</c> (completed / nothing to drain),
+        /// emit nothing and return <c>false</c>. Never throws: a faulting sink is swallowed so this stays safe to
+        /// call from the ALC-unloading teardown path.
+        /// </summary>
+        /// <param name="drained">
+        /// The <see cref="bool"/> returned by <c>IConnection.WaitForImmediateTeardown(TimeSpan)</c>: <c>true</c>
+        /// = drained within the bound (or nothing pending); <c>false</c> = the bounded wait timed out or faulted.
+        /// </param>
+        /// <param name="timeout">The bound that was applied (only used to format the warning text).</param>
+        /// <returns><c>true</c> if a timeout warning was raised; <c>false</c> on the completion (no-warning) path.</returns>
+        public static bool ReportDrainResult(bool drained, TimeSpan timeout)
+        {
+            if (drained)
+                return false;
+
+            try
+            {
+                Warn?.Invoke(FormatTimeoutWarning(timeout));
+            }
+            catch
+            {
+                // Diagnostics must never break the ALC-unload teardown path — swallow a faulting sink
+                // (e.g. GD unavailable mid editor-reload), exactly like the GD.Push* call sites do.
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `DisconnectAndDrain` bounded-JOINs the dispatched SignalR teardown via `IConnection.WaitForImmediateTeardown(timeout)` — the connection root of the godot#78513 reload fix. That call returns a `bool` (verified against McpPlugin 6.10.0: `true` = drained within the bound / nothing pending / already disposed; `false` = the bounded `Task.Wait(timeout)` timed out or faulted), but the prior code **ignored** it — so a black-holed host that never drains silently degraded to the old #78513 behavior with no diagnostic.
- Now emit exactly **one** `GD.PushWarning` (not an error) when the bounded wait **times out**; the completion path emits nothing. The **timeout value + proceed-anyway semantics are UNCHANGED** — observability only.
- The decision lives in a new pure-managed `GodotMcpDrainDiagnostics` seam (injectable `Action<string>` warning sink, defaulted by `GodotMcpConnection`'s static ctor to a defensively-wrapped `GD.PushWarning`), so it never throws into the ALC-unloading handler and is CI-unit-testable without a Godot binary — mirroring the existing `GodotMcpAssemblyResolver.Log` / `GodotMcpStjReflectionCache.Log` static-sink pattern.

## Test plan
- [x] New xUnit suite pins **both branches** (timeout -> warned; completion -> not warned), the single-warning guarantee, the never-throws contract (null + faulting sink), and the message shape.
- [x] Suite 1 `dotnet build Godot-MCP.sln`: 0 errors.
- [x] Suite 2 `dotnet test Godot-MCP.Tests`: 891/891 pass (0 failures).
- [x] `scripts/check-runtime-boundary.py`: 0 violations (the new file is pure-managed, game-safe, correctly under `Runtime/`).
- Forbidden NuGet pins (ReflectorNet 5.3.1 / McpPlugin 6.10.0) untouched.

Closes #189