### PR TITLE
refactor(tools): consolidate duplicated editor-tool guard helpers

### DIFF
--- a/addons/godot_mcp/Editor/Tools/EditorToolGuards.cs
+++ b/addons/godot_mcp/Editor/Tools/EditorToolGuards.cs
@@ -1,0 +1,100 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#if TOOLS
+#nullable enable
+using System;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// Shared guard helpers for the editor-only (<c>#if TOOLS</c>) tool families. These centralize the
+    /// small, repeated precondition checks several <c>Tool_*</c> handlers previously performed inline:
+    /// resolving the edited scene root / editor resource filesystem (throwing a consistent error when the
+    /// editor is in a state that makes the operation impossible), asserting a resource exists, validating a
+    /// ClassDB class name before instantiating it, and creating a target directory on demand. Behavior is
+    /// identical to the inlined checks they replace — this is a pure de-duplication.
+    ///
+    /// <para>
+    /// Every helper touches a Godot editor/native API (<see cref="EditorInterface"/>, <see cref="ClassDB"/>,
+    /// <see cref="DirAccess"/>, <see cref="ResourceLoader"/>), so the whole class lives behind
+    /// <c>#if TOOLS</c> and is exercised via the headless Godot smoke (test.md Suite 3), not the plain-xUnit
+    /// host. Callers must already be on the editor main thread (the <c>Tool_*</c> handlers invoke these from
+    /// inside their <c>MainThread.Instance.Run(...)</c> body).
+    /// </para>
+    /// </summary>
+    internal static class EditorToolGuards
+    {
+        /// <summary>
+        /// The currently-edited scene root, or throw when no scene is open. Pass <paramref name="message"/>
+        /// to override the default "no edited scene" text for a call site with a more specific intent.
+        /// Main-thread only.
+        /// </summary>
+        internal static Node GetEditedSceneRootOrThrow(string? message = null)
+            => EditorInterface.Singleton.GetEditedSceneRoot()
+                ?? throw new Exception(message ?? "No scene is currently being edited.");
+
+        /// <summary>
+        /// The editor's resource filesystem, or throw when it is unavailable. Main-thread only.
+        /// </summary>
+        internal static EditorFileSystem GetResourceFileSystemOrThrow()
+            => EditorInterface.Singleton.GetResourceFilesystem()
+                ?? throw new Exception("Editor resource filesystem is not available.");
+
+        /// <summary>
+        /// Throw an <see cref="ArgumentException"/> (attributed to <paramref name="paramName"/>) when no
+        /// resource exists at <paramref name="resPath"/>. Pass <paramref name="message"/> to override the
+        /// default text for a call site that phrases the miss differently. Main-thread only.
+        /// </summary>
+        internal static void RequireResourceExists(string resPath, string paramName, string? message = null)
+        {
+            if (!ResourceLoader.Exists(resPath))
+                throw new ArgumentException(message ?? $"No resource exists at '{resPath}'.", paramName);
+        }
+
+        /// <summary>
+        /// Validate a Godot <paramref name="className"/> and instantiate it as <typeparamref name="T"/>,
+        /// throwing an <see cref="ArgumentException"/> (attributed to <paramref name="paramName"/>) when the
+        /// class is unknown, cannot be instantiated, does not derive from
+        /// <paramref name="requireParentClass"/> (when supplied), or does not instantiate to
+        /// <typeparamref name="T"/>. Returns the validated, freshly-instantiated instance. Main-thread only.
+        /// </summary>
+        internal static T ValidateClassDbInstantiation<[MustBeVariant] T>(
+            string className, string paramName, string? requireParentClass = null)
+            where T : GodotObject
+        {
+            if (!ClassDB.ClassExists(className))
+                throw new ArgumentException($"Unknown Godot class '{className}'.", paramName);
+            if (!ClassDB.CanInstantiate(className))
+                throw new ArgumentException($"Godot class '{className}' cannot be instantiated (abstract/virtual).", paramName);
+            if (requireParentClass != null && !ClassDB.IsParentClass(className, requireParentClass))
+                throw new ArgumentException($"Godot class '{className}' does not derive from {requireParentClass}.", paramName);
+
+            return ClassDB.Instantiate(className).As<T>()
+                ?? throw new ArgumentException($"Godot class '{className}' did not instantiate to a {typeof(T).Name}.", paramName);
+        }
+
+        /// <summary>
+        /// Ensure <paramref name="absDir"/> exists, creating it recursively when missing and throwing on
+        /// failure. Mirrors the "ResourceSaver/FileAccess does not create parent dirs" guard the create-style
+        /// tools share. Main-thread only.
+        /// </summary>
+        internal static void EnsureDirectoryExists(string absDir)
+        {
+            if (!DirAccess.DirExistsAbsolute(absDir))
+            {
+                var mkErr = DirAccess.MakeDirRecursiveAbsolute(absDir);
+                if (mkErr != Error.Ok)
+                    throw new Exception($"Failed to create target directory '{absDir}': {mkErr}.");
+            }
+        }
+    }
+}
+#endif

