### PR TITLE
fix(script): precise script-validate diagnostics + class_name self-hide suppression

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -141,6 +141,12 @@
     <Compile Include="..\addons\godot_mcp\Runtime\Data\ScriptDiagnostic.cs" Link="Source\ScriptDiagnostic.cs" />
     <Compile Include="..\addons\godot_mcp\Runtime\Data\ScriptDiagnosticsResult.cs" Link="Source\ScriptDiagnosticsResult.cs" />
     <Compile Include="..\addons\godot_mcp\Runtime\Tools\ScriptErrorCapture.cs" Link="Source\ScriptErrorCapture.cs" />
+    <!-- script-validate diagnostics POST-FILTER — pure-managed (no Godot native types, no #if TOOLS): the
+         class_name extractor + global-class self-hide false-positive predicate (issue #194). The editor
+         Validate handler (Tool_Script.Validate.cs, #if TOOLS) calls it to drop the spurious "Class X hides a
+         global script class" row a class_name file's own probe re-declaration triggers; the classification is
+         unit-tested here, the live editor wiring via the headless Godot smoke (test.md Suite 3). -->
+    <Compile Include="..\addons\godot_mcp\Runtime\Tools\ScriptDiagnosticsFilter.cs" Link="Source\ScriptDiagnosticsFilter.cs" />
     <!-- In-game runtime ERROR CAPTURE (issue #160) — pure-managed pieces only (no Godot native types, no
          #if TOOLS): the RuntimeError row + source enum, the RuntimeErrorsResult model, the bounded ring-buffer
          RuntimeErrorCollector (monotonic sequence + since-marker poll), the RuntimeErrorFactory (engine-record

--- a/Godot-MCP.Tests/ScriptDiagnosticsTests.cs
+++ b/Godot-MCP.Tests/ScriptDiagnosticsTests.cs
@@ -270,6 +270,70 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Equal(2, capture.EndSession().Length);
         }
 
+        // ---- ScriptErrorCapture: anonymous probe-path attribution (issue #194) --------------------
+
+        [Theory]
+        [InlineData("gdscript://-9223369043698707884.gd", true)]
+        [InlineData("GDScript://anything.gd", true)]            // scheme is matched case-insensitively
+        [InlineData("res://scripts/ai.gd", false)]
+        [InlineData(@"C:\proj\scripts\ai.gd", false)]
+        [InlineData("user://x.gd", false)]
+        [InlineData("", false)]
+        [InlineData(null, false)]
+        public void IsAnonymousProbePath_DetectsSyntheticGdScriptScheme(string? path, bool expected)
+        {
+            Assert.Equal(expected, ScriptErrorCapture.IsAnonymousProbePath(path));
+        }
+
+        [Fact]
+        public void Session_AnonymousProbePath_IsAttributedToSessionTarget()
+        {
+            // The validate probe is a throwaway GDScript with no ResourcePath, so Godot tags its parse error
+            // with a synthetic 'gdscript://<hash>.gd' name. Before #194 the path-match filter DROPPED that row
+            // (it never equals the res:// target) -> zero structured rows -> generic ParseError fallback. It
+            // must now be KEPT and re-stamped with the file actually under validation.
+            var capture = new ScriptErrorCapture();
+            capture.BeginSession("res://scripts/ai.gd");
+
+            capture.Route(EngineErrorKind.Script, "gdscript://-9223369043698707884.gd", 3,
+                "cond", "Parse Error: Unexpected token.");
+
+            var only = Assert.Single(capture.EndSession());
+            Assert.Equal("res://scripts/ai.gd", only.Path);   // remapped to the real file, not the synthetic name
+            Assert.Equal(3, only.Line);
+            Assert.Equal("Parse Error: Unexpected token.", only.Message);
+        }
+
+        [Fact]
+        public void Route_AnonymousProbePath_LogSink_ShowsSessionTarget_NotSyntheticName()
+        {
+            // console-get-logs (the passive LogSink) must surface the real res:// path during validation, not
+            // the confusing throwaway 'gdscript://<hash>.gd' temp name the engine assigns the probe (#194 #3).
+            var lines = new System.Collections.Generic.List<string>();
+            var capture = new ScriptErrorCapture { LogSink = (_, m) => lines.Add(m) };
+            capture.BeginSession("res://scripts/board.gd");
+
+            capture.Route(EngineErrorKind.Script, "gdscript://-42.gd", 5, "cond", "boom");
+
+            var line = Assert.Single(lines);
+            Assert.Contains("res://scripts/board.gd:5", line);
+            Assert.DoesNotContain("gdscript://", line);
+        }
+
+        [Fact]
+        public void Route_AnonymousProbePath_NoSession_LeavesSyntheticNameInLog()
+        {
+            // With no validation session there is nothing to attribute the synthetic path to, so it is left as
+            // reported (the remap is strictly a validation-session convenience, not a global rewrite).
+            var lines = new System.Collections.Generic.List<string>();
+            var capture = new ScriptErrorCapture { LogSink = (_, m) => lines.Add(m) };
+
+            capture.Route(EngineErrorKind.Script, "gdscript://-42.gd", 5, "cond", "boom");
+
+            var line = Assert.Single(lines);
+            Assert.Contains("gdscript://-42.gd", line);
+        }
+
         [Fact]
         public void Route_IsThreadSafe_OnlyTargetFileSurvivesConcurrentNoise()
         {
@@ -339,6 +403,110 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             };
             list.Sort((a, b) => a.Severity.CompareTo(b.Severity));
             Assert.Equal(ScriptDiagnosticSeverity.Error, list.First().Severity);
+        }
+    }
+
+    /// <summary>
+    /// Pure-managed coverage for <see cref="ScriptDiagnosticsFilter"/> (issue #194): the <c>class_name</c>
+    /// extractor and the global-class self-hide false-positive predicate the editor validator uses to drop the
+    /// spurious "Class X hides a global script class" row a class_name file's own probe re-declaration triggers.
+    /// No Godot binary required (pure string classification), so these run in the default parallel pool.
+    /// </summary>
+    public class ScriptDiagnosticsFilterTests
+    {
+        // ---- ExtractClassNames -------------------------------------------------------------------
+
+        [Fact]
+        public void ExtractClassNames_FindsSingleDeclaration()
+        {
+            var names = ScriptDiagnosticsFilter.ExtractClassNames("class_name AI\nextends RefCounted\n");
+            var only = Assert.Single(names);
+            Assert.Equal("AI", only);
+        }
+
+        [Fact]
+        public void ExtractClassNames_FindsDeclaration_AfterExtends()
+        {
+            // Godot 4 allows `extends` first, then `class_name` on its own line.
+            var names = ScriptDiagnosticsFilter.ExtractClassNames("extends Control\nclass_name Board\n");
+            Assert.Equal(new[] { "Board" }, names);
+        }
+
+        [Fact]
+        public void ExtractClassNames_NoDeclaration_ReturnsEmpty()
+        {
+            Assert.Empty(ScriptDiagnosticsFilter.ExtractClassNames("extends Node\nfunc _ready():\n\tpass\n"));
+        }
+
+        [Fact]
+        public void ExtractClassNames_IgnoresCommentedAndMidLineTokens()
+        {
+            // A `class_name` inside a comment, or not at line-start, is NOT a real declaration.
+            var src = "# class_name Ghost\nextends Node\nvar x = \"class_name Nope\"\n";
+            Assert.Empty(ScriptDiagnosticsFilter.ExtractClassNames(src));
+        }
+
+        [Fact]
+        public void ExtractClassNames_NullOrEmpty_ReturnsEmpty()
+        {
+            Assert.Empty(ScriptDiagnosticsFilter.ExtractClassNames(null));
+            Assert.Empty(ScriptDiagnosticsFilter.ExtractClassNames(""));
+        }
+
+        // ---- IsGlobalClassSelfHide ---------------------------------------------------------------
+
+        [Theory]
+        [InlineData("Class \"AI\" hides a global script class.")]
+        [InlineData("Parse Error: Class \"AI\" hides a global script class.")]   // engine "Parse Error:" prefix tolerated
+        [InlineData("class \"AI\" HIDES A GLOBAL SCRIPT CLASS")]                  // marker matched case-insensitively
+        public void IsGlobalClassSelfHide_True_ForDeclaredClassNameHide(string message)
+        {
+            var declared = new[] { "AI" };
+            Assert.True(ScriptDiagnosticsFilter.IsGlobalClassSelfHide(message, declared));
+        }
+
+        [Fact]
+        public void IsGlobalClassSelfHide_False_ForGenuineParseError()
+        {
+            var declared = new[] { "AI" };
+            Assert.False(ScriptDiagnosticsFilter.IsGlobalClassSelfHide(
+                "Unexpected identifier \"asdfasdf\" in class body.", declared));
+        }
+
+        [Fact]
+        public void IsGlobalClassSelfHide_False_WhenHiddenClassIsNotDeclaredByThisFile()
+        {
+            // A genuine conflict against ANOTHER file's global class name (not one THIS file declares) must NOT
+            // be suppressed — only the file's OWN self-hide is the false positive.
+            var declared = new[] { "AI" };
+            Assert.False(ScriptDiagnosticsFilter.IsGlobalClassSelfHide(
+                "Class \"Board\" hides a global script class.", declared));
+        }
+
+        [Fact]
+        public void IsGlobalClassSelfHide_False_WhenFileDeclaresNoClassName()
+        {
+            Assert.False(ScriptDiagnosticsFilter.IsGlobalClassSelfHide(
+                "Class \"AI\" hides a global script class.", System.Array.Empty<string>()));
+        }
+
+        [Fact]
+        public void IsGlobalClassSelfHide_RequiresWholeIdentifierMatch_NotSubstring()
+        {
+            // "AI" must not match as a substring of "MAIN"/"AItem"; the message names a different class.
+            var declared = new[] { "AI" };
+            Assert.False(ScriptDiagnosticsFilter.IsGlobalClassSelfHide(
+                "Class \"MAIN\" hides a global script class.", declared));
+        }
+
+        [Fact]
+        public void IsGlobalClassSelfHide_Overload_ExtractsFromSource()
+        {
+            const string source = "class_name Board\nextends RefCounted\n";
+            Assert.True(ScriptDiagnosticsFilter.IsGlobalClassSelfHide(
+                "Class \"Board\" hides a global script class.", source));
+            Assert.False(ScriptDiagnosticsFilter.IsGlobalClassSelfHide(
+                "Some unrelated parse error.", source));
         }
     }
 

--- a/Godot-MCP.Tests/ScriptDiagnosticsTests.cs
+++ b/Godot-MCP.Tests/ScriptDiagnosticsTests.cs
@@ -447,6 +447,17 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         }
 
         [Fact]
+        public void ExtractClassNames_FindsDeclaration_WithNonAsciiIdentifier()
+        {
+            // GDScript 4 permits Unicode letters in identifiers, so `class_name Αρχή` is valid. The extractor's
+            // capture group is Unicode-aware (\p{L}\p{Nd}) — an ASCII-only [A-Za-z0-9_] class would return empty
+            // here, leaving the #194 self-hide false positive un-suppressed for non-ASCII class_name files.
+            var names = ScriptDiagnosticsFilter.ExtractClassNames("class_name Αρχή\nextends RefCounted\n");
+            var only = Assert.Single(names);
+            Assert.Equal("Αρχή", only);
+        }
+
+        [Fact]
         public void ExtractClassNames_NullOrEmpty_ReturnsEmpty()
         {
             Assert.Empty(ScriptDiagnosticsFilter.ExtractClassNames(null));
@@ -507,6 +518,20 @@ namespace com.IvanMurzak.Godot.MCP.Tests
                 "Class \"Board\" hides a global script class.", source));
             Assert.False(ScriptDiagnosticsFilter.IsGlobalClassSelfHide(
                 "Some unrelated parse error.", source));
