### PR TITLE
feat(connection): verify downloaded server zip against SHA256SUMS before execute (fail-closed)

### DIFF
--- a/Godot-MCP.Tests/GodotMcpServerChecksumTests.cs
+++ b/Godot-MCP.Tests/GodotMcpServerChecksumTests.cs
@@ -1,0 +1,237 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Runtime.InteropServices;
+using com.IvanMurzak.Godot.MCP.Connection;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the pure-managed, fail-closed download-integrity logic (<see cref="GodotMcpServerView"/>'s
+    /// SHA256SUMS URL builder, coreutils-format parser, digest lookup/compare, and the single
+    /// <see cref="GodotMcpServerView.VerifyZipChecksum"/> verdict) that the editor manager
+    /// (<c>GodotMcpServerManager.DownloadAndUnpackBinary</c>, <c>#if TOOLS</c>) calls BEFORE
+    /// <c>ZipFile.ExtractToDirectory</c> / <c>Process.Start</c> — so a downloaded server zip is NEVER extracted
+    /// or launched unless its SHA256 matches the release's published <c>SHA256SUMS</c> manifest (issue #192).
+    /// Every assertion is a deterministic string/enum transform with NO Godot binary and NO real download, so
+    /// the same assertions hold on the Linux CI runner and on a Windows dev box. The HTTP fetch + file IO that
+    /// surround this verdict live in the editor-only manager and are verified via the headless Godot smoke.
+    ///
+    /// <para>
+    /// The <see cref="LiveV8Sha256Sums"/> fixture is the VERBATIM content of the real
+    /// <c>v8.0.0</c> release manifest (the version this addon pins) at
+    /// https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/v8.0.0/SHA256SUMS — so the parser is
+    /// proven against the exact two-space coreutils format that production will see, and the win-x64 digest is
+    /// the real one. Updating the pinned <c>ServerVersion</c> in future does not invalidate these tests: they
+    /// assert the FORMAT contract, not a moving digest.
+    /// </para>
+    /// </summary>
+    public class GodotMcpServerChecksumTests
+    {
+        /// <summary>
+        /// The verbatim live <c>SHA256SUMS</c> from the GameDev-MCP-Server <c>v8.0.0</c> release — standard
+        /// coreutils output: <c>&lt;64-lowercase-hex&gt;␠␠&lt;filename&gt;</c>, one line per RID zip, LF-terminated.
+        /// All 7 published RIDs are present.
+        /// </summary>
+        const string LiveV8Sha256Sums =
+            "5f17508e92812fbf9522eb552641d21dc2383fc2f6cf371f5413ad06c9820282  gamedev-mcp-server-linux-arm64.zip\n" +
+            "844d4ad8cd152df44287341235ca2ae67cdb69b496252678eb6491f0bdc53319  gamedev-mcp-server-linux-x64.zip\n" +
+            "ad0f50042dfa1edde26a9f26968538146ba792cc0188a47f6bfc1ae573bb513e  gamedev-mcp-server-osx-arm64.zip\n" +
+            "d25993216e610401c8925716d9ad0f8ecaf3dc93443b12cfd057a75495ef9952  gamedev-mcp-server-osx-x64.zip\n" +
+            "702f1d708c25dde6a58d3335c7adb92aa5fe36be618003821ceb040a9b59c51b  gamedev-mcp-server-win-arm64.zip\n" +
+            "7383638dbc1cad84cf3b85617405c29c7885a51e34b1ef7b8b8864d0656814cb  gamedev-mcp-server-win-x64.zip\n" +
+            "b171e1d8318d0ce4e88d30a5e86ad1cac1acea946ef1a71cd410a27f917c9799  gamedev-mcp-server-win-x86.zip\n";
+
+        /// <summary>The real win-x64 digest from the live v8.0.0 manifest (verbatim).</summary>
+        const string LiveWinX64Digest = "7383638dbc1cad84cf3b85617405c29c7885a51e34b1ef7b8b8864d0656814cb";
+
+        // --- SHA256SUMS URL builder (sibling of the zip URL, same v-tag) ---
+
+        [Fact]
+        public void Sha256SumsUrl_IsSiblingOfZipUrlUnderSameVTag()
+        {
+            // The manifest MUST live under the same v<version> release tag as the zip, with the fixed
+            // `SHA256SUMS` asset name — so the integrity manifest can never drift from the binary it covers.
+            var sumsUrl = GodotMcpServerView.Sha256SumsUrl("8.0.0");
+            Assert.Equal(
+                "https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/v8.0.0/SHA256SUMS",
+                sumsUrl);
+
+            // It shares the release-download directory prefix with the per-RID zip URL.
+            var zipUrl = GodotMcpServerView.DownloadUrl("8.0.0", OSPlatform.Windows, Architecture.X64);
+            var zipDir = zipUrl.Substring(0, zipUrl.LastIndexOf('/') + 1);
+            Assert.StartsWith(zipDir, sumsUrl);
+        }
+
+        [Fact]
+        public void Sha256SumsUrl_DefaultOverload_PinsServerVersion()
+        {
+            var sumsUrl = GodotMcpServerView.Sha256SumsUrl();
+            Assert.Equal(GodotMcpServerView.Sha256SumsUrl(GodotMcpServerView.ServerVersion), sumsUrl);
+            Assert.Contains($"/releases/download/v{GodotMcpServerView.ServerVersion}/SHA256SUMS", sumsUrl);
+        }
+
+        [Fact]
+        public void Sha256SumsUrl_PrePrefixedVersion_NotDoublePrefixed()
+        {
+            Assert.Equal(
+                "https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/v8.0.0/SHA256SUMS",
+                GodotMcpServerView.Sha256SumsUrl("v8.0.0"));
+        }
+
+        // --- Parser: the exact two-space coreutils line format ---
+
+        [Fact]
+        public void ParseSha256Sums_LiveManifest_ParsesAllSevenEntriesWithLowercaseDigests()
+        {
+            var map = GodotMcpServerView.ParseSha256Sums(LiveV8Sha256Sums);
+
+            Assert.Equal(7, map.Count);
+            // The RIGHT RID is selected among the 7 — win-x64 maps to ITS digest, not a neighbour's.
+            Assert.Equal(LiveWinX64Digest, map["gamedev-mcp-server-win-x64.zip"]);
+            Assert.Equal("844d4ad8cd152df44287341235ca2ae67cdb69b496252678eb6491f0bdc53319",
+                map["gamedev-mcp-server-linux-x64.zip"]);
+            Assert.Equal("b171e1d8318d0ce4e88d30a5e86ad1cac1acea946ef1a71cd410a27f917c9799",
+                map["gamedev-mcp-server-win-x86.zip"]);
+            // Every value is a 64-char lowercase hex digest.
+            foreach (var digest in map.Values)
+            {
+                Assert.Equal(64, digest.Length);
+                Assert.Equal(digest.ToLowerInvariant(), digest);
+            }
+        }
+
+        [Fact]
+        public void ParseSha256Sums_TolerantOfCrlfAndBlankLinesAndUppercaseHex()
+        {
+            const string text =
+                "\r\n" +
+                "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789  gamedev-mcp-server-win-x64.zip\r\n" +
+                "\r\n";
+            var map = GodotMcpServerView.ParseSha256Sums(text);
+            Assert.Single(map);
+            // Digest normalized to lowercase.
+            Assert.Equal("abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+                map["gamedev-mcp-server-win-x64.zip"]);
+        }
+
+        [Fact]
+        public void ParseSha256Sums_StripsBinaryModeStarMarker()
+        {
+            // coreutils binary mode emits `<hex> *<name>`; the '*' is not part of the filename.
+            const string text =
+                "7383638dbc1cad84cf3b85617405c29c7885a51e34b1ef7b8b8864d0656814cb *gamedev-mcp-server-win-x64.zip\n";
+            var map = GodotMcpServerView.ParseSha256Sums(text);
+            Assert.True(map.ContainsKey("gamedev-mcp-server-win-x64.zip"));
+            Assert.Equal(LiveWinX64Digest, map["gamedev-mcp-server-win-x64.zip"]);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   \n  \n")]                                  // only whitespace
+        [InlineData("not-a-digest  gamedev-mcp-server-win-x64.zip\n")] // first token isn't 64-hex
+        [InlineData("7383638dbc1cad84cf3b85617405c29c7885a51e34b1ef7b8b8864d065681\n")] // hex too short, no filename
+        [InlineData("zzz3638dbc1cad84cf3b85617405c29c7885a51e34b1ef7b8b8864d0656814cb  x.zip\n")] // non-hex chars
+        public void ParseSha256Sums_MalformedOrEmpty_YieldsNoUsableEntry(string? text)
+        {
+            var map = GodotMcpServerView.ParseSha256Sums(text);
+            Assert.Empty(map);
+        }
+
+        // --- Lookup + compare ---
+
+        [Fact]
+        public void LookupDigest_ReturnsEntryForRid_NullWhenMissing()
+        {
+            var map = GodotMcpServerView.ParseSha256Sums(LiveV8Sha256Sums);
+            Assert.Equal(LiveWinX64Digest, GodotMcpServerView.LookupDigest(map, "gamedev-mcp-server-win-x64.zip"));
+            Assert.Null(GodotMcpServerView.LookupDigest(map, "gamedev-mcp-server-freebsd-x64.zip"));
+        }
+
+        [Fact]
+        public void DigestMatches_IsCaseInsensitive_AndFailsClosedOnNullOrEmpty()
+        {
+            Assert.True(GodotMcpServerView.DigestMatches(LiveWinX64Digest, LiveWinX64Digest.ToUpperInvariant()));
+            Assert.True(GodotMcpServerView.DigestMatches("  " + LiveWinX64Digest + "  ", LiveWinX64Digest));
+            Assert.False(GodotMcpServerView.DigestMatches(LiveWinX64Digest, null));
+            Assert.False(GodotMcpServerView.DigestMatches(null, LiveWinX64Digest));
+            Assert.False(GodotMcpServerView.DigestMatches("", ""));
+            Assert.False(GodotMcpServerView.DigestMatches(LiveWinX64Digest, "deadbeef"));
+        }
+
+        // --- The single fail-closed verdict (what the editor manager calls) ---
+
+        [Fact]
+        public void VerifyZipChecksum_RealPair_IsVerified()
+        {
+            // The real win-x64 digest against the real live manifest → SAFE to extract/execute. This is the
+            // exact pair production sees (operator-confirmable: `gh release download v8.0.0 --pattern
+            // gamedev-mcp-server-win-x64.zip` then `sha256sum` equals LiveWinX64Digest).
+            var verdict = GodotMcpServerView.VerifyZipChecksum(
+                LiveV8Sha256Sums, "gamedev-mcp-server-win-x64.zip", LiveWinX64Digest);
+            Assert.Equal(GodotMcpServerView.ChecksumVerdict.Verified, verdict);
+        }
+
+        [Fact]
+        public void VerifyZipChecksum_RealPair_VerifiedWithUppercaseComputedDigest()
+        {
+            // BCL Convert.ToHexString emits UPPER-case; the verdict must accept it (case-insensitive compare).
+            var verdict = GodotMcpServerView.VerifyZipChecksum(
+                LiveV8Sha256Sums, "gamedev-mcp-server-win-x64.zip", LiveWinX64Digest.ToUpperInvariant());
+            Assert.Equal(GodotMcpServerView.ChecksumVerdict.Verified, verdict);
+        }
+
+        [Fact]
+        public void VerifyZipChecksum_TamperedDigest_IsRejected()
+        {
+            // A tampered/compromised zip whose SHA256 differs by a single nibble must be REJECTED (fail-closed).
+            var tampered = "0" + LiveWinX64Digest.Substring(1);
+            var verdict = GodotMcpServerView.VerifyZipChecksum(
+                LiveV8Sha256Sums, "gamedev-mcp-server-win-x64.zip", tampered);
+            Assert.Equal(GodotMcpServerView.ChecksumVerdict.DigestMismatch, verdict);
+        }
+
+        [Fact]
+        public void VerifyZipChecksum_MissingEntryForRid_IsRejected()
+        {
+            // The manifest parsed fine but has no line for THIS RID's asset → fail-closed (MissingEntry).
+            var verdict = GodotMcpServerView.VerifyZipChecksum(
+                LiveV8Sha256Sums, "gamedev-mcp-server-freebsd-x64.zip", LiveWinX64Digest);
+            Assert.Equal(GodotMcpServerView.ChecksumVerdict.MissingEntry, verdict);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("garbage with no valid sha lines\n")]
+        public void VerifyZipChecksum_UnparsableManifest_IsRejected(string? manifest)
+        {
+            // An empty/unparsable manifest must NEVER pass (do not execute an unverified binary).
+            var verdict = GodotMcpServerView.VerifyZipChecksum(
+                manifest, "gamedev-mcp-server-win-x64.zip", LiveWinX64Digest);
+            Assert.Equal(GodotMcpServerView.ChecksumVerdict.ManifestUnparsable, verdict);
+        }
+
+        [Fact]
+        public void ChecksumFailureReason_NamesTheActionableCause()
+        {
+            // The editor fail-closed log line must be actionable: it names the manifest, the asset, and the cause.
+            var asset = "gamedev-mcp-server-win-x64.zip";
+            Assert.Contains(asset,
+                GodotMcpServerView.ChecksumFailureReason(GodotMcpServerView.ChecksumVerdict.DigestMismatch, asset));
+            Assert.Contains(asset,
+                GodotMcpServerView.ChecksumFailureReason(GodotMcpServerView.ChecksumVerdict.MissingEntry, asset));
+            Assert.Contains("SHA256SUMS",
+                GodotMcpServerView.ChecksumFailureReason(GodotMcpServerView.ChecksumVerdict.ManifestUnparsable, asset));
+        }
+    }
+}

--- a/addons/godot_mcp/Editor/Connection/GodotMcpServerManager.cs
+++ b/addons/godot_mcp/Editor/Connection/GodotMcpServerManager.cs
@@ -14,6 +14,7 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Godot;
@@ -200,6 +201,20 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                     await src.CopyToAsync(dst);
                 }
 
+                // FAIL-CLOSED INTEGRITY GATE (verify-before-execute). The zip is on disk but UNTRUSTED. Before
+                // extracting or launching it, download the release's SHA256SUMS manifest (sibling of the zip
+                // URL under the same v<ServerVersion> tag), compute the downloaded zip's SHA256 (pure BCL), and
+                // compare against the manifest entry for THIS RID. On MISMATCH / MISSING entry / unparsable
+                // manifest we delete the temp zip and return the existing download-failure path WITHOUT
+                // extracting or launching — an unverified binary must NEVER be executed (a compromised release
+                // asset or a trusted-CA MITM would otherwise yield arbitrary code execution; issue #192).
+                var assetZipName = GodotMcpServerView.AssetZipName(os, arch);
+                if (!await VerifyDownloadedArchive(archivePath, serverVersion, assetZipName))
+                {
+                    try { File.Delete(archivePath); } catch { /* best effort */ }
+                    return false;
+                }
+
                 _log($"[Godot-MCP] unpacking GameDev-MCP-Server binary to: {platformFolder}");
                 // The shared GameDev-MCP-Server release zips are NOT layout-uniform: the win zips are FLAT
                 // (gamedev-mcp-server.exe at the zip root) while the osx/linux zips wrap the binary in a
@@ -257,6 +272,108 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 _logError($"[Godot-MCP] failed to download/unpack server binary: {ex.Message}");
                 return false;
             }
