### PR TITLE
feat(cli): real from-scratch install-plugin + always-on E2E install test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,6 +227,30 @@ jobs:
     with:
       godotVersion: "4.5.1"
 
+  # from-scratch terminal-install E2E across the Godot engine matrix (mono). Gates
+  # the release alongside the addon-load smoke so a broken from-scratch terminal
+  # install (create-project + install-plugin) can NEVER ship in a release.
+  e2e-install-4-3:
+    needs: [check-version-tag]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    uses: ./.github/workflows/test_cli_e2e_install.yml
+    with:
+      godotVersion: "4.3.0"
+
+  e2e-install-4-4:
+    needs: [check-version-tag]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    uses: ./.github/workflows/test_cli_e2e_install.yml
+    with:
+      godotVersion: "4.4.0"
+
+  e2e-install-4-5:
+    needs: [check-version-tag]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    uses: ./.github/workflows/test_cli_e2e_install.yml
+    with:
+      godotVersion: "4.5.1"
+
   # godot_mcp runtime INTEGRATION harness across the Godot engine matrix (mono):
   # downloads the released gamedev-mcp-server, boots a headless game with the
   # in-game runtime + error capture, and asserts the live SignalR roundtrip +
@@ -290,6 +314,9 @@ jobs:
         test-godot-4-3,
         test-godot-4-4,
         test-godot-4-5,
+        e2e-install-4-3,
+        e2e-install-4-4,
+        e2e-install-4-5,
       ]
     if: needs.check-version-tag.outputs.should_release == 'true'
     outputs:

--- a/.github/workflows/test_cli_e2e_install.yml
+++ b/.github/workflows/test_cli_e2e_install.yml
@@ -1,0 +1,165 @@
+# ┌──────────────────────────────────────────────────────────────────┐
+# │  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+# │  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+# │  Copyright (c) 2026 Ivan Murzak                                  │
+# │  Licensed under the Apache License, Version 2.0.                 │
+# └──────────────────────────────────────────────────────────────────┘
+#
+# Reusable workflow: prove the FROM-SCRATCH terminal install actually produces a
+# WORKING Godot project. On a clean runner this runs the REAL `godot-cli` flow a
+# user would run — there is no committed test project; everything is scaffolded by
+# the CLI itself:
+#
+#   1. build the CLI (cli/) from source;
+#   2. in a temp dir, `godot-cli create-project --dotnet`;
+#   3. `godot-cli install-plugin --source <repo>/addons/godot_mcp` — the offline /
+#      CI path (no GitHub release exists for un-merged code; the default download
+#      path is unit-tested with a mocked fetch in cli/tests). This materializes
+#      addons/godot_mcp/, adds the two NuGet PackageReferences to the generated
+#      csproj, and enables the plugin in project.godot;
+#   4. import the project + `dotnet build` (the addon globs into the project
+#      assembly, so a green build proves it compiles against the addon's pins);
+#   5. boot the headless Godot editor and assert "[Godot-MCP] plugin loaded" AND
+#      no FileNotFoundException / assembly-resolution error.
+#
+# Modeled on test_godot_plugin.yml (same chickensoft-games/setup-godot mono +
+# .NET 8 toolchain), but it never copies a pre-made addon into a committed test
+# project — it drives the actual terminal commands, so a regression in
+# create-project / install-plugin (the from-scratch story) BREAKS this gate.
+# Called once per matrix version by test_pull_request.yml and release.yml.
+name: Test CLI E2E Install
+
+on:
+  workflow_call:
+    inputs:
+      godotVersion:
+        description: "Godot mono version to install and boot (e.g. 4.3.0, 4.4.0, 4.5.1)."
+        required: true
+        type: string
+
+jobs:
+  e2e-install:
+    name: e2e install ${{ inputs.godotVersion }} (mono)
+    runs-on: ubuntu-latest
+    env:
+      # The scaffolded project lives OUTSIDE the repo checkout so the install is a
+      # genuine from-scratch consumer (not the in-repo addon source dir).
+      WORK: ${{ github.workspace }}/.e2e-consumer
+      PROJECT_NAME: E2EConsumer
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Setup Godot ${{ inputs.godotVersion }} (mono)
+        uses: chickensoft-games/setup-godot@v2
+        with:
+          version: ${{ inputs.godotVersion }}
+          use-dotnet: true
+          include-templates: false
+
+      - name: Report Godot version
+        shell: bash
+        run: godot --version --headless
+
+      - name: Build the CLI from source
+        shell: bash
+        working-directory: ./cli
+        run: |
+          set -euo pipefail
+          npm ci
+          npm run build
+          test -f bin/godot-cli.js
+
+      - name: Scaffold a fresh --dotnet project (the real terminal flow)
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf "${WORK}"
+          mkdir -p "${WORK}"
+          node "${GITHUB_WORKSPACE}/cli/bin/godot-cli.js" create-project \
+            --dotnet --name "${PROJECT_NAME}" "${WORK}/project"
+          test -f "${WORK}/project/project.godot"
+          test -f "${WORK}/project/${PROJECT_NAME}.csproj"
+
+      - name: Install the addon from the repo source (--source, offline/CI path)
+        shell: bash
+        run: |
+          set -euo pipefail
+          node "${GITHUB_WORKSPACE}/cli/bin/godot-cli.js" install-plugin \
+            --source "${GITHUB_WORKSPACE}/addons/godot_mcp" "${WORK}/project"
+          # Addon files materialized.
+          test -f "${WORK}/project/addons/godot_mcp/plugin.cfg"
+          test -f "${WORK}/project/addons/godot_mcp/Editor/GodotMcpPlugin.cs"
+          # Both NuGet pins added to the generated consumer csproj.
+          grep -q 'com.IvanMurzak.ReflectorNet' "${WORK}/project/${PROJECT_NAME}.csproj"
+          grep -q 'com.IvanMurzak.McpPlugin' "${WORK}/project/${PROJECT_NAME}.csproj"
+          # Plugin enabled in project.godot.
+          grep -q 'res://addons/godot_mcp/plugin.cfg' "${WORK}/project/project.godot"
+
+      - name: Import the project (generate .godot layout)
+        shell: bash
+        run: |
+          set -uo pipefail
+          # A cold project has no .godot/. Headless import materializes the
+          # .godot/mono layout; it prints benign "progress dialog" warnings and
+          # may exit non-zero on teardown — neither is fatal (the real gates are
+          # the dotnet build + the plugin-loaded assertion below). Mirrors
+          # test_godot_plugin.yml's import step.
+          godot --headless --path "${WORK}/project" --import --quit 2>&1 | tee "${WORK}/import.log" || true
+          echo "Import pass complete."
+
+      - name: Build C# (addon compiles into the consumer assembly)
+        shell: bash
+        run: |
+          set -euo pipefail
+          dotnet build "${WORK}/project/${PROJECT_NAME}.csproj" \
+            --configuration Debug 2>&1 | tee "${WORK}/build.log"
+          if ! ls "${WORK}/project"/.godot/mono/temp/bin/*/${PROJECT_NAME}.dll >/dev/null 2>&1; then
+            echo "::error::C# build did not produce ${PROJECT_NAME}.dll — the from-scratch install does not compile against the addon's NuGet pins."
+            cat "${WORK}/build.log" || true
+            exit 1
+          fi
+
+      - name: Boot editor headless and assert the addon loads
+        shell: bash
+        run: |
+          set -euo pipefail
+          godot --headless --path "${WORK}/project" --editor --quit \
+            2>&1 | tee "${WORK}/editor-boot.log" || true
+
+          echo "----- editor-boot.log -----"
+          cat "${WORK}/editor-boot.log"
+
+          if ! grep -qF "[Godot-MCP] plugin loaded" "${WORK}/editor-boot.log"; then
+            echo "::error::'[Godot-MCP] plugin loaded' was NOT found — the from-scratch terminal install did not load on Godot ${{ inputs.godotVersion }}."
+            exit 1
+          fi
+
+          if grep -qE "FileNotFoundException|Could not load file or assembly|Cannot open file|Failed to load script|Unable to load addon|addon .* failed" "${WORK}/editor-boot.log"; then
+            echo "::error::An assembly-resolution / addon-load error appeared in the editor boot output on Godot ${{ inputs.godotVersion }}."
+            exit 1
+          fi
+
+          echo "Godot ${{ inputs.godotVersion }}: from-scratch terminal install loaded cleanly."
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-install-${{ inputs.godotVersion }}-logs
+          path: |
+            ${{ env.WORK }}/import.log
+            ${{ env.WORK }}/build.log
+            ${{ env.WORK }}/editor-boot.log
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -90,6 +90,27 @@ jobs:
     with:
       godotVersion: "4.5.1"
 
+  # (e) from-scratch terminal-install E2E across the Godot engine matrix (mono):
+  #     build the CLI, scaffold a --dotnet project, run the REAL `install-plugin`
+  #     (materialize addon + add NuGet pins + enable), dotnet build, and assert the
+  #     editor boots with "[Godot-MCP] plugin loaded". This guards the documented
+  #     terminal Quick Start — a regression in create-project / install-plugin that
+  #     breaks a from-scratch install breaks this gate.
+  e2e-install-4-3:
+    uses: ./.github/workflows/test_cli_e2e_install.yml
+    with:
+      godotVersion: "4.3.0"
+
+  e2e-install-4-4:
+    uses: ./.github/workflows/test_cli_e2e_install.yml
+    with:
+      godotVersion: "4.4.0"
+
+  e2e-install-4-5:
+    uses: ./.github/workflows/test_cli_e2e_install.yml
+    with:
+      godotVersion: "4.5.1"
+
   # Single-source the server version the harness downloads from the addon's authoritative
   # constant (GodotMcpServerView.ServerVersion) instead of trusting the reusable workflow's
   # hardcoded default. This guarantees the harness ALWAYS runs against the server release the

--- a/README.md
+++ b/README.md
@@ -55,31 +55,37 @@ Godot-MCP is the Godot counterpart of [Unity-MCP](https://github.com/IvanMurzak/
 
 # Quick Start
 
-Get up and running in a few steps using the [`godot-cli`](https://www.npmjs.com/package/godot-cli) (the Godot analog of `unity-mcp-cli`):
-
-> **Prerequisite:** first add the addon files and the two NuGet packages to your project — see
-> [Installation](#installation) Steps 1–2. `install-plugin` below only flips the `project.godot`
-> enable flag; it does not copy the addon or add the NuGet pins, so the editor cannot load the plugin
-> without them.
+Get up and running from a terminal using the [`godot-cli`](https://www.npmjs.com/package/godot-cli) (the Godot analog of `unity-mcp-cli`) — no manual file copying or csproj editing required:
 
 ```bash
 # 1. Install godot-cli
 npm install -g godot-cli
 
-# 2. Enable the godot_mcp addon in your Godot C# project (addon files + NuGet pins must already be present)
+# 2. (Optional) Scaffold a fresh Godot C# project — skip if you already have one
+godot-cli create-project --dotnet ./MyGodotProject
+
+# 3. Install the godot_mcp addon: downloads addons/godot_mcp/ from the matching
+#    GitHub release, adds the required NuGet packages to your .csproj, and enables
+#    the plugin in project.godot — all idempotently
 godot-cli install-plugin ./MyGodotProject
 
-# 3. Pick an AI agent (Claude Code, Cursor, Copilot, …) and write its MCP config
+# 4. Pick an AI agent (Claude Code, Cursor, Copilot, …) and write its MCP config
 godot-cli setup-mcp claude-code ./MyGodotProject
 
-# 4. Open the Godot editor (auto-connects with the right GODOT_MCP_* env vars)
+# 5. Open the Godot editor (auto-connects with the right GODOT_MCP_* env vars)
 godot-cli open ./MyGodotProject
 
-# 5. Wait until the plugin answers the readiness probe
+# 6. Wait until the plugin answers the readiness probe
 godot-cli wait-for-ready ./MyGodotProject
 ```
 
 That's it. Ask your AI *"Create 3 cubes in a circle with radius 2"* and watch it happen. ✨
+
+> **Offline / dev install:** `install-plugin --source <path-to>/addons/godot_mcp` copies the addon from
+> a local directory instead of downloading it. Prefer the matching release version with
+> `install-plugin --version <x.y.z>` if you need a specific addon build. The manual route (copy the
+> addon + add the NuGet packages yourself) is still documented under [Installation](#installation)
+> Steps 1–2 for the Asset Library / hand-managed flows.
 
 > See the [full CLI documentation](https://github.com/IvanMurzak/Godot-MCP/blob/main/cli/README.md) for every command, editor-resolution order, and connection env vars.
 
@@ -233,6 +239,13 @@ not compile.
 
 Pick **one** of the following ways to get the `addons/godot_mcp/` folder into your Godot C# project.
 
+> **Fully automated (recommended for terminal workflows):**
+> [`godot-cli`](https://www.npmjs.com/package/godot-cli) `install-plugin ./MyGodotProject` does **all of
+> Step 1 and Step 2 in one command** — it downloads `addons/godot_mcp/` from the matching GitHub release,
+> adds the two NuGet packages to your `.csproj`, and enables the plugin in `project.godot`, idempotently.
+> Use `--source <path>/addons/godot_mcp` to install from a local copy offline. The manual Options A–C
+> below remain for in-editor (Asset Library) and hand-managed installs.
+
 ### Option A — Godot Asset Library (recommended)
 
 The easiest path: install directly from inside the editor.
@@ -260,11 +273,11 @@ directory by hand.
 
 ---
 
-After the files are in place, **enable** the plugin:
-**Project → Project Settings → Plugins → Godot-MCP → Enable** (or run
-[`godot-cli`](https://www.npmjs.com/package/godot-cli) `install-plugin ./MyGodotProject`, which flips the
-same enable flag in `project.godot` — it does **not** copy the addon files, so the files from Option A/B/C
-must already be present). On a successful load the editor Output panel prints:
+After the files are in place (Options A–C), **enable** the plugin:
+**Project → Project Settings → Plugins → Godot-MCP → Enable**. (If you used the fully-automated
+[`godot-cli`](https://www.npmjs.com/package/godot-cli) `install-plugin` above, the plugin is already
+enabled and the NuGet packages are already added — skip straight to [Step 3](#step-3-install-an-ai-agent).)
+On a successful load the editor Output panel prints:
 
 ```
 [Godot-MCP] plugin loaded

--- a/cli/README.md
+++ b/cli/README.md
@@ -34,8 +34,8 @@ Requires Node `^20.19.0 || >=22.12.0`.
 | `setup-skills <agent> [path]` | Generate Godot-MCP skill files (a `SKILL.md`-per-tool-family) under the agent's skills path. `--list` shows each agent's skills support. |
 | `configure [path]` | List / enable / disable tools, prompts, and resources in the project-local `.godot-mcp/features.json`. |
 | `close [path]` | Gracefully stop the Godot editor running for a project (`--force` to hard-kill). |
-| `install-plugin [path]` | Enable the `godot_mcp` addon in `project.godot` `[editor_plugins]`. |
-| `remove-plugin [path]` | Disable the `godot_mcp` addon in `project.godot` `[editor_plugins]`. |
+| `install-plugin [path]` | Install the `godot_mcp` addon end-to-end: materialize `res://addons/godot_mcp/` (download the matching GitHub release, or `--source <path>` a local copy), add the required NuGet `PackageReference`s to the project `.csproj`, and enable the plugin. Idempotent. |
+| `remove-plugin [path]` | Disable the `godot_mcp` addon in `project.godot` `[editor_plugins]` (does not delete the addon files). |
 | `update` | Check npm for a newer `godot-cli` and install it. |
 
 ### Editor resolution (`open`)
@@ -96,6 +96,33 @@ exposes no skill-generate HTTP endpoint, so no server or running editor is requi
 *additionally* auto-generates skills in-process on plugin boot via
 `GodotMcpConnection.Start` → `GenerateSkillFilesIfNeeded`; the CLI command is the
 server-less, scriptable path that does not need a live editor.)
+
+## `install-plugin`
+
+`godot-cli install-plugin [path]` is a **real installer** — it makes a from-scratch terminal install
+produce a working project, in one idempotent command:
+
+```bash
+godot-cli install-plugin ./MyGodotProject                      # download the matching release + install
+godot-cli install-plugin --version 0.11.1 ./MyGodotProject     # pin a specific addon release
+godot-cli install-plugin --source ./Godot-MCP/addons/godot_mcp ./MyGodotProject   # offline / dev copy
+```
+
+It performs three steps:
+
+1. **Materialize `res://addons/godot_mcp/`.** By default it downloads `godot-mcp-addon-<version>.zip`
+   over HTTPS from **github.com only** (the `IvanMurzak/Godot-MCP` release `v<version>`; the version
+   defaults to the CLI's own version). Non-`github.com` hosts and plain `http` are rejected. With
+   `--source <path>` it copies the addon from a local directory instead (no network) — `<path>` may be a
+   directory that *is* `addons/godot_mcp` or one that *contains* it.
+2. **Add the NuGet packages** the addon needs (`com.IvanMurzak.ReflectorNet`, `com.IvanMurzak.McpPlugin`)
+   to the project's `.csproj`, idempotently — adding when missing, reconciling a stale version, and
+   leaving a correct pin untouched. The versions are single-sourced from the addon's own
+   `Godot-MCP.csproj` pins, so the scaffold can never drift.
+3. **Enable the plugin** in `project.godot` `[editor_plugins]`.
+
+It is library-safe (returns a `{ kind: 'success' | 'failure' }` union; never throws past the public
+boundary) and idempotent — re-running on an already-installed project reports no change.
 
 ## Library API
 

--- a/cli/src/commands/install-plugin.ts
+++ b/cli/src/commands/install-plugin.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander';
+import { createRequire } from 'module';
 import * as path from 'path';
 import * as ui from '../utils/ui.js';
 import { verbose } from '../utils/ui.js';
@@ -6,32 +7,79 @@ import { installPlugin } from '../lib/install-plugin.js';
 
 interface InstallPluginCliOptions {
   path?: string;
+  source?: string;
+  version?: string;
+}
+
+/** The CLI's own version — the default addon release version to download. */
+function cliVersion(): string {
+  try {
+    const require = createRequire(import.meta.url);
+    const pkg = require('../../package.json') as { version: string };
+    return pkg.version;
+  } catch {
+    return '';
+  }
 }
 
 export const installPluginCommand = new Command('install-plugin')
