### PR TITLE
ci: add Godot 4.6 + 4.7 to the engine test matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@
 #
 # The release is gated on the full test set as `needs:` — the .NET build+test,
 # the godot-mcp-cli node tests (test_cli.yml), and the Godot engine smoke matrix
-# (test_godot_plugin.yml for 4.3/4.4/4.5). The release proceeds only if all pass.
+# (test_godot_plugin.yml for 4.3 → 4.7). The release proceeds only if all pass.
 #
 # Manual dispatch (workflow_dispatch) bypasses the version_changed check (there
 # is no push diff to inspect) but STILL honors tag_exists — a dispatch cuts a
@@ -227,6 +227,20 @@ jobs:
     with:
       godotVersion: "4.5.1"
 
+  test-godot-4-6:
+    needs: [check-version-tag]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    uses: ./.github/workflows/test_godot_plugin.yml
+    with:
+      godotVersion: "4.6.3"
+
+  test-godot-4-7:
+    needs: [check-version-tag]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    uses: ./.github/workflows/test_godot_plugin.yml
+    with:
+      godotVersion: "4.7.0"
+
   # from-scratch terminal-install E2E across the Godot engine matrix (mono). Gates
   # the release alongside the addon-load smoke so a broken from-scratch terminal
   # install (create-project + install-plugin) can NEVER ship in a release.
@@ -250,6 +264,20 @@ jobs:
     uses: ./.github/workflows/test_cli_e2e_install.yml
     with:
       godotVersion: "4.5.1"
+
+  e2e-install-4-6:
+    needs: [check-version-tag]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    uses: ./.github/workflows/test_cli_e2e_install.yml
+    with:
+      godotVersion: "4.6.3"
+
+  e2e-install-4-7:
+    needs: [check-version-tag]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    uses: ./.github/workflows/test_cli_e2e_install.yml
+    with:
+      godotVersion: "4.7.0"
 
   # godot_mcp runtime INTEGRATION harness across the Godot engine matrix (mono):
   # downloads the released gamedev-mcp-server, boots a headless game with the
@@ -282,6 +310,22 @@ jobs:
       godotVersion: "4.5.1"
       serverVersion: ${{ needs.check-version-tag.outputs.server_version }}
 
+  runtime-harness-4-6:
+    needs: [check-version-tag]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    uses: ./.github/workflows/test_godot_runtime_harness.yml
+    with:
+      godotVersion: "4.6.3"
+      serverVersion: ${{ needs.check-version-tag.outputs.server_version }}
+
+  runtime-harness-4-7:
+    needs: [check-version-tag]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    uses: ./.github/workflows/test_godot_runtime_harness.yml
+    with:
+      godotVersion: "4.7.0"
+      serverVersion: ${{ needs.check-version-tag.outputs.server_version }}
+
   # NOTE: the MCP server is NOT built or released here anymore. The addon consumes the
   # shared GameDev-MCP-Server (https://github.com/IvanMurzak/GameDev-MCP-Server), whose
   # own release workflow publishes the `gamedev-mcp-server-<rid>.zip` assets the addon
@@ -298,8 +342,11 @@ jobs:
   release-addon:
     runs-on: ubuntu-latest
     # The release gate depends ONLY on the DETERMINISTIC test legs (check-version-tag,
-    # the .NET build+test, the cli node tests, and the addon-LOAD godot smoke). The
-    # runtime-harness-4-{3,4,5} legs are deliberately NOT in this `needs:` array: they are
+    # the .NET build+test, the cli node tests, the addon-LOAD godot smoke, and the
+    # from-scratch e2e-install) across the FULL Godot matrix (4.3 → 4.7). This MUST stay
+    # in lockstep with test_pull_request.yml's matrix so a green PR can never produce a red
+    # release gate — when you add/remove a Godot version, edit BOTH files together. The
+    # runtime-harness-4-{3..7} legs are deliberately NOT in this `needs:` array: they are
     # an end-to-end INTEGRATION harness that downloads an external server release and runs a
     # live, concurrency-sensitive roundtrip — a transient harness flake or an unavailable
     # upstream server release must NEVER block a Godot-MCP release. The harness legs still
@@ -314,9 +361,13 @@ jobs:
         test-godot-4-3,
         test-godot-4-4,
         test-godot-4-5,
+        test-godot-4-6,
+        test-godot-4-7,
         e2e-install-4-3,
         e2e-install-4-4,
         e2e-install-4-5,
+        e2e-install-4-6,
+        e2e-install-4-7,
       ]
     if: needs.check-version-tag.outputs.should_release == 'true'
     outputs:

