### PR TITLE
chore(release): 0.12.0

### DIFF
--- a/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
@@ -65,7 +65,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// drift if you forget). The live, parsed value in <see cref="PluginVersion"/> is the source of
         /// truth; <see cref="ResolvePluginVersion"/> emits a warning whenever it has to fall back here.
         /// </summary>
-        const string FallbackPluginVersion = "0.11.1";
+        const string FallbackPluginVersion = "0.12.0";
 
         /// <summary>
         /// Plugin version reported to the server in the MCP handshake. Resolved ONCE from

--- a/addons/godot_mcp/Runtime/GodotMcpRuntime.cs
+++ b/addons/godot_mcp/Runtime/GodotMcpRuntime.cs
@@ -274,7 +274,7 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
         /// <c>version=</c> (the live parsed value above is the source of truth; this is only the degraded
         /// fallback). Mirrors <c>GodotMcpConnection.FallbackPluginVersion</c>.
         /// </summary>
-        const string FallbackPluginVersion = "0.11.1";
+        const string FallbackPluginVersion = "0.12.0";
 
         /// <summary>
         /// Ensure a <see cref="MainThreadDispatcher"/> Node exists in the running game's

--- a/addons/godot_mcp/plugin.cfg
+++ b/addons/godot_mcp/plugin.cfg
@@ -3,5 +3,5 @@
 name="Godot-MCP"
 description="Model Context Protocol (MCP) integration for the Godot Editor. AI tools in C#, cloud-connected to ai-game.dev."
 author="Ivan Murzak"
-version="0.11.1"
+version="0.12.0"
 script="Editor/GodotMcpPlugin.cs"

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "godot-cli",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "godot-cli",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.6.2",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "godot-cli",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Cross-platform CLI tool for Godot-MCP (Skills & MCP). Resolves and launches the Godot editor with MCP connection env vars, runs MCP/system tools over HTTP, probes server health, configures AI agents (Claude Code, Cursor, VS Code, …), and enables/disables the godot_mcp addon. Works with Claude Code, Cursor, Copilot, and any MCP client.",
   "type": "module",
   "main": "dist/lib.js",

--- a/cli/tests/cli.test.ts
+++ b/cli/tests/cli.test.ts
@@ -218,7 +218,13 @@ describe('CLI integration', () => {
         '; Engine configuration file.\nconfig_version=5\n\n[application]\n\nconfig/name="Test"\n',
       );
 
-      const install = runCli(['install-plugin', '--path', tmpDir]);
+      // install-plugin defaults to DOWNLOADING the addon for the CLI's own version;
+      // in a dev checkout that version's GitHub release may not exist yet (so every
+      // release-version bump would 404 here). Install from the in-repo addon via
+      // --source so this integration test is hermetic — no network, no dependency on
+      // a published release.
+      const addonSource = path.resolve(__dirname, '..', '..', 'addons', 'godot_mcp');
+      const install = runCli(['install-plugin', '--path', tmpDir, '--source', addonSource]);
       expect(install.exitCode).toBe(0);
       let text = fs.readFileSync(path.join(tmpDir, 'project.godot'), 'utf-8');
       expect(text).toContain('[editor_plugins]');

--- a/docs/assetlib/SUBMISSION.md
+++ b/docs/assetlib/SUBMISSION.md
@@ -25,11 +25,11 @@ this file is just the field values. Keep it in sync whenever any field changes.
 | **Asset name** | `Godot-MCP` |
 | **Category** | `Tools` (an Addon-side category — categories are split into Addons / Projects, and picking an Addon category is what makes this entry an Addon and surfaces it in the in-editor *AssetLib* tab; there is no separate "Type" field) |
 | **Godot version** | `4.3` (lowest supported; the addon also runs on 4.4 / 4.5 — a single entry cannot carry multiple engine versions, so each version it should advertise needs its own resubmission) |
-| **Version** | `0.11.1` (must match `addons/godot_mcp/plugin.cfg` `version=` and the `v0.11.1` tag) |
+| **Version** | `0.12.0` (must match `addons/godot_mcp/plugin.cfg` `version=` and the `v0.12.0` tag) |
 | **Repository host** | `GitHub` |
 | **Repository URL** | `https://github.com/IvanMurzak/Godot-MCP` |
 | **Issues URL** | `https://github.com/IvanMurzak/Godot-MCP/issues` |
-| **Download Commit** | the commit hash the `v0.11.1` tag points at — get it with `git rev-list -n1 v0.11.1` (a hash, not the tag name) |
+| **Download Commit** | the commit hash the `v0.12.0` tag points at — get it with `git rev-list -n1 v0.12.0` (a hash, not the tag name) |
 | **License** | `Apache-2.0` |
 | **Icon URL** | `https://raw.githubusercontent.com/IvanMurzak/Godot-MCP/main/addons/godot_mcp/icon.png` (square 512×512 PNG; AssetLib requires square PNG/JPG ≥ 128×128 — SVG is not accepted) |
 


### PR DESCRIPTION
Bumps `addons/godot_mcp/plugin.cfg` to **0.12.0** (the single source of truth for the release version) to cut the release for #204.

**What ships in 0.12.0** — `godot-cli install-plugin` is now a real installer (downloads the addon from the GitHub Release, or `--source` for local/CI, adds the two NuGet pins to the consumer csproj, enables the plugin), plus a headless-Godot **E2E install test** that runs the real from-scratch terminal flow and gates **every PR and every release** across Godot 4.3 / 4.4 / 4.5.

Version-bump only — produced by `node scripts/bump-version.mjs 0.12.0` (plugin.cfg + cli/package*.json + FallbackPluginVersion ×2 + AssetLib notes).

Merging to `main` triggers `release.yml`: GitHub Release `v0.12.0` (addon zip) + `godot-cli@0.12.0` published to npm via OIDC + Godot Asset Library version edit. Server pin `ServerVersion=8.0.1` is already released (all 7 RID zips present).