### PR TITLE
feat(cli): build C# before open so the addon loads on first editor open

### DIFF
--- a/.github/workflows/test_cli_e2e_install.yml
+++ b/.github/workflows/test_cli_e2e_install.yml
@@ -17,15 +17,22 @@
 #      path is unit-tested with a mocked fetch in cli/tests). This materializes
 #      addons/godot_mcp/, adds the two NuGet PackageReferences to the generated
 #      csproj, and enables the plugin in project.godot;
-#   4. import the project + `dotnet build` (the addon globs into the project
-#      assembly, so a green build proves it compiles against the addon's pins);
+#   4. import the project, then build the C# with the CLI's OWN build path
+#      (`godot-cli build` — the same build `godot-cli open` runs before launch),
+#      NOT a hand-rolled `dotnet build`. The addon globs into the project
+#      assembly, so a green build proves it compiles against the addon's pins;
 #   5. boot the headless Godot editor and assert "[Godot-MCP] plugin loaded" AND
-#      no FileNotFoundException / assembly-resolution error.
+#      no FileNotFoundException / "Unable to load addon" / assembly-resolution
+#      error.
 #
 # Modeled on test_godot_plugin.yml (same chickensoft-games/setup-godot mono +
 # .NET 8 toolchain), but it never copies a pre-made addon into a committed test
 # project — it drives the actual terminal commands, so a regression in
-# create-project / install-plugin (the from-scratch story) BREAKS this gate.
+# create-project / install-plugin / the build-before-open path (the from-scratch
+# story) BREAKS this gate. Because step 4 uses `godot-cli build` instead of a raw
+# `dotnet build`, the gate also catches the original "first open disables the
+# addon" bug: if the CLI stops building before open, nothing else produces the
+# assembly and the plugin-loaded assertion goes red.
 # Called once per matrix version by test_pull_request.yml and release.yml.
 name: Test CLI E2E Install
 
@@ -118,14 +125,21 @@ jobs:
           godot --headless --path "${WORK}/project" --import --quit 2>&1 | tee "${WORK}/import.log" || true
           echo "Import pass complete."
 
-      - name: Build C# (addon compiles into the consumer assembly)
+      - name: Build C# via the CLI's OWN build-before-open path (no hand-rolled dotnet build)
         shell: bash
         run: |
           set -euo pipefail
