### PR TITLE
feat: route GD.Push*/GD.Print diagnostics through GodotMcpLog so console-get-logs is complete (PR-2)

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -80,6 +80,13 @@
     <Compile Include="..\addons\godot_mcp\Runtime\Connection\GodotMcpLogLevel.cs" Link="Source\GodotMcpLogLevel.cs" />
     <Compile Include="..\addons\godot_mcp\Runtime\Connection\GodotMcpLogger.cs" Link="Source\GodotMcpLogger.cs" />
     <Compile Include="..\addons\godot_mcp\Runtime\Connection\GodotMcpLoggerProvider.cs" Link="Source\GodotMcpLoggerProvider.cs" />
+    <!-- Central diagnostic sink (GD.* by severity + GodotLogCollector append, swallow-on-fault). It touches
+         the Godot runtime GD.* API (like RouteFrameworkLog before it), so it is NOT unit-tested — but several
+         sources compiled in here (MainThreadDispatcher.cs, GodotMcpRuntime.cs, the #if GODOT4_5_OR_GREATER
+         GodotScriptErrorLogger.cs) now route their diagnostics through it, so it must compile in for those to
+         resolve GodotMcpLog. Compiled-but-uncalled in this binary-less host, exactly like RouteFrameworkLog's
+         GD.* sink (issue B / PR-2). -->
+    <Compile Include="..\addons\godot_mcp\Runtime\Connection\GodotMcpLog.cs" Link="Source\GodotMcpLog.cs" />
     <!-- MCP-features enable-map — pure-managed (no Godot native types, no #if TOOLS, no McpPlugin dependency):
          the per-kind feature-state list (GodotMcpFeatureMap/GodotMcpFeatureState) that GodotMcpConfig serializes,
          and the merge/capture logic (GodotMcpFeatureStateMerge) the boot-reapply + window-toggle drive. The live

--- a/README.md
+++ b/README.md
@@ -202,7 +202,10 @@ errors from the *running game* and is **OFF by default** — opt in with `builde
 
 **console**
 
-- `console-get-logs` — Read the plugin's collected editor logs (with filtering).
+- `console-get-logs` — Read the plugin's collected editor logs (with filtering). This includes the
+  plugin's connection lifecycle diagnostics (connect/disconnect, drain-timeout, config save/load,
+  skill-gen, dev-control, dispatcher, and runtime-capture warnings), which route through the same
+  capture sink as its framework logs.
 - `console-clear-logs` — Clear the collected log cache.
 
 **reflection**

--- a/addons/godot_mcp/Editor/Connection/DevControl/DevControlServer.cs
+++ b/addons/godot_mcp/Editor/Connection/DevControl/DevControlServer.cs
@@ -81,7 +81,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection.DevControl
             }
             catch (Exception ex)
             {
-                GD.PushError($"[dev-control] failed to bind {BaseUrl}: {ex.Message}");
+                GodotMcpLog.Error($"[dev-control] failed to bind {BaseUrl}: {ex.Message}");
                 return;
             }
 
@@ -92,7 +92,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection.DevControl
             };
             _acceptThread.Start();
 
-            GD.Print($"[dev-control] Listening on http://{BindHost}:{_port}");
+            GodotMcpLog.Info($"[dev-control] Listening on http://{BindHost}:{_port}");
         }
 
         void AcceptLoop()

--- a/addons/godot_mcp/Editor/Extensions/ConsumerProjectFile.cs
+++ b/addons/godot_mcp/Editor/Extensions/ConsumerProjectFile.cs
@@ -12,6 +12,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using com.IvanMurzak.Godot.MCP.Connection;
 using Godot;
 
 namespace com.IvanMurzak.Godot.MCP.Extensions
@@ -58,7 +59,7 @@ namespace com.IvanMurzak.Godot.MCP.Extensions
             }
             catch (Exception ex)
             {
-                GD.PushError($"[Godot-MCP] could not read consumer .csproj '{_path}': {ex.Message}");
+                GodotMcpLog.Error($"[Godot-MCP] could not read consumer .csproj '{_path}': {ex.Message}");
                 return null;
             }
         }
@@ -76,7 +77,7 @@ namespace com.IvanMurzak.Godot.MCP.Extensions
             }
             catch (Exception ex)
             {
-                GD.PushError($"[Godot-MCP] could not write consumer .csproj '{_path}': {ex.Message}");
+                GodotMcpLog.Error($"[Godot-MCP] could not write consumer .csproj '{_path}': {ex.Message}");
                 return false;
             }
         }

--- a/addons/godot_mcp/Editor/GodotMcpPlugin.cs
+++ b/addons/godot_mcp/Editor/GodotMcpPlugin.cs
@@ -229,27 +229,16 @@ namespace com.IvanMurzak.Godot.MCP
 
         /// <summary>
         /// Print an informational lifecycle line to the Godot output AND capture it into the
-        /// <see cref="GodotLogCollector"/> so it is retrievable via the <c>console-get-logs</c> tool.
+        /// <see cref="GodotLogCollector"/> so it is retrievable via the <c>console-get-logs</c> tool. Thin
+        /// forward to the central <see cref="GodotMcpLog"/> sink (which does both and swallows on fault).
         /// </summary>
-        static void Log(string message)
-        {
-            GD.Print(message);
-            GodotLogCollector.Current?.Append(GodotLogType.Log, message);
-        }
+        static void Log(string message) => GodotMcpLog.Info(message);
 
         /// <summary>Warning-level analog of <see cref="Log"/>.</summary>
-        static void LogWarning(string message)
-        {
-            GD.PushWarning(message);
-            GodotLogCollector.Current?.Append(GodotLogType.Warning, message);
-        }
+        static void LogWarning(string message) => GodotMcpLog.Warning(message);
 
         /// <summary>Error-level analog of <see cref="Log"/>.</summary>
-        static void LogError(string message)
-        {
-            GD.PushError(message);
-            GodotLogCollector.Current?.Append(GodotLogType.Error, message);
-        }
+        static void LogError(string message) => GodotMcpLog.Error(message);
 
         /// <summary>
         /// Build the connection, register the dock wired to it, and boot the MCP connection. Isolated in
@@ -483,10 +472,10 @@ namespace com.IvanMurzak.Godot.MCP
             {
                 // Off-thread teardown skips OS.RemoveLogger (an engine call). Acceptable: the #78513 ALC-unload
                 // path is always main-thread, so the logger is always removed before an unload that matters.
-                TryLog("[Godot-MCP] teardown ran off the main thread; skipping Node.Free + engine-logger remove (connection torn down).");
+                Log("[Godot-MCP] teardown ran off the main thread; skipping Node.Free + engine-logger remove (connection torn down).");
             }
 
-            TryLog("[Godot-MCP] plugin unloaded");
+            Log("[Godot-MCP] plugin unloaded");
 
             // 5) Null the process-wide statics so a stale router/hook does not outlive this instance.
             //    NOTE: GodotLogCollector.Current is DELIBERATELY left in place (NOT nulled) — see the
@@ -645,22 +634,13 @@ namespace com.IvanMurzak.Godot.MCP
         }
 
         /// <summary>
-        /// Best-effort log helper for the teardown path. Wrapped because mid-reload the Godot logging API
-        /// (<c>GD.Print</c>) or the log collector may already be unavailable; a teardown diagnostic must
-        /// never throw on the ALC-unloading path.
+        /// Best-effort error-log helper for a named teardown step. Forwards to the central
+        /// <see cref="GodotMcpLog"/> sink, which swallows internally — so this no longer carries its own
+        /// try/catch (mid-reload the Godot logging API or the log collector may be unavailable; a teardown
+        /// diagnostic must never throw on the ALC-unloading path, and <c>GodotMcpLog.Emit</c> guarantees that).
         /// </summary>
-        static void TryLog(string message)
-        {
-            try { Log(message); }
-            catch { /* logging itself must not break teardown */ }
-        }
-
-        /// <summary>Best-effort error-log helper for a named teardown step (never throws).</summary>
         static void TryLogTeardownError(string step, System.Exception ex)
-        {
-            try { LogError($"[Godot-MCP] teardown step '{step}' failed: {ex.Message}"); }
-            catch { /* swallow — teardown must not throw on the unload path */ }
-        }
+            => GodotMcpLog.Error($"[Godot-MCP] teardown step '{step}' failed: {ex.Message}");
     }
 }
 #endif

--- a/addons/godot_mcp/Editor/GodotMcpPlugin.cs
+++ b/addons/godot_mcp/Editor/GodotMcpPlugin.cs
@@ -13,7 +13,6 @@ using System.Runtime.CompilerServices;
 using Godot;
 using com.IvanMurzak.Godot.MCP.Connection;
 using com.IvanMurzak.Godot.MCP.Connection.DevControl;
-using com.IvanMurzak.Godot.MCP.Data;
 using com.IvanMurzak.Godot.MCP.MainThreadDispatch;
 using com.IvanMurzak.Godot.MCP.Tools;
 using com.IvanMurzak.Godot.MCP.UI;

--- a/addons/godot_mcp/Editor/UI/ConnectionPanel.cs
+++ b/addons/godot_mcp/Editor/UI/ConnectionPanel.cs
@@ -829,7 +829,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             {
                 // Reject: restore the displayed value to the current configured host.
                 _hostField.Text = _connection.Config.CustomHost;
-                GD.PushWarning($"[Godot-MCP] ignored invalid server URL: '{text}' (must be an absolute http/https URL).");
+                GodotMcpLog.Warning($"[Godot-MCP] ignored invalid server URL: '{text}' (must be an absolute http/https URL).");
                 return;
             }
 
@@ -1082,7 +1082,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             ApplyCloudAuthState();
             ApplyAlertVisibility(_connection.ConnectionStatus);
 
-            GD.PushWarning("[Godot-MCP] server rejected the authorization token; cleared — press Authorize.");
+            GodotMcpLog.Warning("[Godot-MCP] server rejected the authorization token; cleared — press Authorize.");
         }
 
         /// <summary>

--- a/addons/godot_mcp/Editor/UI/SkillsPanel.cs
+++ b/addons/godot_mcp/Editor/UI/SkillsPanel.cs
@@ -275,7 +275,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             catch (Exception ex)
             {
                 // Never let a generation failure escape the editor UI handler; surface it in the status + Output.
-                GD.PushError($"[Godot-MCP] skill generation failed: {ex.Message}");
+                GodotMcpLog.Error($"[Godot-MCP] skill generation failed: {ex.Message}");
                 SetStatus($"Skill generation failed: {ex.Message}", error: true);
             }
         }

--- a/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
@@ -106,7 +106,9 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             // the handshake version to this literal (the local-server download is pinned independently by
             // GodotMcpServerView.ServerVersion), so a silent drift here misreports the plugin version.
             // Guard the warning itself so the never-throws contract holds even if GD is unavailable mid
-            // editor-reload.
+            // editor-reload. Intentionally NOT routed through GodotMcpLog: this runs inside the static
+            // type-initializer (before any GodotLogCollector exists), so the GD.* call is kept direct and
+            // self-guarded — a config read must never depend on collector availability (design §2.3).
             try
             {
                 GD.PushWarning(
@@ -270,26 +272,16 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         public event Action? AgentsUpdated;
 
         /// <summary>
-        /// Wire the pure-managed <see cref="GodotMcpDrainDiagnostics"/> seam's warning sink to a defensively
-        /// wrapped <see cref="GD.PushWarning(string)"/> exactly once, when this type is first touched (which is
+        /// Wire the pure-managed <see cref="GodotMcpDrainDiagnostics"/> seam's warning sink to
+        /// <see cref="GodotMcpLog.Warning(string)"/> exactly once, when this type is first touched (which is
         /// guaranteed before any <see cref="DisconnectAndDrain"/> call). The seam stays Godot-free + unit-testable;
-        /// the actual editor/runtime warning is emitted through this swallow-on-fault wrapper so a timeout report
-        /// never throws into the ALC-unloading teardown path even if GD is unavailable mid editor-reload.
+        /// the actual editor/runtime warning routes through the central <see cref="GodotMcpLog"/> sink, which
+        /// also captures it into <c>console-get-logs</c> and swallows on fault so a timeout report never throws
+        /// into the ALC-unloading teardown path even if GD is unavailable mid editor-reload.
         /// </summary>
         static GodotMcpConnection()
         {
-            GodotMcpDrainDiagnostics.Warn = PushWarningSafe;
-        }
-
-        /// <summary>
-        /// Emit a warning via <see cref="GD.PushWarning(string)"/>, swallowing any failure (GD may be unavailable
-        /// mid editor-reload). Same defensive discipline as the inline <c>try { GD.Push* } catch { }</c> call sites
-        /// in <see cref="DisconnectAndDrain"/> — diagnostics must never break the boot/unload path.
-        /// </summary>
-        static void PushWarningSafe(string message)
-        {
-            try { GD.PushWarning(message); }
-            catch { /* GD may be unavailable mid-reload; swallow */ }
+            GodotMcpDrainDiagnostics.Warn = GodotMcpLog.Warning;
         }
 
         public GodotMcpConnection(GodotMcpConfig? config = null)
@@ -306,7 +298,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         {
             if (_plugin != null)
             {
-                GD.Print("[Godot-MCP] connection already started; ignoring duplicate Start().");
+                GodotMcpLog.Info("[Godot-MCP] connection already started; ignoring duplicate Start().");
                 return;
             }
 
@@ -438,7 +430,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
             var mode = _config.ActiveMode;
             var host = _config.Host;
-            GD.Print($"[Godot-MCP] connecting (mode={mode}, host={host}) ...");
+            GodotMcpLog.Info($"[Godot-MCP] connecting (mode={mode}, host={host}) ...");
 
             // Fire-and-forget connect; KeepConnected drives reconnection in the client.
             _ = ConnectAsync();
@@ -665,29 +657,16 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
         /// <summary>
         /// The Godot sink the <see cref="GodotMcpLoggerProvider"/> routes the reused framework's log lines
-        /// to: write to the Godot Output by severity (info/debug/trace → <see cref="GD.Print"/>, warning →
-        /// <see cref="GD.PushWarning"/>, error/critical → <see cref="GD.PushError"/>) AND append to
-        /// <see cref="GodotLogCollector.Current"/> so <c>console-get-logs</c> captures the framework lines
-        /// too. The level decision already happened in the logger (this only runs for enabled lines). The
-        /// framework never logs secrets, and this pass-through adds none.
+        /// to: a thin forward to the central <see cref="GodotMcpLog.Route"/> sink, which writes to the Godot
+        /// Output by severity (info/debug/trace → <see cref="GD.Print"/>, warning → <see cref="GD.PushWarning"/>,
+        /// error/critical → <see cref="GD.PushError"/>) AND appends to <see cref="GodotLogCollector.Current"/>
+        /// so <c>console-get-logs</c> captures the framework lines too. The level decision already happened in
+        /// the logger (this only runs for enabled lines). The framework never logs secrets, and this
+        /// pass-through adds none. Sharing the one <see cref="GodotMcpLog"/> path means framework logs and the
+        /// plugin's ad-hoc diagnostics now land in the same capture sink.
         /// </summary>
         static void RouteFrameworkLog(GodotLogType logType, string message)
-        {
-            switch (logType)
-            {
-                case GodotLogType.Error:
-                    GD.PushError(message);
-                    break;
-                case GodotLogType.Warning:
-                    GD.PushWarning(message);
-                    break;
-                default:
-                    GD.Print(message);
-                    break;
-            }
-
-            GodotLogCollector.Current?.Append(logType, message);
-        }
+            => GodotMcpLog.Route(logType, message);
 
         // --- MCP feature enable-map (tools / prompts / resources) -----------------------------------------
 
@@ -768,7 +747,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                     var mkdir = DirAccess.MakeDirRecursiveAbsolute(skillsDir);
                     if (mkdir != Error.Ok)
                     {
-                        GD.PushWarning($"[Godot-MCP] auto-generate skills: could not create folder {skillsDir} ({mkdir}).");
+                        GodotMcpLog.Warning($"[Godot-MCP] auto-generate skills: could not create folder {skillsDir} ({mkdir}).");
                         return;
                     }
                 }
@@ -787,11 +766,11 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                     _config.ProjectRootPath = originalProjectRoot;
                 }
 
-                GD.Print($"[Godot-MCP] auto-generate skills: ensured up-to-date skills in {skillsDir}.");
+                GodotMcpLog.Info($"[Godot-MCP] auto-generate skills: ensured up-to-date skills in {skillsDir}.");
             }
             catch (Exception ex)
             {
-                GD.PushError($"[Godot-MCP] auto-generate skills failed: {ex.Message}");
+                GodotMcpLog.Error($"[Godot-MCP] auto-generate skills failed: {ex.Message}");
             }
         }
 
@@ -956,11 +935,11 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             try
             {
                 await plugin.Disconnect();
-                GD.Print("[Godot-MCP] disconnected.");
+                GodotMcpLog.Info("[Godot-MCP] disconnected.");
             }
             catch (Exception ex)
             {
-                GD.PushError($"[Godot-MCP] disconnect failed: {ex.Message}");
+                GodotMcpLog.Error($"[Godot-MCP] disconnect failed: {ex.Message}");
             }
         }
 
@@ -1014,7 +993,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             }
             catch (Exception ex)
             {
-                GD.PushWarning($"[Godot-MCP] could not resolve res://.env path: {ex.Message}");
+                GodotMcpLog.Warning($"[Godot-MCP] could not resolve res://.env path: {ex.Message}");
                 return;
             }
 
@@ -1023,7 +1002,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 return;
 
             GodotMcpEnvFile.Apply(_config, values);
-            GD.Print($"[Godot-MCP] applied {values.Count} setting(s) from project .env ({envPath}).");
+            GodotMcpLog.Info($"[Godot-MCP] applied {values.Count} setting(s) from project .env ({envPath}).");
         }
 
         /// <summary>
@@ -1049,7 +1028,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             }
             catch (Exception ex)
             {
-                GD.PushWarning($"[Godot-MCP] could not resolve persisted config path: {ex.Message}");
+                GodotMcpLog.Warning($"[Godot-MCP] could not resolve persisted config path: {ex.Message}");
                 return;
             }
 
@@ -1058,7 +1037,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 return;
 
             GodotMcpConfigStore.ApplyPersisted(_config, persisted);
-            GD.Print($"[Godot-MCP] loaded persisted config ({path}).");
+            GodotMcpLog.Info($"[Godot-MCP] loaded persisted config ({path}).");
         }
 
         /// <summary>
@@ -1071,11 +1050,11 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             try
             {
                 GodotMcpConfigStore.Save(ConfigFilePath, _config);
-                GD.Print($"[Godot-MCP] saved config ({ConfigFilePath}).");
+                GodotMcpLog.Info($"[Godot-MCP] saved config ({ConfigFilePath}).");
             }
             catch (Exception ex)
             {
-                GD.PushError($"[Godot-MCP] failed to save config: {ex.Message}");
+                GodotMcpLog.Error($"[Godot-MCP] failed to save config: {ex.Message}");
             }
         }
 
@@ -1096,9 +1075,9 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                     return;
 
                 if (ok)
-                    GD.Print("[Godot-MCP] connected.");
+                    GodotMcpLog.Info("[Godot-MCP] connected.");
                 else
-                    GD.PushWarning("[Godot-MCP] initial connect returned false; client will keep retrying if KeepConnected.");
+                    GodotMcpLog.Warning("[Godot-MCP] initial connect returned false; client will keep retrying if KeepConnected.");
             }
             catch (ObjectDisposedException)
             {
@@ -1114,7 +1093,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 if (!ReferenceEquals(_plugin, plugin))
                     return;
 
-                GD.PushError($"[Godot-MCP] connect failed: {ex.Message}");
+                GodotMcpLog.Error($"[Godot-MCP] connect failed: {ex.Message}");
             }
         }
 
@@ -1147,8 +1126,8 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             {
                 // Emergency-shutdown path: never let a disconnect failure escape into the ALC-unloading
                 // handler (an exception there would abort the very unload we are trying to enable).
-                try { GD.PushError($"[Godot-MCP] immediate disconnect failed: {ex.Message}"); }
-                catch { /* GD may be unavailable mid-reload; swallow */ }
+                // GodotMcpLog.Error swallows internally, so no inline try/catch is needed here.
+                GodotMcpLog.Error($"[Godot-MCP] immediate disconnect failed: {ex.Message}");
             }
         }
 
@@ -1188,8 +1167,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             try { plugin.DisconnectImmediate(); }
             catch (Exception ex)
             {
-                try { GD.PushError($"[Godot-MCP] immediate disconnect (drain) failed: {ex.Message}"); }
-                catch { /* GD may be unavailable mid-reload; swallow */ }
+                GodotMcpLog.Error($"[Godot-MCP] immediate disconnect (drain) failed: {ex.Message}");
             }
 
             // 1.5) Bounded-JOIN that dispatched teardown BEFORE Dispose (which would tear down the manager and
@@ -1211,8 +1189,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             catch (Exception ex)
             {
                 drained = false; // treat a fault like a timeout — the teardown did not provably drain.
-                try { GD.PushError($"[Godot-MCP] wait-for-immediate-teardown (drain) failed: {ex.Message}"); }
-                catch { /* GD may be unavailable mid-reload; swallow */ }
+                GodotMcpLog.Error($"[Godot-MCP] wait-for-immediate-teardown (drain) failed: {ex.Message}");
             }
             GodotMcpDrainDiagnostics.ReportDrainResult(drained, timeout);
 
@@ -1220,8 +1197,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             try { plugin.Dispose(); }
             catch (Exception ex)
             {
-                try { GD.PushError($"[Godot-MCP] plugin dispose (drain) failed: {ex.Message}"); }
-                catch { /* GD may be unavailable mid-reload; swallow */ }
+                GodotMcpLog.Error($"[Godot-MCP] plugin dispose (drain) failed: {ex.Message}");
             }
         }
 
@@ -1271,8 +1247,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 }
                 catch (Exception ex)
                 {
-                    try { GD.PushError($"[Godot-MCP] immediate disconnect (pre-dispose) failed: {ex.Message}"); }
-                    catch { /* GD may be unavailable mid-reload */ }
+                    GodotMcpLog.Error($"[Godot-MCP] immediate disconnect (pre-dispose) failed: {ex.Message}");
                 }
 
                 try
@@ -1281,7 +1256,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 }
                 catch (Exception ex)
                 {
-                    GD.PushError($"[Godot-MCP] error disposing connection: {ex.Message}");
+                    GodotMcpLog.Error($"[Godot-MCP] error disposing connection: {ex.Message}");
                 }
                 _plugin = null;
             }

--- a/addons/godot_mcp/Runtime/Connection/GodotMcpLog.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotMcpLog.cs
@@ -1,0 +1,97 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using com.IvanMurzak.Godot.MCP.Data;
+using com.IvanMurzak.Godot.MCP.Tools;
+using Godot;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// The single capture point for the plugin's own diagnostic lines. Every <c>GD.Print</c> /
+    /// <c>GD.PushWarning</c> / <c>GD.PushError</c> the addon emits routes through here so the line is BOTH
+    /// (1) written to the Godot Output by severity AND (2) appended to
+    /// <see cref="GodotLogCollector.Current"/>, making it retrievable via the <c>console-get-logs</c> tool.
+    /// Before this helper, those ad-hoc <c>GD.Push*</c>/<c>GD.Print</c> call sites (connect/disconnect,
+    /// drain-timeout, config save/load, skill-gen, dev-control, dispatcher, runtime-capture, the #171 rebind
+    /// warning, …) were GD-only and therefore invisible to <c>console-get-logs</c> — this routing is the
+    /// intentional behavior change of PR-2.
+    ///
+    /// <para>
+    /// Lives OUTSIDE <c>#if TOOLS</c> (it ships into an exported game build where
+    /// <see cref="Runtime.GodotMcpRuntime"/> / <c>RuntimeErrorCapture</c> /
+    /// <see cref="MainThreadDispatch.MainThreadDispatcher"/> use it) and touches only the Godot runtime
+    /// <see cref="GD"/> API — exactly the surface <see cref="GodotMcpConnection"/> already depends on. Not
+    /// unit-tested (the <see cref="GD"/> sink faults in the binary-less xUnit host, like
+    /// <c>GodotMcpConnection.RouteFrameworkLog</c> before it); its severity→sink decision is trivial and
+    /// covered by the Suite-3 headless smoke.
+    /// </para>
+    ///
+    /// <para>
+    /// <see cref="Emit"/>'s internal try/catch is what lets every call site DROP its own defensive
+    /// <c>try { GD.Push* } catch { }</c> wrapper: a diagnostic must never throw (GD may be unavailable mid
+    /// editor-reload, and a collector append must never escape into the ALC-unloading teardown path). This
+    /// subsumes the former <c>GodotMcpPlugin.TryLog</c>/<c>TryLogTeardownError</c>,
+    /// <c>GodotMcpConnection.PushWarningSafe</c>, and the per-call drain-path try/catch blocks.
+    /// </para>
+    /// </summary>
+    internal static class GodotMcpLog
+    {
+        /// <summary>Info-level diagnostic: <c>GD.Print</c> + collector append (never throws).</summary>
+        internal static void Info(string message)
+            => Emit(GodotLogType.Log, message, () => GD.Print(message));
+
+        /// <summary>Warning-level diagnostic: <c>GD.PushWarning</c> + collector append (never throws).</summary>
+        internal static void Warning(string message)
+            => Emit(GodotLogType.Warning, message, () => GD.PushWarning(message));
+
+        /// <summary>Error-level diagnostic: <c>GD.PushError</c> + collector append (never throws).</summary>
+        internal static void Error(string message)
+            => Emit(GodotLogType.Error, message, () => GD.PushError(message));
+
+        /// <summary>
+        /// Route an already-leveled framework line to the matching <see cref="GD"/> sink by severity AND the
+        /// collector, preserving the incoming <paramref name="logType"/> on the collector append (so Debug /
+        /// Trace are not flattened to Log). Replaces the former <c>GodotMcpConnection.RouteFrameworkLog</c>
+        /// body, so framework logs and ad-hoc diagnostics share this one path.
+        /// </summary>
+        internal static void Route(GodotLogType logType, string message)
+        {
+            switch (logType)
+            {
+                case GodotLogType.Error:
+                    Emit(logType, message, () => GD.PushError(message));
+                    break;
+                case GodotLogType.Warning:
+                    Emit(logType, message, () => GD.PushWarning(message));
+                    break;
+                default:
+                    Emit(logType, message, () => GD.Print(message));
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// The one sanctioned native sink: invoke the <see cref="GD"/> writer, then append to the collector.
+        /// BOTH steps are independently swallowed — a diagnostic must NEVER throw (GD may be unavailable mid
+        /// editor-reload, and the collector append must never escape into a teardown / unload path). This
+        /// internal try/catch is what lets every call site drop its own defensive wrapper.
+        /// </summary>
+        static void Emit(GodotLogType logType, string message, Action gd)
+        {
+            try { gd(); }
+            catch { /* GD may be unavailable mid editor-reload; swallow */ }
+
+            try { GodotLogCollector.Current?.Append(logType, message); }
+            catch { /* a diagnostic must never throw */ }
+        }
+    }
+}

--- a/addons/godot_mcp/Runtime/GodotMcpRuntime.cs
+++ b/addons/godot_mcp/Runtime/GodotMcpRuntime.cs
@@ -206,7 +206,7 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
                 }
                 catch (Exception ex)
                 {
-                    GD.PushWarning($"[Godot-MCP] runtime error capture failed to install: {ex.Message}");
+                    GodotMcpLog.Warning($"[Godot-MCP] runtime error capture failed to install: {ex.Message}");
                 }
             }
 
@@ -302,7 +302,7 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
 
             if (Engine.GetMainLoop() is not SceneTree tree || tree.Root == null)
             {
-                GD.PushWarning(
+                GodotMcpLog.Warning(
                     "[Godot-MCP] runtime dispatcher bootstrap: no live SceneTree yet — tool handlers cannot " +
                     "marshal to the main thread until a MainThreadDispatcher is in the tree. Call " +
                     "GodotMcpRuntime.Initialize(...).Build() once the SceneTree is available (e.g. from an " +
@@ -319,7 +319,7 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
             // Initialize().Build() already returned at the Instance != null guard above.)
             tree.Root.CallDeferred(Node.MethodName.AddChild, dispatcher);
 
-            GD.Print($"[Godot-MCP] runtime main-thread dispatcher scheduled ('{DispatcherNodeName}').");
+            GodotMcpLog.Info($"[Godot-MCP] runtime main-thread dispatcher scheduled ('{DispatcherNodeName}').");
         }
     }
 }

--- a/addons/godot_mcp/Runtime/MainThread/MainThreadDispatcher.cs
+++ b/addons/godot_mcp/Runtime/MainThread/MainThreadDispatcher.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Threading;
+using com.IvanMurzak.Godot.MCP.Connection;
 using Godot;
 
 namespace com.IvanMurzak.Godot.MCP.MainThreadDispatch
@@ -216,7 +217,7 @@ namespace com.IvanMurzak.Godot.MCP.MainThreadDispatch
                 }
                 catch (Exception ex)
                 {
-                    GD.PushError($"[Godot-MCP] MainThreadDispatcher per-tick callback threw: {ex}");
+                    GodotMcpLog.Error($"[Godot-MCP] MainThreadDispatcher per-tick callback threw: {ex}");
                 }
             }
         }
@@ -263,7 +264,7 @@ namespace com.IvanMurzak.Godot.MCP.MainThreadDispatch
             }
             catch (Exception ex)
             {
-                GD.PushError($"[Godot-MCP] MainThreadDispatcher action threw: {ex}");
+                GodotMcpLog.Error($"[Godot-MCP] MainThreadDispatcher action threw: {ex}");
             }
         }
 

--- a/addons/godot_mcp/Runtime/Tools/GodotScriptErrorLogger.cs
+++ b/addons/godot_mcp/Runtime/Tools/GodotScriptErrorLogger.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using com.IvanMurzak.Godot.MCP.Connection;
 using com.IvanMurzak.Godot.MCP.Data;
 using Godot;
 
@@ -344,7 +345,7 @@ namespace com.IvanMurzak.Godot.MCP.Tools
                     // engine errors land in a collector the current handle no longer reads → runtime-errors-get
                     // falls silently quiet, the #160 failure this feature prevents). Surface the rebind so a
                     // stale-sink regression is never silent again.
-                    GD.PushWarning(
+                    GodotMcpLog.Warning(
                         "[Godot-MCP] engine error-logger re-installed with a new capture; rebinding the live " +
                         "logger to it so runtime errors route to the current collector (issue #171).");
                     _installed!.RebindCapture(capture);

--- a/addons/godot_mcp/Runtime/Tools/Tool_Console.GetLogs.cs
+++ b/addons/godot_mcp/Runtime/Tools/Tool_Console.GetLogs.cs
@@ -28,7 +28,9 @@ namespace com.IvanMurzak.Godot.MCP.Tools
         )]
         [Description("Retrieve captured Godot-MCP editor log lines, newest-first. The Godot analog of " +
             "Unity's 'console-get-logs'. NOTE: Godot's C# API exposes no global log hook, so this returns " +
-            "the plugin's own captured editor activity (not the entire Godot editor console).\n" +
+            "the plugin's own captured editor activity (not the entire Godot editor console) — including its " +
+            "connection lifecycle diagnostics (connect/disconnect, drain-timeout, config save/load, skill-gen, " +
+            "dev-control, dispatcher, and runtime-capture warnings).\n" +
             "Inputs:\n" +
             "  - 'maxEntries' (default 100, min 1): caps the returned array (most-recent lines kept).\n" +
             "  - 'logTypeFilter' (default null = all): restrict to Log / Warning / Error.\n" +


### PR DESCRIPTION
## Summary
PR-2 (the second and final PR) of the approved error-capture-unification design (PR-1 = #220, merged).

- Adds `addons/godot_mcp/Runtime/Connection/GodotMcpLog.cs` — the **single capture point** (`Info`/`Warning`/`Error`/`Route`) that (1) writes to `GD.*` by severity, (2) appends to `GodotLogCollector.Current`, and (3) swallows faults via an internal `Emit` try/catch. It lives **outside `#if TOOLS`** (ships into the exported game build) and touches only the Godot runtime `GD.*` API.
- Mechanical 1:1 sweep of the ~34 `GD.Push(Warning|Error)` + ~13 `GD.Print` call sites (47 across 10 files, dominated by `GodotMcpConnection.cs`) onto `GodotMcpLog.*`.
- Folds the three duplicated defensive wrappers into `GodotMcpLog.Emit`: `GodotMcpPlugin.TryLog`/`TryLogTeardownError`, `GodotMcpConnection.PushWarningSafe`, and the per-call `try { GD.Push* } catch {}` drain-path blocks (the redundant try/catch is deleted — the helper swallows).
- Re-points `RouteFrameworkLog` → `GodotMcpLog.Route`, `GodotMcpDrainDiagnostics.Warn` → `GodotMcpLog.Warning` (the #190 silent-#78513-reintroduction guard, **preserved, not dropped**), and the editor boot's injected `GodotLogSink` → `GodotMcpLog.Route` so framework + ad-hoc logs share one path.
- Keeps `GD.*` **direct** in exactly two spots per the design: `GodotMcpLog.Emit` itself, and `GodotMcpConnection.ResolvePluginVersion` (a static type-initializer that runs before any collector exists — left direct and self-guarded).

## Intentional behavior change (the deliverable)
`console-get-logs` now **additionally surfaces** connection lifecycle diagnostics that were previously `GD`-only: connect/disconnect failures, drain-timeout warnings, config save/load failures, skill-gen failures, dev-control bind failures, dispatcher per-tick callback throws, the #171 rebind warning, and runtime-capture install warnings. This is the deliverable, not a regression — documented in the `console-get-logs` tool description and the README.

**Side effect:** more captured lines ⇒ faster FIFO eviction against `GodotLogCollector`'s `Capacity = 1000` bound. Acceptable. **No secrets are introduced** — every routed string is an existing diagnostic the framework already prints.

## No regressions
The pure-managed cores (`GodotLogCollector`, `ScriptErrorCapture`, `RuntimeErrorCollector`, `EngineErrorRecord`) and the `ScriptErrorCapture.PlanBridgeInstall` funnel are untouched, so the #163/#171/#173/#165/#194 regression suites are unaffected. `GodotMcpLog.cs` is added to `Godot-MCP.Tests.csproj`'s Compile set because `MainThreadDispatcher`/`GodotMcpRuntime`/`GodotScriptErrorLogger` (compiled into the test assembly) now reference it.

## Test plan
- [x] `dotnet build Godot-MCP.sln --configuration Debug` — 0 errors (Suite 1, CI parity).
- [x] `dotnet test Godot-MCP.Tests` — **952 passed / 0 failed** (Suite 2). `ConsoleToolTests` assert structure (newest-first / capacity / filters / stable tool-id), not specific framework lines, so the new routing did not require any test-expectation change.
- [ ] Live-editor / headless Suite-3 behavioral verification: build-verified; live-editor verification pending operator (no Godot binary in CI; the Godot 4.5/4.6/4.7 mono addon-load matrix exercises the `#if GODOT4_5_OR_GREATER` `GodotScriptErrorLogger` path).

Closes #221