### PR TITLE
refactor(addon): introduce ErrorCaptureManager owning error-capture channels (PR-1)

### DIFF
--- a/Godot-MCP.Tests/ErrorCaptureManagerTests.cs
+++ b/Godot-MCP.Tests/ErrorCaptureManagerTests.cs
@@ -1,0 +1,245 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.Godot.MCP.Tools;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Direct coverage for <see cref="ErrorCaptureManager"/> — the instance-based lifecycle coordinator that owns
+    /// the engine-logger channel install/rebind/teardown and the statics-clearing policy for the error/log
+    /// capture layer (PR-1, channel-unify). The manager's native touches (<c>OS.AddLogger</c>/<c>OS.RemoveLogger</c>
+    /// via the bridge, <c>GD.Print</c>) are all behind delegate seams, so these tests drive it with PURE-MANAGED
+    /// recording lambdas and assert install/teardown WITHOUT any Godot binary.
+    ///
+    /// <para>
+    /// The manager's RUNTIME profile is ALSO exercised end-to-end by <see cref="RuntimeErrorCaptureRebindTests"/>
+    /// (which now delegates through the manager) — those pin the #171 rebind decision via the
+    /// <c>FakeEngineLoggerBridge</c>. This file pins what is unique to the manager facade: that the EDITOR profile
+    /// wires a passive <see cref="ScriptErrorCapture.LogSink"/>, that the RUNTIME profile wires a structured
+    /// <see cref="ScriptErrorCapture.ErrorSink"/> + publishes <see cref="RuntimeErrorCollector.Current"/>, that
+    /// <see cref="ErrorCaptureManager.Teardown"/> is the single statics-clearing owner (nulls
+    /// <see cref="ScriptErrorCapture.Current"/> via the bridge + <see cref="RuntimeErrorCollector.Current"/> for the
+    /// runtime profile), and — critically — that it NEVER nulls <see cref="GodotLogCollector.Current"/> (issue #173).
+    /// </para>
+    ///
+    /// <para>
+    /// These mutate process-wide statics (<see cref="ScriptErrorCapture.Current"/>,
+    /// <see cref="RuntimeErrorCollector.Current"/>, <see cref="GodotLogCollector.Current"/>), so this class joins the
+    /// shared serial <see cref="RuntimeErrorCaptureSerialCollection"/> and every test snapshots + restores those in
+    /// a finally.
+    /// </para>
+    /// </summary>
+    [Collection(RuntimeErrorCaptureSerialCollection.Name)]
+    public class ErrorCaptureManagerTests
+    {
+        // ── Editor profile ────────────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void InstallEditor_WiresPassiveLogSink_ToCollector_AndHandsCaptureToBridge()
+        {
+            WithCleanStatics(() =>
+            {
+                var collector = new GodotLogCollector();
+                ScriptErrorCapture? handed = null;
+
+                var manager = ErrorCaptureManager.InstallEditor(
+                    collector,
+                    bridgeInstall: c => { handed = c; return c; },
+                    bridgeUninstall: () => { },
+                    log: _ => { });
+
+                Assert.True(manager.IsInstalled);
+                Assert.NotNull(handed);
+                // The editor profile wires a passive LogSink (the console-get-logs path), NOT a structured ErrorSink.
+                Assert.NotNull(handed!.LogSink);
+                Assert.Null(handed.ErrorSink);
+
+                // Routing an engine error through the handed capture lands a flattened line in the collector.
+                Assert.Equal(0, collector.Count);
+                handed.Route(EngineErrorKind.Error, "res://x.gd", 12, message: null, rationale: "boom");
+                Assert.Equal(1, collector.Count);
+            });
+        }
+
+        [Fact]
+        public void InstallEditor_Teardown_NullsScriptCaptureCurrent_ViaBridge_AndLeavesLogCollector()
+        {
+            WithCleanStatics(() =>
+            {
+                var collector = new GodotLogCollector();
+                GodotLogCollector.Current = collector;          // the editor publishes the live buffer at boot
+                ScriptErrorCapture.Current = new ScriptErrorCapture();
+                RuntimeErrorCollector.Current = new RuntimeErrorCollector();
+                var bridgeUninstallCalls = 0;
+
+                var manager = ErrorCaptureManager.InstallEditor(
+                    collector,
+                    bridgeInstall: c => c,
+                    // Mirror GodotScriptErrorLoggerBridge.Uninstall: removes the logger + nulls Current.
+                    bridgeUninstall: () => { bridgeUninstallCalls++; ScriptErrorCapture.Current = null; },
+                    log: _ => { });
+
+                var runtimeBefore = RuntimeErrorCollector.Current;
+                manager.Teardown();
+
+                Assert.False(manager.IsInstalled);
+                Assert.Equal(1, bridgeUninstallCalls);
+                Assert.Null(ScriptErrorCapture.Current);                 // statics-clearing policy: bridge nulled it
+                Assert.Same(collector, GodotLogCollector.Current);       // #173: log buffer left readable
+                Assert.Same(runtimeBefore, RuntimeErrorCollector.Current); // editor teardown never touches it
+            });
+        }
+
+        // ── Runtime profile ───────────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void InstallRuntime_PublishesCollector_AndWiresStructuredErrorSink()
+        {
+            WithCleanStatics(() =>
+            {
+                ScriptErrorCapture? handed = null;
+
+                var manager = ErrorCaptureManager.InstallRuntime(
+                    bridgeInstall: c => { handed = c; return c; },
+                    bridgeUninstall: () => { },
+                    log: _ => { });
+
+                Assert.True(manager.IsInstalled);
+                Assert.NotNull(manager.RuntimeCollector);
+                Assert.Same(manager.RuntimeCollector, RuntimeErrorCollector.Current); // published
+
+                // The runtime profile wires a structured ErrorSink (runtime-errors-get path), NOT a LogSink.
+                Assert.NotNull(handed);
+                Assert.NotNull(handed!.ErrorSink);
+                Assert.Null(handed.LogSink);
+
+                // A routed engine error lands as a structured row in the published collector.
+                handed.Route(EngineErrorKind.Script, "res://p.gd", 5, message: null, rationale: "bad index",
+                    function: "_process");
+                Assert.Equal(1, manager.RuntimeCollector!.Count);
+                var row = manager.RuntimeCollector.QuerySince(0, 10, out _).Single();
+                Assert.Equal(RuntimeErrorSource.Engine, row.Source);
+                Assert.Equal("bad index", row.Message);
+                Assert.Equal("_process", row.Function);
+            });
+        }
+
+        [Fact]
+        public void InstallRuntime_FreshCapturePerInstall_BridgeReceivesDistinctRouters()
+        {
+            // The per-install capture freshness is load-bearing for the #171 rebind (a re-entrant install must
+            // resolve to Rebind, which it can only do if a NEW capture instance is handed in). Two installs ⇒ two
+            // distinct captures.
+            WithCleanStatics(() =>
+            {
+                var handed = new List<ScriptErrorCapture>();
+
+                var m1 = ErrorCaptureManager.InstallRuntime(
+                    bridgeInstall: c => { handed.Add(c); return c; }, bridgeUninstall: () => { }, log: _ => { });
+                m1.Teardown();
+                var m2 = ErrorCaptureManager.InstallRuntime(
+                    bridgeInstall: c => { handed.Add(c); return c; }, bridgeUninstall: () => { }, log: _ => { });
+                m2.Teardown();
+
+                Assert.Equal(2, handed.Count);
+                Assert.NotSame(handed[0], handed[1]);
+            });
+        }
+
+        [Fact]
+        public void InstallRuntime_Teardown_NullsRuntimeCollectorCurrent_AndCallsBridge_AndLeavesLogCollector()
+        {
+            WithCleanStatics(() =>
+            {
+                var logBuffer = new GodotLogCollector();
+                GodotLogCollector.Current = logBuffer;
+                var bridgeUninstallCalls = 0;
+
+                var manager = ErrorCaptureManager.InstallRuntime(
+                    bridgeInstall: c => c,
+                    bridgeUninstall: () => bridgeUninstallCalls++,
+                    log: _ => { });
+
+                Assert.NotNull(RuntimeErrorCollector.Current);
+                manager.Teardown();
+
+                Assert.False(manager.IsInstalled);
+                Assert.Equal(1, bridgeUninstallCalls);
+                Assert.Null(RuntimeErrorCollector.Current);          // statics-clearing policy: runtime collector cleared
+                Assert.Same(logBuffer, GodotLogCollector.Current);   // #173: log buffer left readable
+            });
+        }
+
+        // ── Idempotency + #173 ────────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Teardown_IsIdempotent_SecondCallIsNoOp_AndDoesNotThrow()
+        {
+            WithCleanStatics(() =>
+            {
+                var bridgeUninstallCalls = 0;
+                var manager = ErrorCaptureManager.InstallRuntime(
+                    bridgeInstall: c => c, bridgeUninstall: () => bridgeUninstallCalls++, log: _ => { });
+
+                manager.Teardown();
+                var ex = Record.Exception(() => manager.Teardown()); // second call
+
+                Assert.Null(ex);
+                Assert.Equal(1, bridgeUninstallCalls); // the bridge teardown ran exactly once
+                Assert.False(manager.IsInstalled);
+            });
+        }
+
+        [Fact]
+        public void Teardown_NeverNullsGodotLogCollectorCurrent_Issue173_BothProfiles()
+        {
+            WithCleanStatics(() =>
+            {
+                // Editor profile.
+                var editorBuffer = new GodotLogCollector();
+                GodotLogCollector.Current = editorBuffer;
+                ErrorCaptureManager.InstallEditor(editorBuffer, c => c, () => { }, _ => { }).Teardown();
+                Assert.Same(editorBuffer, GodotLogCollector.Current);
+
+                // Runtime profile (independent buffer).
+                var runtimeSessionBuffer = new GodotLogCollector();
+                GodotLogCollector.Current = runtimeSessionBuffer;
+                ErrorCaptureManager.InstallRuntime(c => c, () => { }, _ => { }).Teardown();
+                Assert.Same(runtimeSessionBuffer, GodotLogCollector.Current);
+            });
+        }
+
+        // ── helpers ───────────────────────────────────────────────────────────────────────────────────────────
+
+        /// <summary>Snapshot every process-wide static this suite touches and restore it in a finally, so a failed
+        /// assertion can never leak install state into a sibling test in the shared serial collection.</summary>
+        static void WithCleanStatics(Action body)
+        {
+            var priorScript = ScriptErrorCapture.Current;
+            var priorRuntime = RuntimeErrorCollector.Current;
+            var priorLog = GodotLogCollector.Current;
+            ScriptErrorCapture.Current = null;
+            RuntimeErrorCollector.Current = null;
+            GodotLogCollector.Current = null;
+            try { body(); }
+            finally
+            {
+                ScriptErrorCapture.Current = priorScript;
+                RuntimeErrorCollector.Current = priorRuntime;
+                GodotLogCollector.Current = priorLog;
+            }
+        }
+    }
+}