+        }
+
+        [Fact]
+        public void IsGlobalClassSelfHide_True_ForNonAsciiDeclaredClassName()
+        {
+            // End-to-end #194 reproduction for a non-ASCII class_name: extraction (Unicode-aware capture) AND the
+            // whole-identifier match (IsIdentifierChar uses char.IsLetterOrDigit, already Unicode-aware) must agree
+            // so the self-hide row is suppressed. With an ASCII-only extractor this returned false (un-suppressed).
+            const string source = "class_name Αρχή\nextends RefCounted\n";
+            Assert.True(ScriptDiagnosticsFilter.IsGlobalClassSelfHide(
+                "Class \"Αρχή\" hides a global script class.", source));
+            // A genuine conflict against a DIFFERENT (non-ASCII) class this file does not declare is NOT suppressed.
+            Assert.False(ScriptDiagnosticsFilter.IsGlobalClassSelfHide(
+                "Class \"Τέλος\" hides a global script class.", source));
         }
     }
 

--- a/addons/godot_mcp/Editor/Tools/Tool_Script.Validate.cs
+++ b/addons/godot_mcp/Editor/Tools/Tool_Script.Validate.cs
@@ -188,6 +188,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             var capture = ScriptErrorCapture.Current;
             capture?.BeginSession(resPath);
             Error err;
