### PR TITLE
test: serialize all process-wide-static mutators against parallel races

### DIFF
--- a/Godot-MCP.Tests/EditorReflectionToolTests.cs
+++ b/Godot-MCP.Tests/EditorReflectionToolTests.cs
@@ -209,27 +209,6 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Equal(0, c.Count);
         }
 
-        // ---- GetOrCreate fallback ----------------------------------------------------------------
-
-        [Fact]
-        public void GetOrCreate_WhenCurrentNull_ReturnsAndCachesFresh()
-        {
-            var saved = GodotLogCollector.Current;
-            try
-            {
-                GodotLogCollector.Current = null;
-                var first = GodotLogCollector.GetOrCreate();
-                Assert.NotNull(first);
-                // Caches into Current, so a second call returns the SAME instance.
-                Assert.Same(first, GodotLogCollector.GetOrCreate());
-                Assert.Same(first, GodotLogCollector.Current);
-            }
-            finally
-            {
-                GodotLogCollector.Current = saved;
-            }
-        }
-
         // ---- Models: serialization round-trips ---------------------------------------------------
 
         [Fact]
@@ -311,6 +290,43 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Empty(back!.Nodes);
             Assert.Null(back.ActiveNode);
             Assert.Equal(0, back.Count);
+        }
+    }
+
+    /// <summary>
+    /// The single <see cref="GodotLogCollector.GetOrCreate"/> fallback fact that mutates the process-wide
+    /// <see cref="GodotLogCollector.Current"/> static — extracted out of the otherwise-parallel
+    /// <see cref="EditorReflectionToolTests"/> so it joins the serial
+    /// <see cref="GodotLogCollectorCurrentCollection"/> (shared with <see cref="GodotLogCollectorTests"/> /
+    /// <see cref="ConsoleToolTests"/>) and can never race the concurrent <c>Current = null</c> in their ctors
+    /// (issue #195). Snapshots/restores <c>Current</c> around the test, mirroring those classes' pattern, so
+    /// it is non-destructive even when run alongside them in the same serial collection.
+    /// </summary>
+    [Collection(GodotLogCollectorCurrentCollection.Name)]
+    public class GodotLogCollectorGetOrCreateTests : IDisposable
+    {
+        readonly GodotLogCollector? _savedCurrent;
+
+        public GodotLogCollectorGetOrCreateTests()
+        {
+            _savedCurrent = GodotLogCollector.Current;
+            GodotLogCollector.Current = null;
+        }
+
+        public void Dispose()
+        {
+            GodotLogCollector.Current = _savedCurrent;
+        }
+
+        [Fact]
+        public void GetOrCreate_WhenCurrentNull_ReturnsAndCachesFresh()
+        {
+            GodotLogCollector.Current = null;
+            var first = GodotLogCollector.GetOrCreate();
+            Assert.NotNull(first);
+            // Caches into Current, so a second call returns the SAME instance.
+            Assert.Same(first, GodotLogCollector.GetOrCreate());
+            Assert.Same(first, GodotLogCollector.Current);
         }
     }
 }

--- a/Godot-MCP.Tests/RuntimeErrorCaptureRebindTests.cs
+++ b/Godot-MCP.Tests/RuntimeErrorCaptureRebindTests.cs
@@ -48,8 +48,7 @@ namespace com.IvanMurzak.Godot.MCP.Tests
     /// saves + restores that state in a finally, so a failed assertion can never leak into another test.
     /// </para>
     /// </summary>
-    [Collection(nameof(RuntimeErrorCaptureRebindTests))]
-    [CollectionDefinition(nameof(RuntimeErrorCaptureRebindTests), DisableParallelization = true)]
+    [Collection(RuntimeErrorCaptureSerialCollection.Name)]
     public class RuntimeErrorCaptureRebindTests
     {
         // ── PlanBridgeInstall: the pure-managed decision the real bridge shares ─────────────────────────────
@@ -318,5 +317,22 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             try { body(); }
             finally { ScriptErrorCapture.Current = prior; }
         }