--- a/addons/godot_mcp/Editor/Tools/Tool_FileSystem.List.cs
+++ b/addons/godot_mcp/Editor/Tools/Tool_FileSystem.List.cs
@@ -46,8 +46,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             {
                 var dirPath = ResPathNormalizer.NormalizeDir(path);
 
-                var efs = EditorInterface.Singleton.GetResourceFilesystem()
-                    ?? throw new Exception("Editor resource filesystem is not available.");
+                var efs = EditorToolGuards.GetResourceFileSystemOrThrow();
 
                 var dir = efs.GetFilesystemPath(dirPath)
                     ?? throw new ArgumentException($"Directory '{dirPath}' was not found in the project filesystem.", nameof(path));

--- a/addons/godot_mcp/Editor/Tools/Tool_FileSystem.Reimport.cs
+++ b/addons/godot_mcp/Editor/Tools/Tool_FileSystem.Reimport.cs
@@ -46,8 +46,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         {
             return MainThread.Instance.Run(() =>
             {
-                var efs = EditorInterface.Singleton.GetResourceFilesystem()
-                    ?? throw new Exception("Editor resource filesystem is not available.");
+                var efs = EditorToolGuards.GetResourceFileSystemOrThrow();
 
                 var hasFiles = files != null && files.Count > 0;
 

--- a/addons/godot_mcp/Editor/Tools/Tool_Node.Create.cs
+++ b/addons/godot_mcp/Editor/Tools/Tool_Node.Create.cs
@@ -52,8 +52,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         {
             return MainThread.Instance.Run(() =>
             {
-                var root = EditorInterface.Singleton.GetEditedSceneRoot()
-                    ?? throw new Exception("No scene is currently being edited; open or create a scene first.");
+                var root = EditorToolGuards.GetEditedSceneRootOrThrow("No scene is currently being edited; open or create a scene first.");
 
                 // Resolve the parent (default: edited scene root). An explicit parentNodeRef must resolve
                 // (and throws when it does not) — only a genuinely-null ref falls back to the scene root.
@@ -68,8 +67,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 Node node;
                 if (!string.IsNullOrEmpty(instanceScenePath))
                 {
-                    if (!ResourceLoader.Exists(instanceScenePath))
-                        throw new ArgumentException($"No resource exists at '{instanceScenePath}'.", nameof(instanceScenePath));
+                    EditorToolGuards.RequireResourceExists(instanceScenePath, nameof(instanceScenePath));
 
                     var packed = ResourceLoader.Load<PackedScene>(instanceScenePath)
                         ?? throw new ArgumentException($"Resource at '{instanceScenePath}' is not a PackedScene.", nameof(instanceScenePath));
@@ -80,14 +78,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 else
                 {
                     var className = string.IsNullOrEmpty(typeClassName) ? "Node" : typeClassName!;
-                    if (!ClassDB.ClassExists(className))
-                        throw new ArgumentException($"Unknown Godot class '{className}'.", nameof(typeClassName));
-                    if (!ClassDB.CanInstantiate(className))
-                        throw new ArgumentException($"Godot class '{className}' cannot be instantiated (abstract/virtual).", nameof(typeClassName));
-
-                    var instance = ClassDB.Instantiate(className).As<Node>()
-                        ?? throw new ArgumentException($"Godot class '{className}' did not instantiate to a Node.", nameof(typeClassName));
-                    node = instance;
+                    node = EditorToolGuards.ValidateClassDbInstantiation<Node>(className, nameof(typeClassName));
                 }
 
                 if (!string.IsNullOrEmpty(name))

--- a/addons/godot_mcp/Editor/Tools/Tool_Node.Delete.cs
+++ b/addons/godot_mcp/Editor/Tools/Tool_Node.Delete.cs
@@ -39,8 +39,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         {
             return MainThread.Instance.Run(() =>
             {
-                var root = EditorInterface.Singleton.GetEditedSceneRoot()
-                    ?? throw new Exception("No scene is currently being edited.");
+                var root = EditorToolGuards.GetEditedSceneRootOrThrow();
 
                 var node = ResolveNode(nodeRef, out var error)
                     ?? throw new ArgumentException(error ?? "Node not found.", nameof(nodeRef));

--- a/addons/godot_mcp/Editor/Tools/Tool_Node.Duplicate.cs
+++ b/addons/godot_mcp/Editor/Tools/Tool_Node.Duplicate.cs
@@ -40,8 +40,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         {
             return MainThread.Instance.Run(() =>
             {
-                var root = EditorInterface.Singleton.GetEditedSceneRoot()
-                    ?? throw new Exception("No scene is currently being edited.");
+                var root = EditorToolGuards.GetEditedSceneRootOrThrow();
 
                 var node = ResolveNode(nodeRef, out var error)
                     ?? throw new ArgumentException(error ?? "Node not found.", nameof(nodeRef));

--- a/addons/godot_mcp/Editor/Tools/Tool_Node.SetParent.cs
+++ b/addons/godot_mcp/Editor/Tools/Tool_Node.SetParent.cs
@@ -45,8 +45,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         {
             return MainThread.Instance.Run(() =>
             {
-                var root = EditorInterface.Singleton.GetEditedSceneRoot()
-                    ?? throw new Exception("No scene is currently being edited.");
+                var root = EditorToolGuards.GetEditedSceneRootOrThrow();
 
                 var node = ResolveNode(nodeRef, out var error)
                     ?? throw new ArgumentException(error ?? "Node not found.", nameof(nodeRef));

--- a/addons/godot_mcp/Editor/Tools/Tool_Resource.Create.cs
+++ b/addons/godot_mcp/Editor/Tools/Tool_Resource.Create.cs
@@ -60,25 +60,13 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                         $"or '{ResourceMoveToolId}'/'{ResourceDeleteToolId}' to relocate/remove it first.", nameof(resourcePath));
 
                 var className = string.IsNullOrEmpty(typeClassName) ? "Resource" : typeClassName!;
-                if (!ClassDB.ClassExists(className))
-                    throw new ArgumentException($"Unknown Godot class '{className}'.", nameof(typeClassName));
-                if (!ClassDB.CanInstantiate(className))
-                    throw new ArgumentException($"Godot class '{className}' cannot be instantiated (abstract/virtual).", nameof(typeClassName));
-                if (!ClassDB.IsParentClass(className, "Resource"))
-                    throw new ArgumentException($"Godot class '{className}' does not derive from Resource.", nameof(typeClassName));
-
-                var resource = ClassDB.Instantiate(className).As<Resource>()
-                    ?? throw new ArgumentException($"Godot class '{className}' did not instantiate to a Resource.", nameof(typeClassName));
+                var resource = EditorToolGuards.ValidateClassDbInstantiation<Resource>(
+                    className, nameof(typeClassName), requireParentClass: "Resource");
 
                 // ResourceSaver.Save does NOT create missing parent directories — create them first so a
                 // nested target path (e.g. 'res://materials/wood.tres') works like Unity's CreateAsset.
                 var targetDir = ResPathNormalizer.ParentDir(resPath);
-                if (!DirAccess.DirExistsAbsolute(targetDir))
-                {
-                    var mkErr = DirAccess.MakeDirRecursiveAbsolute(targetDir);
-                    if (mkErr != Error.Ok)
-                        throw new Exception($"Failed to create target directory '{targetDir}': {mkErr}.");
-                }
+                EditorToolGuards.EnsureDirectoryExists(targetDir);
 
                 var saveErr = ResourceSaver.Save(resource, resPath);
                 if (saveErr != Error.Ok)

--- a/addons/godot_mcp/Editor/Tools/Tool_Resource.Find.cs
+++ b/addons/godot_mcp/Editor/Tools/Tool_Resource.Find.cs
@@ -68,8 +68,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             return MainThread.Instance.Run(() =>
             {
                 var result = new ResourceFindResult();
-                var efs = EditorInterface.Singleton.GetResourceFilesystem()
-                    ?? throw new Exception("Editor resource filesystem is not available.");
+                var efs = EditorToolGuards.GetResourceFileSystemOrThrow();
 
                 // 1) Direct lookup by uid (mapped to a res:// path).
                 if (hasUid)
@@ -87,8 +86,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                         ? (ResolveUidToPath(resourcePath!) ?? throw new ArgumentException($"uid '{resourcePath}' does not resolve to any resource.", nameof(resourcePath)))
                         : resourcePath!;
 
-                    if (!ResourceLoader.Exists(resPath))
-                        throw new ArgumentException($"No resource exists at '{resPath}'.", nameof(resourcePath));
+                    EditorToolGuards.RequireResourceExists(resPath, nameof(resourcePath));
 
                     AddSingle(result, resPath);
                     return result;

--- a/addons/godot_mcp/Editor/Tools/Tool_Scene.Create.cs
+++ b/addons/godot_mcp/Editor/Tools/Tool_Scene.Create.cs
@@ -53,13 +53,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                     throw new ArgumentException($"resourcePath must end with '.tscn' or '.scn'; got '{resourcePath}'.", nameof(resourcePath));
 
                 var className = string.IsNullOrEmpty(rootTypeClassName) ? "Node" : rootTypeClassName!;
-                if (!ClassDB.ClassExists(className))
-                    throw new ArgumentException($"Unknown Godot class '{className}'.", nameof(rootTypeClassName));
-                if (!ClassDB.CanInstantiate(className))
-                    throw new ArgumentException($"Godot class '{className}' cannot be instantiated.", nameof(rootTypeClassName));
-
-                var root = ClassDB.Instantiate(className).As<Node>()
-                    ?? throw new ArgumentException($"Godot class '{className}' did not instantiate to a Node.", nameof(rootTypeClassName));
+                var root = EditorToolGuards.ValidateClassDbInstantiation<Node>(className, nameof(rootTypeClassName));
 
                 if (!string.IsNullOrEmpty(rootName))
                     root.Name = rootName;
@@ -75,12 +69,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                     // nested target path (e.g. 'res://levels/level_2.tscn') saves instead of failing with
                     // CantOpen, matching Tool_Resource.Create and Unity's CreateAsset behavior.
                     var targetDir = ResPathNormalizer.ParentDir(resourcePath);
-                    if (!DirAccess.DirExistsAbsolute(targetDir))
-                    {
-                        var mkErr = DirAccess.MakeDirRecursiveAbsolute(targetDir);
-                        if (mkErr != Error.Ok)
-                            throw new Exception($"Failed to create target directory '{targetDir}': {mkErr}.");
-                    }
+                    EditorToolGuards.EnsureDirectoryExists(targetDir);
 
                     var saveErr = ResourceSaver.Save(packed, resourcePath);
                     if (saveErr != Error.Ok)
@@ -97,8 +86,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                 EditorInterface.Singleton.GetResourceFilesystem().UpdateFile(resourcePath);
                 EditorInterface.Singleton.OpenSceneFromPath(resourcePath);
 
-                var editedRoot = EditorInterface.Singleton.GetEditedSceneRoot()
-                    ?? throw new Exception($"Created '{resourcePath}' but the editor has no edited scene root afterwards.");
+                var editedRoot = EditorToolGuards.GetEditedSceneRootOrThrow($"Created '{resourcePath}' but the editor has no edited scene root afterwards.");
 
                 return ToActiveSceneData(editedRoot);
             });

--- a/addons/godot_mcp/Editor/Tools/Tool_Scene.GetData.cs
+++ b/addons/godot_mcp/Editor/Tools/Tool_Scene.GetData.cs
@@ -43,8 +43,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         {
             return MainThread.Instance.Run(() =>
             {
-                var root = EditorInterface.Singleton.GetEditedSceneRoot()
-                    ?? throw new Exception("No scene is currently being edited.");
+                var root = EditorToolGuards.GetEditedSceneRootOrThrow();
 
                 // Walk the whole tree when -1 is requested; otherwise honor the explicit bound. A very
                 // large sentinel is used for "unbounded" so Tool_Node.ToNodeData can stay depth-counted.

--- a/addons/godot_mcp/Editor/Tools/Tool_Scene.Open.cs
+++ b/addons/godot_mcp/Editor/Tools/Tool_Scene.Open.cs
@@ -43,8 +43,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             {
                 if (!resourcePath.StartsWith("res://", StringComparison.Ordinal))
                     throw new ArgumentException($"resourcePath must be a 'res://' path; got '{resourcePath}'.", nameof(resourcePath));
-                if (!ResourceLoader.Exists(resourcePath))
-                    throw new ArgumentException($"No scene resource exists at '{resourcePath}'.", nameof(resourcePath));
+                EditorToolGuards.RequireResourceExists(resourcePath, nameof(resourcePath), $"No scene resource exists at '{resourcePath}'.");
 
                 EditorInterface.Singleton.OpenSceneFromPath(resourcePath);
 

--- a/addons/godot_mcp/Editor/Tools/Tool_Scene.Save.cs
+++ b/addons/godot_mcp/Editor/Tools/Tool_Scene.Save.cs
@@ -41,8 +41,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         {
             return MainThread.Instance.Run(() =>
             {
-                var editedRoot = EditorInterface.Singleton.GetEditedSceneRoot()
-                    ?? throw new Exception("No scene is currently being edited; nothing to save.");
+                var editedRoot = EditorToolGuards.GetEditedSceneRootOrThrow("No scene is currently being edited; nothing to save.");
 
                 if (!string.IsNullOrEmpty(path))
                 {

--- a/addons/godot_mcp/Editor/Tools/Tool_Script.cs
+++ b/addons/godot_mcp/Editor/Tools/Tool_Script.cs
@@ -167,12 +167,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             // nested target (e.g. 'res://scripts/ai/Brain.cs') works, mirroring Tool_Resource.Create.
             var slash = resPath.LastIndexOf('/');
             var targetDir = slash >= 0 ? resPath.Substring(0, slash + 1) : ResPathNormalizer.ResScheme;
-            if (!DirAccess.DirExistsAbsolute(targetDir))
-            {
-                var mkErr = DirAccess.MakeDirRecursiveAbsolute(targetDir);
-                if (mkErr != Error.Ok)
-                    throw new Exception($"Failed to create target directory '{targetDir}': {mkErr}.");
-            }
+            EditorToolGuards.EnsureDirectoryExists(targetDir);
 
             using (var file = FileAccess.Open(resPath, FileAccess.ModeFlags.Write))
             {

--- a/addons/godot_mcp/Editor/UI/Agents/GodotAgentConfigurators.cs
+++ b/addons/godot_mcp/Editor/UI/Agents/GodotAgentConfigurators.cs
@@ -43,8 +43,13 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents
         /// <summary>Every Godot-visible configurator, in display order (Custom last, Unity AI excluded).</summary>
         public static IReadOnlyList<AgentConfig.AiAgentConfigurator> All => _configurators;
 
+        // The display names, materialized once: the underlying configurator set is fixed at compile time
+        // (the shared registry is static and immutable), so there is no need to rebuild the list per read.
+        static readonly IReadOnlyList<string> _agentNames =
+            _configurators.Select(c => c.AgentName).ToList();
+
         /// <summary>The display names, in display order — populates the dock's agent dropdown.</summary>
-        public static IReadOnlyList<string> AgentNames => _configurators.Select(c => c.AgentName).ToList();
+        public static IReadOnlyList<string> AgentNames => _agentNames;
 
         /// <summary>The configurator with the given <paramref name="agentId"/>, or null when absent / id is empty / excluded.</summary>
         public static AgentConfig.AiAgentConfigurator? GetByAgentId(string? agentId)


### PR DESCRIPTION
## Summary

Tier-1 `/simplify` cleanup — **pure de-duplication, zero behavior change**. Extracts the repeated precondition/guard boilerplate scattered across `addons/godot_mcp/Editor/Tools/*` into a new internal static `EditorToolGuards` (behind `#if TOOLS`, same `com.IvanMurzak.Godot.MCP.Tools` namespace):

- **`GetEditedSceneRootOrThrow(message?)`** — replaces **7** inline `GetEditedSceneRoot() ?? throw` sites (Node Create/Delete/Duplicate/SetParent, Scene Create/GetData/Save). Each call's existing throw message is preserved exactly via the optional override; the 4 bare sites share the default.
- **`GetResourceFileSystemOrThrow()`** — **3** identical `GetResourceFilesystem() ?? throw "Editor resource filesystem is not available."` sites (FileSystem List/Reimport, Resource.Find).
- **`RequireResourceExists(path, paramName, message?)`** — **3** `ResourceLoader.Exists` guards (Node.Create, Resource.Find, Scene.Open). Scene.Open keeps its distinct *"No scene resource exists…"* wording via the override param.
- **`ValidateClassDbInstantiation<T>(className, paramName, requireParentClass?)`** — the `ClassDB.ClassExists`/`CanInstantiate`/`.As<T>() ?? throw` validation in the **3** `*.Create` tools. Resource.Create's extra *derive-from-Resource* check is preserved via `requireParentClass: "Resource"`.
- **`EnsureDirectoryExists(absDir)`** — the dir-create-or-throw guard in Resource.Create, Scene.Create, and Script's write path (**3** sites).
- **`GodotAgentConfigurators.AgentNames`** is now a cached `static readonly` list instead of rebuilding via `.Select(...).ToList()` on every read (the configurator set is fixed at compile time).

### Behavior-preservation notes
- Every exception message is preserved verbatim, **except** `Scene.Create`'s "cannot be instantiated." which gains the "(abstract/virtual)" suffix the sibling `*.Create` tools already used — same meaning, unified text. These guards are `#if TOOLS` (no xUnit coverage), so no test asserts on the strings.
- `Resource.Move`'s dir-create was intentionally left alone (distinct *"destination directory"* wording); `Tool_Resource.cs` / `Tool_Script.cs` `GetResourceFilesystem()` sites use `?.`/return-not-throw and were left alone.

### Deferred (brief item 7)
The `ProjectSettings.GlobalizePath("res://").TrimEnd('/')` helper was **deferred**: its ~7 sites span Editor/UI, Editor/Extensions **and** Runtime/Connection (`GodotMcpConnection.cs`), crossing the editor/runtime module boundary and flagged in the task as collision-risk. Left as-is to keep this PR scoped to the editor-tool guards (the stated priority).

No NuGet pin (`ReflectorNet` 5.3.1 / `McpPlugin` 6.10.0) or `plugin.cfg` changes.

## Test plan
- [x] `dotnet build Godot-MCP.sln --configuration Debug` — 0 errors (14 pre-existing warnings, unchanged)
- [x] `dotnet test Godot-MCP.Tests` — **945 passed / 0 failed**