+            ScriptDiagnostic[] captured = Array.Empty<ScriptDiagnostic>();
             using (var probe = new GDScript { SourceCode = content })
             {
                 try
@@ -197,22 +198,38 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 finally
                 {
                     if (capture != null)
-                    {
-                        var captured = capture.EndSession();
-                        diagnostics.AddRange(captured);
-                    }
+                        captured = capture.EndSession();
                 }
             }
+            diagnostics.AddRange(captured);
 
             // 4.5+ precise path: the session captured the engine's script errors for THIS file (the session's
-            // path-match filter restricts rows to resPath, plus any pathless rows the engine emitted, which are
-            // stamped with resPath below). When present, those structured rows ARE the diagnostics.
-            if (capture != null && diagnostics.Count > 0)
+            // path-match filter restricts rows to resPath — including the throwaway probe's anonymous
+            // 'gdscript://' rows, which ScriptErrorCapture.Route remaps onto resPath, issue #194 — plus any
+            // pathless rows the engine emitted, stamped with resPath below). Gate on whether the session
+            // captured ANY structured rows (NOT on diagnostics.Count): when it did, those rows ARE the
+            // diagnostics and we must NOT also fall through to the coarse Error-code fallback below — even if
+            // self-hide suppression empties the list (a valid class_name script must end up ok:true, not get a
+            // generic ParseError re-added).
+            if (capture != null && captured.Length > 0)
             {
                 // Stamp the path on any rows the engine reported without a file (defensive).
                 foreach (var d in diagnostics)
                     if (string.IsNullOrEmpty(d.Path))
                         d.Path = resPath;
+
+                // Suppress the global-class self-hide FALSE POSITIVE (issue #194): validating a real file's
+                // source through a throwaway probe re-declares any 'class_name X' the file owns, so Godot
+                // reports 'Class "X" hides a global script class.' against X's already-registered global —
+                // which is the file's OWN registration. The real file is valid and opens cleanly in the editor,
+                // so drop those rows (keyed on a class_name the file under validation itself declares). Genuine
+                // parse errors in the same file (and class_name conflicts against OTHER files' names) are
+                // unaffected. Pure-managed classification (ScriptDiagnosticsFilter) so it is CI-unit-tested.
+                var declaredClassNames = ScriptDiagnosticsFilter.ExtractClassNames(content);
+                if (declaredClassNames.Count > 0)
+                    diagnostics.RemoveAll(d =>
+                        ScriptDiagnosticsFilter.IsGlobalClassSelfHide(d.Message, declaredClassNames));
+
                 return diagnostics;
             }
 