-          dotnet build "${WORK}/project/${PROJECT_NAME}.csproj" \
-            --configuration Debug 2>&1 | tee "${WORK}/build.log"
+          # This is the crux of the regression guard: build the C# assembly with
+          # the SAME `godot-cli build` path that `godot-cli open` runs before it
+          # launches the editor — NOT a hand-rolled `dotnet build`. If the CLI ever
+          # stops building before open (the original "Unable to load addon …
+          # Disabling the addon" bug), `godot-cli build` is the only thing
+          # producing the assembly here, so the plugin-loaded assertion below goes
+          # red. A raw `dotnet build` would have masked exactly that gap.
+          node "${GITHUB_WORKSPACE}/cli/bin/godot-cli.js" build \
+            "${WORK}/project" 2>&1 | tee "${WORK}/build.log"
           if ! ls "${WORK}/project"/.godot/mono/temp/bin/*/${PROJECT_NAME}.dll >/dev/null 2>&1; then
-            echo "::error::C# build did not produce ${PROJECT_NAME}.dll — the from-scratch install does not compile against the addon's NuGet pins."
+            echo "::error::godot-cli build did not produce ${PROJECT_NAME}.dll — the CLI's build-before-open path does not compile the from-scratch install against the addon's NuGet pins."
             cat "${WORK}/build.log" || true
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ godot-cli install-plugin ./MyGodotProject
 # 4. Pick an AI agent (Claude Code, Cursor, Copilot, …) and write its MCP config
 godot-cli setup-mcp claude-code ./MyGodotProject
 
-# 5. Open the Godot editor (auto-connects with the right GODOT_MCP_* env vars)
+# 5. Open the Godot editor — builds the C# assembly first (so the addon loads on
+#    the very first open) then auto-connects with the right GODOT_MCP_* env vars
 godot-cli open ./MyGodotProject
 
 # 6. Wait until the plugin answers the readiness probe

--- a/cli/README.md
+++ b/cli/README.md
@@ -25,7 +25,8 @@ Requires Node `^20.19.0 || >=22.12.0`.
 
 | Command | What it does |
 | --- | --- |
-| `open [path]` | Resolve the Godot editor binary and launch `--editor --path <project>` with `GODOT_MCP_*` connection env vars. |
+| `open [path]` | Build the project's C# assembly (so the addon loads on first open — see below), resolve the Godot editor binary, and launch `--editor --path <project>` with `GODOT_MCP_*` connection env vars. `--no-build` skips the build. |
+| `build [path]` | Build the project's C# assembly (`dotnet build`) so the `godot_mcp` addon loads on the next editor open. GDScript-only projects (no `.csproj`) are a no-op. This is the same build `open` runs before launching. |
 | `run-tool <tool> [path]` | POST to `<url>/api/tools/<tool>` with JSON input. |
 | `run-system-tool <tool> [path]` | POST to `<url>/api/system-tools/<tool>` (tools not exposed to MCP clients). |
 | `status [path]` | Detect a running Godot editor for the project and probe MCP-server health. |
@@ -37,6 +38,22 @@ Requires Node `^20.19.0 || >=22.12.0`.
 | `install-plugin [path]` | Install the `godot_mcp` addon end-to-end: materialize `res://addons/godot_mcp/` (download the matching GitHub release, or `--source <path>` a local copy), add the required NuGet `PackageReference`s to the project `.csproj`, and enable the plugin. Idempotent. |
 | `remove-plugin [path]` | Disable the `godot_mcp` addon in `project.godot` `[editor_plugins]` (does not delete the addon files). |
 | `update` | Check npm for a newer `godot-cli` and install it. |
+
+### Build before open (`open` / `build`)
+
+`open` **builds the project's C# assembly before launching the editor**. Godot instantiates an
+enabled addon's `EditorPlugin` as soon as the editor loads — so on a *fresh* first open of a C#
+project that was never built, no assembly exists yet and Godot fails with
+`Unable to load addon script 'res://addons/godot_mcp/Editor/GodotMcpPlugin.cs' … Disabling the addon`.
+Building first guarantees the assembly is present when the addon is instantiated.
+
+- The build is the same one `godot-cli build` runs: `dotnet build <project>.csproj --configuration Debug`.
+- **GDScript-only projects** (no `.csproj` at the root) are skipped automatically — there is nothing to compile.
+- The build runs **unconditionally** for C# projects; `dotnet build` is incremental, so an up-to-date
+  project is a fast no-op. Pass `--no-build` to `open` to skip it (e.g. you already built, or want to
+  open as fast as possible).
+- If the build **fails**, `open` does **not** launch the editor (launching would just reproduce the
+  disable-addon failure); the error is surfaced instead.
 
 ### Editor resolution (`open`)
 

--- a/cli/src/commands/build.ts
+++ b/cli/src/commands/build.ts
@@ -33,7 +33,7 @@ export const buildCommand = new Command('build')
       onProgress: (event) => {
         switch (event.phase) {
           case 'build-running':
-            spinner.text = `Building ${event.csprojPath} ...`;
+            spinner.text = `Building ${path.basename(event.csprojPath)} ...`;
             verbose(`Build command: ${event.command}`);
             break;
           case 'build-skipped':

--- a/cli/src/commands/build.ts
+++ b/cli/src/commands/build.ts
@@ -30,6 +30,19 @@ export const buildCommand = new Command('build')
       projectPath,
       configuration: options.configuration,
       dotnetPath: options.dotnetPath,
+      onProgress: (event) => {
+        switch (event.phase) {
+          case 'build-running':
+            spinner.text = `Building ${event.csprojPath} ...`;
+            verbose(`Build command: ${event.command}`);
+            break;
+          case 'build-skipped':
+            verbose('No .csproj at project root — skipping build (GDScript-only).');
+            break;
+          default:
+            break;
+        }
+      },
     });
 
     if (result.kind === 'failure') {
@@ -50,6 +63,9 @@ export const buildCommand = new Command('build')
       ui.label('Project', result.projectPath);
       if (result.csprojPath) ui.label('Built', result.csprojPath);
       if (result.configuration) ui.label('Configuration', result.configuration);
+      // Surface the captured `dotnet build` output in verbose mode — otherwise
+      // a slow non-incremental first build shows only a static spinner.
+      if (result.output) verbose(result.output.trim());
     }
 
     for (const warning of result.warnings) {

--- a/cli/src/commands/build.ts
+++ b/cli/src/commands/build.ts
@@ -1,0 +1,59 @@
+import { Command } from 'commander';
+import * as path from 'path';
+import * as ui from '../utils/ui.js';
+import { verbose } from '../utils/ui.js';
+import { buildProject } from '../lib/build.js';
+
+interface BuildCliOptions {
+  path?: string;
+  configuration?: string;
+  dotnetPath?: string;
+}
+
+export const buildCommand = new Command('build')
+  .description(
+    'Build the Godot project\'s C# assembly (dotnet build) so the godot_mcp addon loads on the next editor open. GDScript-only projects (no .csproj) are a no-op. This is the same build `open` runs before launching the editor.',
+  )
+  .argument('[path]', 'Path to the Godot project (defaults to current directory)')
+  .option('--path <path>', 'Path to the Godot project (defaults to current directory)')
+  .option('--configuration <cfg>', 'MSBuild configuration to compile (default: Debug)')
+  .option('--dotnet-path <path>', 'Explicit dotnet executable path (default: dotnet on PATH)')
+  .action(async (positionalPath: string | undefined, options: BuildCliOptions) => {
+    const resolvedPath = positionalPath ?? options.path ?? process.cwd();
+    const projectPath = path.resolve(resolvedPath);
+
+    ui.heading('Building Godot C# project');
+    verbose(`Project path: ${projectPath}`);
+
+    const spinner = ui.startSpinner('Building C# assembly...');
+    const result = await buildProject({
+      projectPath,
+      configuration: options.configuration,
+      dotnetPath: options.dotnetPath,
+    });
+
+    if (result.kind === 'failure') {
+      spinner.error('Build failed');
+      ui.error(result.errorMessage);
+      for (const warning of result.warnings) {
+        console.log('');
+        ui.warn(warning);
+      }
+      process.exit(1);
+    }
+
+    if (result.skipped) {
+      spinner.success('No C# to build (GDScript-only project)');
+      ui.info('This project has no .csproj at its root — nothing to compile.');
+    } else {
+      spinner.success('C# assembly built');
+      ui.label('Project', result.projectPath);
+      if (result.csprojPath) ui.label('Built', result.csprojPath);
+      if (result.configuration) ui.label('Configuration', result.configuration);
+    }
+
+    for (const warning of result.warnings) {
+      console.log('');
+      ui.warn(warning);
+    }
+  });

--- a/cli/src/commands/open.ts
+++ b/cli/src/commands/open.ts
@@ -39,6 +39,8 @@ export const openCommand = new Command('open')
   .argument('[path]', 'Path to the Godot project (defaults to current directory)')
   .option('--path <path>', 'Path to the Godot project (defaults to current directory)')
   .option('--editor-path <path>', 'Explicit path to the Godot editor executable (skips discovery)')
+  .option('--no-build', 'Skip building the C# assembly before launching (GDScript-only projects skip automatically)')
+  .option('--build-configuration <cfg>', 'MSBuild configuration for the pre-open build (default: Debug)')
   .option('--no-connect', 'Open without MCP connection environment variables')
   .option('--url <url>', 'MCP server host to connect to (sets GODOT_MCP_HOST)')
   .option('--cloud-url <url>', 'Cloud base URL override (sets GODOT_MCP_CLOUD_URL)')
@@ -52,6 +54,8 @@ export const openCommand = new Command('open')
       options: {
         path?: string;
         editorPath?: string;
+        build?: boolean;
+        buildConfiguration?: string;
         connect?: boolean;
         url?: string;
         cloudUrl?: string;
@@ -99,11 +103,15 @@ export const openCommand = new Command('open')
         process.exit(1);
       }
 
-      const spinner = ui.startSpinner('Locating Godot editor...');
+      const spinner = ui.startSpinner(
+        options.build === false ? 'Locating Godot editor...' : 'Building C# assembly...',
+      );
 
       const result = await openProject({
         projectPath,
         editorPath: options.editorPath,
+        build: options.build !== false,
+        buildConfiguration: options.buildConfiguration,
         noConnect: options.connect === false,
         url: options.url,
         cloudUrl: options.cloudUrl,
@@ -113,6 +121,22 @@ export const openCommand = new Command('open')
         logLevel: options.logLevel,
         onProgress: (event) => {
           switch (event.phase) {
+            case 'build-running': {
+              spinner.text = `Building ${event.csprojPath} ...`;
+              verbose(`Build command: ${event.command}`);
+              break;
+            }
+            case 'build-skipped': {
+              verbose('No .csproj at project root — skipping build (GDScript-only).');
+              break;
+            }
+            case 'build-succeeded': {
+              spinner.success('C# assembly built');
+              verbose(`Built: ${event.csprojPath} (${event.configuration})`);
+              spinner.text = 'Locating Godot editor...';
+              spinner.start();
+              break;
+            }
             case 'editor-resolved': {
               spinner.success('Godot editor located');
               verbose(`Editor path: ${event.editorPath}`);

--- a/cli/src/commands/open.ts
+++ b/cli/src/commands/open.ts
@@ -127,7 +127,10 @@ export const openCommand = new Command('open')
               break;
             }
             case 'build-skipped': {
+              // GDScript-only project: no C# to compile. Correct the spinner so
+              // it doesn't leave "Building C# assembly..." implying a build ran.
               verbose('No .csproj at project root — skipping build (GDScript-only).');
+              spinner.text = 'Locating Godot editor...';
               break;
             }
             case 'build-succeeded': {

--- a/cli/src/commands/open.ts
+++ b/cli/src/commands/open.ts
@@ -122,7 +122,7 @@ export const openCommand = new Command('open')
         onProgress: (event) => {
           switch (event.phase) {
             case 'build-running': {
-              spinner.text = `Building ${event.csprojPath} ...`;
+              spinner.text = `Building ${path.basename(event.csprojPath)} ...`;
               verbose(`Build command: ${event.command}`);
               break;
             }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { createRequire } from 'module';
+import { buildCommand } from './commands/build.js';
 import { openCommand } from './commands/open.js';
 import { runToolCommand } from './commands/run-tool.js';
 import { runSystemToolCommand } from './commands/run-system-tool.js';
@@ -29,6 +30,7 @@ program
 
 // Register all subcommands
 const subcommands = [
+  buildCommand,
   closeCommand,
   configureCommand,
   createProjectCommand,

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -14,6 +14,7 @@
 // via the `exports` field in package.json).
 
 export { openProject } from './lib/open.js';
+export { buildProject } from './lib/build.js';
 export { createProject } from './lib/create-project.js';
 export { runTool, runSystemTool } from './lib/run-tool.js';
 export { setupMcp, listAgentIds } from './lib/setup-mcp.js';
@@ -32,6 +33,12 @@ export type {
   OpenProjectFailure,
   OpenProjectAuthOption,
   OpenProjectConnectionMode,
+  // build-project
+  BuildProjectOptions,
+  BuildProjectResult,
+  BuildProjectSuccess,
+  BuildProjectFailure,
+  BuildSkipReason,
   // create-project
   CreateProjectOptions,
   CreateProjectResult,

--- a/cli/src/lib/build.ts
+++ b/cli/src/lib/build.ts
@@ -1,0 +1,204 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawn } from 'child_process';
+import { resolveProjectPath, isGodotProjectDir } from './open.js';
+import { emitProgress } from './progress.js';
+import type { BuildProjectOptions, BuildProjectResult } from './types.js';
+
+/**
+ * Locate the single consumer `.csproj` directly at the Godot project root — the
+ * `.csproj` Godot compiles every project `.cs` (addon included) into. A
+ * `--dotnet` scaffold writes `<AssemblyName>.csproj` there. Returns `null` when
+ * the project has no root csproj (a GDScript-only project — nothing to build).
+ *
+ * When more than one csproj sits at the root, the first alphabetically is
+ * returned and the ambiguity is pushed onto `warnings` (all root csprojs compile
+ * into the same Godot assembly, so building one builds the dependency graph the
+ * editor will load). Pure / read-only `fs`. Exported for unit tests.
+ */
+export function findProjectCsproj(
+  projectPath: string,
+  warnings: string[],
+): string | null {
+  let names: string[];
+  try {
+    names = fs.readdirSync(projectPath).filter((n) => n.toLowerCase().endsWith('.csproj'));
+  } catch {
+    return null;
+  }
+  if (names.length === 0) return null;
+  names.sort();
+  if (names.length > 1) {
+    warnings.push(
+      `Multiple .csproj files found at the project root (${names.join(', ')}); built ${names[0]}.`,
+    );
+  }
+  return path.join(projectPath, names[0]);
+}
+
+/** Default MSBuild configuration the build step compiles. */
+const DEFAULT_CONFIGURATION = 'Debug';
+
+/**
+ * Build the C# assembly for a Godot project BEFORE the editor opens, so the
+ * editor finds a compiled assembly when it instantiates enabled `EditorPlugin`s
+ * (otherwise a fresh first open fails with "Unable to load addon script … —
+ * Disabling the addon", godotengine/godot#112701-class behavior).
+ *
+ * Library-safe: never calls `process.exit`, never throws past the public
+ * boundary, never writes to stdout/stderr (observability is via `onProgress`).
+ *
+ * Behavior:
+ *   - Validates the path is an existing Godot project (`project.godot`).
+ *   - GDScript-only projects (no root `.csproj`) are a SUCCESS with
+ *     `skipped: true` / `skipReason: 'no-csproj'` — there is nothing to compile.
+ *   - C# projects (a root `.csproj`) are built ALWAYS via `dotnet build <csproj>`.
+ *     `dotnet build` is itself incremental, so an up-to-date project is a fast
+ *     no-op; building unconditionally avoids the staleness-detection bugs that a
+ *     "build-if-missing/stale" heuristic would introduce (the exact failure mode
+ *     this fix exists to prevent — a stale/absent assembly the editor can't load).
+ *   - A non-zero `dotnet build` exit (or a spawn error such as a missing
+ *     `dotnet`) is a structured `{ kind: 'failure' }` carrying the captured
+ *     output, so the caller can surface why the editor would disable the addon.
+ */
+export async function buildProject(options: BuildProjectOptions): Promise<BuildProjectResult> {
+  const warnings: string[] = [];
+  let resolvedProjectPath: string | undefined;
+
+  try {
+    const { projectPath } = resolveProjectPath(options.projectPath, process.cwd());
+    resolvedProjectPath = projectPath;
+
+    if (!fs.existsSync(projectPath)) {
+      throw new Error(`Project path does not exist: ${projectPath}`);
+    }
+
+    if (!isGodotProjectDir(projectPath)) {
+      throw new Error(`Not a Godot project (missing project.godot): ${projectPath}`);
+    }
+
+    emitProgress(options.onProgress, {
+      phase: 'start',
+      message: `Building C# for Godot project at ${projectPath}`,
+    });
+
+    const csprojPath = findProjectCsproj(projectPath, warnings);
+    if (csprojPath === null) {
+      // GDScript-only project — nothing to compile. The editor opens fine
+      // without an assembly when no C# is present.
+      emitProgress(options.onProgress, {
+        phase: 'build-skipped',
+        message: 'No .csproj at the project root — GDScript-only project, skipping build.',
+        reason: 'no-csproj',
+      });
+      emitProgress(options.onProgress, { phase: 'done', message: 'Build skipped (no C#).' });
+      return {
+        kind: 'success',
+        success: true,
+        projectPath,
+        skipped: true,
+        skipReason: 'no-csproj',
+        warnings,
+      };
+    }
+
+    const configuration = options.configuration ?? DEFAULT_CONFIGURATION;
+    const dotnetBin = options.dotnetPath ?? 'dotnet';
+    const args = ['build', csprojPath, '--configuration', configuration];
+
+    emitProgress(options.onProgress, {
+      phase: 'build-running',
+      message: `Building ${path.basename(csprojPath)} (${configuration})`,
+      csprojPath,
+      command: [dotnetBin, ...args].join(' '),
+    });
+
+    const run = await runDotnetBuild(dotnetBin, args, projectPath, options.spawnImpl);
+
+    if (run.code !== 0) {
+      const detail = run.output.trim();
+      throw new Error(
+        `dotnet build failed (exit ${run.code ?? 'null'}) for ${csprojPath}.` +
+          (detail.length > 0 ? `\n${detail}` : ''),
+      );
+    }
+
+    emitProgress(options.onProgress, {
+      phase: 'done',
+      message: `Built ${path.basename(csprojPath)} (${configuration}).`,
+    });
+
+    return {
+      kind: 'success',
+      success: true,
+      projectPath,
+      csprojPath,
+      configuration,
+      skipped: false,
+      output: run.output,
+      warnings,
+    };
+  } catch (err: unknown) {
+    const errorObj = err instanceof Error ? err : new Error(String(err));
+    return {
+      kind: 'failure',
+      success: false,
+      projectPath: resolvedProjectPath,
+      warnings,
+      errorMessage: errorObj.message,
+      error: errorObj,
+    };
+  }
+}
+
+/** A finished `dotnet build` invocation: its exit code + combined output. */
+interface DotnetBuildRun {
+  code: number | null;
+  output: string;
+}
+
+/**
+ * Spawn `dotnet build`, capturing stdout+stderr, and resolve once it exits.
+ * Unlike the editor launch (which detaches), the build is awaited to completion
+ * so the assembly exists before the caller proceeds. Library-safe: a spawn
+ * `error` (e.g. `dotnet` not on PATH) resolves as a non-zero run rather than
+ * throwing past the boundary. `spawnImpl` is injectable for unit tests.
+ */
+function runDotnetBuild(
+  bin: string,
+  args: string[],
+  cwd: string,
+  spawnImpl: typeof spawn = spawn,
+): Promise<DotnetBuildRun> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (run: DotnetBuildRun): void => {
+      if (settled) return;
+      settled = true;
+      resolve(run);
+    };
+
+    let child: import('child_process').ChildProcess;
+    try {
+      child = spawnImpl(bin, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      finish({ code: 127, output: `Failed to spawn "${bin}": ${msg}` });
+      return;
+    }
+
+    let output = '';
+    child.stdout?.on('data', (chunk: Buffer | string) => {
+      output += chunk.toString();
+    });
+    child.stderr?.on('data', (chunk: Buffer | string) => {
+      output += chunk.toString();
+    });
+    child.on('error', (err: Error) => {
+      finish({ code: 127, output: `${output}\nFailed to run "${bin}": ${err.message}` });
+    });
+    child.on('close', (code: number | null) => {
+      finish({ code, output });
+    });
+  });
+}