+        }
+
+        /// <summary>
+        /// The number of attempts for the SHA256SUMS manifest fetch (1 initial + retries) before we
+        /// fail-closed. A TRANSIENT network error on the manifest fetch is retried (the binary is already
+        /// downloaded; only the integrity manifest is missing) — but a persistent failure NEVER falls through
+        /// to executing an unverified binary.
+        /// </summary>
+        const int Sha256SumsFetchAttempts = 3;
+
+        /// <summary>Backoff between SHA256SUMS fetch attempts.</summary>
+        static readonly TimeSpan Sha256SumsRetryDelay = TimeSpan.FromSeconds(1.0);
+
+        /// <summary>
+        /// Fail-closed verify-before-execute gate. Downloads the release's <c>SHA256SUMS</c> manifest (with a
+        /// bounded transient-retry), computes the downloaded zip's SHA256 (pure BCL
+        /// <see cref="SHA256.HashData(System.ReadOnlySpan{byte})"/> — no new deps), and compares against the
+        /// manifest entry for <paramref name="assetZipName"/> via the pure-managed
+        /// <see cref="GodotMcpServerView.VerifyZipChecksum"/>. Returns true ONLY when the digest matched the
+        /// manifest. Every failure path — a manifest we could not fetch after all retries, an unparsable
+        /// manifest, a missing entry, or a digest mismatch — returns false with a clear, actionable error so
+        /// the caller skips extraction/launch. Never throws.
+        /// </summary>
+        async Task<bool> VerifyDownloadedArchive(string archivePath, string serverVersion, string assetZipName)
+        {
+            var sumsUrl = GodotMcpServerView.Sha256SumsUrl(serverVersion);
+
+            // 1) Fetch the integrity manifest (bounded transient-retry). A null result means every attempt
+            //    failed — fail-closed (do NOT execute an unverified binary).
+            var sha256SumsText = await FetchSha256SumsText(sumsUrl);
+            if (sha256SumsText == null)
+            {
+                _logError(
+                    $"[Godot-MCP] refusing to launch server: could not download the {GodotMcpServerView.Sha256SumsAssetName} " +
+                    $"integrity manifest from {sumsUrl} after {Sha256SumsFetchAttempts} attempt(s). " +
+                    "The downloaded binary was NOT verified and will not be executed (fail-closed).");
+                return false;
+            }
+
+            // 2) Compute the downloaded zip's SHA256 (pure BCL).
+            string actualHexDigest;
+            try
+            {
+                await using var zipStream = File.OpenRead(archivePath);
+                var hashBytes = await SHA256.HashDataAsync(zipStream);
+                actualHexDigest = Convert.ToHexString(hashBytes); // upper-case hex; compare is case-insensitive
+            }
+            catch (Exception ex)
+            {
+                _logError($"[Godot-MCP] refusing to launch server: failed to compute the downloaded zip's SHA256: {ex.Message}");
+                return false;
+            }
+
+            // 3) Parse + compare via the pure-managed verifier (unit-tested with no Godot binary).
+            var verdict = GodotMcpServerView.VerifyZipChecksum(sha256SumsText, assetZipName, actualHexDigest);
+            if (verdict != GodotMcpServerView.ChecksumVerdict.Verified)
+            {
+                _logError(
+                    $"[Godot-MCP] refusing to launch server: {GodotMcpServerView.ChecksumFailureReason(verdict, assetZipName)}. " +
+                    "The binary will not be extracted or executed (fail-closed).");
+                return false;
+            }
+
+            _log($"[Godot-MCP] verified '{assetZipName}' against {GodotMcpServerView.Sha256SumsAssetName} (SHA256 OK).");
+            return true;
+        }
+
+        /// <summary>
+        /// Download the <c>SHA256SUMS</c> manifest text with a bounded transient-retry. Returns the manifest
+        /// body, or null when every attempt failed (the fail-closed signal). The manifest is small text — read
+        /// it fully into a string. Never throws.
+        /// </summary>
+        async Task<string?> FetchSha256SumsText(string sumsUrl)
+        {
+            for (var attempt = 1; attempt <= Sha256SumsFetchAttempts; attempt++)
+            {
+                try
+                {
+                    using var client = new HttpClient();
+                    using var response = await client.GetAsync(sumsUrl);
+                    response.EnsureSuccessStatusCode();
+                    return await response.Content.ReadAsStringAsync();
+                }
+                catch (Exception ex)
+                {
+                    if (attempt < Sha256SumsFetchAttempts)
+                    {
+                        _logWarning(
+                            $"[Godot-MCP] {GodotMcpServerView.Sha256SumsAssetName} fetch attempt {attempt}/{Sha256SumsFetchAttempts} " +
+                            $"failed ({ex.Message}); retrying…");
+                        try { await Task.Delay(Sha256SumsRetryDelay); } catch { /* ignore */ }
+                    }
+                    else
+                    {
+                        _logWarning(
+                            $"[Godot-MCP] {GodotMcpServerView.Sha256SumsAssetName} fetch attempt {attempt}/{Sha256SumsFetchAttempts} " +
+                            $"failed ({ex.Message}).");
+                    }
+                }
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/addons/godot_mcp/Runtime/Connection/GodotMcpServerView.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotMcpServerView.cs
@@ -223,6 +223,196 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         public static string DownloadUrl(OSPlatform os, Architecture arch) =>
             DownloadUrl(ServerVersion, os, arch);
 
+        // --- SHA256SUMS integrity manifest (download-verify-before-execute, fail-closed) ---
+
+        /// <summary>
+        /// The name of the integrity manifest asset attached to every GameDev-MCP-Server release: a standard
+        /// coreutils <c>sha256sum</c> output file listing one <c>&lt;hex&gt;␠␠&lt;filename&gt;</c> line per
+        /// per-RID server zip. LIVE on the pinned <c>v8.0.0</c> release (and every future release).
+        /// </summary>
+        public const string Sha256SumsAssetName = "SHA256SUMS";
+
+        /// <summary>
+        /// The URL of the release's <c>SHA256SUMS</c> manifest — the SIBLING of the per-RID zip
+        /// <see cref="DownloadUrl(string, OSPlatform, Architecture)"/> under the SAME <c>v&lt;serverVersion&gt;</c>
+        /// release tag:
+        /// <c>https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/v&lt;serverVersion&gt;/SHA256SUMS</c>.
+        /// The downloaded zip's SHA256 is verified against this manifest BEFORE extraction/execution
+        /// (fail-closed). Pure string build — unit-testable with no Godot binary.
+        /// </summary>
+        public static string Sha256SumsUrl(string serverVersion) =>
+            $"https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/{ReleaseTag(serverVersion)}/{Sha256SumsAssetName}";
+
+        /// <summary>
+        /// The <c>SHA256SUMS</c> manifest URL for the PINNED <see cref="ServerVersion"/> — the production path,
+        /// taking NO version parameter so the manifest tag can never drift from the zip tag.
+        /// </summary>
+        public static string Sha256SumsUrl() => Sha256SumsUrl(ServerVersion);
+
+        /// <summary>
+        /// Parse a coreutils <c>sha256sum</c> manifest into a <c>{filename → lowercase-hex-digest}</c> map.
+        /// The exact LIVE format is one line per file: a 64-character lowercase hex digest, then TWO spaces
+        /// (the coreutils text-mode separator), then the file name —
+        /// <c>844d4ad8…53319␠␠gamedev-mcp-server-linux-x64.zip</c>. Tolerances applied (so a hand-edited or
+        /// CRLF manifest still parses, while a malformed one yields no usable entry):
+        /// <list type="bullet">
+        /// <item>CRLF and bare-LF line endings; blank lines skipped.</item>
+        /// <item>Leading/trailing whitespace on each line trimmed.</item>
+        /// <item>The coreutils binary-mode <c>'*'</c> marker before the filename (<c>&lt;hex&gt; *&lt;name&gt;</c>)
+        /// is stripped.</item>
+        /// <item>A line whose first token is NOT a 64-char hex string, or which has no filename, is SKIPPED
+        /// (it never produces a spurious entry — fail-closed at the lookup layer).</item>
+        /// </list>
+        /// Digests are normalized to lowercase; filenames are kept verbatim (case-sensitive, matching the
+        /// asset names). On a duplicate filename the LAST entry wins. Never throws — a null/empty/garbage
+        /// input yields an empty map. Pure managed; unit-testable with no Godot binary.
+        /// </summary>
+        public static System.Collections.Generic.IReadOnlyDictionary<string, string> ParseSha256Sums(string? sha256SumsText)
+        {
+            var map = new System.Collections.Generic.Dictionary<string, string>(System.StringComparer.Ordinal);
+            if (string.IsNullOrEmpty(sha256SumsText))
+                return map;
+
+            foreach (var rawLine in sha256SumsText!.Replace("\r\n", "\n").Split('\n'))
+            {
+                var line = rawLine.Trim();
+                if (line.Length == 0)
+                    continue;
+
+                // Split into the digest token and the remainder (the filename). The coreutils separator is two
+                // spaces, but we split on the FIRST run of whitespace so a single-space or tab variant still
+                // parses — the digest token is fixed-width 64 hex, the filename is everything after.
+                var sepIndex = -1;
+                for (var i = 0; i < line.Length; i++)
+                {
+                    if (line[i] == ' ' || line[i] == '\t')
+                    {
+                        sepIndex = i;
+                        break;
+                    }
+                }
+                if (sepIndex <= 0 || sepIndex >= line.Length - 1)
+                    continue;
+
+                var digestToken = line.Substring(0, sepIndex);
+                if (!IsHex64(digestToken))
+                    continue;
+
+                var fileName = line.Substring(sepIndex + 1).TrimStart(' ', '\t');
+                // coreutils binary-mode marker: `<hex> *<name>`. Strip a single leading '*'.
+                if (fileName.StartsWith("*", System.StringComparison.Ordinal))
+                    fileName = fileName.Substring(1);
+                fileName = fileName.Trim();
+                if (fileName.Length == 0)
+                    continue;
+
+                map[fileName] = digestToken.ToLowerInvariant();
+            }
+
+            return map;
+        }
+
+        /// <summary>True when <paramref name="value"/> is exactly 64 ASCII hex characters (a SHA256 hex digest).</summary>
+        static bool IsHex64(string value)
+        {
+            if (value.Length != 64)
+                return false;
+            foreach (var c in value)
+            {
+                var isHex = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+                if (!isHex)
+                    return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Look up the expected SHA256 digest for <paramref name="assetZipName"/> (e.g.
+        /// <c>gamedev-mcp-server-win-x64.zip</c>) in a parsed <see cref="ParseSha256Sums"/> map. Returns the
+        /// lowercase hex digest, or null when the manifest has no entry for that asset (the MISSING-entry
+        /// fail-closed case). Pure managed.
+        /// </summary>
+        public static string? LookupDigest(
+            System.Collections.Generic.IReadOnlyDictionary<string, string> parsedSha256Sums,
+            string assetZipName)
+        {
+            if (parsedSha256Sums == null || string.IsNullOrEmpty(assetZipName))
+                return null;
+            return parsedSha256Sums.TryGetValue(assetZipName, out var digest) ? digest : null;
+        }
+
+        /// <summary>
+        /// Case-insensitive hex-digest equality (both sides trimmed). A null/empty digest on either side is
+        /// NEVER a match (fail-closed: an unknown digest must not pass). Pure managed.
+        /// </summary>
+        public static bool DigestMatches(string? expectedHexDigest, string? actualHexDigest)
+        {
+            if (string.IsNullOrWhiteSpace(expectedHexDigest) || string.IsNullOrWhiteSpace(actualHexDigest))
+                return false;
+            return string.Equals(expectedHexDigest!.Trim(), actualHexDigest!.Trim(), System.StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// The verdict of verifying a downloaded zip against a release <c>SHA256SUMS</c> manifest.
+        /// </summary>
+        public enum ChecksumVerdict
+        {
+            /// <summary>The manifest parsed, contained this asset's entry, and the digest matched. SAFE to extract/execute.</summary>
+            Verified,
+
+            /// <summary>The manifest text was missing/empty/unparsable (no usable entries). Fail-closed.</summary>
+            ManifestUnparsable,
+
+            /// <summary>The manifest parsed but had no line for this asset's zip name. Fail-closed.</summary>
+            MissingEntry,
+
+            /// <summary>The manifest's entry for this asset did NOT match the downloaded zip's digest. Fail-closed.</summary>
+            DigestMismatch
+        }
+
+        /// <summary>
+        /// The single fail-closed integrity decision the editor manager calls BEFORE
+        /// <c>ZipFile.ExtractToDirectory</c> / <c>Process.Start</c>: parse the release's <c>SHA256SUMS</c>,
+        /// find the entry for <paramref name="assetZipName"/>, and compare it (case-insensitive hex) against
+        /// the locally-computed SHA256 of the downloaded zip (<paramref name="actualZipHexDigest"/>). Returns
+        /// <see cref="ChecksumVerdict.Verified"/> ONLY when the manifest parsed, contained the asset, and the
+        /// digest matched; every other outcome is a distinct fail-closed verdict the caller MUST treat as
+        /// "do NOT extract, do NOT launch". Keeping this here (not inline in the <c>#if TOOLS</c> manager)
+        /// makes the entire decision unit-testable with no Godot binary and no real download. Never throws.
+        /// </summary>
+        /// <param name="sha256SumsText">The raw downloaded <c>SHA256SUMS</c> manifest text.</param>
+        /// <param name="assetZipName">This RID's zip name, e.g. <c>gamedev-mcp-server-win-x64.zip</c>.</param>
+        /// <param name="actualZipHexDigest">The SHA256 of the downloaded zip, as lowercase/any-case hex.</param>
+        public static ChecksumVerdict VerifyZipChecksum(string? sha256SumsText, string assetZipName, string? actualZipHexDigest)
+        {
+            var parsed = ParseSha256Sums(sha256SumsText);
+            if (parsed.Count == 0)
+                return ChecksumVerdict.ManifestUnparsable;
+
+            var expected = LookupDigest(parsed, assetZipName);
+            if (expected == null)
+                return ChecksumVerdict.MissingEntry;
+
+            return DigestMatches(expected, actualZipHexDigest)
+                ? ChecksumVerdict.Verified
+                : ChecksumVerdict.DigestMismatch;
+        }
+
+        /// <summary>
+        /// A short, actionable human-readable reason for a non-<see cref="ChecksumVerdict.Verified"/> verdict,
+        /// for the editor manager's fail-closed log line. Pure string transform.
+        /// </summary>
+        public static string ChecksumFailureReason(ChecksumVerdict verdict, string assetZipName) => verdict switch
+        {
+            ChecksumVerdict.ManifestUnparsable =>
+                $"the downloaded {Sha256SumsAssetName} manifest was empty or unparsable",
+            ChecksumVerdict.MissingEntry =>
+                $"the {Sha256SumsAssetName} manifest has no entry for '{assetZipName}'",
+            ChecksumVerdict.DigestMismatch =>
+                $"the downloaded '{assetZipName}' SHA256 did not match the {Sha256SumsAssetName} manifest entry",
+            _ => "the checksum was verified"
+        };
+
         // --- Version match (EXACT, like Unity) ---
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Fail-closed integrity gate: `GodotMcpServerManager.DownloadAndUnpackBinary` now downloads the release's `SHA256SUMS` (sibling URL under the same `v<ServerVersion>` tag, with a bounded transient retry), computes the downloaded zip's SHA256 (pure BCL `SHA256.HashDataAsync`, no new deps), and verifies it against the manifest entry for this RID **before** `ZipFile.ExtractToDirectory` / `Process.Start`. On mismatch / missing entry / unparsable-or-unfetchable manifest it deletes the temp zip and returns the download-failure path **without** extracting or launching, with a clear actionable error — an unverified binary is never executed.
- The SHA256SUMS URL builder, coreutils-format parser, digest lookup/compare, and the single fail-closed verdict (`VerifyZipChecksum`) live in the pure-managed `GodotMcpServerView` (outside `#if TOOLS`), so the whole decision is xUnit-testable with no Godot binary and no real download.
- 22 new tests in `Godot-MCP.Tests`: valid digest passes (against the **verbatim live v8.0.0 manifest** + real win-x64 digest), tampered digest rejected, missing-entry-for-RID rejected, malformed/empty manifest rejected, the exact two-space coreutils format parses (CRLF, binary-mode `*` marker, uppercase-hex normalization, right-RID selection among the 7), URL builder is the same-tag sibling of the zip URL.
- `ServerVersion` stays `8.0.0`; forbidden NuGet pins (ReflectorNet 5.3.1 / McpPlugin 6.10.0) untouched. Also closes the Godot CI harness's no-checksum download gap (#187).

## Test plan
- [x] `dotnet build Godot-MCP.sln` — 0 errors.
- [x] `dotnet test Godot-MCP.Tests` — 913 passed / 0 failed (+22 new checksum tests).
- [x] Operator-confirmed end-to-end: real `gh release download v8.0.0 gamedev-mcp-server-win-x64.zip` → `sha256sum` = `7383638d…656814cb`, which equals the live `SHA256SUMS` entry and the `VerifyZipChecksum` `Verified` fixture.

Closes #192