--- a/addons/godot_mcp/Runtime/Tools/ScriptDiagnosticsFilter.cs
+++ b/addons/godot_mcp/Runtime/Tools/ScriptDiagnosticsFilter.cs
@@ -43,10 +43,14 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         /// Matches a top-level GDScript <c>class_name &lt;Identifier&gt;</c> declaration and captures the
         /// declared name. Anchored at line start (after optional leading whitespace) so a <c>class_name</c>
         /// token inside a comment (<c># class_name Foo</c>) or mid-expression is not picked up. <c>class_name</c>
-        /// must precede an identifier (letter/underscore then word chars). Multiline + culture-invariant.
+        /// must precede an identifier: a Unicode letter or underscore, then Unicode letters / decimal digits /
+        /// underscores — GDScript 4 permits non-ASCII identifiers (e.g. <c>class_name Αρχή</c>), so the capture
+        /// uses <c>\p{L}</c>/<c>\p{Nd}</c> rather than ASCII-only classes, keeping it consistent with
+        /// <see cref="IsIdentifierChar"/> (which already uses the Unicode-aware <c>char.IsLetterOrDigit</c>).
+        /// Multiline + culture-invariant.
         /// </summary>
         static readonly Regex ClassNameDeclPattern = new(
-            @"^[ \t]*class_name[ \t]+([A-Za-z_][A-Za-z0-9_]*)",
+            @"^[ \t]*class_name[ \t]+([\p{L}_][\p{L}\p{Nd}_]*)",
             RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
         /// <summary>

--- a/addons/godot_mcp/Runtime/Tools/ScriptDiagnosticsFilter.cs
+++ b/addons/godot_mcp/Runtime/Tools/ScriptDiagnosticsFilter.cs
@@ -1,0 +1,126 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// Pure-managed post-processing for <c>script-validate</c> diagnostics — the classification logic that
+    /// decides which engine-reported rows are GENUINE errors versus artifacts of validating a file's source
+    /// through a throwaway probe. Kept binary-free (no Godot API, no <c>#if TOOLS</c>) so it is unit-testable
+    /// in the plain xUnit host, mirroring the <see cref="ScriptErrorCapture"/> router it complements.
+    ///
+    /// <para>
+    /// The one artifact this filters is the <b>global-class self-hide false positive</b> (issue #194). The
+    /// validator reloads a throwaway <c>GDScript</c> built from a real project file's source to harvest its
+    /// parse errors. If that file declares <c>class_name X</c>, Godot has ALREADY registered <c>X</c> as a
+    /// global script class (from the on-disk file itself), so reloading the probe — whose source re-declares
+    /// <c>class_name X</c> — makes the engine emit <c>Class "X" hides a global script class.</c>. That row is
+    /// spurious: the real file is valid and opens without error in the editor; the "conflict" is the file
+    /// hiding its OWN registration. This filter drops exactly those rows (a "hides a global script class"
+    /// message whose class name is one the file under validation itself declares), so a valid
+    /// <c>class_name</c> script validates <c>ok:true</c> with no diagnostics.
+    /// </para>
+    /// </summary>
+    public static class ScriptDiagnosticsFilter
+    {
+        /// <summary>The engine's stable marker for the self-hide parse error (Godot's GDScript parser emits
+        /// <c>Class "%s" hides a global script class.</c>). Matched case-insensitively as a substring so a
+        /// <c>"Parse Error: "</c> prefix or a trailing period does not defeat it.</summary>
+        const string HidesGlobalClassMarker = "hides a global script class";
+
+        /// <summary>
+        /// Matches a top-level GDScript <c>class_name &lt;Identifier&gt;</c> declaration and captures the
+        /// declared name. Anchored at line start (after optional leading whitespace) so a <c>class_name</c>
+        /// token inside a comment (<c># class_name Foo</c>) or mid-expression is not picked up. <c>class_name</c>
+        /// must precede an identifier (letter/underscore then word chars). Multiline + culture-invariant.
+        /// </summary>
+        static readonly Regex ClassNameDeclPattern = new(
+            @"^[ \t]*class_name[ \t]+([A-Za-z_][A-Za-z0-9_]*)",
+            RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+        /// <summary>
+        /// Extract every <c>class_name</c> a GDScript source declares (usually zero or one; a file can only
+        /// register one global class, but this returns all matches defensively). Pure string parsing — no
+        /// engine call. Returns an empty list when <paramref name="source"/> is null/empty or declares none.
+        /// </summary>
+        public static IReadOnlyList<string> ExtractClassNames(string? source)
+        {
+            var names = new List<string>();
+            if (string.IsNullOrEmpty(source))
+                return names;
+
+            foreach (Match m in ClassNameDeclPattern.Matches(source))
+            {
+                var name = m.Groups[1].Value;
+                if (name.Length > 0 && !names.Contains(name))
+                    names.Add(name);
+            }
+            return names;
+        }
+
+        /// <summary>
+        /// True when <paramref name="message"/> is the benign global-class self-hide false positive for a
+        /// class the validated file itself declares (issue #194): the message carries the engine's
+        /// "hides a global script class" marker AND names one of <paramref name="declaredClassNames"/>. The
+        /// engine quotes the offending name (<c>Class "X" hides ...</c>); rather than depend on the exact quote
+        /// glyph, the name is matched as a whole identifier token anywhere in the message. Returns false when
+        /// the file declares no class_name (nothing to self-hide) or the message is some other error.
+        /// </summary>
+        public static bool IsGlobalClassSelfHide(string? message, IReadOnlyCollection<string> declaredClassNames)
+        {
+            if (string.IsNullOrEmpty(message) || declaredClassNames == null || declaredClassNames.Count == 0)
+                return false;
+
+            if (message!.IndexOf(HidesGlobalClassMarker, StringComparison.OrdinalIgnoreCase) < 0)
+                return false;
+
+            foreach (var name in declaredClassNames)
+                if (ContainsWholeIdentifier(message, name))
+                    return true;
+
+            return false;
+        }
+
+        /// <summary>Convenience overload: extract the class names from <paramref name="source"/> and test the
+        /// message against them in one call (the shape the editor validator uses).</summary>
+        public static bool IsGlobalClassSelfHide(string? message, string? source)
+            => IsGlobalClassSelfHide(message, ExtractClassNames(source));
+
+        /// <summary>
+        /// Whether <paramref name="word"/> occurs in <paramref name="haystack"/> bounded on both sides by a
+        /// non-identifier character (or a string edge) — so <c>"AI"</c> matches <c>Class "AI" hides…</c> but
+        /// not the <c>AI</c> inside <c>MAIN</c> or <c>AItem</c>. Ordinal (GDScript identifiers are
+        /// case-sensitive).
+        /// </summary>
+        static bool ContainsWholeIdentifier(string haystack, string word)
+        {
+            if (string.IsNullOrEmpty(word))
+                return false;
+
+            int idx = 0;
+            while ((idx = haystack.IndexOf(word, idx, StringComparison.Ordinal)) >= 0)
+            {
+                var leftOk = idx == 0 || !IsIdentifierChar(haystack[idx - 1]);
+                var end = idx + word.Length;
+                var rightOk = end >= haystack.Length || !IsIdentifierChar(haystack[end]);
+                if (leftOk && rightOk)
+                    return true;
+                idx = end;
+            }
+            return false;
+        }
+
+        static bool IsIdentifierChar(char c) => char.IsLetterOrDigit(c) || c == '_';
+    }
+}

--- a/addons/godot_mcp/Runtime/Tools/ScriptErrorCapture.cs
+++ b/addons/godot_mcp/Runtime/Tools/ScriptErrorCapture.cs
@@ -218,15 +218,36 @@ namespace com.IvanMurzak.Godot.MCP.Tools
 
             var logType = kind == EngineErrorKind.Warning ? GodotLogType.Warning : GodotLogType.Error;
 
+            // issue #194: the script-validate tool reloads a THROWAWAY GDScript with no ResourcePath to harvest
+            // a file's parse errors, so Godot tags those errors with a synthetic 'gdscript://<hash>.gd' name
+            // instead of the real res:// path. While a validation session targets a specific file, remap that
+            // synthetic path to the file actually under validation. This fixes BOTH user-visible symptoms: the
+            // captured diagnostic (and console-get-logs line) now carries the real res:// path, AND the row is
+            // no longer dropped by the path-match filter below (a 'gdscript://' path never equals the res://
+            // target), which previously left validation with zero structured rows → the generic-ParseError
+            // fallback. Only the probe (reloaded synchronously on this thread during the session) produces an
+            // anonymous path, so attributing it to the session target is safe; real off-thread errors carry a
+            // res:// / absolute path and are unaffected. The remap is gated on an open session targeting a file.
+            var effectivePath = filePath;
+            if (IsAnonymousProbePath(filePath))
+            {
+                lock (_gate)
+                {
+                    if (_sessionTarget != null)
+                        effectivePath = _sessionTarget;
+                }
+            }
+
             // Passive capture: surface a path:line prefix so console-get-logs is self-describing.
-            LogSink?.Invoke(logType, FormatLogLine(kind, filePath, line, text));
+            LogSink?.Invoke(logType, FormatLogLine(kind, effectivePath, line, text));
 
             // Structured capture (in-game runtime): forward the full origin + deep backtrace so
             // runtime-errors-get can return file/line/function/type AND the multi-frame stack, not just a
             // flattened line. Always fires (errors are not session-gated). Wrapped for parity with the in-game
             // C# fault handlers: this runs on the engine's (multi-threaded) log callback, so a throwing sink
-            // must never escape back into the engine.
-            try { ErrorSink?.Invoke(new EngineErrorRecord(kind, filePath, line, function, text, frames, stackTrace)); }
+            // must never escape back into the engine. (In-game there is never a validation session, so
+            // effectivePath == filePath there; the remap only ever changes an editor-validation probe path.)
+            try { ErrorSink?.Invoke(new EngineErrorRecord(kind, effectivePath, line, function, text, frames, stackTrace)); }
             catch { /* a captured engine-error sink must never throw back into the engine callback */ }
 
             // Validation capture: only script errors, only while a session is open.
@@ -244,20 +265,33 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 // dependency error in ANOTHER script) can fire mid-session and would otherwise be silently
                 // mis-attributed to the file under validation. An empty engine path is kept (the caller stamps
                 // the target path on it) since the engine occasionally omits the source for a script error.
+                // The throwaway probe's anonymous 'gdscript://' path was already remapped to the session target
+                // above, so it passes this filter (matches the target) and is correctly recorded for this file.
                 if (_sessionTarget != null
-                    && !string.IsNullOrEmpty(filePath)
-                    && !PathsMatch(filePath, _sessionTarget))
+                    && !string.IsNullOrEmpty(effectivePath)
+                    && !PathsMatch(effectivePath, _sessionTarget))
                 {
                     return;
                 }
 
                 _session.Add(new ScriptDiagnostic(
-                    path: filePath ?? string.Empty,
+                    path: effectivePath ?? string.Empty,
                     line: line,
                     message: text,
                     severity: ScriptDiagnosticSeverity.Error));
             }
         }