+    }
+
+    /// <summary>
+    /// Shared serial collection for EVERY test class that mutates the <see cref="RuntimeErrorCapture"/>
+    /// family of process-wide statics — <see cref="RuntimeErrorCollector.Current"/>, the
+    /// <see cref="RuntimeErrorCapture"/> install-state / <see cref="RuntimeErrorCapture.IsInstalled"/>, and the
+    /// <c>GodotMcpRuntime._installForTests</c> / <c>_uninstallForTests</c> seams. Both
+    /// <see cref="RuntimeErrorCaptureTests"/> and <see cref="RuntimeErrorCaptureRebindTests"/> join it so the
+    /// two never run in parallel against that shared install state (issue #195): previously
+    /// <c>RuntimeErrorCaptureTests</c> was bare/parallel while <c>RuntimeErrorCaptureRebindTests</c> sat in its
+    /// own (self-named) collection, an active latent race. One shared <c>DisableParallelization</c> collection
+    /// serializes them together.
+    /// </summary>
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public sealed class RuntimeErrorCaptureSerialCollection
+    {
+        public const string Name = "RuntimeErrorCapture (serial)";
     }
 }

--- a/Godot-MCP.Tests/RuntimeErrorCaptureTests.cs
+++ b/Godot-MCP.Tests/RuntimeErrorCaptureTests.cs
@@ -30,7 +30,17 @@ namespace com.IvanMurzak.Godot.MCP.Tests
     /// host with no Godot binary. The capture INSTALLER (<c>RuntimeErrorCapture.Install</c>, which registers
     /// the engine logger via <c>OS.AddLogger</c> + the AppDomain/TaskScheduler hooks) and the 4.5 engine
     /// Logger subclass are verified by the headless Godot runtime smoke (test.md Suite 3).
+    ///
+    /// <para>
+    /// Several facts here mutate the <see cref="RuntimeErrorCapture"/> family of process-wide statics
+    /// (<see cref="RuntimeErrorCollector.Current"/>, the install-state / <see cref="RuntimeErrorCapture.IsInstalled"/>,
+    /// and the <c>GodotMcpRuntime._installForTests</c> / <c>_uninstallForTests</c> seams), so this class joins the
+    /// shared serial <see cref="RuntimeErrorCaptureSerialCollection"/> — the SAME collection as
+    /// <see cref="RuntimeErrorCaptureRebindTests"/> — so the two never race that shared state (issue #195). Each
+    /// fact still snapshots/restores the statics in a finally via the local helpers below.
+    /// </para>
     /// </summary>
+    [Collection(RuntimeErrorCaptureSerialCollection.Name)]
     public class RuntimeErrorCaptureTests
     {
         // ---- RuntimeError / RuntimeErrorsResult serialization ------------------------------------

--- a/Godot-MCP.Tests/SceneNodeToolTests.cs
+++ b/Godot-MCP.Tests/SceneNodeToolTests.cs
@@ -212,40 +212,57 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Equal(string.Empty, NodePathNormalizer.Normalize(null!, "Main"));
         }
 
-        // ---- GodotMcpReflector -------------------------------------------------------------------
+    }
+
+    /// <summary>
+    /// The two <see cref="GodotMcpReflector.GetOrCreate"/> facts that mutate the process-wide
+    /// <see cref="GodotMcpReflector.Current"/> static — extracted out of the otherwise-parallel
+    /// <see cref="SceneNodeToolTests"/> so they join the serial <see cref="GodotMcpReflectorCurrentCollection"/>
+    /// and can never race another class that touches that static (issue #195: currently unraced, but the same
+    /// bare-mutator antipattern as the other three statics, so it is guarded pre-emptively and enforced by the
+    /// drift-guard). Snapshots/restores <c>Current</c> in the ctor/Dispose so the suite is non-destructive.
+    /// </summary>
+    [Collection(GodotMcpReflectorCurrentCollection.Name)]
+    public class GodotMcpReflectorCurrentTests : System.IDisposable
+    {
+        readonly Reflector? _savedCurrent;
+
+        public GodotMcpReflectorCurrentTests()
+        {
+            _savedCurrent = GodotMcpReflector.Current;
+        }
+
+        public void Dispose()
+        {
+            GodotMcpReflector.Current = _savedCurrent;
+        }
 
         [Fact]
         public void GodotMcpReflector_GetOrCreate_FallsBack_WhenNoCurrent()
         {
-            var saved = GodotMcpReflector.Current;
-            try
-            {
-                GodotMcpReflector.Current = null;
-                var reflector = GodotMcpReflector.GetOrCreate();
-                Assert.NotNull(reflector);
-                // The fallback is NOT cached into Current (the connection remains the sole owner).
-                Assert.Null(GodotMcpReflector.Current);
-            }
-            finally
-            {
-                GodotMcpReflector.Current = saved;
-            }
+            GodotMcpReflector.Current = null;
+            var reflector = GodotMcpReflector.GetOrCreate();
+            Assert.NotNull(reflector);
+            // The fallback is NOT cached into Current (the connection remains the sole owner).
+            Assert.Null(GodotMcpReflector.Current);
         }
 
         [Fact]
         public void GodotMcpReflector_GetOrCreate_ReturnsCurrent_WhenSet()
         {
-            var saved = GodotMcpReflector.Current;
-            try
-            {
-                var mine = new Reflector();
-                GodotMcpReflector.Current = mine;
-                Assert.Same(mine, GodotMcpReflector.GetOrCreate());
-            }
-            finally
-            {
-                GodotMcpReflector.Current = saved;
-            }
+            var mine = new Reflector();
+            GodotMcpReflector.Current = mine;
+            Assert.Same(mine, GodotMcpReflector.GetOrCreate());
         }
+    }
+
+    /// <summary>
+    /// Dedicated serial collection for writers of the process-wide <see cref="GodotMcpReflector.Current"/>
+    /// static (issue #195), keeping the rest of <see cref="SceneNodeToolTests"/> parallel.
+    /// </summary>
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public sealed class GodotMcpReflectorCurrentCollection
+    {
+        public const string Name = "GodotMcpReflector.Current (serial)";
     }
 }