-  .description('Enable the godot_mcp addon in a project (adds res://addons/godot_mcp/plugin.cfg to project.godot [editor_plugins])')
+  .description(
+    'Install the godot_mcp addon into a Godot C# project: materialize res://addons/godot_mcp/ (download the matching GitHub release, or --source a local copy), add the required NuGet PackageReferences to the project .csproj, and enable the plugin in project.godot.',
+  )
   .argument('[path]', 'Path to the Godot project')
   .option('--path <path>', 'Path to the Godot project')
+  .option(
+    '--source <path>',
+    'Install the addon from a local directory (offline / dev / CI) instead of downloading it',
+  )
+  .option(
+    '--version <x.y.z>',
+    'Addon release version to download (defaults to this CLI version). Ignored with --source.',
+  )
   .action(async (positionalPath: string | undefined, options: InstallPluginCliOptions) => {
     const resolvedPath = positionalPath ?? options.path ?? process.cwd();
     const projectPath = path.resolve(resolvedPath);
 
-    ui.heading('Enabling godot_mcp addon');
+    ui.heading('Installing godot_mcp addon');
     verbose(`Project path: ${projectPath}`);
+    if (options.source) verbose(`--source: ${options.source}`);
 
-    const spinner = ui.startSpinner('Updating project.godot...');
-    const result = await installPlugin({ godotProjectPath: projectPath });
+    const spinner = ui.startSpinner('Installing addon...');
+    const result = await installPlugin({
+      godotProjectPath: projectPath,
+      source: options.source,
+      version: options.version ?? cliVersion(),
+    });
 
     if (result.kind === 'failure') {
-      spinner.error('Failed to enable plugin');
+      spinner.error('Failed to install plugin');
       ui.error(result.error.message);
+      for (const warning of result.warnings) {
+        console.log('');
+        ui.warn(warning);
+      }
       process.exit(1);
     }
 
     if (result.changed) {
-      spinner.success('godot_mcp addon enabled');
+      spinner.success('godot_mcp addon installed and enabled');
     } else {
       spinner.success('godot_mcp addon was already enabled');
+    }
+
+    // Addon files outcome.
+    if (result.materialize.source === 'download') {
+      ui.label('Addon files', `downloaded → ${result.materialize.addonDir}`);
+    } else if (result.materialize.source === 'local') {
+      ui.label('Addon files', `copied from ${result.materialize.sourceDir} → ${result.materialize.addonDir}`);
+    }
+
+    // csproj outcome.
+    if (result.csproj.csprojPath) {
+      const summary = result.csproj.packages
+        .map((p) => `${p.id}@${p.version} (${p.action})`)
+        .join(', ');
+      ui.label('NuGet packages', summary || '(none)');
     }
 
     ui.label('project.godot', result.projectGodotPath);

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -62,6 +62,8 @@ export type {
   InstallPluginResult,
   InstallPluginSuccess,
   InstallPluginFailure,
+  AddonMaterializeOutcome,
+  CsprojPatchOutcome,
   RemovePluginOptions,
   RemovePluginResult,
   RemovePluginSuccess,

--- a/cli/src/lib/install-plugin.ts
+++ b/cli/src/lib/install-plugin.ts
@@ -42,8 +42,9 @@ const ADDON_REL_DIR = path.join('addons', 'godot_mcp');
  * boundary; returns a `{ kind: 'success' | 'failure' }` union. Idempotent: a
  * re-run that finds the addon present, the pins present, and the plugin already
  * enabled reports `changed: false` and makes no writes. On a download/copy
- * failure the project is left as found (the addon dir is only swapped in after a
- * successful fetch+extract; a partial extraction is rolled back).
+ * failure the project is left as found: both paths materialize into a temp
+ * sibling and only swap it into the addon dir after a fully successful
+ * fetch+extract / copy, so a partial materialization is rolled back.
  */
 export async function installPlugin(opts: InstallPluginOptions): Promise<InstallPluginResult> {
   const warnings: string[] = [];
@@ -70,7 +71,7 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
     const materialize = await materializeAddon(projectPath, opts, warnings);
 
     // 2. Patch the consumer csproj with the addon's NuGet PackageReferences.
-    const csproj = patchConsumerCsproj(projectPath, warnings);
+    const csproj = patchConsumerCsproj(projectPath, warnings, opts.onProgress);
 
     // 3. Enable the plugin in project.godot.
     const text = fs.readFileSync(projectGodotPath, 'utf-8');
@@ -130,7 +131,7 @@ async function materializeAddon(
 
   if (opts.source !== undefined && opts.source !== '') {
     const sourceDir = resolveAddonSourceDir(opts.source);
-    copyAddonFromLocal(sourceDir, addonDir, opts.onProgress);
+    copyAddonFromLocal(sourceDir, projectPath, addonDir, opts.onProgress);
     emitProgress(opts.onProgress, {
       phase: 'addon-materialized',
       message: `Copied addon from ${sourceDir}`,
@@ -197,35 +198,64 @@ function resolveAddonSourceDir(source: string): string {
   );
 }
 
-/** Recursively copy a local addon dir into the project's addons/godot_mcp/ (replacing). */
-function copyAddonFromLocal(sourceDir: string, addonDir: string, onProgress?: ProgressCallback): void {
-  emitProgress(onProgress, { phase: 'addon-extracting', message: `Copying addon from ${sourceDir}` });
-  // Replace any existing addon dir to keep the copy deterministic + idempotent.
-  fs.rmSync(addonDir, { recursive: true, force: true });
-  fs.mkdirSync(addonDir, { recursive: true });
-  fs.cpSync(sourceDir, addonDir, { recursive: true });
-  if (!fs.existsSync(path.join(addonDir, 'plugin.cfg'))) {
-    throw new Error(`Copy completed but ${path.join(addonDir, 'plugin.cfg')} is missing.`);
+/**
+ * Materialize the addon into a fresh staging sibling via `fill`, then atomically
+ * swap it into `addonDir`. A mid-fill failure leaves the existing addon untouched
+ * (staging is discarded), honoring the install's documented rollback guarantee.
+ * Shared by both the local-copy and download/extract paths.
+ */
+function stageThenSwapAddon(
+  projectPath: string,
+  addonDir: string,
+  fill: (staging: string) => void,
+): void {
+  const addonReal = path.resolve(addonDir);
+  const staging = path.resolve(projectPath, `.godot-mcp-addon-staging-${process.pid}-${Date.now()}`);
+  fs.rmSync(staging, { recursive: true, force: true });
+  fs.mkdirSync(staging, { recursive: true });
+  try {
+    fill(staging);
+    // Swap staging -> addonDir only after `fill` fully succeeded.
+    fs.rmSync(addonReal, { recursive: true, force: true });
+    fs.mkdirSync(path.dirname(addonReal), { recursive: true });
+    fs.renameSync(staging, addonReal);
+  } finally {
+    // Best-effort cleanup if the swap didn't consume staging.
+    fs.rmSync(staging, { recursive: true, force: true });
   }
+}
+
+/**
+ * Recursively copy a local addon dir into the project's addons/godot_mcp/. Stages
+ * into a temp sibling and swaps, so a mid-copy failure leaves the existing addon
+ * intact (matching the download path's rollback guarantee). Deterministic +
+ * idempotent: the swap replaces any existing addon dir.
+ */
+function copyAddonFromLocal(
+  sourceDir: string,
+  projectPath: string,
+  addonDir: string,
+  onProgress?: ProgressCallback,
+): void {
+  emitProgress(onProgress, { phase: 'addon-extracting', message: `Copying addon from ${sourceDir}` });
+  stageThenSwapAddon(projectPath, addonDir, (staging) => {
+    fs.cpSync(sourceDir, staging, { recursive: true });
+    if (!fs.existsSync(path.join(staging, 'plugin.cfg'))) {
+      throw new Error(`Copy completed but ${path.join(sourceDir, 'plugin.cfg')} did not yield a plugin.cfg.`);
+    }
+  });
 }
 
 /**
  * Write the zip entries that live under `addons/godot_mcp/` into the project. The
  * release zip expands to `addons/godot_mcp/...`, so entries are written relative
  * to the project root. Path-safety: every resolved target MUST stay inside the
- * project's addons/godot_mcp dir (reject zip-slip `../` traversal). The target
- * addon dir is replaced so the install is deterministic + idempotent.
+ * staging dir (reject zip-slip `../` traversal). The target addon dir is replaced
+ * atomically so the install is deterministic + idempotent and rollback-safe.
  */
 function extractAddonEntries(entries: ZipEntry[], projectPath: string, addonDir: string): void {
-  const addonReal = path.resolve(addonDir);
-  // Stage into a temp sibling, then swap, so a mid-extract failure leaves the
-  // existing addon intact.
-  const staging = path.resolve(projectPath, `.godot-mcp-addon-staging-${process.pid}-${Date.now()}`);
-  fs.rmSync(staging, { recursive: true, force: true });
-  fs.mkdirSync(staging, { recursive: true });
-
-  let wrotePluginCfg = false;
-  try {
+  stageThenSwapAddon(projectPath, addonDir, (staging) => {
+    let wrotePluginCfg = false;
     for (const entry of entries) {
       // Only the addons/godot_mcp/ subtree is relevant.
       const prefix = 'addons/godot_mcp/';
@@ -252,15 +282,7 @@ function extractAddonEntries(entries: ZipEntry[], projectPath: string, addonDir:
         'Downloaded addon zip did not contain addons/godot_mcp/plugin.cfg — the archive is not a valid godot_mcp addon release.',
       );
     }
-
-    // Swap staging -> addonDir.
-    fs.rmSync(addonReal, { recursive: true, force: true });
-    fs.mkdirSync(path.dirname(addonReal), { recursive: true });
-    fs.renameSync(staging, addonReal);
-  } finally {
-    // Best-effort cleanup if the swap didn't consume staging.
-    fs.rmSync(staging, { recursive: true, force: true });
-  }
+  });
 }
 
 /**
@@ -271,8 +293,12 @@ function extractAddonEntries(entries: ZipEntry[], projectPath: string, addonDir:
  * project), the patch is skipped with a warning — the addon's C# cannot compile
  * without one, but that is the consumer's project shape to fix.
  */
-function patchConsumerCsproj(projectPath: string, warnings: string[]): CsprojPatchOutcome {
-  const csprojPath = findConsumerCsproj(projectPath);
+function patchConsumerCsproj(
+  projectPath: string,
+  warnings: string[],
+  onProgress?: ProgressCallback,
+): CsprojPatchOutcome {
+  const csprojPath = findConsumerCsproj(projectPath, warnings);
   if (csprojPath === null) {
     warnings.push(
       'No .csproj found at the project root — the godot_mcp addon is C# and needs a Godot.NET.Sdk project. ' +
@@ -285,6 +311,11 @@ function patchConsumerCsproj(projectPath: string, warnings: string[]): CsprojPat
   const patched = addAddonPackageReferences(before);
   if (patched.changed) {
     fs.writeFileSync(csprojPath, patched.text);
+    emitProgress(onProgress, {
+      phase: 'csproj-patched',
+      message: `Added addon PackageReferences to ${csprojPath}`,
+      csprojPath,
+    });
   }
 
   return {
@@ -299,7 +330,7 @@ function patchConsumerCsproj(projectPath: string, warnings: string[]): CsprojPat
 }
 
 /** The single `*.csproj` directly at the project root, or null when none/ambiguous. */
-function findConsumerCsproj(projectPath: string): string | null {
+function findConsumerCsproj(projectPath: string, warnings: string[]): string | null {
   let names: string[];
   try {
     names = fs.readdirSync(projectPath).filter((n) => n.toLowerCase().endsWith('.csproj'));
@@ -309,9 +340,15 @@ function findConsumerCsproj(projectPath: string): string | null {
   if (names.length === 0) return null;
   // A scaffolded Godot project has exactly one root csproj. If there are several,
   // pick deterministically (first alphabetically) — better than failing the whole
-  // install; a warning is not added because all root csprojs compile into the same
-  // Godot assembly and would all need the pins.
+  // install; all root csprojs compile into the same Godot assembly and would each
+  // need the pins, but warn so the heuristic's choice is observable.
   names.sort();
+  if (names.length > 1) {
+    warnings.push(
+      `Multiple .csproj files found at the project root (${names.join(', ')}); patched ${names[0]}. ` +
+        'If a different one is the Godot project, add the addon PackageReferences to it as well.',
+    );
+  }
   return path.join(projectPath, names[0]);
 }
 

--- a/cli/src/lib/install-plugin.ts
+++ b/cli/src/lib/install-plugin.ts
@@ -1,29 +1,49 @@
 import * as fs from 'fs';
+import * as path from 'path';
 import {
   GODOT_MCP_PLUGIN_PATH,
   projectGodotPath as resolveProjectGodotPath,
   togglePluginInText,
 } from '../utils/project-godot.js';
+import { addAddonPackageReferences } from '../utils/csproj-deps.js';
+import { ADDON_PACKAGE_REFERENCES } from '../utils/addon-deps.js';
+import {
+  addonDownloadUrl,
+  assertTrustedDownloadUrl,
+} from '../utils/addon-source.js';
+import { parseZip, type ZipEntry } from '../utils/unzip.js';
 import { emitProgress } from './progress.js';
 import { requireGodotProject } from './validation.js';
 import type {
+  AddonMaterializeOutcome,
+  CsprojPatchOutcome,
   InstallPluginOptions,
   InstallPluginResult,
+  ProgressCallback,
   RemovePluginOptions,
   RemovePluginResult,
 } from './types.js';
 
+/** Relative path of the addon dir inside a Godot project. */
+const ADDON_REL_DIR = path.join('addons', 'godot_mcp');
+
 /**
- * Enable the `godot_mcp` addon in a project's `project.godot` `[editor_plugins]`
- * `enabled` array. Library-safe: no stdout noise, no process.exit, no throws
- * past the public boundary.
+ * Install the `godot_mcp` addon into a Godot C# project as a REAL installer:
  *
- * v1 is intentionally minimal — it only flips the project.godot plugin-enable
- * state. It does NOT copy addon files or patch the consumer `.csproj` with the
- * NuGet PackageReferences the addon needs (that is the consumer's responsibility
- * per the addon's install docs); a warning surfaces that requirement.
+ *  1. Materialize `res://addons/godot_mcp/` — by default downloading
+ *     `godot-mcp-addon-<version>.zip` over HTTPS from github.com only (the
+ *     `IvanMurzak/Godot-MCP` release `v<version>`), or, with `--source <path>`,
+ *     copying the addon from a local directory (offline / dev / CI).
+ *  2. Add the two NuGet `PackageReference`s the addon needs to the consumer
+ *     `.csproj`, idempotently and single-sourced from the addon's own pins.
+ *  3. Flip the `[editor_plugins] enabled` flag in `project.godot`.
  *
- * Idempotent: enabling an already-enabled plugin returns `changed: false`.
+ * Library-safe: no stdout noise, no `process.exit`, no throws past the public
+ * boundary; returns a `{ kind: 'success' | 'failure' }` union. Idempotent: a
+ * re-run that finds the addon present, the pins present, and the plugin already
+ * enabled reports `changed: false` and makes no writes. On a download/copy
+ * failure the project is left as found (the addon dir is only swapped in after a
+ * successful fetch+extract; a partial extraction is rolled back).
  */
 export async function installPlugin(opts: InstallPluginOptions): Promise<InstallPluginResult> {
   const warnings: string[] = [];
@@ -43,14 +63,20 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
 
     emitProgress(opts.onProgress, {
       phase: 'start',
-      message: `Enabling godot_mcp addon for ${projectPath}`,
+      message: `Installing godot_mcp addon into ${projectPath}`,
     });
 
-    const text = fs.readFileSync(projectGodotPath, 'utf-8');
-    const result = togglePluginInText(text, true, GODOT_MCP_PLUGIN_PATH);
+    // 1. Materialize the addon files (download / local copy / skip).
+    const materialize = await materializeAddon(projectPath, opts, warnings);
 
-    if (result.kind === 'changed') {
-      fs.writeFileSync(projectGodotPath, result.text);
+    // 2. Patch the consumer csproj with the addon's NuGet PackageReferences.
+    const csproj = patchConsumerCsproj(projectPath, warnings);
+
+    // 3. Enable the plugin in project.godot.
+    const text = fs.readFileSync(projectGodotPath, 'utf-8');
+    const toggled = togglePluginInText(text, true, GODOT_MCP_PLUGIN_PATH);
+    if (toggled.kind === 'changed') {
+      fs.writeFileSync(projectGodotPath, toggled.text);
       emitProgress(opts.onProgress, {
         phase: 'manifest-patched',
         message: `Wrote ${projectGodotPath}`,
@@ -58,18 +84,16 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
       });
     }
 
-    warnings.push(
-      'Ensure the project .csproj declares the com.IvanMurzak.ReflectorNet and com.IvanMurzak.McpPlugin PackageReferences the addon needs (see the addon README).',
-    );
-
-    emitProgress(opts.onProgress, { phase: 'done', message: 'godot_mcp addon enabled.' });
+    emitProgress(opts.onProgress, { phase: 'done', message: 'godot_mcp addon installed.' });
 
     return {
       kind: 'success',
       success: true,
-      changed: result.kind === 'changed',
+      changed: toggled.kind === 'changed',
       projectGodotPath,
-      enabledPlugins: result.enabled,
+      enabledPlugins: toggled.enabled,
+      materialize,
+      csproj,
       warnings,
     };
   } catch (err: unknown) {
@@ -80,6 +104,215 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
       error: err instanceof Error ? err : new Error(String(err)),
     };
   }
+}
+
+/**
+ * Materialize `addons/godot_mcp/` into the project from the GitHub release zip
+ * (default) or a local `--source` directory. Idempotent for the local-copy and
+ * download paths: the target dir is replaced atomically-ish (extract/copy into a
+ * temp sibling, then swap), so a failure leaves the existing addon untouched.
+ */
+async function materializeAddon(
+  projectPath: string,
+  opts: InstallPluginOptions,
+  warnings: string[],
+): Promise<AddonMaterializeOutcome> {
+  const addonDir = path.join(projectPath, ADDON_REL_DIR);
+
+  if (opts.skipMaterialize === true) {
+    if (!fs.existsSync(path.join(addonDir, 'plugin.cfg'))) {
+      warnings.push(
+        `skipMaterialize was set but ${path.join(addonDir, 'plugin.cfg')} is absent — the editor cannot load the plugin until the addon files are present.`,
+      );
+    }
+    return { source: 'skipped', addonDir };
+  }
+
+  if (opts.source !== undefined && opts.source !== '') {
+    const sourceDir = resolveAddonSourceDir(opts.source);
+    copyAddonFromLocal(sourceDir, addonDir, opts.onProgress);
+    emitProgress(opts.onProgress, {
+      phase: 'addon-materialized',
+      message: `Copied addon from ${sourceDir}`,
+      addonDir,
+      source: 'local',
+    });
+    return { source: 'local', addonDir, sourceDir };
+  }
+
+  // Download path. Default the version to the CLI's own version (passed by the
+  // command via opts.version); fail clearly if neither is available.
+  const version = (opts.version ?? '').trim();
+  if (version === '') {
+    throw new Error(
+      'No addon version to download. Pass --version <x.y.z> or --source <path> to install from a local copy.',
+    );
+  }
+  const url = addonDownloadUrl(version);
+  assertTrustedDownloadUrl(url); // fail-closed: github.com + https only.
+
+  emitProgress(opts.onProgress, {
+    phase: 'addon-downloading',
+    message: `Downloading addon ${version} from ${url}`,
+    url,
+  });
+
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  const response = await fetchImpl(url);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download addon ${version}: HTTP ${response.status} ${response.statusText} from ${url}. ` +
+        `Verify the release v${version} exists, or use --source <path> for an offline/dev install.`,
+    );
+  }
+  const archive = Buffer.from(await response.arrayBuffer());
+
+  emitProgress(opts.onProgress, { phase: 'addon-extracting', message: 'Extracting addon zip' });
+  const entries = parseZip(archive);
+  extractAddonEntries(entries, projectPath, addonDir);
+
+  emitProgress(opts.onProgress, {
+    phase: 'addon-materialized',
+    message: `Downloaded + extracted addon to ${addonDir}`,
+    addonDir,
+    source: 'download',
+  });
+  return { source: 'download', addonDir, downloadUrl: url };
+}
+
+/** Resolve + validate a `--source` directory: it must exist and contain plugin.cfg. */
+function resolveAddonSourceDir(source: string): string {
+  const resolved = path.resolve(source);
+  // Accept either a path that IS addons/godot_mcp (contains plugin.cfg directly)
+  // or a path that CONTAINS addons/godot_mcp.
+  if (fs.existsSync(path.join(resolved, 'plugin.cfg'))) {
+    return resolved;
+  }
+  const nested = path.join(resolved, 'addons', 'godot_mcp');
+  if (fs.existsSync(path.join(nested, 'plugin.cfg'))) {
+    return nested;
+  }
+  throw new Error(
+    `--source ${resolved} does not contain a godot_mcp addon (no plugin.cfg found at it or at addons/godot_mcp/).`,
+  );
+}
+
+/** Recursively copy a local addon dir into the project's addons/godot_mcp/ (replacing). */
+function copyAddonFromLocal(sourceDir: string, addonDir: string, onProgress?: ProgressCallback): void {
+  emitProgress(onProgress, { phase: 'addon-extracting', message: `Copying addon from ${sourceDir}` });
+  // Replace any existing addon dir to keep the copy deterministic + idempotent.
+  fs.rmSync(addonDir, { recursive: true, force: true });
+  fs.mkdirSync(addonDir, { recursive: true });
+  fs.cpSync(sourceDir, addonDir, { recursive: true });
+  if (!fs.existsSync(path.join(addonDir, 'plugin.cfg'))) {
+    throw new Error(`Copy completed but ${path.join(addonDir, 'plugin.cfg')} is missing.`);
+  }
+}
+
+/**
+ * Write the zip entries that live under `addons/godot_mcp/` into the project. The
+ * release zip expands to `addons/godot_mcp/...`, so entries are written relative
+ * to the project root. Path-safety: every resolved target MUST stay inside the
+ * project's addons/godot_mcp dir (reject zip-slip `../` traversal). The target
+ * addon dir is replaced so the install is deterministic + idempotent.
+ */
+function extractAddonEntries(entries: ZipEntry[], projectPath: string, addonDir: string): void {
+  const addonReal = path.resolve(addonDir);
+  // Stage into a temp sibling, then swap, so a mid-extract failure leaves the
+  // existing addon intact.
+  const staging = path.resolve(projectPath, `.godot-mcp-addon-staging-${process.pid}-${Date.now()}`);
+  fs.rmSync(staging, { recursive: true, force: true });
+  fs.mkdirSync(staging, { recursive: true });
+
+  let wrotePluginCfg = false;
+  try {
+    for (const entry of entries) {
+      // Only the addons/godot_mcp/ subtree is relevant.
+      const prefix = 'addons/godot_mcp/';
+      if (!entry.path.startsWith(prefix)) continue;
+      const rel = entry.path.slice(prefix.length);
+      if (rel === '') continue; // the dir entry itself
+
+      const target = path.resolve(staging, rel);
+      // Zip-slip guard: target must remain under staging.
+      if (target !== staging && !target.startsWith(staging + path.sep)) {
+        throw new Error(`Refusing to extract entry escaping the addon dir: ${entry.path}`);
+      }
+      if (entry.isDirectory) {
+        fs.mkdirSync(target, { recursive: true });
+        continue;
+      }
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, entry.bytes);
+      if (rel === 'plugin.cfg') wrotePluginCfg = true;
+    }
+
+    if (!wrotePluginCfg) {
+      throw new Error(
+        'Downloaded addon zip did not contain addons/godot_mcp/plugin.cfg — the archive is not a valid godot_mcp addon release.',
+      );
+    }
+
+    // Swap staging -> addonDir.
+    fs.rmSync(addonReal, { recursive: true, force: true });
+    fs.mkdirSync(path.dirname(addonReal), { recursive: true });
+    fs.renameSync(staging, addonReal);
+  } finally {
+    // Best-effort cleanup if the swap didn't consume staging.
+    fs.rmSync(staging, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Find the consumer's `.csproj` (the one Godot compiles the addon into) and add
+ * the two addon NuGet PackageReferences idempotently. The csproj is the single
+ * `*.csproj` at the project root (the `--dotnet` scaffold writes
+ * `<AssemblyName>.csproj` there). When there is no csproj (a GDScript-only
+ * project), the patch is skipped with a warning — the addon's C# cannot compile
+ * without one, but that is the consumer's project shape to fix.
+ */
+function patchConsumerCsproj(projectPath: string, warnings: string[]): CsprojPatchOutcome {
+  const csprojPath = findConsumerCsproj(projectPath);
+  if (csprojPath === null) {
+    warnings.push(
+      'No .csproj found at the project root — the godot_mcp addon is C# and needs a Godot.NET.Sdk project. ' +
+        `Create one (e.g. \`godot-cli create-project --dotnet\`) and add the ${ADDON_PACKAGE_REFERENCES.map((r) => r.id).join(' + ')} PackageReferences.`,
+    );
+    return { changed: false, packages: [] };
+  }
+
+  const before = fs.readFileSync(csprojPath, 'utf-8');
+  const patched = addAddonPackageReferences(before);
+  if (patched.changed) {
+    fs.writeFileSync(csprojPath, patched.text);
+  }
+
+  return {
+    csprojPath,
+    changed: patched.changed,
+    packages: patched.changes.map((c) => ({
+      id: c.id,
+      action: c.action,
+      version: c.version,
+    })),
+  };
+}
+
+/** The single `*.csproj` directly at the project root, or null when none/ambiguous. */
+function findConsumerCsproj(projectPath: string): string | null {
+  let names: string[];
+  try {
+    names = fs.readdirSync(projectPath).filter((n) => n.toLowerCase().endsWith('.csproj'));
+  } catch {
+    return null;
+  }
+  if (names.length === 0) return null;
+  // A scaffolded Godot project has exactly one root csproj. If there are several,
+  // pick deterministically (first alphabetically) — better than failing the whole
+  // install; a warning is not added because all root csprojs compile into the same
+  // Godot assembly and would all need the pins.
+  names.sort();
+  return path.join(projectPath, names[0]);
 }
 
 /**

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -16,6 +16,11 @@
 export type ProgressEvent =
   | { phase: 'start'; message: string }
   | { phase: 'manifest-patched'; message: string; manifestPath: string }
+  // installPlugin (materialize addon) phases
+  | { phase: 'addon-downloading'; message: string; url: string }
+  | { phase: 'addon-extracting'; message: string }
+  | { phase: 'addon-materialized'; message: string; addonDir: string; source: 'download' | 'local' }
+  | { phase: 'csproj-patched'; message: string; csprojPath: string }
   // createProject phases
   | { phase: 'project-scaffolded'; message: string; projectPath: string }
   // openProject phases
@@ -294,7 +299,52 @@ export type RunSystemToolFailure = RunToolFailure;
 export interface InstallPluginOptions {
   /** Absolute or relative path to the Godot project root. */
   godotProjectPath: string;
+  /**
+   * Local directory to copy `addons/godot_mcp/` from instead of downloading it
+   * from the GitHub release (offline / dev / CI path). When set, no network call
+   * is made; the directory must contain the addon files (a `plugin.cfg`).
+   */
+  source?: string;
+  /**
+   * Addon release version to download (`<version>` in
+   * `godot-mcp-addon-<version>.zip`, tag `v<version>`). Defaults to the CLI's own
+   * version. Ignored when `source` is set. Used only on the download path.
+   */
+  version?: string;
+  /**
+   * Skip materializing the addon files (download / copy) and only enable the
+   * plugin + patch the csproj. Restores the pre-installer behavior for callers
+   * that manage the addon files themselves.
+   */
+  skipMaterialize?: boolean;
+  /**
+   * Injectable fetch for tests (mock the GitHub download). Defaults to
+   * `globalThis.fetch`. Used only on the download path.
+   */
+  fetchImpl?: typeof fetch;
   onProgress?: ProgressCallback;
+}
+
+/** What `install-plugin` did to materialize the `addons/godot_mcp/` files. */
+export interface AddonMaterializeOutcome {
+  /** Where the addon files came from. `skipped` when `skipMaterialize` was set. */
+  source: 'download' | 'local' | 'skipped';
+  /** Absolute path to the materialized `addons/godot_mcp/` directory. */
+  addonDir: string;
+  /** The download URL used (download path only). */
+  downloadUrl?: string;
+  /** The local source directory used (`--source` path only). */
+  sourceDir?: string;
+}
+
+/** What `install-plugin` did to the consumer `.csproj`'s PackageReferences. */
+export interface CsprojPatchOutcome {
+  /** Absolute path to the consumer `.csproj` that was patched, if one was found. */
+  csprojPath?: string;
+  /** True when the csproj text was modified. */
+  changed: boolean;
+  /** Per-package summary: each addon pin's add / update / unchanged outcome. */
+  packages: { id: string; action: 'added' | 'updated' | 'unchanged'; version: string }[];
 }
 
 export interface InstallPluginSuccess {
@@ -304,6 +354,10 @@ export interface InstallPluginSuccess {
   changed: boolean;
   projectGodotPath: string;
   enabledPlugins: string[];
+  /** Addon-files materialization outcome (download / local copy / skipped). */
+  materialize: AddonMaterializeOutcome;
+  /** Consumer csproj PackageReference patch outcome. */
+  csproj: CsprojPatchOutcome;
   warnings: string[];
 }
 

--- a/cli/src/utils/addon-deps.ts
+++ b/cli/src/utils/addon-deps.ts
@@ -1,0 +1,36 @@
+// The NuGet PackageReferences a consumer's Godot C# project MUST declare so the
+// `addons/godot_mcp/` sources compile into the project assembly (Godot globs every
+// `*.cs` under the project into one assembly — see the addon README
+// "Consumer-install story"). `install-plugin` writes these into the generated
+// consumer `.csproj` so a from-scratch terminal install actually builds.
+//
+// SINGLE SOURCE OF TRUTH: these values mirror the addon's own reused pins in
+// `Godot-MCP.csproj` (`com.IvanMurzak.ReflectorNet`, `com.IvanMurzak.McpPlugin`).
+// They are NOT a bump of those pins — they are the SAME values, copied so the
+// scaffold installs exactly what the addon was built against. A parity test
+// (`cli/tests/addon-deps-parity.test.ts`) reads `Godot-MCP.csproj` and FAILS the
+// build if these constants ever drift from the addon's pins, so the scaffold can
+// never silently install a mismatched version.
+//
+// No top-level side effects; pure data + pure string transforms only.
+
+/** A single NuGet `<PackageReference>` the consumer csproj must declare. */
+export interface AddonPackageReference {
+  /** The NuGet package id (the `Include=` attribute). */
+  id: string;
+  /** The pinned version (the `Version=` attribute). */
+  version: string;
+}
+
+/**
+ * The exact NuGet `PackageReference`s the consumer's project `.csproj` needs,
+ * single-sourced from the addon's `Godot-MCP.csproj` pins. Order matches the
+ * addon csproj (ReflectorNet first, then McpPlugin).
+ */
+export const ADDON_PACKAGE_REFERENCES: readonly AddonPackageReference[] = [
+  { id: 'com.IvanMurzak.ReflectorNet', version: '5.3.1' },
+  { id: 'com.IvanMurzak.McpPlugin', version: '6.10.0' },
+] as const;
+
+/** The resource path of the addon manifest a consumer project loads the plugin from. */
+export const ADDON_PLUGIN_CFG_RESOURCE = 'res://addons/godot_mcp/plugin.cfg';

--- a/cli/src/utils/addon-source.ts
+++ b/cli/src/utils/addon-source.ts
@@ -1,0 +1,77 @@
+// Pure helpers for resolving WHERE the `addons/godot_mcp/` files come from when
+// `install-plugin` materializes them: the trusted GitHub-release download URL and
+// the host-trust check. Mirrors the addon's own trusted-source pattern in
+// `addons/godot_mcp/Runtime/Connection/GodotMcpServerView.cs` (github.com only,
+// `releases/download/v<version>/<asset>`). No side effects; unit-testable.
+
+/** GitHub-release host the addon zip is downloaded from. NOTHING else is trusted. */
+export const TRUSTED_DOWNLOAD_HOST = 'github.com';
+
+/** The `owner/repo` the addon releases live under. */
+export const ADDON_RELEASE_REPO = 'IvanMurzak/Godot-MCP';
+
+/**
+ * The release-asset name for an addon version: `godot-mcp-addon-<version>.zip`.
+ * Matches the asset the release workflow attaches (`release.yml` → "Package addon
+ * zip": `zip_name="godot-mcp-addon-${version}.zip"`). The `<version>` is the bare
+ * version WITHOUT a leading `v` (the `v` only appears in the tag). Pure.
+ */
+export function addonAssetName(version: string): string {
+  return `godot-mcp-addon-${stripLeadingV(version)}.zip`;
+}
+
+/**
+ * The git release TAG for an addon version: the version with a leading `v`
+ * (`0.11.1` → `v0.11.1`). The release workflow tags every release `v<version>`
+ * (`release.yml` → `tag=v${version}`); an already-`v`-prefixed input is passed
+ * through unchanged so a caller cannot double-prefix. Pure.
+ */
+export function releaseTag(version: string): string {
+  const v = (version ?? '').trim();
+  return v.startsWith('v') ? v : `v${v}`;
+}
+
+/** Drop a single leading `v`/`V` from a version string. Pure. */
+export function stripLeadingV(version: string): string {
+  const v = (version ?? '').trim();
+  return /^v/i.test(v) ? v.slice(1) : v;
+}
+
+/**
+ * The download URL for an addon version's zip:
+ * `https://github.com/IvanMurzak/Godot-MCP/releases/download/v<version>/godot-mcp-addon-<version>.zip`.
+ * Mirrors `GodotMcpServerView.DownloadUrl`. Pure string build. The host is always
+ * `github.com` by construction; `assertTrustedDownloadUrl` re-checks a
+ * caller-supplied URL before any network call.
+ */
+export function addonDownloadUrl(version: string): string {
+  const bare = stripLeadingV(version);
+  return `https://${TRUSTED_DOWNLOAD_HOST}/${ADDON_RELEASE_REPO}/releases/download/${releaseTag(version)}/${addonAssetName(bare)}`;
+}
+
+/**
+ * Fail-closed host trust check: throw unless `url` is an HTTPS URL whose host is
+ * EXACTLY `github.com` (no subdomains, no `github.com.evil.test`, no http). This
+ * is the security boundary the task requires — reject non-github hosts. Returns
+ * the parsed URL on success. Pure (throws on the unhappy path; the caller turns
+ * it into a structured failure so nothing escapes the public boundary).
+ */
+export function assertTrustedDownloadUrl(url: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Refusing to download addon: malformed URL "${url}".`);
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new Error(
+      `Refusing to download addon: only https is allowed, got "${parsed.protocol}" (${url}).`,
+    );
+  }
+  if (parsed.hostname.toLowerCase() !== TRUSTED_DOWNLOAD_HOST) {
+    throw new Error(
+      `Refusing to download addon from untrusted host "${parsed.hostname}". Only ${TRUSTED_DOWNLOAD_HOST} is trusted.`,
+    );
+  }
+  return parsed;
+}

--- a/cli/src/utils/csproj-deps.ts
+++ b/cli/src/utils/csproj-deps.ts
@@ -69,6 +69,17 @@ function detectIndent(text: string): string {
   return m ? m[1] : '    ';
 }
 
+/**
+ * Detect the dominant line ending of the csproj so inserted/appended XML matches
+ * it (a CRLF csproj should not gain bare-LF lines). Returns `\r\n` when CRLF
+ * line endings outnumber bare-LF ones, else `\n`.
+ */
+function detectEol(text: string): '\n' | '\r\n' {
+  const crlf = (text.match(/\r\n/g) ?? []).length;
+  const lf = (text.match(/\n/g) ?? []).length - crlf;
+  return crlf > lf ? '\r\n' : '\n';
+}
+
 export function addAddonPackageReferences(
   csprojText: string,
   requiredRefs: readonly AddonPackageReference[] = ADDON_PACKAGE_REFERENCES,
@@ -76,6 +87,7 @@ export function addAddonPackageReferences(
   const changes: CsprojPatchChange[] = [];
   let text = csprojText;
   const indent = detectIndent(text);
+  const eol = detectEol(text);
 
   // First pass: reconcile any references that already exist (possibly at a
   // different version). Collect the ones still missing for the append pass.
@@ -102,20 +114,20 @@ export function addAddonPackageReferences(
   // already holds a <PackageReference> (group them together); else append a fresh
   // <ItemGroup> just before </Project>.
   if (missing.length > 0) {
-    const block = missing.map((ref) => `${indent}${renderRef(ref)}`).join('\n');
+    const block = missing.map((ref) => `${indent}${renderRef(ref)}`).join(eol);
 
     const pkgItemGroupClose = findPackageReferenceItemGroupClose(text);
     if (pkgItemGroupClose !== -1) {
       // Insert the missing refs just before that ItemGroup's closing tag.
-      text = `${text.slice(0, pkgItemGroupClose)}${block}\n${text.slice(pkgItemGroupClose)}`;
+      text = `${text.slice(0, pkgItemGroupClose)}${block}${eol}${text.slice(pkgItemGroupClose)}`;
     } else {
       // No PackageReference ItemGroup — append a new one before </Project>.
       const groupIndent = indent.length >= 2 ? indent.slice(0, Math.floor(indent.length / 2)) : '  ';
-      const newGroup = `${groupIndent}<ItemGroup>\n${block}\n${groupIndent}</ItemGroup>\n`;
+      const newGroup = `${groupIndent}<ItemGroup>${eol}${block}${eol}${groupIndent}</ItemGroup>${eol}`;
       const closeIdx = text.lastIndexOf('</Project>');
       if (closeIdx === -1) {
         // Not a recognizable csproj; append best-effort at EOF.
-        text = `${text}\n${newGroup}`;
+        text = `${text}${eol}${newGroup}`;
       } else {
         text = `${text.slice(0, closeIdx)}${newGroup}${text.slice(closeIdx)}`;
       }

--- a/cli/src/utils/csproj-deps.ts
+++ b/cli/src/utils/csproj-deps.ts
@@ -1,0 +1,157 @@
+import { ADDON_PACKAGE_REFERENCES, type AddonPackageReference } from './addon-deps.js';
+
+/**
+ * Idempotently reconcile a Godot consumer `.csproj`'s `<PackageReference>`s so it
+ * declares exactly the addon's two required NuGet pins (see `addon-deps.ts`).
+ *
+ * Pure: operates on the csproj TEXT and returns the new text + what changed; never
+ * touches the filesystem. Exported for unit tests. Handles, idempotently:
+ *  - a project with NO `<ItemGroup>` at all (appends one before `</Project>`);
+ *  - a project that already declares both pins at the right version (no change);
+ *  - a project that declares one or both at a DIFFERENT version (reconciles in place);
+ *  - a project that declares only one of the two (adds the missing one).
+ *
+ * It deliberately does a minimal, well-scoped text edit rather than a full XML
+ * parse/serialize, to preserve the rest of the consumer's csproj formatting
+ * verbatim. The `<PackageReference Include="..." />` shape it reads/writes is the
+ * single self-closing form the scaffold and the addon README both use.
+ */
+
+export type CsprojPatchChange =
+  | { id: string; action: 'added'; version: string }
+  | { id: string; action: 'updated'; from: string; version: string }
+  | { id: string; action: 'unchanged'; version: string };
+
+export interface CsprojPatchResult {
+  /** The new csproj text (identical to input when nothing changed). */
+  text: string;
+  /** True when the text was modified. */
+  changed: boolean;
+  /** One entry per required package describing what happened to it. */
+  changes: CsprojPatchChange[];
+}
+
+/** Escape a string for use inside a RegExp source. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Match an existing `<PackageReference Include="<id>" Version="<ver>" />` element
+ * for a specific package id, capturing the whole element and its version, in
+ * either attribute order (`Include` before or after `Version`). The element may
+ * also be a `<PackageReference ...></PackageReference>` open/close pair.
+ */
+function packageRefRegex(id: string): RegExp {
+  const escId = escapeRegExp(id);
+  // <PackageReference ... Include="id" ... Version="x" ... /> (Include before Version)
+  // or Version before Include. Two alternations cover both orders; either may end
+  // with a self-close `/>` or an explicit `></PackageReference>`.
+  return new RegExp(
+    `<PackageReference\\b[^>]*?\\bInclude\\s*=\\s*"${escId}"[^>]*?\\bVersion\\s*=\\s*"([^"]*)"[^>]*?(?:/>|></PackageReference>)` +
+      `|` +
+      `<PackageReference\\b[^>]*?\\bVersion\\s*=\\s*"([^"]*)"[^>]*?\\bInclude\\s*=\\s*"${escId}"[^>]*?(?:/>|></PackageReference>)`,
+    'i',
+  );
+}
+
+/** Render the canonical self-closing element for a required reference. */
+function renderRef(ref: AddonPackageReference): string {
+  return `<PackageReference Include="${ref.id}" Version="${ref.version}" />`;
+}
+
+/**
+ * Detect the indentation used by the FIRST existing `<PackageReference>` (or fall
+ * back to 4 spaces) so appended/inserted elements match the consumer's style.
+ */
+function detectIndent(text: string): string {
+  const m = text.match(/\n([ \t]*)<PackageReference\b/);
+  return m ? m[1] : '    ';
+}
+
+export function addAddonPackageReferences(
+  csprojText: string,
+  requiredRefs: readonly AddonPackageReference[] = ADDON_PACKAGE_REFERENCES,
+): CsprojPatchResult {
+  const changes: CsprojPatchChange[] = [];
+  let text = csprojText;
+  const indent = detectIndent(text);
+
+  // First pass: reconcile any references that already exist (possibly at a
+  // different version). Collect the ones still missing for the append pass.
+  const missing: AddonPackageReference[] = [];
+
+  for (const ref of requiredRefs) {
+    const re = packageRefRegex(ref.id);
+    const match = text.match(re);
+    if (!match) {
+      missing.push(ref);
+      continue;
+    }
+    const existingVersion = match[1] ?? match[2] ?? '';
+    if (existingVersion === ref.version) {
+      changes.push({ id: ref.id, action: 'unchanged', version: ref.version });
+      continue;
+    }
+    // Reconcile in place: replace the whole element with the canonical pin.
+    text = text.replace(re, renderRef(ref));
+    changes.push({ id: ref.id, action: 'updated', from: existingVersion, version: ref.version });
+  }
+
+  // Second pass: add the missing references. Prefer an existing <ItemGroup> that
+  // already holds a <PackageReference> (group them together); else append a fresh
+  // <ItemGroup> just before </Project>.
+  if (missing.length > 0) {
+    const block = missing.map((ref) => `${indent}${renderRef(ref)}`).join('\n');
+
+    const pkgItemGroupClose = findPackageReferenceItemGroupClose(text);
+    if (pkgItemGroupClose !== -1) {
+      // Insert the missing refs just before that ItemGroup's closing tag.
+      text = `${text.slice(0, pkgItemGroupClose)}${block}\n${text.slice(pkgItemGroupClose)}`;
+    } else {
+      // No PackageReference ItemGroup — append a new one before </Project>.
+      const groupIndent = indent.length >= 2 ? indent.slice(0, Math.floor(indent.length / 2)) : '  ';
+      const newGroup = `${groupIndent}<ItemGroup>\n${block}\n${groupIndent}</ItemGroup>\n`;
+      const closeIdx = text.lastIndexOf('</Project>');
+      if (closeIdx === -1) {
+        // Not a recognizable csproj; append best-effort at EOF.
+        text = `${text}\n${newGroup}`;
+      } else {
+        text = `${text.slice(0, closeIdx)}${newGroup}${text.slice(closeIdx)}`;
+      }
+    }
+
+    for (const ref of missing) {
+      changes.push({ id: ref.id, action: 'added', version: ref.version });
+    }
+  }
+
+  // Restore the required-order in `changes` to match `requiredRefs` for stable output.
+  const orderedChanges = requiredRefs
+    .map((ref) => changes.find((c) => c.id === ref.id))
+    .filter((c): c is CsprojPatchChange => c !== undefined);
+
+  return {
+    text,
+    changed: orderedChanges.some((c) => c.action !== 'unchanged'),
+    changes: orderedChanges,
+  };
+}
+
+/**
+ * Return the index of the `</ItemGroup>` that closes the FIRST `<ItemGroup>`
+ * containing a `<PackageReference>`, or -1 when none exists. Used to group the
+ * added pins with the consumer's existing package references.
+ */
+function findPackageReferenceItemGroupClose(text: string): number {
+  const itemGroupRe = /<ItemGroup\b[^>]*>([\s\S]*?)<\/ItemGroup>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = itemGroupRe.exec(text)) !== null) {
+    if (/<PackageReference\b/i.test(m[1])) {
+      // The close tag starts at the end of the match minus its length.
+      const closeTag = '</ItemGroup>';
+      return m.index + m[0].length - closeTag.length;
+    }
+  }
+  return -1;
+}

--- a/cli/src/utils/unzip.ts
+++ b/cli/src/utils/unzip.ts
@@ -1,0 +1,115 @@
+import * as zlib from 'zlib';
+
+/**
+ * Minimal, dependency-free ZIP reader for the addon-install path. Parses the ZIP
+ * central directory and inflates each entry (STORED `0` + DEFLATE `8` — the only
+ * two compression methods the GitHub release `zip -r` produces). Pure: takes the
+ * archive bytes, returns `{ path, bytes }` entries; performs NO filesystem writes
+ * (the caller decides where the files land, after path-safety checks).
+ *
+ * This avoids adding a native/3rd-party unzip dependency to the lean `godot-cli`
+ * package while staying cross-platform (no shelling out to a system `unzip`).
+ * Exported for unit tests.
+ */
+
+export interface ZipEntry {
+  /** The entry's path inside the archive, using forward slashes. */
+  path: string;
+  /** Decompressed bytes. Empty for directory entries. */
+  bytes: Buffer;
+  /** True when the entry is a directory (path ends with `/`). */
+  isDirectory: boolean;
+}
+
+// ZIP signatures.
+const EOCD_SIGNATURE = 0x06054b50; // End Of Central Directory
+const CDH_SIGNATURE = 0x02014b50; // Central Directory Header
+const LFH_SIGNATURE = 0x04034b50; // Local File Header
+
+/**
+ * Parse a ZIP archive buffer into its entries. Throws a descriptive Error on a
+ * malformed archive (the caller wraps this into a structured failure — it never
+ * propagates past the library's public boundary).
+ */
+export function parseZip(buffer: Buffer): ZipEntry[] {
+  const eocdOffset = findEndOfCentralDirectory(buffer);
+  if (eocdOffset === -1) {
+    throw new Error('Invalid zip: End Of Central Directory record not found.');
+  }
+
+  const entryCount = buffer.readUInt16LE(eocdOffset + 10);
+  const centralDirOffset = buffer.readUInt32LE(eocdOffset + 16);
+
+  const entries: ZipEntry[] = [];
+  let ptr = centralDirOffset;
+
+  for (let i = 0; i < entryCount; i++) {
+    if (buffer.readUInt32LE(ptr) !== CDH_SIGNATURE) {
+      throw new Error(`Invalid zip: bad central directory header at entry ${i}.`);
+    }
+    const compressionMethod = buffer.readUInt16LE(ptr + 10);
+    const compressedSize = buffer.readUInt32LE(ptr + 20);
+    const fileNameLength = buffer.readUInt16LE(ptr + 28);
+    const extraFieldLength = buffer.readUInt16LE(ptr + 30);
+    const commentLength = buffer.readUInt16LE(ptr + 32);
+    const localHeaderOffset = buffer.readUInt32LE(ptr + 42);
+
+    const fileName = buffer.toString('utf8', ptr + 46, ptr + 46 + fileNameLength);
+
+    const bytes = readLocalEntry(buffer, localHeaderOffset, compressionMethod, compressedSize);
+    entries.push({
+      path: fileName.replace(/\\/g, '/'),
+      bytes,
+      isDirectory: fileName.endsWith('/'),
+    });
+
+    ptr += 46 + fileNameLength + extraFieldLength + commentLength;
+  }
+
+  return entries;
+}
+
+/** Read + decompress a single entry given its central-directory metadata. */
+function readLocalEntry(
+  buffer: Buffer,
+  localHeaderOffset: number,
+  compressionMethod: number,
+  compressedSize: number,
+): Buffer {
+  if (buffer.readUInt32LE(localHeaderOffset) !== LFH_SIGNATURE) {
+    throw new Error('Invalid zip: bad local file header.');
+  }
+  // The local header repeats the name/extra lengths; the data starts after them.
+  const lfhNameLength = buffer.readUInt16LE(localHeaderOffset + 26);
+  const lfhExtraLength = buffer.readUInt16LE(localHeaderOffset + 28);
+  const dataStart = localHeaderOffset + 30 + lfhNameLength + lfhExtraLength;
+  const compressed = buffer.subarray(dataStart, dataStart + compressedSize);
+
+  if (compressionMethod === 0) {
+    // STORED — no compression.
+    return Buffer.from(compressed);
+  }
+  if (compressionMethod === 8) {
+    // DEFLATE (raw, no zlib header).
+    return zlib.inflateRawSync(compressed);
+  }
+  throw new Error(`Unsupported zip compression method ${compressionMethod}.`);
+}
+
+/**
+ * Locate the End Of Central Directory record by scanning backwards from EOF for
+ * its signature (the trailing comment is almost always empty, so it is usually
+ * the last 22 bytes — but we scan to be safe).
+ */
+function findEndOfCentralDirectory(buffer: Buffer): number {
+  const minEocdSize = 22;
+  if (buffer.length < minEocdSize) return -1;
+  // Max comment length is 0xFFFF; scan that far back at most.
+  const scanStart = Math.max(0, buffer.length - minEocdSize - 0xffff);
+  for (let i = buffer.length - minEocdSize; i >= scanStart; i--) {
+    if (buffer.readUInt32LE(i) === EOCD_SIGNATURE) {
+      return i;
+    }
+  }
+  return -1;
+}

--- a/cli/tests/addon-deps-parity.test.ts
+++ b/cli/tests/addon-deps-parity.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { ADDON_PACKAGE_REFERENCES } from '../src/utils/addon-deps.js';
+
+// The CLI's ADDON_PACKAGE_REFERENCES must single-source the addon's own reused
+// NuGet pins (Godot-MCP.csproj). If the addon bumps a pin, this test fails until
+// the CLI constant is updated — so a from-scratch terminal install can NEVER write
+// a version the addon was not built against. This is the drift tripwire that lets
+// the runtime stay a pure constant (no build-time csproj read).
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ADDON_CSPROJ = path.resolve(__dirname, '..', '..', 'Godot-MCP.csproj');
+
+/** Parse `<PackageReference Include="id" Version="x" />` pairs from csproj text. */
+function parsePins(text: string): Map<string, string> {
+  const pins = new Map<string, string>();
+  const re = /<PackageReference\b[^>]*?\bInclude\s*=\s*"([^"]+)"[^>]*?\bVersion\s*=\s*"([^"]+)"/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    pins.set(m[1], m[2]);
+  }
+  return pins;
+}
+
+describe('addon-deps parity with Godot-MCP.csproj', () => {
+  it('the csproj is reachable from the test (relative layout sanity)', () => {
+    expect(fs.existsSync(ADDON_CSPROJ)).toBe(true);
+  });
+
+  it('every CLI-written addon pin matches the addon csproj version exactly', () => {
+    const text = fs.readFileSync(ADDON_CSPROJ, 'utf-8');
+    const csprojPins = parsePins(text);
+
+    for (const ref of ADDON_PACKAGE_REFERENCES) {
+      const csprojVersion = csprojPins.get(ref.id);
+      expect(
+        csprojVersion,
+        `Godot-MCP.csproj is missing a <PackageReference> for ${ref.id}`,
+      ).toBeDefined();
+      expect(
+        ref.version,
+        `CLI addon pin ${ref.id}@${ref.version} drifted from Godot-MCP.csproj ${ref.id}@${csprojVersion}. ` +
+          'Update ADDON_PACKAGE_REFERENCES in cli/src/utils/addon-deps.ts to match the addon pin.',
+      ).toBe(csprojVersion);
+    }
+  });
+});

--- a/cli/tests/addon-source.test.ts
+++ b/cli/tests/addon-source.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TRUSTED_DOWNLOAD_HOST,
+  ADDON_RELEASE_REPO,
+  addonAssetName,
+  releaseTag,
+  stripLeadingV,
+  addonDownloadUrl,
+  assertTrustedDownloadUrl,
+} from '../src/utils/addon-source.js';
+
+describe('addon-source — pure URL/tag helpers', () => {
+  it('addonAssetName builds godot-mcp-addon-<version>.zip (no leading v)', () => {
+    expect(addonAssetName('0.11.1')).toBe('godot-mcp-addon-0.11.1.zip');
+    expect(addonAssetName('v0.11.1')).toBe('godot-mcp-addon-0.11.1.zip');
+  });
+
+  it('releaseTag v-prefixes the version, idempotently', () => {
+    expect(releaseTag('0.11.1')).toBe('v0.11.1');
+    expect(releaseTag('v0.11.1')).toBe('v0.11.1');
+  });
+
+  it('stripLeadingV removes a single leading v/V', () => {
+    expect(stripLeadingV('v1.2.3')).toBe('1.2.3');
+    expect(stripLeadingV('V1.2.3')).toBe('1.2.3');
+    expect(stripLeadingV('1.2.3')).toBe('1.2.3');
+  });
+
+  it('addonDownloadUrl targets the IvanMurzak/Godot-MCP github release asset', () => {
+    const url = addonDownloadUrl('0.11.1');
+    expect(url).toBe(
+      `https://${TRUSTED_DOWNLOAD_HOST}/${ADDON_RELEASE_REPO}/releases/download/v0.11.1/godot-mcp-addon-0.11.1.zip`,
+    );
+    // The constructed URL is, by construction, on the trusted host.
+    expect(() => assertTrustedDownloadUrl(url)).not.toThrow();
+  });
+});
+
+describe('assertTrustedDownloadUrl — fail-closed host trust', () => {
+  it('accepts an https github.com URL', () => {
+    expect(() => assertTrustedDownloadUrl('https://github.com/IvanMurzak/Godot-MCP/releases/download/v1/x.zip')).not.toThrow();
+  });
+
+  it('rejects a non-github host', () => {
+    expect(() => assertTrustedDownloadUrl('https://evil.test/x.zip')).toThrowError(/untrusted host/i);
+  });
+
+  it('rejects a look-alike subdomain attack (github.com.evil.test)', () => {
+    expect(() => assertTrustedDownloadUrl('https://github.com.evil.test/x.zip')).toThrowError(/untrusted host/i);
+  });
+
+  it('rejects a github.com subdomain (raw.github.com is not the release host)', () => {
+    expect(() => assertTrustedDownloadUrl('https://raw.github.com/x.zip')).toThrowError(/untrusted host/i);
+  });
+
+  it('rejects plain http', () => {
+    expect(() => assertTrustedDownloadUrl('http://github.com/x.zip')).toThrowError(/only https/i);
+  });
+
+  it('rejects a malformed URL', () => {
+    expect(() => assertTrustedDownloadUrl('not a url')).toThrowError(/malformed URL/i);
+  });
+});

--- a/cli/tests/csproj-deps.test.ts
+++ b/cli/tests/csproj-deps.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { addAddonPackageReferences } from '../src/utils/csproj-deps.js';
+import { ADDON_PACKAGE_REFERENCES } from '../src/utils/addon-deps.js';
+
+const REFLECTOR = ADDON_PACKAGE_REFERENCES[0];
+const MCP = ADDON_PACKAGE_REFERENCES[1];
+
+const FRESH_CSPROJ = `<Project Sdk="Godot.NET.Sdk/4.3.0">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <Nullable>enable</Nullable>
+    <RootNamespace>MyGame</RootNamespace>
+  </PropertyGroup>
+
+</Project>
+`;
+
+describe('addAddonPackageReferences — fresh csproj (no ItemGroup)', () => {
+  it('appends a new ItemGroup with both pins before </Project>', () => {
+    const { text, changed, changes } = addAddonPackageReferences(FRESH_CSPROJ);
+    expect(changed).toBe(true);
+    expect(text).toContain(`<PackageReference Include="${REFLECTOR.id}" Version="${REFLECTOR.version}" />`);
+    expect(text).toContain(`<PackageReference Include="${MCP.id}" Version="${MCP.version}" />`);
+    // The new ItemGroup is inside the Project, before the closing tag.
+    expect(text.indexOf('<ItemGroup>')).toBeLessThan(text.indexOf('</Project>'));
+    expect(changes.every((c) => c.action === 'added')).toBe(true);
+    // Still valid-looking XML: one </Project>, balanced ItemGroup.
+    expect(text.match(/<\/Project>/g)?.length).toBe(1);
+  });
+
+  it('is idempotent — patching an already-patched csproj makes no change', () => {
+    const once = addAddonPackageReferences(FRESH_CSPROJ).text;
+    const twice = addAddonPackageReferences(once);
+    expect(twice.changed).toBe(false);
+    expect(twice.text).toBe(once);
+    expect(twice.changes.every((c) => c.action === 'unchanged')).toBe(true);
+  });
+});
+
+describe('addAddonPackageReferences — both pins already present at the right version', () => {
+  it('reports unchanged and does not duplicate', () => {
+    const withPins = addAddonPackageReferences(FRESH_CSPROJ).text;
+    const { text, changed } = addAddonPackageReferences(withPins);
+    expect(changed).toBe(false);
+    // No duplicate references.
+    expect(text.match(new RegExp(REFLECTOR.id, 'g'))?.length).toBe(1);
+    expect(text.match(new RegExp(MCP.id, 'g'))?.length).toBe(1);
+  });
+});
+
+describe('addAddonPackageReferences — partial (only one pin present)', () => {
+  it('adds the missing pin and leaves the present one untouched', () => {
+    const partial = `<Project Sdk="Godot.NET.Sdk/4.3.0">
+  <ItemGroup>
+    <PackageReference Include="${REFLECTOR.id}" Version="${REFLECTOR.version}" />
+  </ItemGroup>
+</Project>
+`;
+    const { text, changed, changes } = addAddonPackageReferences(partial);
+    expect(changed).toBe(true);
+    expect(text).toContain(`<PackageReference Include="${MCP.id}" Version="${MCP.version}" />`);
+    // ReflectorNet was unchanged; McpPlugin was added.
+    expect(changes.find((c) => c.id === REFLECTOR.id)?.action).toBe('unchanged');
+    expect(changes.find((c) => c.id === MCP.id)?.action).toBe('added');
+    // Both should sit in the same existing ItemGroup (only one ItemGroup).
+    expect(text.match(/<ItemGroup>/g)?.length).toBe(1);
+  });
+});
+
+describe('addAddonPackageReferences — different version present (reconcile)', () => {
+  it('rewrites a stale version in place to the addon pin', () => {
+    const stale = `<Project Sdk="Godot.NET.Sdk/4.3.0">
+  <ItemGroup>
+    <PackageReference Include="${REFLECTOR.id}" Version="1.0.0" />
+    <PackageReference Include="${MCP.id}" Version="6.10.0" />
+  </ItemGroup>
+</Project>
+`;
+    const { text, changed, changes } = addAddonPackageReferences(stale);
+    expect(changed).toBe(true);
+    expect(text).not.toContain('Version="1.0.0"');
+    expect(text).toContain(`<PackageReference Include="${REFLECTOR.id}" Version="${REFLECTOR.version}" />`);
+    const reflectorChange = changes.find((c) => c.id === REFLECTOR.id);
+    expect(reflectorChange?.action).toBe('updated');
+    if (reflectorChange?.action === 'updated') {
+      expect(reflectorChange.from).toBe('1.0.0');
+    }
+    // No duplicate entries.
+    expect(text.match(new RegExp(REFLECTOR.id, 'g'))?.length).toBe(1);
+  });
+
+  it('handles Version-before-Include attribute order', () => {
+    const reordered = `<Project Sdk="Godot.NET.Sdk/4.3.0">
+  <ItemGroup>
+    <PackageReference Version="2.0.0" Include="${REFLECTOR.id}" />
+  </ItemGroup>
+</Project>
+`;
+    const { text, changed } = addAddonPackageReferences(reordered);
+    expect(changed).toBe(true);
+    expect(text).not.toContain('Version="2.0.0"');
+    expect(text.match(new RegExp(REFLECTOR.id, 'g'))?.length).toBe(1);
+  });
+});
+
+describe('addAddonPackageReferences — existing ItemGroup with package refs', () => {
+  it('groups the added pins into the existing PackageReference ItemGroup', () => {
+    const existing = `<Project Sdk="Godot.NET.Sdk/4.3.0">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="SomeOther.Package" Version="1.2.3" />
+  </ItemGroup>
+</Project>
+`;
+    const { text, changed } = addAddonPackageReferences(existing);
+    expect(changed).toBe(true);
+    // Only one ItemGroup — the addon pins joined the existing package group.
+    expect(text.match(/<ItemGroup>/g)?.length).toBe(1);
+    expect(text).toContain('SomeOther.Package');
+    expect(text).toContain(REFLECTOR.id);
+    expect(text).toContain(MCP.id);
+  });
+});

--- a/cli/tests/install-plugin-installer.test.ts
+++ b/cli/tests/install-plugin-installer.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as zlib from 'zlib';
+import { installPlugin } from '../src/lib/install-plugin.js';
+import { GODOT_MCP_PLUGIN_PATH, parseEnabledPlugins } from '../src/utils/project-godot.js';
+import { ADDON_PACKAGE_REFERENCES } from '../src/utils/addon-deps.js';
+
+const MINIMAL_PROJECT = '; Engine configuration file.\nconfig_version=5\n\n[application]\n\nconfig/name="Test"\n';
+const CSPROJ = `<Project Sdk="Godot.NET.Sdk/4.3.0">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+`;
+
+// ---- in-memory zip builder (DEFLATE) ----
+function crc32(buf: Buffer): number {
+  let crc = ~0;
+  for (let i = 0; i < buf.length; i++) {
+    crc ^= buf[i];
+    for (let j = 0; j < 8; j++) crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+  }
+  return ~crc >>> 0;
+}
+function buildZip(files: { path: string; content: Buffer }[]): Buffer {
+  const local: Buffer[] = [];
+  const central: Buffer[] = [];
+  let offset = 0;
+  for (const f of files) {
+    const name = Buffer.from(f.path, 'utf8');
+    const comp = zlib.deflateRawSync(f.content);
+    const crc = crc32(f.content);
+    const lfh = Buffer.alloc(30);
+    lfh.writeUInt32LE(0x04034b50, 0);
+    lfh.writeUInt16LE(20, 4);
+    lfh.writeUInt16LE(8, 8);
+    lfh.writeUInt32LE(crc, 14);
+    lfh.writeUInt32LE(comp.length, 18);
+    lfh.writeUInt32LE(f.content.length, 22);
+    lfh.writeUInt16LE(name.length, 26);
+    const rec = Buffer.concat([lfh, name, comp]);
+    local.push(rec);
+    const cdh = Buffer.alloc(46);
+    cdh.writeUInt32LE(0x02014b50, 0);
+    cdh.writeUInt16LE(8, 10);
+    cdh.writeUInt32LE(crc, 16);
+    cdh.writeUInt32LE(comp.length, 20);
+    cdh.writeUInt32LE(f.content.length, 24);
+    cdh.writeUInt16LE(name.length, 28);
+    cdh.writeUInt32LE(offset, 42);
+    central.push(Buffer.concat([cdh, name]));
+    offset += rec.length;
+  }
+  const lb = Buffer.concat(local);
+  const cb = Buffer.concat(central);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(files.length, 8);
+  eocd.writeUInt16LE(files.length, 10);
+  eocd.writeUInt32LE(cb.length, 12);
+  eocd.writeUInt32LE(lb.length, 16);
+  return Buffer.concat([lb, cb, eocd]);
+}
+
+/** A mock fetch returning a 200 with the given zip bytes. */
+function mockFetchZip(zip: Buffer): typeof fetch {
+  return (async () =>
+    ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      arrayBuffer: async () => zip.buffer.slice(zip.byteOffset, zip.byteOffset + zip.byteLength),
+    }) as unknown as Response) as unknown as typeof fetch;
+}
+
+function mockFetch404(): typeof fetch {
+  return (async () =>
+    ({ ok: false, status: 404, statusText: 'Not Found', arrayBuffer: async () => new ArrayBuffer(0) }) as unknown as Response) as unknown as typeof fetch;
+}
+
+const VALID_ADDON_ZIP = buildZip([
+  { path: 'addons/godot_mcp/plugin.cfg', content: Buffer.from('[plugin]\nname="godot_mcp"\nversion="9.9.9"\n') },
+  { path: 'addons/godot_mcp/Editor/GodotMcpPlugin.cs', content: Buffer.from('// boot\n') },
+  { path: 'addons/godot_mcp/Runtime/Ping.cs', content: Buffer.from('// ping\n') },
+]);
+
+describe('installPlugin — download path (mocked fetch)', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gmcp-dl-'));
+    fs.writeFileSync(path.join(tmp, 'project.godot'), MINIMAL_PROJECT);
+    fs.writeFileSync(path.join(tmp, 'MyGame.csproj'), CSPROJ);
+  });
+  afterEach(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+  it('downloads + extracts the addon, patches the csproj, and enables the plugin', async () => {
+    const result = await installPlugin({
+      godotProjectPath: tmp,
+      version: '1.2.3',
+      fetchImpl: mockFetchZip(VALID_ADDON_ZIP),
+    });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+
+    // addon materialized
+    expect(result.materialize.source).toBe('download');
+    expect(result.materialize.downloadUrl).toContain('github.com');
+    expect(result.materialize.downloadUrl).toContain('v1.2.3');
+    expect(fs.existsSync(path.join(tmp, 'addons', 'godot_mcp', 'plugin.cfg'))).toBe(true);
+    expect(fs.existsSync(path.join(tmp, 'addons', 'godot_mcp', 'Editor', 'GodotMcpPlugin.cs'))).toBe(true);
+
+    // csproj patched with both pins
+    expect(result.csproj.changed).toBe(true);
+    const csprojText = fs.readFileSync(path.join(tmp, 'MyGame.csproj'), 'utf-8');
+    for (const ref of ADDON_PACKAGE_REFERENCES) {
+      expect(csprojText).toContain(`Include="${ref.id}" Version="${ref.version}"`);
+    }
+
+    // plugin enabled
+    expect(result.enabledPlugins).toContain(GODOT_MCP_PLUGIN_PATH);
+    expect(parseEnabledPlugins(fs.readFileSync(path.join(tmp, 'project.godot'), 'utf-8'))).toContain(
+      GODOT_MCP_PLUGIN_PATH,
+    );
+
+    // no staging dir left behind
+    const leftovers = fs.readdirSync(tmp).filter((n) => n.startsWith('.godot-mcp-addon-staging'));
+    expect(leftovers).toHaveLength(0);
+  });
+
+  it('returns a structured failure on a 404, leaving the project untouched', async () => {
+    const result = await installPlugin({
+      godotProjectPath: tmp,
+      version: '404.0.0',
+      fetchImpl: mockFetch404(),
+    });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') {
+      expect(result.error.message).toMatch(/HTTP 404/);
+    }
+    // No addon dir, plugin not enabled, csproj untouched.
+    expect(fs.existsSync(path.join(tmp, 'addons', 'godot_mcp'))).toBe(false);
+    expect(parseEnabledPlugins(fs.readFileSync(path.join(tmp, 'project.godot'), 'utf-8'))).not.toContain(
+      GODOT_MCP_PLUGIN_PATH,
+    );
+    expect(fs.readFileSync(path.join(tmp, 'MyGame.csproj'), 'utf-8')).toBe(CSPROJ);
+  });
+
+  it('rejects a download whose zip lacks plugin.cfg (not a valid addon), leaving the project untouched', async () => {
+    const badZip = buildZip([{ path: 'addons/godot_mcp/README.md', content: Buffer.from('no manifest') }]);
+    const result = await installPlugin({
+      godotProjectPath: tmp,
+      version: '1.0.0',
+      fetchImpl: mockFetchZip(badZip),
+    });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') expect(result.error.message).toMatch(/plugin\.cfg/);
+    expect(fs.existsSync(path.join(tmp, 'addons', 'godot_mcp'))).toBe(false);
+  });
+
+  it('rejects a zip-slip entry trying to escape the addon dir', async () => {
+    const evil = buildZip([
+      { path: 'addons/godot_mcp/plugin.cfg', content: Buffer.from('[plugin]\n') },
+      { path: 'addons/godot_mcp/../../evil.txt', content: Buffer.from('pwned') },
+    ]);
+    const result = await installPlugin({
+      godotProjectPath: tmp,
+      version: '1.0.0',
+      fetchImpl: mockFetchZip(evil),
+    });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') expect(result.error.message).toMatch(/escaping/i);
+    expect(fs.existsSync(path.join(tmp, 'evil.txt'))).toBe(false);
+  });
+
+  it('does not call fetch when no fetchImpl is needed (idempotent re-run after download)', async () => {
+    await installPlugin({ godotProjectPath: tmp, version: '1.2.3', fetchImpl: mockFetchZip(VALID_ADDON_ZIP) });
+    // Re-run: download again (overwrites), but plugin already enabled + pins present.
+    const second = await installPlugin({
+      godotProjectPath: tmp,
+      version: '1.2.3',
+      fetchImpl: mockFetchZip(VALID_ADDON_ZIP),
+    });
+    expect(second.kind).toBe('success');
+    if (second.kind === 'success') {
+      expect(second.changed).toBe(false); // plugin already enabled
+      expect(second.csproj.changed).toBe(false); // pins already present
+      expect(second.csproj.packages.every((p) => p.action === 'unchanged')).toBe(true);
+    }
+  });
+});
+
+describe('installPlugin — host trust on download', () => {
+  it('an empty version is rejected before any network call', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gmcp-nover-'));
+    fs.writeFileSync(path.join(tmp, 'project.godot'), MINIMAL_PROJECT);
+    try {
+      let fetchCalled = false;
+      const spyFetch = (async () => {
+        fetchCalled = true;
+        throw new Error('should not be called');
+      }) as unknown as typeof fetch;
+      const result = await installPlugin({ godotProjectPath: tmp, version: '', fetchImpl: spyFetch });
+      expect(result.kind).toBe('failure');
+      expect(fetchCalled).toBe(false);
+      if (result.kind === 'failure') expect(result.error.message).toMatch(/version|source/i);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('installPlugin — --source local copy', () => {
+  let tmp: string;
+  let src: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gmcp-src-'));
+    fs.writeFileSync(path.join(tmp, 'project.godot'), MINIMAL_PROJECT);
+    fs.writeFileSync(path.join(tmp, 'MyGame.csproj'), CSPROJ);
+    src = fs.mkdtempSync(path.join(os.tmpdir(), 'gmcp-srcdir-'));
+    const addon = path.join(src, 'addons', 'godot_mcp');
+    fs.mkdirSync(path.join(addon, 'Editor'), { recursive: true });
+    fs.writeFileSync(path.join(addon, 'plugin.cfg'), '[plugin]\nname="godot_mcp"\n');
+    fs.writeFileSync(path.join(addon, 'Editor', 'GodotMcpPlugin.cs'), '// boot\n');
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+    fs.rmSync(src, { recursive: true, force: true });
+  });
+
+  it('copies the addon from a directory CONTAINING addons/godot_mcp and never hits the network', async () => {
+    let fetchCalled = false;
+    const spyFetch = (async () => {
+      fetchCalled = true;
+      throw new Error('network should not be used with --source');
+    }) as unknown as typeof fetch;
+    const result = await installPlugin({ godotProjectPath: tmp, source: src, fetchImpl: spyFetch });
+    expect(result.kind).toBe('success');
+    expect(fetchCalled).toBe(false);
+    if (result.kind === 'success') {
+      expect(result.materialize.source).toBe('local');
+      expect(fs.existsSync(path.join(tmp, 'addons', 'godot_mcp', 'plugin.cfg'))).toBe(true);
+      expect(fs.existsSync(path.join(tmp, 'addons', 'godot_mcp', 'Editor', 'GodotMcpPlugin.cs'))).toBe(true);
+      expect(result.csproj.changed).toBe(true);
+      expect(result.enabledPlugins).toContain(GODOT_MCP_PLUGIN_PATH);
+    }
+  });
+
+  it('accepts a --source path that IS the addon dir (contains plugin.cfg directly)', async () => {
+    const directAddon = path.join(src, 'addons', 'godot_mcp');
+    const result = await installPlugin({ godotProjectPath: tmp, source: directAddon });
+    expect(result.kind).toBe('success');
+    if (result.kind === 'success') expect(result.materialize.source).toBe('local');
+  });
+
+  it('fails clearly when --source has no plugin.cfg', async () => {
+    const bare = fs.mkdtempSync(path.join(os.tmpdir(), 'gmcp-bare-'));
+    try {
+      const result = await installPlugin({ godotProjectPath: tmp, source: bare });
+      expect(result.kind).toBe('failure');
+      if (result.kind === 'failure') expect(result.error.message).toMatch(/plugin\.cfg|does not contain/i);
+    } finally {
+      fs.rmSync(bare, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('installPlugin — skipMaterialize', () => {
+  it('patches csproj + enables but does not fetch or copy', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gmcp-skip-'));
+    fs.writeFileSync(path.join(tmp, 'project.godot'), MINIMAL_PROJECT);
+    fs.writeFileSync(path.join(tmp, 'MyGame.csproj'), CSPROJ);
+    try {
+      const result = await installPlugin({ godotProjectPath: tmp, skipMaterialize: true });
+      expect(result.kind).toBe('success');
+      if (result.kind === 'success') {
+        expect(result.materialize.source).toBe('skipped');
+        expect(result.csproj.changed).toBe(true);
+        // warns about the absent addon files
+        expect(result.warnings.some((w) => w.includes('plugin.cfg'))).toBe(true);
+      }
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/tests/install-remove-plugin.test.ts
+++ b/cli/tests/install-remove-plugin.test.ts
@@ -8,41 +8,66 @@ import { GODOT_MCP_PLUGIN_PATH, parseEnabledPlugins } from '../src/utils/project
 
 const MINIMAL_PROJECT = '; Engine configuration file.\nconfig_version=5\n\n[application]\n\nconfig/name="Test"\n';
 
+// A throwaway local addon source containing a plugin.cfg, so the install path
+// never hits the network (the --source / local-copy path).
+function makeAddonSource(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cli-addon-src-'));
+  const addon = path.join(dir, 'addons', 'godot_mcp');
+  fs.mkdirSync(addon, { recursive: true });
+  fs.writeFileSync(path.join(addon, 'plugin.cfg'), '[plugin]\nname="godot_mcp"\nversion="0.0.0"\n');
+  fs.mkdirSync(path.join(addon, 'Editor'), { recursive: true });
+  fs.writeFileSync(path.join(addon, 'Editor', 'GodotMcpPlugin.cs'), '// stub\n');
+  return dir;
+}
+
 describe('install-plugin / remove-plugin — lib logic', () => {
   let tmpDir: string;
   let projectGodot: string;
+  let addonSrc: string;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cli-plugin-lib-'));
     projectGodot = path.join(tmpDir, 'project.godot');
     fs.writeFileSync(projectGodot, MINIMAL_PROJECT);
+    addonSrc = makeAddonSource();
   });
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(addonSrc, { recursive: true, force: true });
   });
 
   it('installPlugin enables the addon and reports changed:true with the plugin in the list', async () => {
-    const result = await installPlugin({ godotProjectPath: tmpDir });
+    const result = await installPlugin({ godotProjectPath: tmpDir, source: addonSrc });
     expect(result.kind).toBe('success');
     if (result.kind === 'success') {
       expect(result.changed).toBe(true);
       expect(result.enabledPlugins).toContain(GODOT_MCP_PLUGIN_PATH);
-      // It must surface the NuGet PackageReference warning.
-      expect(result.warnings.some((w) => w.includes('PackageReference'))).toBe(true);
+      // The addon files were materialized from the local source.
+      expect(result.materialize.source).toBe('local');
+      expect(fs.existsSync(path.join(tmpDir, 'addons', 'godot_mcp', 'plugin.cfg'))).toBe(true);
     }
     expect(parseEnabledPlugins(fs.readFileSync(projectGodot, 'utf-8'))).toContain(GODOT_MCP_PLUGIN_PATH);
   });
 
   it('installPlugin is idempotent — re-enabling reports changed:false', async () => {
-    await installPlugin({ godotProjectPath: tmpDir });
-    const second = await installPlugin({ godotProjectPath: tmpDir });
+    await installPlugin({ godotProjectPath: tmpDir, source: addonSrc });
+    const second = await installPlugin({ godotProjectPath: tmpDir, source: addonSrc });
     expect(second.kind).toBe('success');
     if (second.kind === 'success') expect(second.changed).toBe(false);
   });
 
+  it('installPlugin warns when there is no consumer .csproj to patch', async () => {
+    const result = await installPlugin({ godotProjectPath: tmpDir, source: addonSrc });
+    expect(result.kind).toBe('success');
+    if (result.kind === 'success') {
+      expect(result.csproj.changed).toBe(false);
+      expect(result.warnings.some((w) => w.includes('.csproj'))).toBe(true);
+    }
+  });
+
   it('removePlugin disables a previously-enabled addon (changed:true)', async () => {
-    await installPlugin({ godotProjectPath: tmpDir });
+    await installPlugin({ godotProjectPath: tmpDir, source: addonSrc });
     const result = await removePlugin({ godotProjectPath: tmpDir });
     expect(result.kind).toBe('success');
     if (result.kind === 'success') {
@@ -61,7 +86,7 @@ describe('install-plugin / remove-plugin — lib logic', () => {
   it('installPlugin returns a structured failure (never throws) for a non-Godot dir', async () => {
     const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cli-plugin-empty-'));
     try {
-      const result = await installPlugin({ godotProjectPath: empty });
+      const result = await installPlugin({ godotProjectPath: empty, source: addonSrc });
       expect(result.kind).toBe('failure');
       if (result.kind === 'failure') {
         expect(result.error).toBeInstanceOf(Error);
@@ -84,13 +109,16 @@ describe('install-plugin / remove-plugin — lib logic', () => {
 
 describe('remove-plugin — CLI smoke', () => {
   let tmpDir: string;
+  let addonSrc: string;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cli-rm-smoke-'));
+    addonSrc = makeAddonSource();
   });
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(addonSrc, { recursive: true, force: true });
   });
 
   it('shows help with --help', async () => {
@@ -114,7 +142,7 @@ describe('remove-plugin — CLI smoke', () => {
 
   it('disables an enabled addon and reports success (exit 0)', async () => {
     fs.writeFileSync(path.join(tmpDir, 'project.godot'), MINIMAL_PROJECT);
-    await runCliAsync(['install-plugin', '--path', tmpDir]);
+    await runCliAsync(['install-plugin', '--path', tmpDir, '--source', addonSrc]);
     const { stdout, exitCode } = await runCliAsync(['remove-plugin', '--path', tmpDir]);
     expect(exitCode).toBe(0);
     expect(stdout).toContain('godot_mcp addon disabled');
@@ -124,7 +152,7 @@ describe('remove-plugin — CLI smoke', () => {
 
   it('accepts the positional [path] argument form', async () => {
     fs.writeFileSync(path.join(tmpDir, 'project.godot'), MINIMAL_PROJECT);
-    await runCliAsync(['install-plugin', '--path', tmpDir]);
+    await runCliAsync(['install-plugin', '--path', tmpDir, '--source', addonSrc]);
     const { exitCode } = await runCliAsync(['remove-plugin', tmpDir]);
     expect(exitCode).toBe(0);
   });

--- a/cli/tests/unzip.test.ts
+++ b/cli/tests/unzip.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import * as zlib from 'zlib';
+import { parseZip } from '../src/utils/unzip.js';
+
+/**
+ * Build a minimal but spec-valid ZIP archive in memory from `{ path -> bytes }`.
+ * Supports STORED (method 0) and DEFLATE (method 8). Enough to exercise parseZip
+ * without adding a zip-writer dependency. CRC32 is computed correctly so a strict
+ * reader would also accept it.
+ */
+function crc32(buf: Buffer): number {
+  let crc = ~0;
+  for (let i = 0; i < buf.length; i++) {
+    crc ^= buf[i];
+    for (let j = 0; j < 8; j++) {
+      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+    }
+  }
+  return ~crc >>> 0;
+}
+
+function buildZip(files: { path: string; content: Buffer; method?: 0 | 8 }[]): Buffer {
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  let offset = 0;
+
+  for (const f of files) {
+    const method = f.method ?? 8;
+    const nameBuf = Buffer.from(f.path, 'utf8');
+    const compressed = method === 8 ? zlib.deflateRawSync(f.content) : f.content;
+    const crc = crc32(f.content);
+
+    const lfh = Buffer.alloc(30);
+    lfh.writeUInt32LE(0x04034b50, 0);
+    lfh.writeUInt16LE(20, 4); // version
+    lfh.writeUInt16LE(0, 6); // flags
+    lfh.writeUInt16LE(method, 8);
+    lfh.writeUInt16LE(0, 10); // time
+    lfh.writeUInt16LE(0, 12); // date
+    lfh.writeUInt32LE(crc, 14);
+    lfh.writeUInt32LE(compressed.length, 18);
+    lfh.writeUInt32LE(f.content.length, 22);
+    lfh.writeUInt16LE(nameBuf.length, 26);
+    lfh.writeUInt16LE(0, 28); // extra len
+
+    const localRecord = Buffer.concat([lfh, nameBuf, compressed]);
+    localParts.push(localRecord);
+
+    const cdh = Buffer.alloc(46);
+    cdh.writeUInt32LE(0x02014b50, 0);
+    cdh.writeUInt16LE(20, 4);
+    cdh.writeUInt16LE(20, 6);
+    cdh.writeUInt16LE(0, 8);
+    cdh.writeUInt16LE(method, 10);
+    cdh.writeUInt16LE(0, 12);
+    cdh.writeUInt16LE(0, 14);
+    cdh.writeUInt32LE(crc, 16);
+    cdh.writeUInt32LE(compressed.length, 20);
+    cdh.writeUInt32LE(f.content.length, 24);
+    cdh.writeUInt16LE(nameBuf.length, 28);
+    cdh.writeUInt16LE(0, 30);
+    cdh.writeUInt16LE(0, 32);
+    cdh.writeUInt16LE(0, 34);
+    cdh.writeUInt16LE(0, 36);
+    cdh.writeUInt32LE(0, 38);
+    cdh.writeUInt32LE(offset, 42);
+    centralParts.push(Buffer.concat([cdh, nameBuf]));
+
+    offset += localRecord.length;
+  }
+
+  const localBlob = Buffer.concat(localParts);
+  const centralBlob = Buffer.concat(centralParts);
+
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(0, 4);
+  eocd.writeUInt16LE(0, 6);
+  eocd.writeUInt16LE(files.length, 8);
+  eocd.writeUInt16LE(files.length, 10);
+  eocd.writeUInt32LE(centralBlob.length, 12);
+  eocd.writeUInt32LE(localBlob.length, 16);
+  eocd.writeUInt16LE(0, 20);
+
+  return Buffer.concat([localBlob, centralBlob, eocd]);
+}
+
+describe('parseZip', () => {
+  it('round-trips DEFLATE-compressed entries', () => {
+    const zip = buildZip([
+      { path: 'addons/godot_mcp/plugin.cfg', content: Buffer.from('[plugin]\nname="godot_mcp"\n') },
+      { path: 'addons/godot_mcp/Editor/GodotMcpPlugin.cs', content: Buffer.from('// boot\n') },
+    ]);
+    const entries = parseZip(zip);
+    expect(entries).toHaveLength(2);
+    const cfg = entries.find((e) => e.path === 'addons/godot_mcp/plugin.cfg');
+    expect(cfg?.bytes.toString('utf8')).toBe('[plugin]\nname="godot_mcp"\n');
+  });
+
+  it('round-trips STORED (uncompressed) entries', () => {
+    const zip = buildZip([{ path: 'a.txt', content: Buffer.from('hello'), method: 0 }]);
+    const entries = parseZip(zip);
+    expect(entries[0].bytes.toString('utf8')).toBe('hello');
+  });
+
+  it('flags directory entries', () => {
+    const zip = buildZip([
+      { path: 'addons/godot_mcp/', content: Buffer.alloc(0), method: 0 },
+      { path: 'addons/godot_mcp/plugin.cfg', content: Buffer.from('x') },
+    ]);
+    const entries = parseZip(zip);
+    expect(entries.find((e) => e.path === 'addons/godot_mcp/')?.isDirectory).toBe(true);
+    expect(entries.find((e) => e.path === 'addons/godot_mcp/plugin.cfg')?.isDirectory).toBe(false);
+  });
+
+  it('throws on a buffer with no EOCD record', () => {
+    expect(() => parseZip(Buffer.from('not a zip'))).toThrowError(/End Of Central Directory/i);
+  });
+});


### PR DESCRIPTION
## Summary
- `install-plugin` becomes a real installer: materializes `res://addons/godot_mcp/` (download from the matching github.com release, or `--source` a local copy), idempotently adds the two NuGet `PackageReference`s to the consumer `.csproj` (single-sourced from the addon's `Godot-MCP.csproj` pins, drift-guarded by a parity test), and enables the plugin — so a from-scratch terminal install actually produces a working project.
- New reusable `test_cli_e2e_install.yml` runs the REAL terminal flow on a clean runner (build CLI → `create-project --dotnet` → `install-plugin --source` → import → `dotnet build` → boot headless Godot → assert `[Godot-MCP] plugin loaded` + no assembly-resolution error), wired into PR CI (4.3/4.4/4.5) AND the release test gate + `release-addon` `needs:` so a broken install blocks a release.
- README + cli/README terminal Quick Start rewritten to the now-working one-command flow.

## Test plan
- [x] Target-specific local tests passed (vitest: 312 pass, was 278 — see profile test.md Suite 2b)
- [x] Workflow YAML lints clean (UTF-8)
- [x] Verified locally against real Godot 4.5.1 mono: scaffold + `install-plugin --source` → `dotnet build` (0 errors) → headless editor boot prints `[Godot-MCP] plugin loaded` with no `FileNotFoundException`