+
+        /// <summary>
+        /// True when <paramref name="path"/> is Godot's synthetic <c>gdscript://&lt;hash&gt;.gd</c> name for a
+        /// <c>GDScript</c> that has no resource path — e.g. the throwaway probe the <c>script-validate</c> tool
+        /// reloads to harvest a file's parse errors (issue #194). Such a path never names a real file on disk,
+        /// so while a validation session is open the router remaps it to the file actually under validation.
+        /// Pure string check (no engine call), so it is unit-testable in the binary-less host.
+        /// </summary>
+        public static bool IsAnonymousProbePath(string? path)
+            => !string.IsNullOrEmpty(path)
+               && path!.StartsWith("gdscript://", StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
         /// Compare an engine-reported source path against the session target. The session target is always a


### PR DESCRIPTION
## Summary
- `script-validate` reloads a throwaway `GDScript` (no `ResourcePath`) to harvest a file's parse errors, so Godot 4.5 tags those errors with a synthetic `gdscript://<hash>.gd` path. The session path-match filter then dropped every row (it never equals the `res://` target) → zero structured rows → the generic `"ParseError (engine reported no structured location)."` fallback, and `console-get-logs` surfaced the confusing temp path. **Fix:** `ScriptErrorCapture.Route` now remaps an anonymous `gdscript://` probe path onto the active validation session target, so the row survives the filter and both the captured diagnostic and the passive console log carry the real `res://` path + line.
- Files declaring `class_name X` falsely failed with `Class "X" hides a global script class` — the probe re-declares the file's OWN already-registered global class. **Fix:** `Tool_Script.Validate.ValidateOne` gates the precise/coarse decision on whether the session captured ANY structured rows (not on `diagnostics.Count`) and drops the self-hide false positive for a `class_name` the file itself declares, via the new pure-managed `ScriptDiagnosticsFilter`. A valid `class_name` script now validates `ok:true`.

## Test plan
- [x] Suite 1 — `dotnet build Godot-MCP.sln` (CI parity): 0 errors.
- [x] Suite 2 — `dotnet test Godot-MCP.Tests`: **943 passed / 0 failed**, including 23 new tests (anonymous `gdscript://` path attribution + `class_name` self-hide classification).
- [ ] Suite 3 (operator-only, not a pipeline gate) — live Godot 4.5.1 editor end-to-end (`script-validate` over a real MCP connection) pending operator. The load-bearing live behavior (Godot 4.5 reporting `gdscript://<hash>.gd` for an unset-`ResourcePath` probe Reload) is already demonstrated by the reporter's console output in the issue.

Closes #194