### PR TITLE
fix(addon): keep the "AI Game Developer" dock after an in-session C# rebuild + headless CI guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,6 +241,47 @@ jobs:
     with:
       godotVersion: "4.7.0"
 
+  # in-session-rebuild dock-survival guard across the Godot engine matrix (mono):
+  # boots a headless editor held open with the dev-control bridge, triggers a genuine
+  # in-session C# rebuild, and asserts the "AI Game Developer" dock SURVIVES the hot
+  # reload (godotengine/godot#51626). Gates the release alongside the addon-load smoke
+  # so the "missing dock tab" regression can NEVER ship. MUST stay in lockstep with
+  # test_pull_request.yml's dock-reload-4-{3..7} legs.
+  dock-reload-4-3:
+    needs: [check-version-tag]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    uses: ./.github/workflows/test_godot_dock_reload.yml
+    with:
+      godotVersion: "4.3.0"
+
+  dock-reload-4-4:
+    needs: [check-version-tag]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    uses: ./.github/workflows/test_godot_dock_reload.yml
+    with:
+      godotVersion: "4.4.0"
+
+  dock-reload-4-5:
+    needs: [check-version-tag]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    uses: ./.github/workflows/test_godot_dock_reload.yml
+    with:
+      godotVersion: "4.5.1"
+
+  dock-reload-4-6:
+    needs: [check-version-tag]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    uses: ./.github/workflows/test_godot_dock_reload.yml
+    with:
+      godotVersion: "4.6.3"
+
+  dock-reload-4-7:
+    needs: [check-version-tag]
+    if: needs.check-version-tag.outputs.should_release == 'true'
+    uses: ./.github/workflows/test_godot_dock_reload.yml
+    with:
+      godotVersion: "4.7.0"
+
   # from-scratch terminal-install E2E across the Godot engine matrix (mono). Gates
   # the release alongside the addon-load smoke so a broken from-scratch terminal
   # install (create-project + install-plugin) can NEVER ship in a release.
@@ -342,8 +383,9 @@ jobs:
   release-addon:
     runs-on: ubuntu-latest
     # The release gate depends ONLY on the DETERMINISTIC test legs (check-version-tag,
-    # the .NET build+test, the cli node tests, the addon-LOAD godot smoke, and the
-    # from-scratch e2e-install) across the FULL Godot matrix (4.3 → 4.7). This MUST stay
+    # the .NET build+test, the cli node tests, the addon-LOAD godot smoke, the
+    # in-session-rebuild dock-survival guard (dock-reload), and the from-scratch
+    # e2e-install) across the FULL Godot matrix (4.3 → 4.7). This MUST stay
     # in lockstep with test_pull_request.yml's matrix so a green PR can never produce a red
     # release gate — when you add/remove a Godot version, edit BOTH files together. The
     # runtime-harness-4-{3..7} legs are deliberately NOT in this `needs:` array: they are
@@ -363,6 +405,11 @@ jobs:
         test-godot-4-5,
         test-godot-4-6,
         test-godot-4-7,
+        dock-reload-4-3,
+        dock-reload-4-4,
+        dock-reload-4-5,
+        dock-reload-4-6,
+        dock-reload-4-7,
         e2e-install-4-3,
         e2e-install-4-4,
         e2e-install-4-5,