--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -299,6 +299,13 @@
          (it would touch the live engine and fault in this binary-less host), so it stays compiled-but-uncalled,
          exactly like GodotMcpRuntime.Build(). Its pure-managed mapping is unit-tested via RuntimeErrorFactory. -->
     <Compile Include="..\addons\godot_mcp\Runtime\RuntimeErrorCapture.cs" Link="Source\RuntimeErrorCapture.cs" />
+    <!-- Error-capture lifecycle coordinator — the instance-based facade RuntimeErrorCapture (and the editor
+         GodotMcpPlugin) delegate install/rebind/teardown to. Pure-managed (no Godot native types, no #if TOOLS,
+         references only the version-agnostic GodotScriptErrorLoggerBridge), so it is unit-testable here via the
+         existing FakeEngineLoggerBridge seam (ErrorCaptureManagerTests + the forwarded RuntimeErrorCaptureRebindTests).
+         The editor profile's OS.AddLogger/OS.RemoveLogger touches are behind delegate seams; verified live via the
+         headless Godot smoke (test.md Suite 3). -->
+    <Compile Include="..\addons\godot_mcp\Runtime\Tools\ErrorCaptureManager.cs" Link="Source\ErrorCaptureManager.cs" />
     <!-- Main-thread dispatcher pair — GodotMcpRuntime.EnsureMainThreadDispatcher references both. Pure-managed
          types (MainThreadDispatcher is a Godot Node, but constructing it is a Suite-3 concern; the runtime
          builder-only tests never instantiate it). Compiled in so the runtime sources resolve their usings. -->

--- a/addons/godot_mcp/Editor/GodotMcpPlugin.cs
+++ b/addons/godot_mcp/Editor/GodotMcpPlugin.cs
@@ -45,6 +45,12 @@ namespace com.IvanMurzak.Godot.MCP
         // _ExitTree. Lets a terminal / AI agent inject fake states + simulate user actions on the live dock.
         DevControlServer? _devControl;
 
+        // Owns the editor engine-logger channel lifecycle (install in _EnterTree, teardown in Teardown) via
+        // ErrorCaptureManager's editor profile — replacing the prior direct GodotScriptErrorLoggerBridge
+        // TryInstall/Uninstall call sites so the engine-logger install/teardown + statics-clearing live in one
+        // owner (the two scattered teardown clears collapsed into ErrorCaptureManager.Teardown).
+        ErrorCaptureManager? _errorCapture;
+
         // Guards Teardown() so the body runs at most once per plugin instance — it is reachable from BOTH
         // _ExitTree (the normal plugin-disable path) AND the GodotMcpAssemblyResolver.ReloadTeardown hook
         // (the Godot "Build Project" hot-reload path, which never calls _ExitTree). Whichever fires first