--- a/Godot-MCP.Tests/ScriptDiagnosticsTests.cs
+++ b/Godot-MCP.Tests/ScriptDiagnosticsTests.cs
@@ -8,6 +8,7 @@
 └──────────────────────────────────────────────────────────────────┘
 */
 #nullable enable
+using System;
 using System.Linq;
 using System.Text.Json;
 using com.IvanMurzak.Godot.MCP.Data;
@@ -328,24 +329,6 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         }
 
         [Fact]
-        public void Route_StaticCurrent_IsSettableAndClearable()
-        {
-            var prior = ScriptErrorCapture.Current;
-            try
-            {
-                var c = new ScriptErrorCapture();
-                ScriptErrorCapture.Current = c;
-                Assert.Same(c, ScriptErrorCapture.Current);
-                ScriptErrorCapture.Current = null;
-                Assert.Null(ScriptErrorCapture.Current);
-            }
-            finally
-            {
-                ScriptErrorCapture.Current = prior;
-            }
-        }
-
-        [Fact]
         public void Diagnostics_SortBySeverity_ErrorsBeforeWarnings()
         {
             // Mirrors the ordering Tool_Script.Validate applies before returning.
@@ -357,5 +340,54 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             list.Sort((a, b) => a.Severity.CompareTo(b.Severity));
             Assert.Equal(ScriptDiagnosticSeverity.Error, list.First().Severity);
         }
+    }
+
+    /// <summary>
+    /// The single <see cref="ScriptDiagnosticsTests"/> fact that mutates the process-wide
+    /// <see cref="ScriptErrorCapture.Current"/> static — extracted here so the other ~21 facts of
+    /// <see cref="ScriptDiagnosticsTests"/> (all driving LOCAL <c>new ScriptErrorCapture()</c> instances, never
+    /// the static) stay in the default parallel pool. This class joins the serial
+    /// <see cref="ScriptErrorCaptureCurrentCollection"/> so it can never race the
+    /// <c>ScriptErrorCapture.Current</c> reads/writes in <see cref="RuntimeErrorCaptureRebindTests"/> (issue
+    /// #195), and snapshots/restores <c>Current</c> in its ctor/Dispose.
+    /// </summary>
+    [Collection(ScriptErrorCaptureCurrentCollection.Name)]
+    public class ScriptErrorCaptureCurrentTests : IDisposable
+    {
+        readonly ScriptErrorCapture? _savedCurrent;
+
+        public ScriptErrorCaptureCurrentTests()
+        {
+            _savedCurrent = ScriptErrorCapture.Current;
+        }
+
+        public void Dispose()
+        {
+            ScriptErrorCapture.Current = _savedCurrent;
+        }
+
+        [Fact]
+        public void Route_StaticCurrent_IsSettableAndClearable()
+        {
+            var c = new ScriptErrorCapture();
+            ScriptErrorCapture.Current = c;
+            Assert.Same(c, ScriptErrorCapture.Current);
+            ScriptErrorCapture.Current = null;
+            Assert.Null(ScriptErrorCapture.Current);
+        }
+    }
+
+    /// <summary>
+    /// Dedicated serial collection for writers of the process-wide <see cref="ScriptErrorCapture.Current"/>
+    /// static (issue #195). <see cref="RuntimeErrorCaptureRebindTests"/> also writes that static, but it lives
+    /// in the broader <see cref="RuntimeErrorCaptureSerialCollection"/>; since a test class can join only ONE
+    /// collection, this dedicated collection serializes <see cref="ScriptErrorCaptureCurrentTests"/> on its own.
+    /// The drift-guard (<c>TestIsolationGuardTests</c>) only requires SOME <c>[Collection]</c> on a static
+    /// writer — both collections satisfy that.
+    /// </summary>
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public sealed class ScriptErrorCaptureCurrentCollection
+    {
+        public const string Name = "ScriptErrorCapture.Current (serial)";
     }
 }