--- a/cli/src/lib/open.ts
+++ b/cli/src/lib/open.ts
@@ -11,6 +11,7 @@ import {
   ENV_TOKEN,
 } from '../utils/connection.js';
 import { emitProgress } from './progress.js';
+import { buildProject } from './build.js';
 import type {
   OpenEnvInputs,
   OpenProjectAuthOption,
@@ -100,6 +101,7 @@ export async function openProject(options: OpenProjectOptions): Promise<OpenProj
   const warnings: string[] = [];
   let resolvedProjectPath: string | undefined;
   let resolvedEditorPath: string | undefined;
+  let built = false;
 
   try {
     const { projectPath } = resolveProjectPath(options.projectPath, process.cwd());
@@ -139,7 +141,39 @@ export async function openProject(options: OpenProjectOptions): Promise<OpenProj
         projectPath,
         warnings,
         alreadyRunning: true,
+        built: false,
       };
+    }
+
+    // Build the C# assembly BEFORE launching the editor, so a fresh first open
+    // finds a compiled assembly when it instantiates enabled EditorPlugins
+    // (otherwise the editor shows "Unable to load addon script … Disabling the
+    // addon"). GDScript-only projects are skipped inside buildProject. Opt out
+    // with `build: false`. A build failure aborts the open — launching anyway
+    // would reproduce the very disable-addon failure this guards against.
+    if (options.build !== false) {
+      const buildResult = await buildProject({
+        projectPath,
+        configuration: options.buildConfiguration,
+        dotnetPath: options.dotnetPath,
+        spawnImpl: options.buildSpawnImpl,
+        onProgress: options.onProgress,
+      });
+      if (buildResult.kind === 'failure') {
+        throw new Error(
+          `Build before open failed; not launching the editor (it would disable the addon).\n${buildResult.errorMessage}`,
+        );
+      }
+      for (const w of buildResult.warnings) warnings.push(w);
+      built = !buildResult.skipped;
+      if (!buildResult.skipped && buildResult.csprojPath !== undefined) {
+        emitProgress(options.onProgress, {
+          phase: 'build-succeeded',
+          message: 'C# assembly built before launch.',
+          csprojPath: buildResult.csprojPath,
+          configuration: buildResult.configuration ?? 'Debug',
+        });
+      }
     }
 
     // Locate the Godot binary.