--- a/.github/workflows/test_godot_dock_reload.yml
+++ b/.github/workflows/test_godot_dock_reload.yml
@@ -1,0 +1,145 @@
+# ┌──────────────────────────────────────────────────────────────────┐
+# │  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+# │  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+# │  Copyright (c) 2026 Ivan Murzak                                  │
+# │  Licensed under the Apache License, Version 2.0.                 │
+# └──────────────────────────────────────────────────────────────────┘
+#
+# Reusable workflow: the godotengine/godot#51626 IN-SESSION-REBUILD dock-survival
+# guard. Unlike test_godot_plugin.yml (which only boots `--editor --quit` and greps
+# "[Godot-MCP] plugin loaded" — a clean boot that does NOT exercise an in-session
+# C# reload), this boots a HEADLESS editor and HOLDS IT OPEN with the DEV-ONLY
+# dev-control bridge enabled, asserts the "AI Game Developer" dock is in the editor
+# dock tree, then triggers a GENUINE in-session C# rebuild by rewriting the project
+# assembly on disk (Godot's HotReloadAssemblyWatcher reloads it mid-session), and
+# asserts the dock STILL in the tree after the reload.
+#
+# On the pre-fix addon the reloaded EditorPlugin never re-adds the dock, the
+# dev-control bridge (which lives on the freed dock) never comes back, and the
+# harness fails RED. On the fixed addon the reloaded plugin re-registers a fresh
+# dock + bridge and the harness passes. (Verified RED-on-pre-fix / GREEN-on-fix
+# locally on Godot 4.5.1 mono.)
+#
+# Called once per matrix version by test_pull_request.yml AND release.yml — keep
+# the two matrices in lockstep (4.3.0 / 4.4.0 / 4.5.1 / 4.6.3 / 4.7.0).
+name: Test Godot Dock Reload
+
+on:
+  workflow_call:
+    inputs:
+      godotVersion:
+        description: "Godot mono version to install and boot (e.g. 4.3.0, 4.4.0, 4.5.1)."
+        required: true
+        type: string
+
+jobs:
+  dock-reload:
+    name: dock reload ${{ inputs.godotVersion }} (mono)
+    runs-on: ubuntu-latest
+    env:
+      # The in-repo test project. The addon is copied into <TEST_PROJECT>/addons/
+      # at runtime (a dev junction does not survive checkout). Same project the
+      # addon-load smoke + runtime harness use.
+      TEST_PROJECT: Godot-Tests
+      # Loopback-only dev-control bridge port the harness polls.
+      DEV_CONTROL_PORT: "9920"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Setup Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Setup Godot ${{ inputs.godotVersion }} (mono)
+        uses: chickensoft-games/setup-godot@v2
+        with:
+          version: ${{ inputs.godotVersion }}
+          use-dotnet: true
+          include-templates: false
+
+      - name: Report Godot version
+        shell: bash
+        run: godot --version --headless
+
+      - name: Copy addon into the test project
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf "${TEST_PROJECT}/addons/godot_mcp"
+          mkdir -p "${TEST_PROJECT}/addons"
+          cp -r addons/godot_mcp "${TEST_PROJECT}/addons/godot_mcp"
+          test -f "${TEST_PROJECT}/addons/godot_mcp/plugin.cfg"
+          test -f "${TEST_PROJECT}/addons/godot_mcp/Editor/GodotMcpPlugin.cs"
+
+      - name: Pin the testbed build SDK to the matrix Godot version
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The committed Godot-Tests.csproj pins the addon engine FLOOR (Godot.NET.Sdk/4.3.0).
+          # For an in-session RELOAD we want the editor and the build to agree on the SDK so the
+          # HotReloadAssemblyWatcher reliably detects the rebuilt assembly across versions. The
+          # checkout is disposable, so rewrite ONLY the <Project Sdk=...> pin per leg (anchor on
+          # the Sdk="..." attribute so comment mentions of 4.3.0 are left intact). Mirrors the
+          # runtime-harness leg.
+          GODOT_VERSION="${{ inputs.godotVersion }}"
+          sed -i "s#Sdk=\"Godot.NET.Sdk/[0-9][0-9.]*\"#Sdk=\"Godot.NET.Sdk/${GODOT_VERSION}\"#" "${TEST_PROJECT}/${TEST_PROJECT}.csproj"
+          echo "Pinned ${TEST_PROJECT}.csproj SDK:"
+          head -1 "${TEST_PROJECT}/${TEST_PROJECT}.csproj"
+
+      - name: Import the project (generate .godot layout)
+        shell: bash
+        run: |
+          set -uo pipefail
+          # Cold checkout has no .godot/. Headless import materializes it; benign teardown
+          # warnings / non-zero exits are not fatal (same caveat as test_godot_plugin.yml).
+          godot --headless --path "${TEST_PROJECT}" --import --quit 2>&1 | tee import.log || true
+          echo "Import pass complete."
+
+      - name: Build C# (addon compiles into the project assembly)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Deterministic build (Godot.NET.Sdk resolves GodotSharp from nuget.org). This seeds the
+          # FIRST assembly the editor loads on boot; the harness rebuilds it again mid-session to
+          # trigger the in-session reload.
+          dotnet build "${TEST_PROJECT}/${TEST_PROJECT}.csproj" --configuration Debug 2>&1 | tee build.log
+          if ! ls "${TEST_PROJECT}"/.godot/mono/temp/bin/*/Godot-MCP-Tests.dll >/dev/null 2>&1; then
+            echo "::error::C# build did not produce Godot-MCP-Tests.dll — the addon failed to compile."
+            cat build.log || true
+            exit 1
+          fi
+
+      - name: In-session rebuild — assert the dock survives
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The harness boots the editor headless + held-open with the dev-control bridge, asserts
+          # the dock is in-tree, rewrites the assembly on disk (a genuine in-session rebuild that
+          # Godot's HotReloadAssemblyWatcher picks up), waits for the ALC reload, and asserts the
+          # dock is STILL in-tree. Exit 0 = survived; non-zero = the godot#51626 regression.
+          python scripts/dock_reload_harness.py \
+            --godot "$(command -v godot)" \
+            --project "${TEST_PROJECT}" \
+            --csproj "${TEST_PROJECT}/${TEST_PROJECT}.csproj" \
+            --port "${DEV_CONTROL_PORT}" \
+            --boot-deadline 120 \
+            --reload-deadline 120
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dock-reload-${{ inputs.godotVersion }}-logs
+          path: |
+            import.log
+            build.log
+            ${{ env.TEST_PROJECT }}/harness-editor.log
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -103,6 +103,38 @@ jobs:
     with:
       godotVersion: "4.7.0"
 
+  # (f) the in-session-rebuild dock-survival guard across the Godot engine matrix
+  #     (mono) via the reusable test_godot_dock_reload.yml — boots a headless editor
+  #     held open with the dev-control bridge, triggers a GENUINE in-session C#
+  #     rebuild (rewrites the assembly on disk → Godot's HotReloadAssemblyWatcher
+  #     hot-reloads it), and asserts the "AI Game Developer" dock SURVIVES the reload
+  #     (godotengine/godot#51626 "missing dock tab" regression). MUST stay in lockstep
+  #     with release.yml's dock-reload legs.
+  dock-reload-4-3:
+    uses: ./.github/workflows/test_godot_dock_reload.yml
+    with:
+      godotVersion: "4.3.0"
+
+  dock-reload-4-4:
+    uses: ./.github/workflows/test_godot_dock_reload.yml
+    with:
+      godotVersion: "4.4.0"
+
+  dock-reload-4-5:
+    uses: ./.github/workflows/test_godot_dock_reload.yml
+    with:
+      godotVersion: "4.5.1"
+
+  dock-reload-4-6:
+    uses: ./.github/workflows/test_godot_dock_reload.yml
+    with:
+      godotVersion: "4.6.3"
+
+  dock-reload-4-7:
+    uses: ./.github/workflows/test_godot_dock_reload.yml
+    with:
+      godotVersion: "4.7.0"
+
   # (e) from-scratch terminal-install E2E across the Godot engine matrix (mono):
   #     build the CLI, scaffold a --dotnet project, run the REAL `install-plugin`
   #     (materialize addon + add NuGet pins + enable), dotnet build, and assert the

--- a/addons/godot_mcp/Editor/GodotMcpPlugin.cs
+++ b/addons/godot_mcp/Editor/GodotMcpPlugin.cs
@@ -60,7 +60,67 @@ namespace com.IvanMurzak.Godot.MCP
         // overwrites a newer one because _EnterTree always sets Current = this last.
         static GodotMcpPlugin? Current;
 
+        /// <summary>
+        /// Constructor — the load-bearing seam for surviving a Godot "Build Project" hot-reload
+        /// (godotengine/godot#51626). A C# rebuild re-instantiates this <see cref="EditorPlugin"/> script
+        /// IN PLACE: the native plugin node never leaves the editor tree, so <see cref="_EnterTree"/> is NOT
+        /// called again — yet <see cref="Teardown"/> (run from the ALC-unloading hook) already freed the dock.
+        /// The result, with no compensating action, is the "AI Game Developer" tab silently disappearing until
+        /// the addon is disabled/re-enabled (the user-reported bug).
+        ///
+        /// <para>
+        /// We distinguish the two paths by <see cref="Godot.Node.IsInsideTree"/> at ctor time:
+        /// <list type="bullet">
+        ///   <item>NORMAL first boot — Godot constructs the plugin BEFORE adding it to the editor tree, so
+        ///   <c>IsInsideTree()</c> is <c>false</c>; <see cref="_EnterTree"/> performs the boot. The ctor does
+        ///   nothing.</item>
+        ///   <item>HOT-RELOAD re-instantiation — the node is ALREADY in the tree, so <c>IsInsideTree()</c> is
+        ///   <c>true</c>; <see cref="_EnterTree"/> will not fire. We re-run the boot (which re-adds the dock +
+        ///   dev-control bridge) deferred to the next idle frame, because <see cref="EditorPlugin.AddControlToDock"/>
+        ///   requires the plugin to be live in the editor tree.</item>
+        /// </list>
+        /// Verified empirically on a headless 4.5.1 editor: on reload the ctor runs with
+        /// <c>IsInsideTree()==true</c> while <c>_EnterTree</c> does not re-fire; deferring the boot re-registers
+        /// the dock and the "AI Game Developer" tab returns.
+        /// </para>
+        /// </summary>
+        public GodotMcpPlugin()
+        {
+            if (IsInsideTree())
+            {
+                Log("[Godot-MCP] reload re-instantiation detected — re-registering dock on next idle frame.");
+                // Defer to the next idle frame: the plugin is in-tree but mid-reload; AddControlToDock and the
+                // dock subtree build are safest once the reload settles. Callable.From → CallDeferred avoids a
+                // captured-lambda delegate connection (consistent with the dock's object+method Callable style).
+                Callable.From(BootAfterReload).CallDeferred();
+            }
+        }
+
+        /// <summary>
+        /// Re-run the full editor boot after a hot-reload re-instantiation (see the constructor). Bails if the
+        /// plugin was removed from the tree before the deferred call landed. Routes through the SAME
+        /// <see cref="EnterTreeBoot"/> the normal <see cref="_EnterTree"/> path uses, so a reloaded plugin is
+        /// indistinguishable from a freshly-booted one (resolver + dispatcher + connection + dock + bridge).
+        /// </summary>
+        void BootAfterReload()
+        {
+            if (!IsInsideTree())
+                return; // removed before the deferred frame — nothing to boot
+            EnterTreeBoot();
+        }
+
         public override void _EnterTree()
+        {
+            EnterTreeBoot();
+        }
+
+        /// <summary>
+        /// The shared boot body, reused by the normal <see cref="_EnterTree"/> path AND the hot-reload
+        /// re-entry path (<see cref="BootAfterReload"/>). Installs the log collector + assembly resolver, arms
+        /// the reload-safe teardown, builds the dispatcher, then <see cref="BootMcp"/> (connection + dock +
+        /// dev-control bridge).
+        /// </summary>
+        void EnterTreeBoot()
         {
             // Install the process-wide log collector first so every lifecycle line below (resolver
             // probes, plugin-loaded, connection state) is captured for the 'console-get-logs' tool.

--- a/addons/godot_mcp/Editor/GodotMcpPlugin.cs
+++ b/addons/godot_mcp/Editor/GodotMcpPlugin.cs
@@ -166,6 +166,11 @@ namespace com.IvanMurzak.Godot.MCP
 
             // Pump for off-thread → main-thread work. Added as a child of this EditorPlugin Node so it
             // lives in the editor SceneTree and gets _Process ticks for the lifetime of the plugin.
+            // FreeStaleNode first so the hot-reload re-entry (BootAfterReload, deferred to a later idle
+            // frame) is idempotent even if the ALC-unload Teardown has not yet freed the prior instance's
+            // dispatcher/dock on this matrix version: re-creating without freeing would orphan the old
+            // dispatcher child + add a duplicate. (The normal first boot has nothing to free.)
+            FreeStaleNode(ref _dispatcher);
             _dispatcher = new MainThreadDispatcher { Name = DispatcherNodeName };
             AddChild(_dispatcher);
 
@@ -189,6 +194,15 @@ namespace com.IvanMurzak.Godot.MCP
         {
             try
             {
+                // Idempotent across the hot-reload re-entry path (BootAfterReload): if a prior dock is
+                // still live (Teardown not yet run on this matrix version when the deferred boot lands),
+                // remove + free it before re-creating so we never add a SECOND "AI Game Developer" control.
+                if (_dock != null)
+                {
+                    if (GodotObject.IsInstanceValid(_dock))
+                        RemoveControlFromDocks(_dock);
+                    FreeStaleNode(ref _dock);
+                }
                 _dock = new GodotMcpDock(connection);
                 AddControlToDock(DockSlot.RightUl, _dock);
             }
@@ -593,6 +607,25 @@ namespace com.IvanMurzak.Godot.MCP
             // (not a C# delegate/lambda), so none of them is a ManagedCallable and none can survive into the ALC
             // unload as a leftover managed connection. The dock Free() above severs every native connection
             // deterministically as it tears the subtree down.
+        }
+
+        /// <summary>
+        /// Free a still-live Node referenced by <paramref name="node"/> and null the reference, so the
+        /// hot-reload re-boot (<see cref="BootAfterReload"/>) can re-create dock/dispatcher idempotently
+        /// even if <see cref="Teardown"/> has not yet freed the prior instance's nodes on this Godot
+        /// version. A null or already-disposed node just clears the reference (nothing to free). Defensive
+        /// throughout — re-boot runs deferred, possibly racing a partial teardown, and must not fault.
+        /// </summary>
+        static void FreeStaleNode<T>(ref T? node) where T : global::Godot.Node
+        {
+            try
+            {
+                if (node != null && GodotObject.IsInstanceValid(node))
+                    node.Free();
+            }
+            catch (System.ObjectDisposedException) { /* already gone — benign */ }
+            catch (System.Exception ex) { TryLogTeardownError("free stale node", ex); }
+            node = null;
         }
 
         /// <summary>