--- a/Godot-MCP.Tests/TestIsolationGuardTests.cs
+++ b/Godot-MCP.Tests/TestIsolationGuardTests.cs
@@ -1,0 +1,228 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Durable drift-guard for issue #195: a meta-test that scans the test project's own <c>.cs</c> SOURCE
+    /// files and FAILS if any test class WRITES one of the known process-wide-static mutators yet lacks a
+    /// <c>[Collection(...)]</c> attribute. Without serialization those writers run in xUnit's default parallel
+    /// pool and can clobber a sibling class that snapshots the same static — the exact flaky-test race this
+    /// task hardened.
+    ///
+    /// <para>
+    /// WHY SOURCE-SCAN, NOT REFLECTION: reflection sees a type's members (methods/fields), but NOT the IL
+    /// bodies of those methods, so it cannot tell whether a method assigns <c>SomeStatic.Current = ...</c>.
+    /// A robust check therefore reads the test <c>.cs</c> files at test time and regex-matches the static
+    /// writes, mapping each to its enclosing class. The files are reliably reachable: <see cref="ThisDir"/> is
+    /// resolved from <c>[CallerFilePath]</c> (baked in at compile time, valid in the CI checkout where
+    /// <c>dotnet test</c> runs from the same tree). This needs no Godot binary and is fully CI-runnable.
+    /// </para>
+    ///
+    /// <para>
+    /// The guarded statics are the four <c>*.Current</c> setters plus the <c>RuntimeErrorCapture</c>
+    /// install/uninstall state mutators (see <see cref="GuardedWritePattern"/>). A future contributor who adds
+    /// a 5th unguarded mutator gets a failing test whose message names the offending class + static and the
+    /// fix (join a <c>DisableParallelization = true</c> collection).
+    /// </para>
+    /// </summary>
+    public class TestIsolationGuardTests
+    {
+        /// <summary>Absolute path to the directory containing THIS source file = the test project's source root.</summary>
+        static string ThisDir([CallerFilePath] string path = "") => Path.GetDirectoryName(path)!;
+
+        /// <summary>
+        /// Matches a WRITE to one of the process-wide statics this task serialized. Anchored on an assignment
+        /// (<c>=</c> not followed by <c>=</c>) so a READ (<c>var x = Foo.Current;</c>) is NOT flagged — only a
+        /// mutation that creates the race. <c>RuntimeErrorCapture.Install()</c> / <c>.Uninstall()</c> are
+        /// state mutators (they register/drop the engine logger + flip IsInstalled), so a call to either also
+        /// counts as a mutation even without an <c>=</c>.
+        /// </summary>
+        static readonly Regex GuardedWritePattern = new(
+            @"\b(?:GodotLogCollector|RuntimeErrorCollector|ScriptErrorCapture|GodotMcpReflector)\.Current\s*=(?!=)"
+            + @"|\bRuntimeErrorCapture\.(?:Install|Uninstall)\s*\(",
+            RegexOptions.Compiled);
+
+        /// <summary>Matches a top-level <c>... class Name ...</c> declaration, capturing the class name.</summary>
+        static readonly Regex ClassDeclPattern = new(
+            @"^\s*(?:public|internal|sealed|abstract|static|partial|\s)*\bclass\s+([A-Za-z_][A-Za-z0-9_]*)",
+            RegexOptions.Compiled);
+
+        /// <summary>Matches a <c>[Collection(...)]</c> attribute on a class.</summary>
+        static readonly Regex CollectionAttrPattern = new(@"\[\s*Collection\s*\(", RegexOptions.Compiled);
+
+        /// <summary>Matches an xUnit test method marker so we only enforce on real test classes.</summary>
+        static readonly Regex FactOrTheoryPattern = new(@"\[\s*(?:Fact|Theory)\b", RegexOptions.Compiled);
+
+        [Fact]
+        public void EveryProcessWideStaticMutator_RunsInASerialCollection()
+        {
+            var dir = ThisDir();
+            Assert.True(Directory.Exists(dir), $"Test source dir not found: {dir}");
+
+            var files = Directory.EnumerateFiles(dir, "*.cs", SearchOption.AllDirectories)
+                // Skip generated build output if any slipped into the tree.
+                .Where(f => !f.Replace('\\', '/').Contains("/obj/") && !f.Replace('\\', '/').Contains("/bin/"))
+                .OrderBy(f => f, StringComparer.Ordinal)
+                .ToList();
+
+            Assert.NotEmpty(files);
+
+            var violations = new List<string>();
+            var sawAnyGuardedWrite = false;
+
+            foreach (var file in files)
+            {
+                foreach (var cls in EnumerateClasses(file))
+                {
+                    if (!cls.HasGuardedWrite)
+                        continue;
+
+                    sawAnyGuardedWrite = true;
+
+                    // Only test classes (those with [Fact]/[Theory]) participate in xUnit parallelization, so
+                    // only they can race. A plain helper/model class with a guarded write is not a test class.
+                    if (!cls.IsTestClass)
+                        continue;
+
+                    if (!cls.HasCollectionAttribute)
+                    {
+                        violations.Add(
+                            $"  - {cls.Name}  (in {Path.GetFileName(file)})  writes {cls.FirstGuardedStatic} "
+                            + "but has NO [Collection(...)] attribute.");
+                    }
+                }
+            }
+
+            // Sanity: the scanner must actually be finding the known mutators. If this trips, the regex or the
+            // source layout drifted and the guard is silently inert — fail loudly so it gets fixed.
+            Assert.True(sawAnyGuardedWrite,
+                "Drift-guard found ZERO process-wide-static writes across the test sources — the scanner is "
+                + "likely broken (regex or source layout changed). Expected to see writes to "
+                + "GodotLogCollector.Current / RuntimeErrorCollector.Current / ScriptErrorCapture.Current / "
+                + "GodotMcpReflector.Current / RuntimeErrorCapture.Install|Uninstall.");
+
+            Assert.True(violations.Count == 0,
+                "Process-wide-static mutator(s) found WITHOUT a [Collection(...)] serial collection — these "
+                + "run in xUnit's default parallel pool and can clobber a sibling class that snapshots the same "
+                + "static (issue #195 flaky-test race). Fix: tag the class with "
+                + "[Collection(\"<Static>.Current (serial)\")] joined to a "
+                + "[CollectionDefinition(..., DisableParallelization = true)], snapshotting/restoring the static "
+                + "in the ctor/Dispose. Offending class(es):\n" + string.Join("\n", violations));
+        }
+
+        /// <summary>
+        /// Cheap brace-depth class splitter: walks the file line-by-line, tracks <c>{ }</c> nesting to attribute
+        /// each line to the innermost open top-level (namespace-direct) class, and records whether that class's
+        /// body contains a guarded static WRITE, a <c>[Collection]</c> attribute, and a <c>[Fact]/[Theory]</c>.
+        /// Block/line comments are stripped before matching so a <c>// Foo.Current = ...</c> or a doc-comment
+        /// <c>&lt;see cref="...Current"/&gt;</c> never false-positives.
+        /// </summary>
+        static IEnumerable<ClassScan> EnumerateClasses(string file)
+        {
+            var raw = File.ReadAllText(file);
+            var code = StripComments(raw);
+            var lines = code.Split('\n');
+
+            var scans = new List<ClassScan>();
+            // Open classes as (index-into-scans, braceDepthAtDecl, entered). `entered` flips true once brace
+            // depth rises ABOVE the declaration depth (i.e. the class body's `{` was seen) — only THEN may the
+            // class close when depth falls back to its declaration depth. Without the `entered` gate a class
+            // whose `{` is on the NEXT line (the common `public class Foo\n{` shape) would be popped on its own
+            // declaration line (depth still == decl depth), so its body would never be scanned.
+            var open = new List<(int idx, int depth, bool entered)>();
+            // Pending attribute lines accumulate before a class decl so the [Collection] right above the class
+            // is attributed to it.
+            var pendingHasCollection = false;
+            int braceDepth = 0;
+
+            foreach (var line in lines)
+            {
+                // Detect a class declaration on this line BEFORE counting its braces.
+                var m = ClassDeclPattern.Match(line);
+                if (m.Success)
+                {
+                    var scan = new ClassScan { Name = m.Groups[1].Value, HasCollectionAttribute = pendingHasCollection };
+                    scans.Add(scan);
+                    open.Add((scans.Count - 1, braceDepth, false));
+                    pendingHasCollection = false;
+                }
+                else if (CollectionAttrPattern.IsMatch(line))
+                {
+                    // A [Collection(...)] attribute line preceding the next class decl.
+                    pendingHasCollection = true;
+                }
+
+                // Attribute the line's content to the innermost open class (if any).
+                if (open.Count > 0)
+                {
+                    var top = scans[open[^1].idx];
+                    if (FactOrTheoryPattern.IsMatch(line))
+                        top.IsTestClass = true;
+                    var gw = GuardedWritePattern.Match(line);
+                    if (gw.Success)
+                    {
+                        top.HasGuardedWrite = true;
+                        top.FirstGuardedStatic ??= gw.Value.Trim();
+                    }
+                }
+
+                // Update brace depth, mark classes whose body we've now entered, then close any whose body
+                // brace has balanced back out.
+                braceDepth += CountChar(line, '{') - CountChar(line, '}');
+                for (int k = 0; k < open.Count; k++)
+                {
+                    if (!open[k].entered && braceDepth > open[k].depth)
+                        open[k] = (open[k].idx, open[k].depth, true);
+                }
+                while (open.Count > 0 && open[^1].entered && braceDepth <= open[^1].depth)
+                    open.RemoveAt(open.Count - 1);
+            }
+
+            return scans;
+        }
+
+        sealed class ClassScan
+        {
+            public string Name = "";
+            public bool HasGuardedWrite;
+            public bool HasCollectionAttribute;
+            public bool IsTestClass;
+            public string? FirstGuardedStatic;
+        }
+
+        static int CountChar(string s, char c)
+        {
+            int n = 0;
+            foreach (var ch in s)
+                if (ch == c) n++;
+            return n;
+        }
+
+        /// <summary>Strips <c>/* ... */</c> block comments and <c>// ...</c> line comments (no string-literal
+        /// awareness needed — the guarded patterns never appear inside a string literal in this suite, and
+        /// stripping comments is what prevents doc-comment <c>&lt;see cref&gt;</c> false-positives).</summary>
+        static string StripComments(string src)
+        {
+            // Block comments first (handles multi-line doc/banner blocks), then single-line.
+            src = Regex.Replace(src, @"/\*.*?\*/", " ", RegexOptions.Singleline);
+            src = Regex.Replace(src, @"//[^\n]*", " ");
+            return src;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Hardens xUnit test isolation (issue #195): every test class that WRITES a process-wide static now runs in a `DisableParallelization = true` serial collection, closing the latent flaky-test races where a bare/parallel mutator could clobber a sibling class that snapshots the same static.
- Covers all four statics — `GodotLogCollector.Current`, the `RuntimeErrorCapture` family (`RuntimeErrorCollector.Current` + install-state + `_installForTests`/`_uninstallForTests` seams), `ScriptErrorCapture.Current`, `GodotMcpReflector.Current` — by extracting the lone mutating fact(s) out of otherwise-parallel classes into small serial-collection classes (keeping the bulk of each suite parallel), and by merging the two `RuntimeErrorCapture` suites into one shared serial collection.
- Adds a durable source-scan drift-guard (`TestIsolationGuardTests`) that FAILS CI — naming the offending class + static — if a future contributor adds a 5th unguarded mutator. Reflection can't see IL method bodies, so the guard scans the test `.cs` sources at test time; it includes a self-sanity assert so it can never go silently inert.

## Scope / invariants
- **TEST-ONLY**: `addons/godot_mcp/**` untouched; NuGet pins `ReflectorNet 5.3.1` / `McpPlugin 6.10.0` untouched. No production change.

## Test plan
- [x] Suite 1 — `dotnet build Godot-MCP.sln` (CI parity): 0 errors.
- [x] Suite 2 — `dotnet test Godot-MCP.Tests`: 914/914 passed, 0 failures.
- [x] Race-targeted 30x stress loop over the static-touching classes (GodotLogCollector|ConsoleTool|EditorReflectionTool|RuntimeErrorCapture|ScriptDiagnostics|SceneNodeTool): green every iteration (127/127 each).
- [x] Drift-guard negative test: injecting an unguarded `GodotLogCollector.Current = null` into a bare test class makes the guard fail and name the class; reverted.

Closes #195