@@ -206,6 +240,7 @@ export async function openProject(options: OpenProjectOptions): Promise<OpenProj
       editorPid: pid,
       projectPath,
       warnings,
+      built,
     };
   } catch (err: unknown) {
     const errorObj = err instanceof Error ? err : new Error(String(err));

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -23,6 +23,10 @@ export type ProgressEvent =
   | { phase: 'csproj-patched'; message: string; csprojPath: string }
   // createProject phases
   | { phase: 'project-scaffolded'; message: string; projectPath: string }
+  // buildProject phases (also emitted by openProject when it builds first)
+  | { phase: 'build-running'; message: string; csprojPath: string; command: string }
+  | { phase: 'build-skipped'; message: string; reason: BuildSkipReason }
+  | { phase: 'build-succeeded'; message: string; csprojPath: string; configuration: string }
   // openProject phases
   | { phase: 'editor-resolved'; message: string; editorPath: string }
   | {
@@ -111,6 +115,53 @@ export interface SetupSkillsFailure {
 export type SetupSkillsResult = SetupSkillsSuccess | SetupSkillsFailure;
 
 // ---------------------------------------------------------------------------
+// build-project
+// ---------------------------------------------------------------------------
+
+/** Why a build was skipped rather than run. */
+export type BuildSkipReason = 'no-csproj';
+
+export interface BuildProjectOptions {
+  /** Path to the Godot project to build. Defaults to `process.cwd()`. */
+  projectPath?: string;
+  /** MSBuild configuration to compile. Defaults to `Debug` (CI parity). */
+  configuration?: string;
+  /** Explicit `dotnet` executable path. Defaults to `dotnet` on `PATH`. */
+  dotnetPath?: string;
+  /** Injectable `child_process.spawn` for tests (mock the build). */
+  spawnImpl?: typeof import('child_process').spawn;
+  onProgress?: ProgressCallback;
+}
+
+export interface BuildProjectSuccess {
+  kind: 'success';
+  success: true;
+  projectPath: string;
+  /** True when the project had no C# to build (GDScript-only). */
+  skipped: boolean;
+  /** Set when `skipped` is true. */
+  skipReason?: BuildSkipReason;
+  /** The `.csproj` that was built (absent when skipped). */
+  csprojPath?: string;
+  /** The MSBuild configuration compiled (absent when skipped). */
+  configuration?: string;
+  /** Captured `dotnet build` stdout+stderr (absent when skipped). */
+  output?: string;
+  warnings: string[];
+}
+
+export interface BuildProjectFailure {
+  kind: 'failure';
+  success: false;
+  projectPath?: string;
+  warnings: string[];
+  errorMessage: string;
+  error: Error;
+}
+
+export type BuildProjectResult = BuildProjectSuccess | BuildProjectFailure;
+
+// ---------------------------------------------------------------------------
 // open-project
 // ---------------------------------------------------------------------------
 
@@ -125,6 +176,19 @@ export interface OpenProjectOptions {
   projectPath?: string;
   /** Explicit Godot editor executable path (skips resolution). */
   editorPath?: string;
+  /**
+   * Build the C# assembly (`dotnet build`) before launching the editor so a
+   * fresh first open loads the addon instead of failing with "Unable to load
+   * addon script … Disabling the addon". Defaults to `true`. Set `false` to skip
+   * (GDScript-only projects are skipped automatically — see `buildProject`).
+   */
+  build?: boolean;
+  /** MSBuild configuration for the pre-open build. Defaults to `Debug`. */
+  buildConfiguration?: string;
+  /** Explicit `dotnet` executable path for the pre-open build. */
+  dotnetPath?: string;
+  /** Injectable `child_process.spawn` for the pre-open build (tests). */
+  buildSpawnImpl?: typeof import('child_process').spawn;
   /** If `true`, skip wiring the GODOT_MCP_* env vars onto the editor process. */
   noConnect?: boolean;
   /** MCP server host — sets `GODOT_MCP_HOST`. */
@@ -151,6 +215,12 @@ export interface OpenProjectSuccess {
   warnings: string[];
   /** True when an editor was already running for this project; launch skipped. */
   alreadyRunning?: boolean;
+  /**
+   * Whether the C# assembly was built before launch: `true` when a build ran,
+   * `false` when skipped (`--no-build`, a GDScript-only project, or an
+   * already-running editor short-circuit).
+   */
+  built?: boolean;
 }
 
 export interface OpenProjectFailure {

--- a/cli/tests/build.test.ts
+++ b/cli/tests/build.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EventEmitter } from 'events';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { buildProject, findProjectCsproj } from '../src/lib/build.js';
+import type { ProgressEvent } from '../src/lib/types.js';
+
+/**
+ * Build a fake `child_process.spawn` whose returned child emits the supplied
+ * stdout/stderr and then `close`s with `exitCode`. Records every spawn call so a
+ * test can assert the command + cwd shape. `errorOnSpawn` makes the spawn itself
+ * throw synchronously (mirrors `dotnet` missing from PATH on some platforms).
+ */
+function makeSpawnMock(opts: {
+  exitCode?: number | null;
+  stdout?: string;
+  stderr?: string;
+  emitError?: string;
+  throwOnSpawn?: string;
+}): { spawnImpl: typeof import('child_process').spawn; calls: { bin: string; args: string[]; cwd?: string }[] } {
+  const calls: { bin: string; args: string[]; cwd?: string }[] = [];
+  const spawnImpl = ((bin: string, args: string[], options?: { cwd?: string }) => {
+    calls.push({ bin, args, cwd: options?.cwd });
+    if (opts.throwOnSpawn) {
+      throw new Error(opts.throwOnSpawn);
+    }
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+    };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    // Emit async so listeners are attached first.
+    setImmediate(() => {
+      if (opts.stdout) child.stdout.emit('data', Buffer.from(opts.stdout));
+      if (opts.stderr) child.stderr.emit('data', Buffer.from(opts.stderr));
+      if (opts.emitError) {
+        child.emit('error', new Error(opts.emitError));
+        return;
+      }
+      child.emit('close', opts.exitCode ?? 0);
+    });
+    return child;
+  }) as unknown as typeof import('child_process').spawn;
+  return { spawnImpl, calls };
+}
+
+function writeGodotProject(dir: string, opts: { csproj?: boolean | string[] } = {}): void {
+  fs.writeFileSync(path.join(dir, 'project.godot'), 'config_version=5\n');
+  if (opts.csproj === true) {
+    fs.writeFileSync(path.join(dir, 'MyProject.csproj'), '<Project />');
+  } else if (Array.isArray(opts.csproj)) {
+    for (const name of opts.csproj) fs.writeFileSync(path.join(dir, name), '<Project />');
+  }
+}
+
+describe('findProjectCsproj', () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-build-csproj-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns null when no csproj is present (GDScript-only)', () => {
+    writeGodotProject(tmpDir);
+    expect(findProjectCsproj(tmpDir, [])).toBeNull();
+  });
+
+  it('returns the single root csproj', () => {
+    writeGodotProject(tmpDir, { csproj: true });
+    expect(findProjectCsproj(tmpDir, [])).toBe(path.join(tmpDir, 'MyProject.csproj'));
+  });
+
+  it('picks the first alphabetically and warns when several csprojs exist', () => {
+    writeGodotProject(tmpDir, { csproj: ['Zeta.csproj', 'Alpha.csproj'] });
+    const warnings: string[] = [];
+    expect(findProjectCsproj(tmpDir, warnings)).toBe(path.join(tmpDir, 'Alpha.csproj'));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('Multiple .csproj');
+  });
+
+  it('returns null for a nonexistent directory', () => {
+    expect(findProjectCsproj(path.join(tmpDir, 'nope'), [])).toBeNull();
+  });
+});
+
+describe('buildProject', () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-build-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('fails when the project path does not exist', async () => {
+    const result = await buildProject({ projectPath: path.join(tmpDir, 'missing') });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') {
+      expect(result.errorMessage).toContain('does not exist');
+    }
+  });
+
+  it('fails for a non-Godot directory', async () => {
+    const result = await buildProject({ projectPath: tmpDir });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') {
+      expect(result.errorMessage).toContain('Not a Godot project');
+    }
+  });
+
+  it('skips (success) a GDScript-only project with no csproj — never spawns dotnet', async () => {
+    writeGodotProject(tmpDir);
+    const { spawnImpl, calls } = makeSpawnMock({ exitCode: 0 });
+    const events: ProgressEvent[] = [];
+    const result = await buildProject({
+      projectPath: tmpDir,
+      spawnImpl,
+      onProgress: (e) => events.push(e),
+    });
+    expect(result.kind).toBe('success');
+    if (result.kind === 'success') {
+      expect(result.skipped).toBe(true);
+      expect(result.skipReason).toBe('no-csproj');
+    }
+    expect(calls).toHaveLength(0);
+    expect(events.some((e) => e.phase === 'build-skipped')).toBe(true);
+  });
+
+  it('runs "dotnet build <csproj> --configuration Debug" in the project cwd for a C# project', async () => {
+    writeGodotProject(tmpDir, { csproj: true });
+    const { spawnImpl, calls } = makeSpawnMock({ exitCode: 0, stdout: 'Build succeeded.' });
+    const result = await buildProject({ projectPath: tmpDir, spawnImpl });
+    expect(result.kind).toBe('success');
+    if (result.kind === 'success') {
+      expect(result.skipped).toBe(false);
+      expect(result.csprojPath).toBe(path.join(tmpDir, 'MyProject.csproj'));
+      expect(result.configuration).toBe('Debug');
+      expect(result.output).toContain('Build succeeded.');
+    }
+    expect(calls).toHaveLength(1);
+    expect(calls[0].bin).toBe('dotnet');
+    expect(calls[0].args).toEqual([
+      'build',
+      path.join(tmpDir, 'MyProject.csproj'),
+      '--configuration',
+      'Debug',
+    ]);
+    expect(calls[0].cwd).toBe(path.resolve(tmpDir));
+  });
+
+  it('honors a custom configuration and dotnet path', async () => {
+    writeGodotProject(tmpDir, { csproj: true });
+    const { spawnImpl, calls } = makeSpawnMock({ exitCode: 0 });
+    const result = await buildProject({
+      projectPath: tmpDir,
+      configuration: 'Release',
+      dotnetPath: '/opt/dotnet/dotnet',
+      spawnImpl,
+    });
+    expect(result.kind).toBe('success');
+    expect(calls[0].bin).toBe('/opt/dotnet/dotnet');
+    expect(calls[0].args).toContain('Release');
+  });
+
+  it('fails (structured) and surfaces output when dotnet build exits non-zero', async () => {
+    writeGodotProject(tmpDir, { csproj: true });
+    const { spawnImpl } = makeSpawnMock({ exitCode: 1, stderr: 'error CS0103: missing' });
+    const result = await buildProject({ projectPath: tmpDir, spawnImpl });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') {
+      expect(result.errorMessage).toContain('dotnet build failed');
+      expect(result.errorMessage).toContain('error CS0103');
+    }
+  });
+
+  it('fails (structured) when the spawn itself errors (dotnet missing)', async () => {
+    writeGodotProject(tmpDir, { csproj: true });
+    const { spawnImpl } = makeSpawnMock({ emitError: 'spawn dotnet ENOENT' });
+    const result = await buildProject({ projectPath: tmpDir, spawnImpl });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') {
+      expect(result.errorMessage).toContain('dotnet build failed');
+    }
+  });
+
+  it('fails (structured) when spawn throws synchronously', async () => {
+    writeGodotProject(tmpDir, { csproj: true });
+    const { spawnImpl } = makeSpawnMock({ throwOnSpawn: 'EACCES' });
+    const result = await buildProject({ projectPath: tmpDir, spawnImpl });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') {
+      expect(result.errorMessage).toContain('dotnet build failed');
+    }
+  });
+});