--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -10,9 +10,12 @@
 # Fans out, with fail-fast disabled so every leg reports independently:
 #   (a) .NET build + xUnit  — a PR-aggregate copy of ci.yml's build/test
 #   (b) godot-mcp-cli node tests (20/22) via the reusable test_cli.yml
-#   (c) the godot_mcp addon-load smoke across Godot 4.3 / 4.4 / 4.5 (mono) via
-#       the reusable test_godot_plugin.yml
-#   (d) the runtime INTEGRATION harness across Godot 4.3 / 4.4 / 4.5 (mono) via
+#   (c) the godot_mcp addon-load smoke across Godot 4.3 / 4.4 / 4.5 / 4.6 / 4.7
+#       (mono) via the reusable test_godot_plugin.yml
+#   (e) the from-scratch terminal-install E2E across the same Godot matrix
+#       (test_cli_e2e_install.yml) — MUST stay in lockstep with release.yml's
+#       e2e-install legs so a green PR can never produce a red release gate.
+#   (d) the runtime INTEGRATION harness across Godot 4.3 / 4.4 / 4.5 / 4.6 / 4.7 (mono) via
 #       the reusable test_godot_runtime_harness.yml — downloads the released
 #       gamedev-mcp-server, boots a HEADLESS GAME with the in-game runtime +
 #       error capture, asserts a live SignalR roundtrip AND runtime-error capture
@@ -90,6 +93,16 @@ jobs:
     with:
       godotVersion: "4.5.1"
 
+  test-godot-4-6:
+    uses: ./.github/workflows/test_godot_plugin.yml
+    with:
+      godotVersion: "4.6.3"
+
+  test-godot-4-7:
+    uses: ./.github/workflows/test_godot_plugin.yml
+    with:
+      godotVersion: "4.7.0"
+
   # (e) from-scratch terminal-install E2E across the Godot engine matrix (mono):
   #     build the CLI, scaffold a --dotnet project, run the REAL `install-plugin`
   #     (materialize addon + add NuGet pins + enable), dotnet build, and assert the
@@ -110,6 +123,16 @@ jobs:
     uses: ./.github/workflows/test_cli_e2e_install.yml
     with:
       godotVersion: "4.5.1"
+
+  e2e-install-4-6:
+    uses: ./.github/workflows/test_cli_e2e_install.yml
+    with:
+      godotVersion: "4.6.3"
+
+  e2e-install-4-7:
+    uses: ./.github/workflows/test_cli_e2e_install.yml
+    with:
+      godotVersion: "4.7.0"
 
   # Single-source the server version the harness downloads from the addon's authoritative
   # constant (GodotMcpServerView.ServerVersion) instead of trusting the reusable workflow's
@@ -164,4 +187,18 @@ jobs:
     uses: ./.github/workflows/test_godot_runtime_harness.yml
     with:
       godotVersion: "4.5.1"
+      serverVersion: ${{ needs.resolve-server-version.outputs.serverVersion }}
+
+  runtime-harness-4-6:
+    needs: [resolve-server-version]
+    uses: ./.github/workflows/test_godot_runtime_harness.yml
+    with:
+      godotVersion: "4.6.3"
+      serverVersion: ${{ needs.resolve-server-version.outputs.serverVersion }}
+
+  runtime-harness-4-7:
+    needs: [resolve-server-version]
+    uses: ./.github/workflows/test_godot_runtime_harness.yml
+    with:
+      godotVersion: "4.7.0"
       serverVersion: ${{ needs.resolve-server-version.outputs.serverVersion }}


### PR DESCRIPTION
Adds Godot **4.6.3** and **4.7.0** (mono) to the engine test matrix across all three reusable legs — `test_godot_plugin` (addon-load smoke), `test_cli_e2e_install` (from-scratch terminal install), and `test_godot_runtime_harness` — in **both** `test_pull_request.yml` and `release.yml`. The new `test-godot-4-6/4-7` and `e2e-install-4-6/4-7` legs are added to `release-addon`s `needs[]` gate; the runtime-harness legs stay advisory (decoupled from the gate, same as 4.3–4.5).

**On the PR↔release parity concern:** the PR and release test *sets* were already identical; this keeps them so as we grow the matrix, and adds a comment in both files making the lockstep rule explicit (a green PR can never yield a red release gate). The prior "release red while PR green" impression was actually the *first* PR-CI run of #205 going red on the cli-404 (caught pre-merge and fixed) — the v0.12.0 release run itself was green.

No `plugin.cfg` version bump, so merging this is a release **no-op** (the version gate stays closed). The new 4.6/4.7 legs run on this very PR, so it is self-verifying.