@@ -135,7 +141,15 @@ namespace com.IvanMurzak.Godot.MCP
             // not take down plugin load.
             try
             {
-                GodotScriptErrorLoggerBridge.TryInstall(GodotLogCollector.Current);
+                // Route the editor passive-log channel through ErrorCaptureManager's editor profile. It builds the
+                // same ScriptErrorCapture { LogSink = collector.Append } the bridge's GodotLogCollector overload did
+                // and installs it via GodotScriptErrorLoggerBridge.TryInstall (→ PlanBridgeInstall). The returned
+                // manager owns the teardown (OS.RemoveLogger + ScriptErrorCapture.Current null) in Teardown below.
+                _errorCapture = ErrorCaptureManager.InstallEditor(
+                    GodotLogCollector.Current,
+                    bridgeInstall: GodotScriptErrorLoggerBridge.TryInstall,
+                    bridgeUninstall: GodotScriptErrorLoggerBridge.Uninstall,
+                    log: Log);
             }
             catch (System.Exception ex)
             {
@@ -451,14 +465,17 @@ namespace com.IvanMurzak.Godot.MCP
             //    always run.
             if (MainThreadDispatcher.IsMainThread)
             {
-                // Remove the engine error Logger (4.5+) registered in _EnterTree via OS.AddLogger. THIS is the
+                // Tear down the editor engine-logger channel (4.5+) installed in _EnterTree. THIS is the
                 // godotengine/godot#78513 fix: the engine holds a strong handle to a GodotObject defined in the
                 // COLLECTIBLE addon assembly, which roots the hot-reload ALC and makes its unload fail with the
-                // ".NET: Failed to unload assemblies" flood. OS.RemoveLogger is an engine call and MUST run on
-                // the main thread (mirroring OS.AddLogger), so it lives inside this main-thread guard. Uninstall
-                // is idempotent + defensive (swallows removal failure) and also clears ScriptErrorCapture.Current.
-                try { GodotScriptErrorLoggerBridge.Uninstall(); }
+                // ".NET: Failed to unload assemblies" flood. ErrorCaptureManager.Teardown removes the engine Logger
+                // via the bridge (OS.RemoveLogger — an engine call that MUST run on the main thread, mirroring
+                // OS.AddLogger, so it lives inside this main-thread guard) AND nulls ScriptErrorCapture.Current,
+                // collapsing the two formerly-scattered editor clears into one owner. Idempotent + defensive
+                // (swallows removal failure).
+                try { _errorCapture?.Teardown(); }
                 catch (System.Exception ex) { TryLogTeardownError("engine-logger uninstall", ex); }
+                _errorCapture = null;
 
                 FreeNodes();
             }
@@ -475,12 +492,11 @@ namespace com.IvanMurzak.Godot.MCP
             //    NOTE: GodotLogCollector.Current is DELIBERATELY left in place (NOT nulled) — see the
             //    "Null the process-wide statics" item in this method's XML doc for the full rationale (#173).
 
-            // Drop the engine error-capture router unconditionally. On 4.5+ the main-thread guard above already
-            // called GodotScriptErrorLoggerBridge.Uninstall() (which removes the engine Logger via
-            // OS.RemoveLogger AND nulls Current); this pure-managed re-clear is a belt-and-suspenders that also
-            // covers the off-thread teardown path (where RemoveLogger is skipped) so a stale validation session
-            // never leaks across a reload regardless of which thread tore the plugin down.
-            try { ScriptErrorCapture.Current = null; } catch { /* swallow during unload */ }
+            // (The engine error-capture router teardown is now owned by ErrorCaptureManager.Teardown — called inside
+            //  the main-thread guard above — which removes the engine Logger AND nulls ScriptErrorCapture.Current in
+            //  one place. The prior pure-managed belt-and-suspenders `ScriptErrorCapture.Current = null` re-clear
+            //  here was removed as redundant per the error-capture-unification design: editor teardown always runs
+            //  on the main thread, so the guarded Teardown always runs.)
 
             // Drop ReflectorNet's static MainThread.Instance when it points at OUR GodotMainThread — one of the
             // two godot#78513 ALC pins (the other is the connection transport, bounded-joined in

--- a/addons/godot_mcp/Runtime/RuntimeErrorCapture.cs
+++ b/addons/godot_mcp/Runtime/RuntimeErrorCapture.cs
@@ -9,8 +9,6 @@
 */
 #nullable enable
 using System;
-using System.Threading.Tasks;
-using com.IvanMurzak.Godot.MCP.Data;
 using com.IvanMurzak.Godot.MCP.Tools;
 using Godot;
 
@@ -38,11 +36,23 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
     /// </para>
     ///
     /// <para>
+    /// <b>A thin runtime-profile facade over <see cref="ErrorCaptureManager"/>.</b> The lifecycle mechanics
+    /// (publish the collector, wire the engine logger via a fresh capture per install — the #171 rebind freshness —
+    /// subscribe/unsubscribe the C# fault hooks, the statics-clearing policy) live in
+    /// <see cref="ErrorCaptureManager"/>'s runtime profile. This class keeps the public <see cref="Install"/> /
+    /// <see cref="Uninstall"/> / <see cref="IsInstalled"/> surface its consumers (<c>GodotMcpRuntime</c>,
+    /// <c>GodotMcpRuntimeHandle</c>, the #165 leak-guard) already call, and forwards its own test seams
+    /// (<see cref="_bridgeInstallForTests"/> / <see cref="_bridgeUninstallForTests"/> / <see cref="_logForTests"/>)
+    /// into the manager ctor so the existing <c>RuntimeErrorCaptureRebindTests</c> / <c>RuntimeErrorCaptureTests</c>
+    /// drive the manager's runtime profile end-to-end unchanged.
+    /// </para>
+    ///
+    /// <para>
     /// <b>Default OFF / opt-in.</b> Nothing here runs unless the game explicitly enables it via
     /// <c>GodotMcpRuntime.Initialize(b =&gt; b.WithRuntimeErrorCapture())</c> (or by passing
     /// <c>captureRuntimeErrors: true</c>). No behavior change for a game that does not opt in. Idempotent:
-    /// a second <see cref="Install"/> is a no-op; <see cref="Uninstall"/> is safe to call when nothing is
-    /// installed and is invoked on handle dispose.
+    /// a second <see cref="Install"/> is a no-op (re-asserts the engine logger to the live collector);
+    /// <see cref="Uninstall"/> is safe to call when nothing is installed and is invoked on handle dispose.
     /// </para>
     ///
     /// <para>
@@ -55,10 +65,10 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
     public static class RuntimeErrorCapture
     {
         static readonly object _gate = new();
-        static bool _installed;
-        static RuntimeErrorCollector? _collector;
-        static UnhandledExceptionEventHandler? _domainHandler;
-        static EventHandler<UnobservedTaskExceptionEventArgs>? _taskHandler;
+
+        // The runtime-profile manager that owns the live channels (engine logger + C# fault hooks + the
+        // published RuntimeErrorCollector). Null when nothing is installed.
+        static ErrorCaptureManager? _manager;
 
         // ── Engine-logger bridge + log seams (issue #171) ─────────────────────────────────────────────────
         //
@@ -66,8 +76,9 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
         // call OS.AddLogger / OS.RemoveLogger — native Godot APIs that FAULT (AccessViolationException) in the
         // binary-less xUnit host. The install summary also calls GD.Print (native). These delegate seams let a
         // unit test substitute a PURE-MANAGED fake bridge + log so the re-entrant rebind path (install →
-        // independent bridge teardown → re-install) can be exercised and asserted without a Godot binary. In
-        // production all are null and the real static bridge / GD.Print run. Mirrors the
+        // independent bridge teardown → re-install) can be exercised and asserted without a Godot binary. They
+        // are read at Install()/Uninstall() time and forwarded into the ErrorCaptureManager ctor. In production
+        // all are null and the real static bridge / GD.Print run. Mirrors the
         // GodotMcpRuntime._installForTests / _uninstallForTests pattern. Internal: test-only.
         internal static Func<ScriptErrorCapture, ScriptErrorCapture?>? _bridgeInstallForTests;
         internal static Action? _bridgeUninstallForTests;
@@ -76,86 +87,43 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
         /// <summary>True while capture is installed (an engine logger and/or the C# fault hooks are live).</summary>
         public static bool IsInstalled
         {
-            get { lock (_gate) { return _installed; } }
+            get { lock (_gate) { return _manager?.IsInstalled ?? false; } }
         }
 
         /// <summary>
         /// Install all available capture channels and publish the backing <see cref="RuntimeErrorCollector"/>
         /// as <see cref="RuntimeErrorCollector.Current"/> so <c>runtime-errors-get</c> can read it. Idempotent
-        /// (a second call while installed is a no-op and returns the live collector). Each channel is wired
-        /// defensively — a failure to register one (e.g. the engine logger on an unexpected host) does not
-        /// abort the others. Returns the collector capturing runtime errors.
+        /// (a second call while installed re-asserts the engine logger to the live collector — the #171 rebind
+        /// re-entry — and returns it). Each channel is wired defensively — a failure to register one (e.g. the
+        /// engine logger on an unexpected host) does not abort the others. Returns the collector capturing
+        /// runtime errors. Delegates the lifecycle to <see cref="ErrorCaptureManager"/>'s runtime profile,
+        /// forwarding the current test seams (or the real bridge / <c>GD.Print</c> in production) into it.
         /// </summary>
         public static RuntimeErrorCollector Install()
         {
             lock (_gate)
             {
-                if (_installed && _collector != null)
+                if (_manager != null && _manager.IsInstalled)
                 {
-                    // Idempotent re-entry. The engine logger lives in the bridge's SEPARATE static
-                    // (GodotScriptErrorLoggerBridge._installed), not in our _installed flag, so it could have
-                    // been torn down independently (e.g. an editor-side Uninstall) while ours stayed true.
-                    // Re-assert it via a FRESH capture bound to _collector: if the bridge logger is gone the
-                    // bridge registers anew; if it is still live but on a STALE capture (issue #171), the bridge
-                    // REBINDS it to this fresh capture so engine errors route to _collector — the live collector
-                    // this handle reads — instead of a collector left orphaned by a prior install/uninstall cycle.
-                    TryInstallEngineLogger(_collector);
-                    return _collector;
+                    // Idempotent re-entry. The engine logger lives in the bridge's SEPARATE static, not in the
+                    // manager's _installed flag, so it could have been torn down independently (e.g. an editor-side
+                    // Uninstall) while ours stayed installed. Re-assert it via a FRESH capture bound to the live
+                    // collector: if the bridge logger is gone it registers anew; if it is live but on a STALE
+                    // capture (issue #171) it REBINDS to the fresh one so engine errors route to the live collector.
+                    _manager.ReassertRuntimeEngineLogger();
+                    return _manager.RuntimeCollector!;
                 }
 
-                var collector = new RuntimeErrorCollector();
-
-                // Publish state BEFORE wiring the fault hooks so a throw mid-subscribe still leaves the capture
-                // discoverable AND uninstallable: Uninstall() keys on _installed, and unsubscribes only the
-                // handlers it finds assigned — so a partially-installed pass never leaks a handler for the
-                // process lifetime.
-                RuntimeErrorCollector.Current = collector;
-                _collector = collector;
-                _installed = true;
-
-                // 1) Engine error stream (Godot 4.5+). Wire a structured ErrorSink so engine errors land as
-                //    full RuntimeError rows (file/line/function/type). On < 4.5 the bridge stub returns null —
-                //    this channel is absent; the C# channels below still capture managed faults.
-                var engineInstalled = TryInstallEngineLogger(collector);
-
-                // 2) C# unhandled exceptions — full managed stack trace. Field assigned first, then subscribed,
-                //    so even a throw between the two leaves Uninstall() with a handler reference to detach.
-                _domainHandler = (_, args) =>
-                {
-                    try
-                    {
-                        collector.Append(RuntimeErrorFactory.FromException(
-                            RuntimeErrorSource.UnhandledException, args.ExceptionObject as Exception));
-                    }
-                    catch { /* a fault handler must never throw */ }
-                };
-                AppDomain.CurrentDomain.UnhandledException += _domainHandler;
-
-                // 3) C# unobserved faulted-Task exceptions — full managed stack trace. We intentionally do NOT
-                //    call args.SetObserved(): that would change the game's behavior (suppressing the escalation
-                //    a game may rely on), violating the "no behavior change unless opted in beyond capture"
-                //    posture. We only OBSERVE-FOR-LOGGING here, leaving the runtime's own handling intact.
-                _taskHandler = (_, args) =>
-                {
-                    try
-                    {
-                        collector.Append(RuntimeErrorFactory.FromException(
-                            RuntimeErrorSource.UnobservedTaskException, args.Exception));
-                    }
-                    catch { /* a fault handler must never throw */ }
-                };
-                TaskScheduler.UnobservedTaskException += _taskHandler;
-
-                var summary = engineInstalled
-                    ? "[Godot-MCP] runtime error capture installed (engine 4.5+ logger + C# exception hooks)."
-                    : "[Godot-MCP] runtime error capture installed (C# exception hooks only; engine logger " +
-                      "requires Godot 4.5+).";
-                if (_logForTests != null)
-                    _logForTests(summary);
-                else
-                    GD.Print(summary);
-
-                return collector;
+                // Two-phase install so the manager reference is published BEFORE its channels wire: a throw mid-
+                // wiring then still leaves an uninstallable manager that Uninstall() can tear down (the issue #165
+                // sibling — never leak a process-wide hook with no owner to remove it).
+                var manager = ErrorCaptureManager.CreateRuntime(
+                    bridgeInstall: _bridgeInstallForTests ?? GodotScriptErrorLoggerBridge.TryInstall,
+                    bridgeUninstall: _bridgeUninstallForTests ?? GodotScriptErrorLoggerBridge.Uninstall,
+                    log: _logForTests ?? GD.Print);
+                _manager = manager;
+                manager.InstallRuntimeProfile();
+                return manager.RuntimeCollector!;
             }
         }
 
@@ -163,76 +131,28 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
         /// Test-only installer that wires the PURE-MANAGED channels exactly as <see cref="Install"/> does — the
         /// AppDomain.UnhandledException + TaskScheduler.UnobservedTaskException hooks — and publishes the backing
         /// <see cref="RuntimeErrorCollector"/> as <see cref="RuntimeErrorCollector.Current"/>, but SKIPS the engine
-        /// 4.5+ logger registration and the <c>GD.Print</c> summary line. Both of those call into native Godot,
-        /// which faults (<c>AccessViolationException</c>, aborting the runner) in the binary-less xUnit host — so a
-        /// unit test cannot exercise the real <see cref="Install"/>. After this call <see cref="IsInstalled"/> is
-        /// true and <see cref="RuntimeErrorCollector.Current"/> is non-null, and <see cref="Uninstall"/> (which
-        /// touches no native Godot) tears it back down — exactly the install/uninstall lifecycle the issue #165
-        /// leak-guard test needs to assert on the REAL static state. Not part of the production API.
+        /// 4.5+ logger registration and the <c>GD.Print</c> summary line (both call into native Godot, which faults
+        /// — <c>AccessViolationException</c>, aborting the runner — in the binary-less xUnit host). It runs the
+        /// manager's runtime profile with no-op bridge + log seams to achieve that. After this call
+        /// <see cref="IsInstalled"/> is true and <see cref="RuntimeErrorCollector.Current"/> is non-null, and
+        /// <see cref="Uninstall"/> (which touches no native Godot) tears it back down — exactly the install/uninstall
+        /// lifecycle the issue #165 leak-guard test needs to assert on the REAL static state. Not part of the
+        /// production API.
         /// </summary>
         internal static RuntimeErrorCollector InstallForTestsWithoutEngineHooks()
         {
             lock (_gate)
             {
-                if (_installed && _collector != null)
-                    return _collector;
+                if (_manager != null && _manager.IsInstalled)
+                    return _manager.RuntimeCollector!;
 
-                var collector = new RuntimeErrorCollector();
-                RuntimeErrorCollector.Current = collector;
-                _collector = collector;
-                _installed = true;
-
-                _domainHandler = (_, args) =>
-                {
-                    try
-                    {
-                        collector.Append(RuntimeErrorFactory.FromException(
-                            RuntimeErrorSource.UnhandledException, args.ExceptionObject as Exception));
-                    }
-                    catch { /* a fault handler must never throw */ }
-                };
-                AppDomain.CurrentDomain.UnhandledException += _domainHandler;
-
-                _taskHandler = (_, args) =>
-                {
-                    try
-                    {
-                        collector.Append(RuntimeErrorFactory.FromException(
-                            RuntimeErrorSource.UnobservedTaskException, args.Exception));
-                    }
-                    catch { /* a fault handler must never throw */ }
-                };
-                TaskScheduler.UnobservedTaskException += _taskHandler;
-
-                return collector;
-            }
-        }
-
-        /// <summary>
-        /// Register the Godot 4.5+ engine-error logger feeding <paramref name="collector"/> via the bridge,
-        /// returning true when the engine channel is live. Best-effort: a registration failure (e.g. an
-        /// unexpected host) is swallowed to a warning so the C# fault channels still install. Pre-&lt; 4.5 the
-        /// bridge stub returns null and this returns false (documented degradation). Call under <c>_gate</c>.
-        /// </summary>
-        static bool TryInstallEngineLogger(RuntimeErrorCollector collector)
-        {
-            try
-            {
-                // Build a FRESH capture each call whose ErrorSink targets the CURRENT collector, then hand it to
-                // the bridge. On a re-entrant install (issue #171) the bridge REBINDS its single live logger to
-                // this new capture (see GodotScriptErrorLoggerBridge.TryInstall), so engine errors always route
-                // to the collector the live handle reads — never a stale one left over from a prior install.
-                var capture = new ScriptErrorCapture
-                {
-                    ErrorSink = record => collector.Append(RuntimeErrorFactory.FromEngine(record)),
-                };
-                var install = _bridgeInstallForTests ?? GodotScriptErrorLoggerBridge.TryInstall;
-                return install(capture) != null;
-            }
-            catch (Exception ex)
-            {
-                GD.PushWarning($"[Godot-MCP] runtime engine-error capture not installed: {ex.Message}");
-                return false;
+                var manager = ErrorCaptureManager.CreateRuntime(
+                    bridgeInstall: static _ => null,    // SKIP the engine 4.5+ logger (OS.AddLogger faults in the host)
+                    bridgeUninstall: static () => { },  // nothing native to remove
+                    log: static _ => { });              // SKIP the GD.Print summary (native — faults in the host)
+                _manager = manager;
+                manager.InstallRuntimeProfile();
+                return manager.RuntimeCollector!;
             }
         }
 
@@ -240,35 +160,15 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
         /// Reverse <see cref="Install"/>: remove the engine logger (via the bridge — a no-op on &lt; 4.5),
         /// unsubscribe the AppDomain / TaskScheduler fault hooks, and clear
         /// <see cref="RuntimeErrorCollector.Current"/>. Idempotent and defensive (each step swallows its own
-        /// failure) so it is safe on game shutdown / handle dispose, even mid-teardown.
+        /// failure inside <see cref="ErrorCaptureManager.Teardown"/>) so it is safe on game shutdown / handle
+        /// dispose, even mid-teardown.
         /// </summary>
         public static void Uninstall()
         {
             lock (_gate)
             {
-                if (!_installed)
-                    return;
-
-                try { (_bridgeUninstallForTests ?? GodotScriptErrorLoggerBridge.Uninstall)(); }
-                catch { /* swallow: a logger-removal failure must not break teardown */ }
-
-                if (_domainHandler != null)
-                {
-                    try { AppDomain.CurrentDomain.UnhandledException -= _domainHandler; }
-                    catch { /* swallow */ }
-                    _domainHandler = null;
-                }
-
-                if (_taskHandler != null)
-                {
-                    try { TaskScheduler.UnobservedTaskException -= _taskHandler; }
-                    catch { /* swallow */ }
-                    _taskHandler = null;
-                }
-
-                try { RuntimeErrorCollector.Current = null; } catch { /* swallow */ }
-                _collector = null;
-                _installed = false;
+                _manager?.Teardown();
+                _manager = null;
             }
         }
     }

--- a/addons/godot_mcp/Runtime/Tools/ErrorCaptureManager.cs
+++ b/addons/godot_mcp/Runtime/Tools/ErrorCaptureManager.cs
@@ -134,10 +134,12 @@ namespace com.IvanMurzak.Godot.MCP.Tools
             lock (manager._gate)
             {
                 // Mirror GodotScriptErrorLoggerBridge.TryInstall(GodotLogCollector): a fresh router whose passive
-                // LogSink flattens each engine error/warning into a console-get-logs line.
+                // LogSink flattens each engine error/warning into a console-get-logs line. Reads the stored
+                // _logCollector field (== collector, assigned in the ctor above) so the editor profile's buffer is
+                // a genuine read, symmetric with the runtime profile's _runtimeCollector.
                 var capture = new ScriptErrorCapture
                 {
-                    LogSink = (logType, message) => collector.Append(logType, message),
+                    LogSink = (logType, message) => manager._logCollector!.Append(logType, message),
                 };
                 manager._bridgeInstall(capture);
                 manager._installed = true;

--- a/addons/godot_mcp/Runtime/Tools/ErrorCaptureManager.cs
+++ b/addons/godot_mcp/Runtime/Tools/ErrorCaptureManager.cs
@@ -235,7 +235,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         /// uses the two-phase <see cref="CreateRuntime"/> + <see cref="InstallRuntimeProfile"/> instead, so it can
         /// publish the manager reference before the hooks wire (leak-safety).
         /// </summary>
-        public static ErrorCaptureManager InstallRuntime(
+        internal static ErrorCaptureManager InstallRuntime(
             Func<ScriptErrorCapture, ScriptErrorCapture?> bridgeInstall,
             Action bridgeUninstall,
             Action<string> log)

--- a/addons/godot_mcp/Runtime/Tools/ErrorCaptureManager.cs
+++ b/addons/godot_mcp/Runtime/Tools/ErrorCaptureManager.cs
@@ -1,0 +1,346 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+// Single instance-based lifecycle coordinator that OWNS the engine-logger channel install/rebind/teardown
+// and the statics-clearing policy for the error/log capture layer, with two install profiles (Editor /
+// Runtime) and one idempotent teardown. It collapses the three previously-scattered teardown-clearing sites
+// (GodotMcpPlugin.Teardown's OS.RemoveLogger + ScriptErrorCapture.Current re-clear, and
+// RuntimeErrorCapture.Uninstall's own clears) into ONE owner, while leaving the four pure-managed cores
+// (GodotLogCollector / ScriptErrorCapture / RuntimeErrorCollector / EngineErrorRecord) byte-for-byte
+// unchanged. This is a facade, NOT a merge: every cross-channel invariant (#171 rebind via
+// ScriptErrorCapture.PlanBridgeInstall, #163 deep backtrace, #173 collector-not-nulled, #165 leak-guard,
+// #194 probe remap) is preserved because none of that code moves here.
+//
+// NOT gated by #if TOOLS (RuntimeErrorCapture, which delegates to this, ships into a game build) and NOT
+// gated by #if GODOT4_5_OR_GREATER: this type references ONLY the version-agnostic GodotScriptErrorLoggerBridge
+// (which has both the 4.5 impl and the < 4.5 stub), never Godot.Logger / OS.AddLogger directly, so it compiles
+// on the 4.3 SDK floor that gates CI. It has NO Godot API surface of its own — every native touch (OS.AddLogger
+// / OS.RemoveLogger via the bridge, GD.Print via the summary) is behind a delegate seam, so the manager stays
+// unit-testable in the binary-less xUnit host (the seams are substituted with a pure-managed fake there).
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using com.IvanMurzak.Godot.MCP.Data;
+
+namespace com.IvanMurzak.Godot.MCP.Tools
+{
+    /// <summary>
+    /// Owns the engine-logger channel lifecycle (install / rebind / teardown) and the statics-clearing policy
+    /// for the error/log capture layer. An INSTANCE type (not a new static): the editor holds one for its
+    /// passive-log channel; the in-game runtime holds one (via <c>RuntimeErrorCapture</c>) for its structured
+    /// channel + C# fault hooks. Two install profiles, one teardown:
+    /// <list type="bullet">
+    /// <item><see cref="InstallEditor"/> — wires a passive <see cref="ScriptErrorCapture.LogSink"/> into the
+    /// supplied <see cref="GodotLogCollector"/> so engine errors land in <c>console-get-logs</c> (the editor
+    /// boot path that was <c>GodotScriptErrorLoggerBridge.TryInstall(GodotLogCollector)</c>).</item>
+    /// <item><see cref="InstallRuntime"/> — publishes a fresh <see cref="RuntimeErrorCollector"/>, wires the
+    /// AppDomain + TaskScheduler fault hooks, and installs the engine logger via a FRESH
+    /// <see cref="ScriptErrorCapture.ErrorSink"/> per call (the in-game runtime path).</item>
+    /// <item><see cref="Teardown"/> — idempotent; removes the engine logger (which also nulls
+    /// <see cref="ScriptErrorCapture.Current"/>), unsubscribes the runtime fault hooks, and clears
+    /// <see cref="RuntimeErrorCollector.Current"/> (runtime profile only). Deliberately does NOT null
+    /// <see cref="GodotLogCollector.Current"/> (issue #173).</item>
+    /// </list>
+    ///
+    /// <para>
+    /// Every native touch is behind a delegate seam: <c>bridgeInstall</c> / <c>bridgeUninstall</c> for
+    /// <c>OS.AddLogger</c> / <c>OS.RemoveLogger</c> (through <see cref="GodotScriptErrorLoggerBridge"/>), and
+    /// <c>log</c> for <c>GD.Print</c>. In production the callers pass the real bridge + <c>GD.Print</c>; a unit
+    /// test substitutes a pure-managed fake bridge + no-op log so install / rebind / teardown can be asserted
+    /// with no Godot binary (the same seam pattern <c>RuntimeErrorCapture</c> already exposes).
+    /// </para>
+    /// </summary>
+    public sealed class ErrorCaptureManager
+    {
+        readonly object _gate = new();
+
+        // Editor profile: the console-get-logs buffer the passive LogSink feeds. Null for the runtime profile.
+        readonly GodotLogCollector? _logCollector;
+        // Runtime profile: the runtime-errors-get buffer the structured ErrorSink + C# fault hooks feed. Null
+        // for the editor profile. Non-null is ALSO the runtime-profile discriminator used by Teardown.
+        readonly RuntimeErrorCollector? _runtimeCollector;
+
+        // Native-touch seams (see the class remarks). bridgeInstall mirrors
+        // GodotScriptErrorLoggerBridge.TryInstall(ScriptErrorCapture) → ScriptErrorCapture.PlanBridgeInstall
+        // (RegisterNew / Rebind / AlreadyCurrent); bridgeUninstall mirrors GodotScriptErrorLoggerBridge.Uninstall
+        // (OS.RemoveLogger + nulls ScriptErrorCapture.Current); log mirrors GD.Print.
+        readonly Func<ScriptErrorCapture, ScriptErrorCapture?> _bridgeInstall;
+        readonly Action _bridgeUninstall;
+        readonly Action<string> _log;
+
+        bool _installed;
+
+        // Runtime profile only: the AppDomain / TaskScheduler fault-hook handlers, assigned on install and
+        // unsubscribed on teardown. Held so Teardown detaches exactly the handlers it subscribed.
+        UnhandledExceptionEventHandler? _domainHandler;
+        EventHandler<UnobservedTaskExceptionEventArgs>? _taskHandler;
+
+        ErrorCaptureManager(
+            GodotLogCollector? logCollector,
+            RuntimeErrorCollector? runtimeCollector,
+            Func<ScriptErrorCapture, ScriptErrorCapture?> bridgeInstall,
+            Action bridgeUninstall,
+            Action<string> log)
+        {
+            _logCollector = logCollector;
+            _runtimeCollector = runtimeCollector;
+            _bridgeInstall = bridgeInstall ?? throw new ArgumentNullException(nameof(bridgeInstall));
+            _bridgeUninstall = bridgeUninstall ?? throw new ArgumentNullException(nameof(bridgeUninstall));
+            _log = log ?? throw new ArgumentNullException(nameof(log));
+        }
+
+        /// <summary>True while this manager's channel(s) are installed. Idempotent <see cref="Teardown"/> keys on it.</summary>
+        public bool IsInstalled
+        {
+            get { lock (_gate) { return _installed; } }
+        }
+
+        /// <summary>
+        /// The runtime-profile collector this manager publishes as <see cref="RuntimeErrorCollector.Current"/>,
+        /// or null for the editor profile. Used by <c>RuntimeErrorCapture</c>'s facade to return the live
+        /// collector from <c>Install()</c> without re-reading the static.
+        /// </summary>
+        internal RuntimeErrorCollector? RuntimeCollector => _runtimeCollector;
+
+        // ── Editor profile ──────────────────────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Install the EDITOR passive-log channel: build a fresh <see cref="ScriptErrorCapture"/> whose
+        /// <see cref="ScriptErrorCapture.LogSink"/> appends every engine error/warning to
+        /// <paramref name="collector"/> (the <c>console-get-logs</c> buffer), and hand it to
+        /// <paramref name="bridgeInstall"/> (→ <see cref="ScriptErrorCapture.PlanBridgeInstall"/> →
+        /// RegisterNew / Rebind / AlreadyCurrent). Behaviourally identical to the prior
+        /// <c>GodotScriptErrorLoggerBridge.TryInstall(GodotLogCollector)</c> call in <c>GodotMcpPlugin.EnterTreeBoot</c>.
+        /// Returns the manager so the caller can <see cref="Teardown"/> it on plugin unload.
+        /// </summary>
+        public static ErrorCaptureManager InstallEditor(
+            GodotLogCollector collector,
+            Func<ScriptErrorCapture, ScriptErrorCapture?> bridgeInstall,
+            Action bridgeUninstall,
+            Action<string> log)
+        {
+            if (collector == null)
+                throw new ArgumentNullException(nameof(collector));
+
+            var manager = new ErrorCaptureManager(
+                logCollector: collector, runtimeCollector: null, bridgeInstall, bridgeUninstall, log);
+
+            lock (manager._gate)
+            {
+                // Mirror GodotScriptErrorLoggerBridge.TryInstall(GodotLogCollector): a fresh router whose passive
+                // LogSink flattens each engine error/warning into a console-get-logs line.
+                var capture = new ScriptErrorCapture
+                {
+                    LogSink = (logType, message) => collector.Append(logType, message),
+                };
+                manager._bridgeInstall(capture);
+                manager._installed = true;
+            }
+
+            return manager;
+        }
+
+        // ── Runtime profile ─────────────────────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Construct a RUNTIME-profile manager and publish its fresh <see cref="RuntimeErrorCollector"/> as
+        /// <see cref="RuntimeErrorCollector.Current"/> + mark it installed, WITHOUT yet wiring the engine logger
+        /// or the C# fault hooks. Split from <see cref="InstallRuntimeProfile"/> so the caller
+        /// (<c>RuntimeErrorCapture.Install</c>) can publish the manager reference it will later
+        /// <see cref="Teardown"/> BEFORE the hooks are wired — so a throw mid-wiring still leaves an
+        /// uninstallable manager (mirrors the prior "publish state before wiring the fault hooks" leak-safety,
+        /// the issue #165 sibling). Most callers want the all-in-one <see cref="InstallRuntime"/>.
+        /// </summary>
+        internal static ErrorCaptureManager CreateRuntime(
+            Func<ScriptErrorCapture, ScriptErrorCapture?> bridgeInstall,
+            Action bridgeUninstall,
+            Action<string> log)
+        {
+            var manager = new ErrorCaptureManager(
+                logCollector: null, runtimeCollector: new RuntimeErrorCollector(), bridgeInstall, bridgeUninstall, log);
+
+            lock (manager._gate)
+            {
+                // Publish state BEFORE wiring the fault hooks (below, in InstallRuntimeProfile) so a throw mid-
+                // subscribe still leaves the capture discoverable AND uninstallable.
+                RuntimeErrorCollector.Current = manager._runtimeCollector;
+                manager._installed = true;
+            }
+
+            return manager;
+        }
+
+        /// <summary>
+        /// Wire the RUNTIME profile's channels onto a manager produced by <see cref="CreateRuntime"/>: install
+        /// the engine logger via a FRESH <see cref="ScriptErrorCapture.ErrorSink"/> (the per-install freshness is
+        /// load-bearing for the #171 rebind — a re-entrant install resolves to Rebind), then subscribe the
+        /// AppDomain + TaskScheduler fault hooks, then print the install summary through the <c>log</c> seam.
+        /// Verbatim from the prior <c>RuntimeErrorCapture.Install</c> body.
+        /// </summary>
+        internal void InstallRuntimeProfile()
+        {
+            lock (_gate)
+            {
+                var collector = _runtimeCollector!;
+
+                // 1) Engine error stream (Godot 4.5+). On < 4.5 the bridge stub returns null → channel absent.
+                var engineInstalled = TryInstallRuntimeEngineLogger(collector);
+
+                // 2) C# unhandled exceptions — full managed stack trace. Field assigned first, then subscribed,
+                //    so even a throw between the two leaves Teardown() with a handler reference to detach.
+                _domainHandler = (_, args) =>
+                {
+                    try
+                    {
+                        collector.Append(RuntimeErrorFactory.FromException(
+                            RuntimeErrorSource.UnhandledException, args.ExceptionObject as Exception));
+                    }
+                    catch { /* a fault handler must never throw */ }
+                };
+                AppDomain.CurrentDomain.UnhandledException += _domainHandler;
+
+                // 3) C# unobserved faulted-Task exceptions. We intentionally do NOT call args.SetObserved() —
+                //    OBSERVE-FOR-LOGGING only, leaving the runtime's own escalation handling intact.
+                _taskHandler = (_, args) =>
+                {
+                    try
+                    {
+                        collector.Append(RuntimeErrorFactory.FromException(
+                            RuntimeErrorSource.UnobservedTaskException, args.Exception));
+                    }
+                    catch { /* a fault handler must never throw */ }
+                };
+                TaskScheduler.UnobservedTaskException += _taskHandler;
+
+                var summary = engineInstalled
+                    ? "[Godot-MCP] runtime error capture installed (engine 4.5+ logger + C# exception hooks)."
+                    : "[Godot-MCP] runtime error capture installed (C# exception hooks only; engine logger " +
+                      "requires Godot 4.5+).";
+                _log(summary);
+            }
+        }
+
+        /// <summary>
+        /// Construct + fully install a RUNTIME-profile manager in one call (publish collector, wire engine logger,
+        /// subscribe the C# fault hooks, print the summary). The named API the design specifies; also the path
+        /// the <c>ErrorCaptureManagerTests</c> drive directly with a fake bridge. <c>RuntimeErrorCapture.Install</c>
+        /// uses the two-phase <see cref="CreateRuntime"/> + <see cref="InstallRuntimeProfile"/> instead, so it can
+        /// publish the manager reference before the hooks wire (leak-safety).
+        /// </summary>
+        public static ErrorCaptureManager InstallRuntime(
+            Func<ScriptErrorCapture, ScriptErrorCapture?> bridgeInstall,
+            Action bridgeUninstall,
+            Action<string> log)
+        {
+            var manager = CreateRuntime(bridgeInstall, bridgeUninstall, log);
+            manager.InstallRuntimeProfile();
+            return manager;
+        }
+
+        /// <summary>
+        /// Re-assert the engine logger for the runtime profile by handing the bridge a FRESH capture bound to the
+        /// live <see cref="RuntimeCollector"/> — the idempotent re-entry path of <c>RuntimeErrorCapture.Install</c>
+        /// (#171): if the bridge logger was torn down independently it registers anew; if it is live on a stale
+        /// capture it rebinds to this fresh one so engine errors route to the current collector. No-op when not
+        /// installed or not a runtime profile.
+        /// </summary>
+        internal void ReassertRuntimeEngineLogger()
+        {
+            lock (_gate)
+            {
+                if (!_installed || _runtimeCollector == null)
+                    return;
+                TryInstallRuntimeEngineLogger(_runtimeCollector);
+            }
+        }
+
+        /// <summary>
+        /// Build a FRESH <see cref="ScriptErrorCapture"/> whose <see cref="ScriptErrorCapture.ErrorSink"/> feeds
+        /// <paramref name="collector"/> and hand it to the bridge seam, returning true when the engine channel is
+        /// live. Best-effort: a registration failure is swallowed to a routed warning so the C# fault channels
+        /// still install (and pre-&lt; 4.5 the stub returns null → false). Call under <c>_gate</c>.
+        /// </summary>
+        bool TryInstallRuntimeEngineLogger(RuntimeErrorCollector collector)
+        {
+            try
+            {
+                var capture = new ScriptErrorCapture
+                {
+                    ErrorSink = record => collector.Append(RuntimeErrorFactory.FromEngine(record)),
+                };
+                return _bridgeInstall(capture) != null;
+            }
+            catch (Exception ex)
+            {
+                // Routed through the log seam (not a direct GD.PushWarning) so the manager stays Godot-free and
+                // unit-testable; reached only when the REAL 4.5 bridge throws during OS.AddLogger (rare).
+                _log($"[Godot-MCP] runtime engine-error capture not installed: {ex.Message}");
+                return false;
+            }
+        }
+
+        // ── Teardown (single statics-clearing owner) ─────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Reverse the install: remove the engine logger (via the <c>bridgeUninstall</c> seam — which also nulls
+        /// <see cref="ScriptErrorCapture.Current"/>), unsubscribe the runtime fault hooks, and clear
+        /// <see cref="RuntimeErrorCollector.Current"/> (runtime profile only). Idempotent (no-op on a second call)
+        /// and defensive (each step swallows its own failure) so it is safe on the editor's ALC-unload teardown
+        /// and on game shutdown / handle dispose. The single owner of the statics-clearing policy that previously
+        /// lived in three scattered sites.
+        /// </summary>
+        public void Teardown()
+        {
+            lock (_gate)
+            {
+                if (!_installed)
+                    return;
+
+                // Remove the engine logger + null ScriptErrorCapture.Current (the bridge does both). For the editor
+                // this is OS.RemoveLogger (main-thread only — the caller invokes Teardown inside its main-thread
+                // guard); for the runtime it is the bridge teardown. Swallowed so a removal failure never breaks
+                // the rest of teardown.
+                try { _bridgeUninstall(); }
+                catch { /* a logger-removal failure must not break teardown */ }
+
+                // Runtime profile only: unsubscribe the C# fault hooks (the editor profile never assigned them).
+                if (_domainHandler != null)
+                {
+                    try { AppDomain.CurrentDomain.UnhandledException -= _domainHandler; }
+                    catch { /* swallow */ }
+                    _domainHandler = null;
+                }
+
+                if (_taskHandler != null)
+                {
+                    try { TaskScheduler.UnobservedTaskException -= _taskHandler; }
+                    catch { /* swallow */ }
+                    _taskHandler = null;
+                }
+
+                // Runtime profile only: clear the runtime collector. Gated on _runtimeCollector so the EDITOR
+                // teardown never touches RuntimeErrorCollector.Current (it owns the editor's passive-log channel
+                // only, an unrelated static).
+                if (_runtimeCollector != null)
+                {
+                    try { RuntimeErrorCollector.Current = null; }
+                    catch { /* swallow */ }
+                }
+
+                // GodotLogCollector.Current is DELIBERATELY NOT nulled here (issue #173): the bounded ring of plain
+                // managed LogEntry rows must stay readable through the teardown / reload window — the background
+                // framework log-routing path reads Current?.Append off arbitrary threads, so a null would silently
+                // drop exactly the diagnostics an operator most wants. The next _EnterTree replaces it
+                // (last-writer-wins). A future refactor must NOT re-add a GodotLogCollector.Current = null here.
+
+                _installed = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **PR-1 of the error-capture-unification design** (channel-unify; structural, **zero behavior change**). Adds `addons/godot_mcp/Runtime/Tools/ErrorCaptureManager.cs` — an instance-based facade that OWNS the engine-logger channel lifecycle (install/rebind/teardown) and the statics-clearing policy, with two install profiles (`InstallEditor` / `InstallRuntime`) + one idempotent `Teardown`. Every native touch is behind a delegate seam (`bridgeInstall`/`bridgeUninstall`/`log`), so it stays unit-testable in the binary-less xUnit host and compiles on the 4.3 SDK floor (references only the version-agnostic `GodotScriptErrorLoggerBridge`).
- Routes `GodotMcpPlugin` editor install/teardown + `RuntimeErrorCapture` runtime install/teardown through the manager. `RuntimeErrorCapture` shrinks to a thin runtime-profile facade that keeps its full public/internal surface + the `_bridgeInstallForTests`/`_bridgeUninstallForTests`/`_logForTests` seams, so the existing rebind/runtime suites compile + pass unchanged and exercise the manager's runtime profile via forwarding.
- Collapses the **three** scattered teardown-clearing sites into the manager: removes the now-redundant `ScriptErrorCapture.Current = null` belt-and-suspenders in `GodotMcpPlugin.Teardown`; deliberately does **NOT** null `GodotLogCollector.Current` (#173, with an explicit comment).
- Keeps the four pure-managed cores (`GodotLogCollector`, `ScriptErrorCapture` incl. `PlanBridgeInstall` + the #194 `gdscript://` remap, `RuntimeErrorCollector`, `EngineErrorRecord`) **byte-for-byte unchanged**. Every historical fix (#163 / #171 / #173 / #165 / #194) and its named guard tests are preserved.
- Adds `Godot-MCP.Tests/ErrorCaptureManagerTests.cs` (the runtime profile is additionally covered end-to-end by the forwarded `RuntimeErrorCaptureRebindTests`).

## Behavior
- **`console-get-logs` output is unchanged** — the GD.Push*/GodotMcpLog routing sweep is PR-2 (a separate follow-up); this PR is purely the structural channel-unify.

## Test plan
- [x] Suite 1 — `dotnet build Godot-MCP.sln` (CI parity): **0 errors**.
- [x] Suite 2 — `dotnet test Godot-MCP.Tests`: **952 passed / 0 failed** (was 945 baseline; +7 new `ErrorCaptureManagerTests`). All #163/#171/#173/#165/#194 guard suites green.
- [x] `scripts/check-runtime-boundary.py`: 0 violations (the new `Runtime/` file references no editor-only API).

Closes #219