--- a/cli/tests/open.test.ts
+++ b/cli/tests/open.test.ts
@@ -1,9 +1,25 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EventEmitter } from 'events';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { spawn } from 'child_process';
 import { buildOpenEnv, isGodotProjectDir, openProject } from '../src/lib/open.js';
+
+/**
+ * A fake build-step `spawn`: emits the given exit code on `close` so a test can
+ * exercise openProject's build-before-launch without a real `dotnet`. Distinct
+ * from the module-level `child_process` mock used for the editor launch.
+ */
+function makeBuildSpawn(exitCode: number): typeof spawn {
+  return ((_bin: string, _args: string[]) => {
+    const child = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    setImmediate(() => child.emit('close', exitCode));
+    return child;
+  }) as unknown as typeof spawn;
+}
 
 // ESM module namespaces are non-configurable; mock child_process so we can
 // observe spawn and stub the process-enumeration calls (execFileSync/execSync)
@@ -132,5 +148,106 @@ describe('openProject', () => {
     const env = (opts as { env: Record<string, string> }).env;
     expect(env['GODOT_MCP_HOST']).toBe('http://localhost:8080');
     expect(env['GODOT_MCP_TOKEN']).toBe('secret');
+  });
+
+  it('builds the C# assembly before launching when the project has a csproj', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'project.godot'), 'config_version=5\n');
+    fs.writeFileSync(path.join(tmpDir, 'Proj.csproj'), '<Project />');
+    const fakeBin = path.join(tmpDir, 'godot-bin');
+    fs.writeFileSync(fakeBin, '');
+
+    const fakeChild = { on: vi.fn(), unref: vi.fn(), pid: 4242, once: vi.fn() } as unknown as ReturnType<typeof spawn>;
+    spawnMock.mockReset();
+    spawnMock.mockReturnValue(fakeChild);
+
+    const result = await openProject({
+      projectPath: tmpDir,
+      editorPath: fakeBin,
+      noConnect: true,
+      buildSpawnImpl: makeBuildSpawn(0),
+    });
+
+    expect(result.kind).toBe('success');
+    if (result.kind === 'success') {
+      expect(result.built).toBe(true);
+    }
+    // Editor launch still happened (the build spawn is the injected impl, not spawnMock).
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT build when build:false, but still launches', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'project.godot'), 'config_version=5\n');
+    fs.writeFileSync(path.join(tmpDir, 'Proj.csproj'), '<Project />');
+    const fakeBin = path.join(tmpDir, 'godot-bin');
+    fs.writeFileSync(fakeBin, '');
+
+    const fakeChild = { on: vi.fn(), unref: vi.fn(), pid: 5, once: vi.fn() } as unknown as ReturnType<typeof spawn>;
+    spawnMock.mockReset();
+    spawnMock.mockReturnValue(fakeChild);
+
+    const buildSpawn = vi.fn(makeBuildSpawn(0));
+    const result = await openProject({
+      projectPath: tmpDir,
+      editorPath: fakeBin,
+      noConnect: true,
+      build: false,
+      buildSpawnImpl: buildSpawn as unknown as typeof spawn,
+    });
+
+    expect(result.kind).toBe('success');
+    if (result.kind === 'success') {
+      expect(result.built).toBe(false);
+    }
+    expect(buildSpawn).not.toHaveBeenCalled();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts the launch (failure) when the pre-open build fails', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'project.godot'), 'config_version=5\n');
+    fs.writeFileSync(path.join(tmpDir, 'Proj.csproj'), '<Project />');
+    const fakeBin = path.join(tmpDir, 'godot-bin');
+    fs.writeFileSync(fakeBin, '');
+
+    spawnMock.mockReset();
+
+    const result = await openProject({
+      projectPath: tmpDir,
+      editorPath: fakeBin,
+      noConnect: true,
+      buildSpawnImpl: makeBuildSpawn(1),
+    });
+
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') {
+      expect(result.errorMessage).toContain('Build before open failed');
+    }
+    // Editor was never launched.
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('reports built:false for a GDScript-only project (no csproj) and still launches', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'project.godot'), 'config_version=5\n');
+    const fakeBin = path.join(tmpDir, 'godot-bin');
+    fs.writeFileSync(fakeBin, '');
+
+    const fakeChild = { on: vi.fn(), unref: vi.fn(), pid: 7, once: vi.fn() } as unknown as ReturnType<typeof spawn>;
+    spawnMock.mockReset();
+    spawnMock.mockReturnValue(fakeChild);
+
+    const buildSpawn = vi.fn(makeBuildSpawn(0));
+    const result = await openProject({
+      projectPath: tmpDir,
+      editorPath: fakeBin,
+      noConnect: true,
+      buildSpawnImpl: buildSpawn as unknown as typeof spawn,
+    });
+
+    expect(result.kind).toBe('success');
+    if (result.kind === 'success') {
+      expect(result.built).toBe(false);
+    }
+    // GDScript-only → no dotnet spawn, but editor still launched.
+    expect(buildSpawn).not.toHaveBeenCalled();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- `godot-cli open` now **builds the project's C# assembly before launching the editor**, fixing a fresh first open failing with *"Unable to load addon script 'res://addons/godot_mcp/Editor/GodotMcpPlugin.cs' … Disabling the addon"* — Godot instantiates enabled `EditorPlugin`s before any assembly exists, so an un-built C# project disables the addon on first open.
- New reusable `buildProject` lib fn + `godot-cli build` command (the same build `open` runs). C# projects (a root `.csproj`) build **always** (`dotnet build` is incremental, avoiding stale-assembly bugs); GDScript-only projects skip. `open --no-build` opts out; a build failure aborts the launch.
- Reworked `test_cli_e2e_install.yml` to build via `godot-cli build` instead of a hand-rolled `dotnet build`, so a regression in the build-before-open path turns the plugin-loaded assertion red instead of being masked. PR and release already run the full Godot **4.3.0 / 4.4.0 / 4.5.1 / 4.6.3 / 4.7.0** matrix in lockstep.

## Test plan
- [x] Target-specific local tests passed (see profile test.md):
  - `dotnet build Godot-MCP.sln` → **0 errors**.
  - `dotnet test Godot-MCP.Tests` → **914 passed / 0 failed**.
  - `cd cli && npm test` (vitest) → **328 passed / 0 failed** (build-step unit coverage: project-type detection, command/cwd/spawn shape, custom configuration + dotnet path, non-zero exit, spawn error, sync throw; plus open-before-launch integration: builds, `--no-build`, build-fail abort, GDScript skip).
- [x] Real headless Godot **4.5.1 mono** smoke: `create-project --dotnet` → `install-plugin --source` → import → `godot-cli build` → `--editor --quit` printed `[Godot-MCP] plugin loaded` with **no** "Unable to load addon" / `FileNotFoundException` / assembly-resolution error. (Pre-build boot reproduced the absent-assembly precondition.)