--- a/addons/godot_mcp/Editor/UI/Agents/AgentConfiguratorsPanel.cs
+++ b/addons/godot_mcp/Editor/UI/Agents/AgentConfiguratorsPanel.cs
@@ -82,6 +82,16 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// URL + token + mode off the connection's <see cref="GodotMcpConfig"/> and persists the selected agent via
         /// the connection's <c>Save</c>). Only built by the dock when a live connection exists.
         /// </summary>
+                /// <summary>
+        /// Parameterless ctor for Godot's C# hot-reload bridge (godotengine/godot#51626): a "Build Project"
+        /// reload re-instantiates every live [Tool] script via its parameterless ctor, so a parameter-only
+        /// class throws MissingMemberException ("does not define a parameterless constructor") and breaks the
+        /// reload (it crashed the editor before this was added). The reloaded plugin re-adds a FRESH, wired
+        /// dock (see GodotMcpPlugin's reload re-entry), so this re-instantiated shell is a discarded orphan —
+        /// it only has to exist without faulting.
+        /// </summary>
+        public AgentConfiguratorsPanel() {{ }}
+
         public AgentConfiguratorsPanel(GodotMcpConnection connection)
         {
             _connection = connection;

--- a/addons/godot_mcp/Editor/UI/Agents/AgentConfiguratorsPanel.cs
+++ b/addons/godot_mcp/Editor/UI/Agents/AgentConfiguratorsPanel.cs
@@ -82,7 +82,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// URL + token + mode off the connection's <see cref="GodotMcpConfig"/> and persists the selected agent via
         /// the connection's <c>Save</c>). Only built by the dock when a live connection exists.
         /// </summary>
-                /// <summary>
+        /// <summary>
         /// Parameterless ctor for Godot's C# hot-reload bridge (godotengine/godot#51626): a "Build Project"
         /// reload re-instantiates every live [Tool] script via its parameterless ctor, so a parameter-only
         /// class throws MissingMemberException ("does not define a parameterless constructor") and breaks the
@@ -90,7 +90,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// dock (see GodotMcpPlugin's reload re-entry), so this re-instantiated shell is a discarded orphan —
         /// it only has to exist without faulting.
         /// </summary>
-        public AgentConfiguratorsPanel() {{ }}
+        public AgentConfiguratorsPanel() { }
 
         public AgentConfiguratorsPanel(GodotMcpConnection connection)
         {

--- a/addons/godot_mcp/Editor/UI/ConnectionPanel.cs
+++ b/addons/godot_mcp/Editor/UI/ConnectionPanel.cs
@@ -167,6 +167,16 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// </summary>
         const int TimelineCircleTopOffset = 13;
 
+        /// <summary>
+        /// Parameterless ctor for Godot's C# hot-reload bridge (godotengine/godot#51626): a "Build Project"
+        /// reload re-instantiates every live [Tool] script via its parameterless ctor, so a parameter-only
+        /// class throws MissingMemberException ("does not define a parameterless constructor") and breaks the
+        /// reload (it crashed the editor before this was added). The reloaded plugin re-adds a FRESH, wired
+        /// dock (see GodotMcpPlugin's reload re-entry), so this re-instantiated shell is a discarded orphan —
+        /// it only has to exist without faulting.
+        /// </summary>
+        public ConnectionPanel() { }
+
         public ConnectionPanel(GodotMcpConnection connection)
         {
             _connection = connection;

--- a/addons/godot_mcp/Editor/UI/ExtensionRow.cs
+++ b/addons/godot_mcp/Editor/UI/ExtensionRow.cs
@@ -33,6 +33,16 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
         Button _actionButton = null!;
 
+                /// <summary>
+        /// Parameterless ctor for Godot's C# hot-reload bridge (godotengine/godot#51626): a "Build Project"
+        /// reload re-instantiates every live [Tool] script via its parameterless ctor, so a parameter-only
+        /// class throws MissingMemberException ("does not define a parameterless constructor") and breaks the
+        /// reload (it crashed the editor before this was added). The reloaded plugin re-adds a FRESH, wired
+        /// dock (see GodotMcpPlugin's reload re-entry), so this re-instantiated shell is a discarded orphan —
+        /// it only has to exist without faulting.
+        /// </summary>
+        public ExtensionRow() {{ }}
+
         public ExtensionRow(GodotExtensionDescriptor descriptor, Action<GodotExtensionDescriptor> onAction)
         {
             Descriptor = descriptor;

--- a/addons/godot_mcp/Editor/UI/ExtensionRow.cs
+++ b/addons/godot_mcp/Editor/UI/ExtensionRow.cs
@@ -33,7 +33,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
         Button _actionButton = null!;
 
-                /// <summary>
+        /// <summary>
         /// Parameterless ctor for Godot's C# hot-reload bridge (godotengine/godot#51626): a "Build Project"
         /// reload re-instantiates every live [Tool] script via its parameterless ctor, so a parameter-only
         /// class throws MissingMemberException ("does not define a parameterless constructor") and breaks the
@@ -41,7 +41,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// dock (see GodotMcpPlugin's reload re-entry), so this re-instantiated shell is a discarded orphan —
         /// it only has to exist without faulting.
         /// </summary>
-        public ExtensionRow() {{ }}
+        public ExtensionRow() { }
 
         public ExtensionRow(GodotExtensionDescriptor descriptor, Action<GodotExtensionDescriptor> onAction)
         {

--- a/addons/godot_mcp/Editor/UI/FeatureListWindow.cs
+++ b/addons/godot_mcp/Editor/UI/FeatureListWindow.cs
@@ -49,6 +49,16 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// <summary>The full, unfiltered item set for this kind, captured on (re)populate; the filter runs over it.</summary>
         IReadOnlyList<FeatureRowItem> _allItems = System.Array.Empty<FeatureRowItem>();
 
+                /// <summary>
+        /// Parameterless ctor for Godot's C# hot-reload bridge (godotengine/godot#51626): a "Build Project"
+        /// reload re-instantiates every live [Tool] script via its parameterless ctor, so a parameter-only
+        /// class throws MissingMemberException ("does not define a parameterless constructor") and breaks the
+        /// reload (it crashed the editor before this was added). The reloaded plugin re-adds a FRESH, wired
+        /// dock (see GodotMcpPlugin's reload re-entry), so this re-instantiated shell is a discarded orphan —
+        /// it only has to exist without faulting.
+        /// </summary>
+        public FeatureListWindow() {{ }}
+
         public FeatureListWindow(GodotMcpConnection connection, GodotMcpFeatureKind kind)
         {
             _connection = connection;

--- a/addons/godot_mcp/Editor/UI/FeatureListWindow.cs
+++ b/addons/godot_mcp/Editor/UI/FeatureListWindow.cs
@@ -49,7 +49,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// <summary>The full, unfiltered item set for this kind, captured on (re)populate; the filter runs over it.</summary>
         IReadOnlyList<FeatureRowItem> _allItems = System.Array.Empty<FeatureRowItem>();
 
-                /// <summary>
+        /// <summary>
         /// Parameterless ctor for Godot's C# hot-reload bridge (godotengine/godot#51626): a "Build Project"
         /// reload re-instantiates every live [Tool] script via its parameterless ctor, so a parameter-only
         /// class throws MissingMemberException ("does not define a parameterless constructor") and breaks the
@@ -57,7 +57,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// dock (see GodotMcpPlugin's reload re-entry), so this re-instantiated shell is a discarded orphan —
         /// it only has to exist without faulting.
         /// </summary>
-        public FeatureListWindow() {{ }}
+        public FeatureListWindow() { }
 
         public FeatureListWindow(GodotMcpConnection connection, GodotMcpFeatureKind kind)
         {

--- a/addons/godot_mcp/Editor/UI/FeatureRow.cs
+++ b/addons/godot_mcp/Editor/UI/FeatureRow.cs
@@ -36,7 +36,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         Label _countLabel = null!;
         Label? _tokenLabel;
 
-                /// <summary>
+        /// <summary>
         /// Parameterless ctor for Godot's C# hot-reload bridge (godotengine/godot#51626): a "Build Project"
         /// reload re-instantiates every live [Tool] script via its parameterless ctor, so a parameter-only
         /// class throws MissingMemberException ("does not define a parameterless constructor") and breaks the
@@ -44,7 +44,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// dock (see GodotMcpPlugin's reload re-entry), so this re-instantiated shell is a discarded orphan —
         /// it only has to exist without faulting.
         /// </summary>
-        public FeatureRow() {{ }}
+        public FeatureRow() { }
 
         public FeatureRow(GodotMcpFeatureKind kind, bool showTokens, Action<GodotMcpFeatureKind> onOpen)
         {

--- a/addons/godot_mcp/Editor/UI/FeatureRow.cs
+++ b/addons/godot_mcp/Editor/UI/FeatureRow.cs
@@ -36,6 +36,16 @@ namespace com.IvanMurzak.Godot.MCP.UI
         Label _countLabel = null!;
         Label? _tokenLabel;
 
+                /// <summary>
+        /// Parameterless ctor for Godot's C# hot-reload bridge (godotengine/godot#51626): a "Build Project"
+        /// reload re-instantiates every live [Tool] script via its parameterless ctor, so a parameter-only
+        /// class throws MissingMemberException ("does not define a parameterless constructor") and breaks the
+        /// reload (it crashed the editor before this was added). The reloaded plugin re-adds a FRESH, wired
+        /// dock (see GodotMcpPlugin's reload re-entry), so this re-instantiated shell is a discarded orphan —
+        /// it only has to exist without faulting.
+        /// </summary>
+        public FeatureRow() {{ }}
+
         public FeatureRow(GodotMcpFeatureKind kind, bool showTokens, Action<GodotMcpFeatureKind> onOpen)
         {
             Kind = kind;

--- a/addons/godot_mcp/Editor/UI/FeaturesPanel.cs
+++ b/addons/godot_mcp/Editor/UI/FeaturesPanel.cs
@@ -46,6 +46,16 @@ namespace com.IvanMurzak.Godot.MCP.UI
         FeatureRow _promptsRow = null!;
         FeatureRow _resourcesRow = null!;
 
+                /// <summary>
+        /// Parameterless ctor for Godot's C# hot-reload bridge (godotengine/godot#51626): a "Build Project"
+        /// reload re-instantiates every live [Tool] script via its parameterless ctor, so a parameter-only
+        /// class throws MissingMemberException ("does not define a parameterless constructor") and breaks the
+        /// reload (it crashed the editor before this was added). The reloaded plugin re-adds a FRESH, wired
+        /// dock (see GodotMcpPlugin's reload re-entry), so this re-instantiated shell is a discarded orphan —
+        /// it only has to exist without faulting.
+        /// </summary>
+        public FeaturesPanel() {{ }}
+
         public FeaturesPanel(GodotMcpConnection connection)
         {
             _connection = connection;

--- a/addons/godot_mcp/Editor/UI/FeaturesPanel.cs
+++ b/addons/godot_mcp/Editor/UI/FeaturesPanel.cs
@@ -46,7 +46,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         FeatureRow _promptsRow = null!;
         FeatureRow _resourcesRow = null!;
 
-                /// <summary>
+        /// <summary>
         /// Parameterless ctor for Godot's C# hot-reload bridge (godotengine/godot#51626): a "Build Project"
         /// reload re-instantiates every live [Tool] script via its parameterless ctor, so a parameter-only
         /// class throws MissingMemberException ("does not define a parameterless constructor") and breaks the
@@ -54,7 +54,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// dock (see GodotMcpPlugin's reload re-entry), so this re-instantiated shell is a discarded orphan —
         /// it only has to exist without faulting.
         /// </summary>
-        public FeaturesPanel() {{ }}
+        public FeaturesPanel() { }
 
         public FeaturesPanel(GodotMcpConnection connection)
         {

--- a/addons/godot_mcp/Editor/UI/GodotMcpDock.cs
+++ b/addons/godot_mcp/Editor/UI/GodotMcpDock.cs
@@ -76,6 +76,17 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// connection and threads it through here. A null connection (defensive / design-preview) builds the
         /// header-only chrome with no connection panel.
         /// </summary>
+        /// <summary>
+        /// Parameterless constructor required by Godot's C# hot-reload bridge: on a "Build Project" reload
+        /// (godotengine/godot#51626) the engine re-instantiates every live <c>[Tool]</c> script via its
+        /// parameterless ctor, and a class with only a parameter ctor throws
+        /// <c>MissingMemberException: ... does not define a parameterless constructor</c> (which crashed the
+        /// editor before this was added). The reloaded plugin re-adds a FRESH, fully-wired dock (see
+        /// <c>GodotMcpPlugin</c>'s reload re-entry), so this re-instantiated shell is a discarded orphan — it
+        /// only has to exist without faulting. It builds the header-only chrome (null connection) defensively.
+        /// </summary>
+        public GodotMcpDock() : this(null) { }
+
         public GodotMcpDock(GodotMcpConnection? connection)
         {
             _connection = connection;
@@ -623,7 +634,18 @@ namespace com.IvanMurzak.Godot.MCP.UI
             sb.Append("\"revokeButtonVisible\":").Append(VisibleInTree("RevokeButton") ? "true" : "false").Append(',');
             sb.Append("\"authRequiredAlertVisible\":").Append(VisibleInTree("AuthRequiredAlert") ? "true" : "false").Append(',');
             sb.Append("\"connectionRequiredAlertVisible\":").Append(VisibleInTree("ConnectionRequiredAlert") ? "true" : "false").Append(',');
-            AppendJson(sb, "cloudAuthStatus", Text("CloudAuthStatus"));
+            AppendJson(sb, "cloudAuthStatus", Text("CloudAuthStatus")); sb.Append(',');
+            // --- Dock-registration diagnostics (the godot#51626 "missing AI Game Developer tab" guard) ---
+            // After an in-session C# rebuild, Godot's hot-reload frees this dock and (unfixed) never re-adds it.
+            // These three fields let a headless dev-control harness ASSERT the dock is actually wired into the
+            // editor dock tree — not merely that the bridge answered. diagInsideTree is THE assertion: it is the
+            // VBoxContainer dock's IsInsideTree(), true only while the dock is parented under an editor dock slot.
+            // diagParentPath / diagParentType surface where it is docked (or "<null>" when orphaned) for diagnosis.
+            sb.Append("\"diagInsideTree\":").Append(IsInsideTree() ? "true" : "false").Append(',');
+            // GetParentOrNull<Node>() returns null when un-parented (a plain GetParent() would log an error).
+            var parent = IsInsideTree() ? GetParentOrNull<Node>() : null;
+            AppendJson(sb, "diagParentPath", parent != null ? (string)parent.GetPath() : "<null>"); sb.Append(',');
+            AppendJson(sb, "diagParentType", parent != null ? parent.GetClass() : "<null>");
             sb.Append('}');
             return sb.ToString();
         }

--- a/addons/godot_mcp/Editor/UI/GodotMcpDock.cs
+++ b/addons/godot_mcp/Editor/UI/GodotMcpDock.cs
@@ -71,12 +71,6 @@ namespace com.IvanMurzak.Godot.MCP.UI
         System.Action? _configChangedHandler;
 
         /// <summary>
-        /// Construct the dock wired to the live <paramref name="connection"/> so its connection panel can
-        /// show status and drive Connect/Disconnect/mode/URL. <see cref="GodotMcpPlugin"/> owns the
-        /// connection and threads it through here. A null connection (defensive / design-preview) builds the
-        /// header-only chrome with no connection panel.
-        /// </summary>
-        /// <summary>
         /// Parameterless constructor required by Godot's C# hot-reload bridge: on a "Build Project" reload
         /// (godotengine/godot#51626) the engine re-instantiates every live <c>[Tool]</c> script via its
         /// parameterless ctor, and a class with only a parameter ctor throws
@@ -87,6 +81,12 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// </summary>
         public GodotMcpDock() : this(null) { }
 
+        /// <summary>
+        /// Construct the dock wired to the live <paramref name="connection"/> so its connection panel can
+        /// show status and drive Connect/Disconnect/mode/URL. <see cref="GodotMcpPlugin"/> owns the
+        /// connection and threads it through here. A null connection (defensive / design-preview) builds the
+        /// header-only chrome with no connection panel.
+        /// </summary>
         public GodotMcpDock(GodotMcpConnection? connection)
         {
             _connection = connection;

--- a/addons/godot_mcp/Editor/UI/SkillsPanel.cs
+++ b/addons/godot_mcp/Editor/UI/SkillsPanel.cs
@@ -57,6 +57,16 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// connection's <c>Save</c>, and drives the connection's live plugin to generate). Only built by the dock when
         /// a live connection exists (the AI-agent / features cards share the same connection-null guard).
         /// </summary>
+                /// <summary>
+        /// Parameterless ctor for Godot's C# hot-reload bridge (godotengine/godot#51626): a "Build Project"
+        /// reload re-instantiates every live [Tool] script via its parameterless ctor, so a parameter-only
+        /// class throws MissingMemberException ("does not define a parameterless constructor") and breaks the
+        /// reload (it crashed the editor before this was added). The reloaded plugin re-adds a FRESH, wired
+        /// dock (see GodotMcpPlugin's reload re-entry), so this re-instantiated shell is a discarded orphan —
+        /// it only has to exist without faulting.
+        /// </summary>
+        public SkillsPanel() {{ }}
+
         public SkillsPanel(GodotMcpConnection connection)
         {
             _connection = connection;

--- a/addons/godot_mcp/Editor/UI/SkillsPanel.cs
+++ b/addons/godot_mcp/Editor/UI/SkillsPanel.cs
@@ -57,7 +57,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// connection's <c>Save</c>, and drives the connection's live plugin to generate). Only built by the dock when
         /// a live connection exists (the AI-agent / features cards share the same connection-null guard).
         /// </summary>
-                /// <summary>
+        /// <summary>
         /// Parameterless ctor for Godot's C# hot-reload bridge (godotengine/godot#51626): a "Build Project"
         /// reload re-instantiates every live [Tool] script via its parameterless ctor, so a parameter-only
         /// class throws MissingMemberException ("does not define a parameterless constructor") and breaks the
@@ -65,7 +65,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         /// dock (see GodotMcpPlugin's reload re-entry), so this re-instantiated shell is a discarded orphan —
         /// it only has to exist without faulting.
         /// </summary>
-        public SkillsPanel() {{ }}
+        public SkillsPanel() { }
 
         public SkillsPanel(GodotMcpConnection connection)
         {

--- a/addons/godot_mcp/Runtime/Tools/GodotScriptErrorLogger.cs
+++ b/addons/godot_mcp/Runtime/Tools/GodotScriptErrorLogger.cs
@@ -62,7 +62,19 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         // engine Logger (OS.RemoveLogger/AddLogger), so the single registered logger always feeds whichever
         // ScriptErrorCapture is current. Volatile so the rebind written on the main (install) thread is visible
         // to the engine's multi-threaded _LogError callback without a lock on the hot error path.
-        volatile ScriptErrorCapture _capture;
+        // Nullable because the parameterless ctor (hot-reload re-instantiation, below) leaves it unset — that
+        // orphan never gets registered with the engine, so it is never routed into; _LogError null-guards it.
+        volatile ScriptErrorCapture? _capture;
+
+        /// <summary>
+        /// Parameterless ctor for Godot's C# hot-reload bridge (godotengine/godot#51626): a "Build Project"
+        /// reload re-instantiates every live engine-registered <see cref="Logger"/> via its parameterless ctor,
+        /// so a parameter-only class throws <c>MissingMemberException</c> and breaks the reload. Our teardown
+        /// removed the REAL logger via <c>OS.RemoveLogger</c> before the reload, and the reloaded plugin
+        /// re-installs a fresh one, so this re-instantiated shell is a never-routed-into orphan — <see cref="_capture"/>
+        /// stays null and <see cref="_LogError"/> null-guards it.
+        /// </summary>
+        public GodotScriptErrorLogger() { }
 
         public GodotScriptErrorLogger(ScriptErrorCapture capture)
         {
@@ -75,7 +87,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         /// routing engine errors to a stale capture (whose sink feeds a collector the current handle no longer
         /// reads — the #160 silent-quiet failure).
         /// </summary>
-        public ScriptErrorCapture Capture => _capture;
+        public ScriptErrorCapture? Capture => _capture;
 
         /// <summary>
         /// Repoint this already-registered logger at a NEW <paramref name="capture"/> WITHOUT touching
@@ -106,6 +118,13 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             // otherwise bind 'Godot.Collections' to 'com.IvanMurzak.Godot.Collections' (CS0234).
             global::Godot.Collections.Array<global::Godot.ScriptBacktrace> scriptBacktraces)
         {
+            // Null-guard the router: a hot-reload-re-instantiated orphan (parameterless ctor) has no capture
+            // and is never the registered logger, but guard defensively so a stray engine callback is a no-op
+            // rather than a NullReferenceException escaping back into the engine's log path.
+            var capture = _capture;
+            if (capture == null)
+                return;
+
             // Materialize the deep multi-frame backtrace NOW, on the originating thread, while the
             // non-thread-safe ScriptBacktrace objects are still valid in this callback's frame. The result is
             // pure managed primitives — safe to forward across the thread boundary into the collector. Any
@@ -124,7 +143,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 stackTrace = null;
             }
 
-            _capture.Route(
+            capture.Route(
                 kind: MapKind(errorType),
                 filePath: file,
                 line: line,

--- a/scripts/dock_reload_harness.py
+++ b/scripts/dock_reload_harness.py
@@ -43,7 +43,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import signal
 import subprocess
 import sys
 import time
@@ -179,8 +178,18 @@ def main() -> int:
         # 4) The decisive assertion: the dock must be in-tree again after the reload.
         ok, dock = wait_for_dock(base_url, args.reload_deadline, args.request_timeout)
         if not ok:
-            log("::error::dock did NOT survive the in-session C# rebuild — diagInsideTree is not true after the "
-                "reload (the godot#51626 'missing AI Game Developer tab' regression).")
+            # Distinguish the two failure causes: dock is None means /state never answered (the
+            # dev-control bridge — which lives on the freed dock — never re-bound after the reload),
+            # vs a dock dict whose diagInsideTree is not true (the bridge re-bound but the dock itself
+            # did not re-register). Both are the godot#51626 regression, but the cause differs.
+            if dock is None:
+                log("::error::the dev-control bridge never answered /state after the reload — the "
+                    "dock+bridge were freed by the ALC unload and never re-registered (godot#51626 "
+                    "'missing AI Game Developer tab' regression).")
+            else:
+                log("::error::dock did NOT survive the in-session C# rebuild — the bridge re-bound but "
+                    "diagInsideTree is not true after the reload (the godot#51626 'missing AI Game "
+                    "Developer tab' regression).")
             log(f"[harness] last /state dock: {dock!r}")
             return 1
 
@@ -193,7 +202,9 @@ def main() -> int:
     finally:
         # Always stop the editor + flush the log.
         try:
-            editor.send_signal(signal.SIGTERM)
+            # terminate() is cross-platform (SIGTERM on POSIX, TerminateProcess on Windows) so the
+            # documented Windows local-repro path works as well as the ubuntu-only CI gate.
+            editor.terminate()
             editor.wait(timeout=15)
         except Exception:
             try:

--- a/scripts/dock_reload_harness.py
+++ b/scripts/dock_reload_harness.py
@@ -90,13 +90,17 @@ def count_marker(log_path: str, marker: str) -> int:
 
 def trigger_in_session_rebuild(csproj: str, touch_file: str, config: str) -> None:
     """Rewrite the project assembly on disk so Godot's HotReloadAssemblyWatcher reloads it in-session."""
-    # Touch a source file so the incremental build actually re-emits the assembly (a newer mtime is
-    # what is_assembly_reloading_needed() checks). os.utime to "now" is enough.
+    # Touch a source file so the build sees a changed input. The mtime bump alone is NOT enough to
+    # guarantee a fresh DLL: an incremental `dotnet build` can decide nothing changed and skip the
+    # compile, so the assembly mtime never advances and Godot's HotReloadAssemblyWatcher (which compares
+    # assembly mtime) never fires — the harness would then fail RED for an infra reason, not the
+    # regression. --no-incremental forces a full rebuild that ALWAYS re-emits the assembly with a newer
+    # write time, making the in-session reload trigger deterministic across the whole Godot matrix.
     now = time.time()
     os.utime(touch_file, (now, now))
-    log(f"[harness] touched {touch_file}; rebuilding to produce a newer assembly ...")
+    log(f"[harness] touched {touch_file}; full (non-incremental) rebuild to produce a newer assembly ...")
     proc = subprocess.run(
-        ["dotnet", "build", csproj, "--configuration", config],
+        ["dotnet", "build", csproj, "--configuration", config, "--no-incremental"],
         capture_output=True, text=True,
     )
     if proc.returncode != 0:
@@ -136,11 +140,16 @@ def main() -> int:
 
     log(f"[harness] booting headless editor: {args.godot} --headless --path {args.project} --editor")
     log_fh = open(log_file, "w", encoding="utf-8")
-    # Hold the editor OPEN (no --quit): the in-session reload needs a live session.
-    editor = subprocess.Popen(
-        [args.godot, "--headless", "--path", args.project, "--editor"],
-        stdout=log_fh, stderr=subprocess.STDOUT, env=env,
-    )
+    # Hold the editor OPEN (no --quit): the in-session reload needs a live session. Spawn inside a guard
+    # so a Popen failure (e.g. the godot binary is missing) closes the log handle instead of leaking it.
+    try:
+        editor = subprocess.Popen(
+            [args.godot, "--headless", "--path", args.project, "--editor"],
+            stdout=log_fh, stderr=subprocess.STDOUT, env=env,
+        )
+    except Exception:
+        log_fh.close()
+        raise
 
     rc = 1
     try:

--- a/scripts/dock_reload_harness.py
+++ b/scripts/dock_reload_harness.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+In-session C# rebuild dock-survival harness — the godotengine/godot#51626 guard.
+
+WHAT IT PROVES
+  The "AI Game Developer" editor dock must SURVIVE a Godot in-session C# rebuild ("Build Project").
+  On such a rebuild Godot hot-reloads the addon's collectible AssemblyLoadContext: the addon's
+  Teardown frees the dock, and (UNFIXED) the re-instantiated EditorPlugin never re-adds it, so the
+  dock silently disappears until the addon is disabled/re-enabled. A plain `--editor --quit` boot
+  does NOT exercise this — only an IN-SESSION rebuild does, which is what this harness triggers.
+
+HOW IT WORKS (no extra Godot CLI flag — a real in-session reload)
+  1. Boots a HEADLESS editor (`--editor`, held open) with the DEV-ONLY dev-control bridge enabled
+     (GODOT_MCP_DEV_CONTROL=1) so it can be polled over loopback HTTP.
+  2. Polls `GET /state` and asserts the dock is in the editor dock tree (`diagInsideTree == true`).
+  3. Triggers a GENUINE in-session rebuild by rewriting the project assembly on disk (`dotnet build`
+     after touching a source file). Godot's HotReloadAssemblyWatcher (a 0.5s editor Timer) detects
+     the newer DLL and runs `reload_assemblies` → ALC unload → the addon's reload re-entry.
+  4. Waits for the reload (the editor log prints "assembly unloading" then a SECOND "plugin loaded"),
+     then polls `GET /state` again and asserts the dock is STILL in-tree (`diagInsideTree == true`).
+
+  On the UNFIXED addon the dev-control bridge (which lives on the freed dock) never comes back, so
+  step 4's `/state` poll never succeeds within the deadline → the harness fails RED. On the FIXED
+  addon the reloaded plugin re-registers a fresh dock + bridge and `/state` reports the dock back.
+
+UPSTREAM NOISE (tolerated, never gated on)
+  Godot's own reload emits "An item with the same key has already been added" for some [Tool] classes
+  in generic-heavy assemblies (godotengine/godot #79519 / #87877 / #98094 / #110784). It is non-fatal
+  engine noise — this harness does NOT gate on it.
+
+USAGE
+  python scripts/dock_reload_harness.py \
+      --godot /path/to/Godot_..._console.exe \
+      --project Godot-Tests \
+      --csproj Godot-Tests/Godot-Tests.csproj \
+      --port 9920
+
+  Exit 0 = dock present before AND after the in-session rebuild. Non-zero = the dock did not survive
+  (or never appeared). Pure stdlib (urllib/subprocess) — runs anywhere Python 3.8+ does.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+def log(msg: str) -> None:
+    print(msg, flush=True)
+
+
+def get_state(base_url: str, timeout: float):
+    """GET /state -> the parsed "dock" object, or None on any error (bridge down)."""
+    url = base_url.rstrip("/") + "/state"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            if resp.status != 200:
+                return None
+            return json.loads(resp.read().decode()).get("dock", {})
+    except (urllib.error.URLError, OSError, json.JSONDecodeError):
+        return None
+
+
+def wait_for_dock(base_url: str, deadline_s: float, timeout: float):
+    """Poll /state until the dock reports diagInsideTree == true, or the deadline passes."""
+    end = time.time() + deadline_s
+    last = None
+    while time.time() < end:
+        dock = get_state(base_url, timeout)
+        if dock is not None:
+            last = dock
+            if str(dock.get("diagInsideTree")).lower() == "true":
+                return True, dock
+        time.sleep(1.0)
+    return False, last
+
+
+def count_marker(log_path: str, marker: str) -> int:
+    try:
+        with open(log_path, "r", encoding="utf-8", errors="replace") as f:
+            return f.read().count(marker)
+    except OSError:
+        return 0
+
+
+def trigger_in_session_rebuild(csproj: str, touch_file: str, config: str) -> None:
+    """Rewrite the project assembly on disk so Godot's HotReloadAssemblyWatcher reloads it in-session."""
+    # Touch a source file so the incremental build actually re-emits the assembly (a newer mtime is
+    # what is_assembly_reloading_needed() checks). os.utime to "now" is enough.
+    now = time.time()
+    os.utime(touch_file, (now, now))
+    log(f"[harness] touched {touch_file}; rebuilding to produce a newer assembly ...")
+    proc = subprocess.run(
+        ["dotnet", "build", csproj, "--configuration", config],
+        capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        log("[harness] rebuild FAILED:")
+        log(proc.stdout[-2000:])
+        log(proc.stderr[-2000:])
+        raise SystemExit(3)
+    log("[harness] rebuild OK (assembly rewritten).")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="In-session C# rebuild dock-survival harness (godot#51626).")
+    p.add_argument("--godot", required=True, help="path to the Godot mono editor binary (console variant preferred).")
+    p.add_argument("--project", required=True, help="path to the Godot project dir to open (--path).")
+    p.add_argument("--csproj", required=True, help="path to the project's .csproj to `dotnet build` for the rebuild.")
+    p.add_argument("--touch-file", default=None,
+                   help="source file to touch before the rebuild (default: <project>/addons/godot_mcp/Editor/GodotMcpPlugin.cs).")
+    p.add_argument("--config", default="Debug", help="dotnet build configuration (default Debug).")
+    p.add_argument("--port", type=int, default=9920, help="dev-control bridge port (default 9920).")
+    p.add_argument("--log-file", default=None, help="editor log path (default <project>/harness-editor.log).")
+    p.add_argument("--boot-deadline", type=float, default=90.0, help="seconds to wait for the dock on first boot.")
+    p.add_argument("--reload-deadline", type=float, default=90.0, help="seconds to wait for the dock to return after the rebuild.")
+    p.add_argument("--request-timeout", type=float, default=8.0, help="per-request timeout seconds.")
+    args = p.parse_args()
+
+    base_url = f"http://127.0.0.1:{args.port}"
+    log_file = args.log_file or os.path.join(args.project, "harness-editor.log")
+    touch_file = args.touch_file or os.path.join(args.project, "addons", "godot_mcp", "Editor", "GodotMcpPlugin.cs")
+
+    if not os.path.isfile(touch_file):
+        log(f"FATAL: touch file not found: {touch_file}")
+        return 2
+
+    env = dict(os.environ)
+    env["GODOT_MCP_DEV_CONTROL"] = "1"
+    env["GODOT_MCP_DEV_CONTROL_PORT"] = str(args.port)
+
+    log(f"[harness] booting headless editor: {args.godot} --headless --path {args.project} --editor")
+    log_fh = open(log_file, "w", encoding="utf-8")
+    # Hold the editor OPEN (no --quit): the in-session reload needs a live session.
+    editor = subprocess.Popen(
+        [args.godot, "--headless", "--path", args.project, "--editor"],
+        stdout=log_fh, stderr=subprocess.STDOUT, env=env,
+    )
+
+    rc = 1
+    try:
+        # 1) First boot: assert the dock is in the editor dock tree.
+        log("[harness] waiting for the dock on first boot ...")
+        ok, dock = wait_for_dock(base_url, args.boot_deadline, args.request_timeout)
+        if not ok:
+            log("::error::dock NOT present on first boot — the bridge/dock never came up.")
+            log(f"[harness] last /state dock: {dock!r}")
+            return 1
+        log(f"[harness] BOOT OK: dock in-tree (diagParentType={dock.get('diagParentType')}, "
+            f"diagParentPath={dock.get('diagParentPath')}).")
+        boot_loaded = count_marker(log_file, "[Godot-MCP] plugin loaded")
+
+        # 2) Trigger a genuine in-session rebuild (rewrite the DLL on disk).
+        trigger_in_session_rebuild(args.csproj, touch_file, args.config)
+
+        # 3) Wait for the reload to actually happen (the addon logs "assembly unloading"), THEN assert the
+        #    dock comes back. We poll the log for the unload marker first so we never falsely pass on the
+        #    pre-reload state, then poll /state for diagInsideTree == true.
+        log("[harness] waiting for the in-session ALC reload to fire ...")
+        unload_deadline = time.time() + args.reload_deadline
+        reloaded = False
+        while time.time() < unload_deadline:
+            if count_marker(log_file, "[Godot-MCP] assembly unloading") >= 1:
+                reloaded = True
+                break
+            time.sleep(1.0)
+        if not reloaded:
+            log("::error::the in-session ALC reload never fired (no 'assembly unloading' in the editor log) — "
+                "the HotReloadAssemblyWatcher did not pick up the rebuilt assembly.")
+            return 1
+        log("[harness] reload fired (ALC unloading). Asserting the dock SURVIVES ...")
+
+        # 4) The decisive assertion: the dock must be in-tree again after the reload.
+        ok, dock = wait_for_dock(base_url, args.reload_deadline, args.request_timeout)
+        if not ok:
+            log("::error::dock did NOT survive the in-session C# rebuild — diagInsideTree is not true after the "
+                "reload (the godot#51626 'missing AI Game Developer tab' regression).")
+            log(f"[harness] last /state dock: {dock!r}")
+            return 1
+
+        after_loaded = count_marker(log_file, "[Godot-MCP] plugin loaded")
+        log(f"[harness] AFTER RELOAD: dock in-tree (diagParentType={dock.get('diagParentType')}). "
+            f"plugin-loaded count {boot_loaded} -> {after_loaded}.")
+        log("[harness] PASS — the dock survived the in-session C# rebuild.")
+        rc = 0
+        return rc
+    finally:
+        # Always stop the editor + flush the log.
+        try:
+            editor.send_signal(signal.SIGTERM)
+            editor.wait(timeout=15)
+        except Exception:
+            try:
+                editor.kill()
+            except Exception:
+                pass
+        try:
+            log_fh.close()
+        except Exception:
+            pass
+        # Echo a tail of the editor log for CI diagnosis.
+        try:
+            with open(log_file, "r", encoding="utf-8", errors="replace") as f:
+                tail = f.read().splitlines()[-60:]
+            log("----- editor log (tail) -----")
+            for line in tail:
+                log(line)
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Fix the "AI Game Developer" editor dock disappearing after a Godot in-session "Build Project" rebuild (godotengine/godot#51626): the C# hot-reload unloads the addon ALC → `Teardown` frees the dock, then re-instantiates the `EditorPlugin` **in place** (the native node never leaves the tree, so `_EnterTree` does not re-fire) and nothing re-adds the dock. `GodotMcpPlugin` now detects the reload in its ctor via `IsInsideTree()` and `CallDeferred`s a fresh boot that re-registers the dock + dev-control bridge.
- Add parameterless ctors to the `[Tool]` `GodotObject` classes the reload re-instantiates (dock + panels + rows + the engine-error `Logger`) so the reload no longer throws `MissingMemberException` / crashes the editor; the reloaded plugin re-adds a fresh wired dock, so these re-instantiated shells are discarded orphans.
- Add `diagInsideTree` / `diagParentPath` / `diagParentType` to the dock's dev-control `/state` so a headless harness can assert the dock is actually wired into the editor dock tree.
- New `scripts/dock_reload_harness.py` + reusable `test_godot_dock_reload.yml`: boots a headless editor held open with the dev-control bridge, triggers a **genuine in-session rebuild** (rewrites the project assembly on disk → Godot's `HotReloadAssemblyWatcher` hot-reloads it), and asserts the dock **survives**. Wired across the full Godot mono matrix (4.3.0/4.4.0/4.5.1/4.6.3/4.7.0) on **both** `test_pull_request.yml` and `release.yml` (kept in lockstep; the deterministic guard is in the `release-addon` gate's `needs:`).

## Test plan
- [x] Suite 1 `dotnet build Godot-MCP.sln` — 0 errors.
- [x] Suite 2 `dotnet test Godot-MCP.Tests` — 920 passed / 0 failed (no regression).
- [x] `scripts/check-runtime-boundary.py` — 0 violations.
- [x] Harness proven **RED** on the pre-fix addon (reload re-entry disabled → dock gone, bridge down, exit 1) and **GREEN** after the fix (dock survives, exit 0) on Godot 4.5.1 mono — including against the real `Godot-Tests` CI project with the exact workflow invocation.
- [ ] Full remote rollup (5-version dock-reload matrix + existing legs) green on PR CI — to be confirmed by the CI-wait iteration.

Note: the upstream "An item with the same key has already been added" reload noise (godotengine/godot #79519/#87877/#98094/#110784, generic-heavy assemblies) is non-fatal and is intentionally **not** gated on.