### PR TITLE
feat: add godot-cli install-extension + shared extension catalog

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -273,6 +273,7 @@
          The editor wiring (ConsumerProjectFile.cs, ExtensionsPanel.cs, ExtensionRow.cs) is #if TOOLS and verified
          via the headless Godot smoke (test.md Suite 3); the plan/detect/install logic is unit-tested here. -->
     <Compile Include="..\addons\godot_mcp\Runtime\Extensions\GodotExtensionDescriptor.cs" Link="Source\GodotExtensionDescriptor.cs" />
+    <Compile Include="..\addons\godot_mcp\Runtime\Extensions\GodotExtensionCatalog.cs" Link="Source\GodotExtensionCatalog.cs" />
     <Compile Include="..\addons\godot_mcp\Runtime\Extensions\GodotExtensionRegistry.cs" Link="Source\GodotExtensionRegistry.cs" />
     <Compile Include="..\addons\godot_mcp\Runtime\Extensions\ExtensionInstallPlanner.cs" Link="Source\ExtensionInstallPlanner.cs" />
     <Compile Include="..\addons\godot_mcp\Runtime\Extensions\InstalledStateDetector.cs" Link="Source\InstalledStateDetector.cs" />
@@ -318,6 +319,15 @@
          builder-only tests never instantiate it). Compiled in so the runtime sources resolve their usings. -->
     <Compile Include="..\addons\godot_mcp\Runtime\MainThread\MainThreadDispatcher.cs" Link="Source\MainThreadDispatcher.cs" />
     <Compile Include="..\addons\godot_mcp\Runtime\MainThread\GodotMainThread.cs" Link="Source\GodotMainThread.cs" />
+  </ItemGroup>
+
+  <!--
+    Same shared extension catalog the addon assembly embeds (Godot-MCP.csproj), under the SAME LogicalName so the
+    registry's GodotExtensionCatalog.LoadEmbedded() resolves it from THIS test assembly too. This is what lets
+    GodotExtensionCatalogTests prove the embedded-resource round-trip without a Godot binary.
+  -->
+  <ItemGroup>
+    <EmbeddedResource Include="..\addons\godot_mcp\extensions.catalog.json" LogicalName="Godot-MCP.extensions.catalog.json" />
   </ItemGroup>
 
 </Project>

--- a/Godot-MCP.Tests/GodotExtensionCatalogTests.cs
+++ b/Godot-MCP.Tests/GodotExtensionCatalogTests.cs
@@ -1,0 +1,118 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Linq;
+using com.IvanMurzak.Godot.MCP.Extensions;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the shared-catalog parser <see cref="GodotExtensionCatalog"/>: the JSON → <see cref="GodotExtensionDescriptor"/>
+    /// transform (pure, tolerant of malformed/partial input) AND the embedded-resource round-trip
+    /// (<see cref="GodotExtensionCatalog.LoadEmbedded"/> reads the SAME <c>extensions.catalog.json</c> that ships in the
+    /// addon assembly — embedded into this test assembly under the same LogicalName by Godot-MCP.Tests.csproj). The
+    /// catalog is the single source of truth the dock + CLI both consume; this is the dock half.
+    /// </summary>
+    public class GodotExtensionCatalogTests
+    {
+        const string PopulatedCatalog =
+@"{
+  ""schemaVersion"": 1,
+  ""extensions"": [
+    {
+      ""name"": ""ProBuilder Tools"",
+      ""description"": ""Mesh-editing MCP tools for Godot."",
+      ""packageId"": ""com.IvanMurzak.Godot.MCP.ProBuilder"",
+      ""version"": ""1.2.0"",
+      ""gitUrl"": ""https://github.com/IvanMurzak/Godot-MCP"",
+      ""tools"": [
+        { ""name"": ""probuilder-extrude"", ""description"": ""Extrude faces."" }
+      ]
+    },
+    {
+      ""name"": ""Floating Ext"",
+      ""description"": ""No version pin."",
+      ""packageId"": ""com.x.Floating""
+    }
+  ]
+}";
+
+        [Fact]
+        public void Parse_PopulatedCatalog_MapsAllFields()
+        {
+            var list = GodotExtensionCatalog.Parse(PopulatedCatalog);
+            Assert.Equal(2, list.Count);
+
+            var pb = list[0];
+            Assert.Equal("ProBuilder Tools", pb.Name);
+            Assert.Equal("Mesh-editing MCP tools for Godot.", pb.Description);
+            Assert.Equal("com.IvanMurzak.Godot.MCP.ProBuilder", pb.PackageId);
+            Assert.Equal("1.2.0", pb.Version);
+            Assert.True(pb.HasVersion);
+            Assert.Equal("https://github.com/IvanMurzak/Godot-MCP", pb.GitUrl);
+            Assert.Single(pb.Tools);
+            Assert.Equal("probuilder-extrude", pb.Tools[0].Name);
+            Assert.Equal("Extrude faces.", pb.Tools[0].Description);
+        }
+
+        [Fact]
+        public void Parse_OmittedVersion_YieldsNullVersion()
+        {
+            var list = GodotExtensionCatalog.Parse(PopulatedCatalog);
+            var floating = list[1];
+            Assert.Equal("com.x.Floating", floating.PackageId);
+            Assert.Null(floating.Version);
+            Assert.False(floating.HasVersion);
+            Assert.Empty(floating.Tools);
+        }
+
+        [Fact]
+        public void Parse_DropsEntries_MissingNameOrPackageId()
+        {
+            const string partial =
+@"{ ""extensions"": [
+    { ""name"": """", ""packageId"": ""com.a"" },
+    { ""name"": ""B"", ""packageId"": """" },
+    { ""description"": ""no name or id"" },
+    { ""name"": ""Good"", ""packageId"": ""com.good"" }
+] }";
+            var list = GodotExtensionCatalog.Parse(partial);
+            Assert.Single(list);
+            Assert.Equal("com.good", list[0].PackageId);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("{ not valid json")]
+        [InlineData(@"{ ""extensions"": [] }")]
+        [InlineData("{}")]
+        public void Parse_ReturnsEmpty_OnMissingEmptyOrInvalid(string? json)
+        {
+            Assert.Empty(GodotExtensionCatalog.Parse(json));
+        }
+
+        [Fact]
+        public void LoadEmbedded_RoundTripsTheShippedCatalog()
+        {
+            // The shipped catalog is currently empty, so this proves the embedded resource resolves + parses (an
+            // unresolved resource would ALSO return empty, so we additionally assert the resource is actually present).
+            var assembly = typeof(GodotExtensionCatalog).Assembly;
+            Assert.Contains(GodotExtensionCatalog.EmbeddedResourceName, assembly.GetManifestResourceNames());
+
+            var list = GodotExtensionCatalog.LoadEmbedded();
+            Assert.NotNull(list);
+            // Registry binds to exactly this — they must agree.
+            Assert.Equal(GodotExtensionRegistry.All.Count, list.Count);
+        }
+    }
+}

--- a/Godot-MCP.csproj
+++ b/Godot-MCP.csproj
@@ -38,4 +38,15 @@
     <Compile Remove="Godot-Tests/**/*.cs" />
   </ItemGroup>
 
+  <!--
+    Shared extension catalog (single source of truth — see addons/godot_mcp/extensions.catalog.md). Embedded into the
+    addon assembly so the pure-managed GodotExtensionRegistry can parse the REAL catalog at editor runtime with no
+    res:// / filesystem dependency. The CLI mirrors the same JSON (cli/src/utils/extensions-catalog.ts), enforced
+    byte-equal by a parity test. The LogicalName is fixed so GetManifestResourceStream resolves identically in the
+    addon assembly AND the Godot-MCP.Tests assembly (which embeds the same file under the same name).
+  -->
+  <ItemGroup>
+    <EmbeddedResource Include="addons/godot_mcp/extensions.catalog.json" LogicalName="Godot-MCP.extensions.catalog.json" />
+  </ItemGroup>
+
 </Project>

--- a/addons/godot_mcp/Runtime/Extensions/GodotExtensionCatalog.cs
+++ b/addons/godot_mcp/Runtime/Extensions/GodotExtensionCatalog.cs
@@ -63,7 +63,7 @@ namespace com.IvanMurzak.Godot.MCP.Extensions
             CatalogDocument? doc;
             try
             {
-                doc = JsonSerializer.Deserialize<CatalogDocument>(json!, _options);
+                doc = JsonSerializer.Deserialize<CatalogDocument>(json, _options);
             }
             catch (JsonException)
             {

--- a/addons/godot_mcp/Runtime/Extensions/GodotExtensionCatalog.cs
+++ b/addons/godot_mcp/Runtime/Extensions/GodotExtensionCatalog.cs
@@ -1,0 +1,150 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.Godot.MCP.Extensions
+{
+    /// <summary>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) parser of the SHARED extension catalog JSON
+    /// (<c>addons/godot_mcp/extensions.catalog.json</c> — see <c>extensions.catalog.md</c>). It is the dock's half of
+    /// the "single source of truth consumed by all three install channels" contract: the same JSON is mirrored by the
+    /// CLI (<c>cli/src/utils/extensions-catalog.ts</c>, enforced byte-equal by a parity test).
+    ///
+    /// <para>
+    /// The catalog ships EMBEDDED into the addon assembly as <c>Godot-MCP.extensions.catalog.json</c>
+    /// (<c>&lt;EmbeddedResource&gt;</c> in <c>Godot-MCP.csproj</c>), so the <see cref="GodotExtensionRegistry"/> reads
+    /// the real catalog at runtime with no <c>res://</c> / filesystem dependency — which keeps the registry static,
+    /// pure-managed, and CI-unit-testable. <see cref="Parse"/> is the tested seam; <see cref="LoadEmbedded"/> is the
+    /// thin shell that streams the embedded resource into it.
+    /// </para>
+    ///
+    /// <para>
+    /// Tolerant by design: a missing resource, empty/whitespace text, malformed JSON, or entries missing the required
+    /// <c>name</c> / <c>packageId</c> all collapse to an EMPTY descriptor list rather than throwing — the same
+    /// "no usable catalog → ship empty" discipline the rest of the Extensions infrastructure follows.
+    /// </para>
+    /// </summary>
+    public static class GodotExtensionCatalog
+    {
+        /// <summary>The logical name the catalog JSON is embedded under (see the <c>&lt;EmbeddedResource&gt;</c> LogicalName).</summary>
+        public const string EmbeddedResourceName = "Godot-MCP.extensions.catalog.json";
+
+        static readonly JsonSerializerOptions _options = new()
+        {
+            PropertyNameCaseInsensitive = true,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true
+        };
+
+        /// <summary>
+        /// Parse the shared-catalog JSON text into the ordered <see cref="GodotExtensionDescriptor"/> list. Entries are
+        /// kept in document order; entries missing a non-empty <c>name</c> or <c>packageId</c> are dropped. Returns an
+        /// EMPTY list for null / whitespace / unparseable JSON — never throws.
+        /// </summary>
+        public static IReadOnlyList<GodotExtensionDescriptor> Parse(string? json)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+                return Array.Empty<GodotExtensionDescriptor>();
+
+            CatalogDocument? doc;
+            try
+            {
+                doc = JsonSerializer.Deserialize<CatalogDocument>(json!, _options);
+            }
+            catch (JsonException)
+            {
+                return Array.Empty<GodotExtensionDescriptor>();
+            }
+
+            var entries = doc?.Extensions;
+            if (entries == null || entries.Count == 0)
+                return Array.Empty<GodotExtensionDescriptor>();
+
+            var result = new List<GodotExtensionDescriptor>(entries.Count);
+            foreach (var entry in entries)
+            {
+                if (entry == null)
+                    continue;
+                if (string.IsNullOrWhiteSpace(entry.Name) || string.IsNullOrWhiteSpace(entry.PackageId))
+                    continue;
+
+                var tools = entry.Tools == null
+                    ? Array.Empty<(string, string)>()
+                    : entry.Tools
+                        .Where(t => t != null && !string.IsNullOrWhiteSpace(t!.Name))
+                        .Select(t => (t!.Name!.Trim(), (t.Description ?? string.Empty).Trim()))
+                        .ToArray();
+
+                result.Add(new GodotExtensionDescriptor(
+                    Name: entry.Name!.Trim(),
+                    Description: (entry.Description ?? string.Empty).Trim(),
+                    PackageId: entry.PackageId!.Trim(),
+                    Version: string.IsNullOrWhiteSpace(entry.Version) ? null : entry.Version!.Trim(),
+                    GitUrl: string.IsNullOrWhiteSpace(entry.GitUrl) ? null : entry.GitUrl!.Trim(),
+                    Tools: tools));
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Load + parse the catalog JSON embedded in <paramref name="assembly"/> (defaults to the assembly hosting
+        /// this type). Returns an EMPTY list when the resource is absent or unreadable — never throws.
+        /// </summary>
+        public static IReadOnlyList<GodotExtensionDescriptor> LoadEmbedded(Assembly? assembly = null)
+        {
+            assembly ??= typeof(GodotExtensionCatalog).Assembly;
+            try
+            {
+                using var stream = assembly.GetManifestResourceStream(EmbeddedResourceName);
+                if (stream == null)
+                    return Array.Empty<GodotExtensionDescriptor>();
+
+                using var reader = new StreamReader(stream);
+                return Parse(reader.ReadToEnd());
+            }
+            catch (Exception)
+            {
+                return Array.Empty<GodotExtensionDescriptor>();
+            }
+        }
+
+        // --- JSON DTOs (deserialization shape; mapped to GodotExtensionDescriptor above) -----------------------
+
+        sealed class CatalogDocument
+        {
+            [JsonPropertyName("schemaVersion")] public int SchemaVersion { get; set; }
+            [JsonPropertyName("extensions")] public List<CatalogEntry?>? Extensions { get; set; }
+        }
+
+        sealed class CatalogEntry
+        {
+            [JsonPropertyName("name")] public string? Name { get; set; }
+            [JsonPropertyName("description")] public string? Description { get; set; }
+            [JsonPropertyName("packageId")] public string? PackageId { get; set; }
+            [JsonPropertyName("version")] public string? Version { get; set; }
+            [JsonPropertyName("gitUrl")] public string? GitUrl { get; set; }
+            [JsonPropertyName("tools")] public List<CatalogTool?>? Tools { get; set; }
+        }
+
+        sealed class CatalogTool
+        {
+            [JsonPropertyName("name")] public string? Name { get; set; }
+            [JsonPropertyName("description")] public string? Description { get; set; }
+        }
+    }
+}

--- a/addons/godot_mcp/Runtime/Extensions/GodotExtensionRegistry.cs
+++ b/addons/godot_mcp/Runtime/Extensions/GodotExtensionRegistry.cs
@@ -20,21 +20,23 @@ namespace com.IvanMurzak.Godot.MCP.Extensions
     /// dock panel binds to <see cref="All"/> generically.
     ///
     /// <para>
-    /// <b>Ships EMPTY for now.</b> No Godot-MCP extension package exists on nuget.org yet — creating the first real
-    /// extension package + a <c>Godot-AI-Tools-Template</c> repo + the NuGet publish is a SEPARATE follow-up task. The
-    /// dock renders an honest "coming soon" placeholder while <see cref="All"/> is empty (see the
-    /// <c>ExtensionsPanel</c>). To add a real extension once it is published: append ONE
-    /// <see cref="GodotExtensionDescriptor"/> to <see cref="_descriptors"/> below — no other file needs to change.
+    /// The list is sourced from the SHARED catalog <c>addons/godot_mcp/extensions.catalog.json</c> (the single source
+    /// of truth consumed by the dock, the CLI, and — later — the app; see <c>extensions.catalog.md</c>). That JSON is
+    /// embedded into the addon assembly and parsed once by <see cref="GodotExtensionCatalog.LoadEmbedded"/>. To add a
+    /// real extension once it is published: append ONE entry to <c>extensions.catalog.json</c> — no code changes here.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Ships EMPTY for now.</b> No Godot-MCP extension package exists on nuget.org yet, so the catalog's
+    /// <c>extensions</c> array is empty and the dock renders an honest "coming soon" placeholder while
+    /// <see cref="All"/> is empty (see the <c>ExtensionsPanel</c>).
     /// </para>
     /// </summary>
     public static class GodotExtensionRegistry
     {
-        // The extension descriptor list. EMPTY until the first extension package is published (follow-up task). To
-        // add one, append a `new GodotExtensionDescriptor(...)` line here.
-        static readonly IReadOnlyList<GodotExtensionDescriptor> _descriptors = new GodotExtensionDescriptor[]
-        {
-            // (none yet — see the type doc-comment)
-        };
+        // The extension descriptor list, loaded once from the shared embedded catalog JSON (single source of truth).
+        // EMPTY until the first extension package is published — add one by appending to extensions.catalog.json.
+        static readonly IReadOnlyList<GodotExtensionDescriptor> _descriptors = GodotExtensionCatalog.LoadEmbedded();
 
         /// <summary>Every registered extension descriptor, in display order. Empty until the first package ships.</summary>
         public static IReadOnlyList<GodotExtensionDescriptor> All => _descriptors;

--- a/addons/godot_mcp/extensions.catalog.json
+++ b/addons/godot_mcp/extensions.catalog.json
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": 1,
+  "extensions": []
+}

--- a/addons/godot_mcp/extensions.catalog.md
+++ b/addons/godot_mcp/extensions.catalog.md
@@ -1,0 +1,57 @@
+# Shared extension catalog — `extensions.catalog.json`
+
+`extensions.catalog.json` (this folder) is the **single source of truth** for the Godot-MCP
+**extension catalog** — the list of optional AI-tool-family packages a consumer project can install.
+It is consumed by all THREE install channels so they can never drift:
+
+| Channel | How it consumes the catalog |
+| --- | --- |
+| **Dock** (in-editor `Extensions` panel) | The pure-managed `GodotExtensionRegistry` parses this JSON, which is **embedded into the addon assembly** as `Godot-MCP.extensions.catalog.json` (`<EmbeddedResource>` in `Godot-MCP.csproj`). `GodotExtensionCatalog.LoadEmbedded()` reads it; the dock binds to `GodotExtensionRegistry.All`. |
+| **CLI** (`godot-cli install-extension`) | The CLI ships a typed mirror, `cli/src/utils/extensions-catalog.ts`, kept **byte-identical** to this JSON by the parity test `cli/tests/extensions-catalog-parity.test.ts` (the same single-source discipline `addon-deps.ts` / `addon-deps-parity.test.ts` use for the NuGet pins). The mirror avoids a runtime `../addons` dependency so the published npm package stays self-contained. |
+| **App** (`AI-Game-Dev-App`, later) | Imports the catalog + `installExtension` from the `godot-cli` library (`import { EXTENSIONS_CATALOG, installExtension } from 'godot-cli'`). It never re-implements the list, so it inherits the CLI's parity guarantee transitively. |
+
+## Schema
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "extensions": [
+    {
+      "name": "ProBuilder Tools",                       // display name (row title)
+      "description": "Mesh-editing MCP tools for Godot.", // one-line description
+      "packageId": "com.IvanMurzak.Godot.MCP.ProBuilder", // INSTALL IDENTITY — the NuGet <PackageReference Include="...">
+      "version": "1.2.0",                                  // OPTIONAL pin; omit for a floating reference
+      "gitUrl": "https://github.com/IvanMurzak/...",       // OPTIONAL repo/docs link
+      "tools": [                                           // OPTIONAL contributed-tool list
+        { "name": "probuilder-extrude", "description": "Extrude faces." }
+      ]
+    }
+  ]
+}
+```
+
+- `packageId` is the **install identity**. Installing an extension adds a
+  `<PackageReference Include="<packageId>" Version="<version>" />` to the consumer project's
+  `.csproj` (Godot compiles every `.cs` under the project into one assembly, so the package's
+  `[AiToolType]` tool families compile into the consumer's project). Installed state is detected by
+  matching this id against the consumer's existing package references.
+- `version` is OPTIONAL. When present it pins the reference AND drives the up-to-date / update-available
+  decision (numeric, component-wise compare — `1.10.0` > `1.2.0`). When absent the reference is added
+  WITHOUT a `Version` attribute (floating / centrally-managed), and a present reference is never bumped.
+- `name`, `packageId` are REQUIRED and non-empty; entries missing either are ignored by both parsers.
+
+## Ships empty (for now)
+
+No Godot-MCP extension package exists on nuget.org yet, so `extensions` is `[]` and the dock renders an
+honest "coming soon" placeholder. To add the first real extension once it is published: append ONE entry
+to `extensions` here — no other file changes (the dock reads it via the embedded resource; the CLI's
+parity test forces `extensions-catalog.ts` to be updated to match, which the CLI then consumes).
+
+## Behavioral parity contract
+
+The CLI's `install-extension` (`cli/src/utils/extension-install.ts`) MUST stay behaviorally identical to
+the dock's `ExtensionInstaller` / `ExtensionInstallPlanner` (`addons/godot_mcp/Runtime/Extensions/`):
+add-when-absent, bump-only-upward, no-op-when-equal-or-newer, no-op-when-descriptor-unversioned, and the
+numeric-tolerant version compare. The shared scenario set is encoded on BOTH sides
+(`Godot-MCP.Tests/ExtensionInstallTests.cs` and `cli/tests/extension-install.test.ts`) so a divergence in
+either implementation fails a test.

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to `godot-cli` are documented in this file.
 
+## Unreleased
+
+- `install-extension <id> [path]` — install a Godot-MCP **extension** (an optional AI-tool-family package)
+  into a Godot C# project: resolve `<id>` from the shared catalog, add/update its `<PackageReference>` in
+  the project `.csproj` (added when absent, version-bumped only when newer, no-op when up to date), then
+  ask the user to rebuild. Idempotent and behaviorally identical to the in-editor Extensions dock.
+- Added `installExtension` to the library API, plus the shared `EXTENSIONS_CATALOG` + `findExtension`
+  exports so the app can render/install the same list the dock + CLI use.
+- The extension catalog (`addons/godot_mcp/extensions.catalog.json`) is now the single source of truth
+  consumed by all three channels: the dock parses it via an embedded resource, the CLI mirrors it
+  (`extensions-catalog.ts`, parity-tested), and the app imports it from the `godot-cli` library.
+
 ## 0.1.0
 
 Initial release. A cross-platform CLI for Godot-MCP, mirroring `unity-mcp-cli`'s feature set and structure,

--- a/cli/README.md
+++ b/cli/README.md
@@ -36,6 +36,7 @@ Requires Node `^20.19.0 || >=22.12.0`.
 | `configure [path]` | List / enable / disable tools, prompts, and resources in the project-local `.godot-mcp/features.json`. |
 | `close [path]` | Gracefully stop the Godot editor running for a project (`--force` to hard-kill). |
 | `install-plugin [path]` | Install the `godot_mcp` addon end-to-end: materialize `res://addons/godot_mcp/` (download the matching GitHub release, or `--source <path>` a local copy), add the required NuGet `PackageReference`s to the project `.csproj`, and enable the plugin. Idempotent. |
+| `install-extension <id> [path]` | Install a Godot-MCP **extension** (an optional AI-tool-family package) into the project: resolve `<id>` from the shared catalog, add/update its `<PackageReference>` in the project `.csproj`, then rebuild to restore. Idempotent — behaviorally identical to the in-editor dock. |
 | `remove-plugin [path]` | Disable the `godot_mcp` addon in `project.godot` `[editor_plugins]` (does not delete the addon files). |
 | `update` | Check npm for a newer `godot-cli` and install it. |
 
@@ -141,12 +142,41 @@ It performs three steps:
 It is library-safe (returns a `{ kind: 'success' | 'failure' }` union; never throws past the public
 boundary) and idempotent — re-running on an already-installed project reports no change.
 
+## `install-extension`
+
+`godot-cli install-extension <id> [path]` installs an optional Godot-MCP **extension** (a package that
+adds more AI tool families) into a Godot C# project — the terminal/library channel for the same install
+the in-editor **Extensions** dock performs:
+
+```bash
+godot-cli install-extension com.IvanMurzak.Godot.MCP.ProBuilder ./MyGodotProject   # add/update the PackageReference
+godot-cli install-extension "ProBuilder Tools"                                      # resolve by name; default cwd
+godot-cli install-extension com.IvanMurzak.Godot.MCP.ProBuilder --version 1.3.0     # override the catalog pin
+```
+
+- Resolves `<id>` against the **shared extension catalog** (`addons/godot_mcp/extensions.catalog.json` —
+  the single source of truth the dock, the CLI, and the app all consume), matching by package id (then
+  name), case-insensitive.
+- Read-modify-writes a `<PackageReference Include="<packageId>" Version="<version>" />` into the project's
+  root `.csproj`: **added** when absent, version **bumped** only when the catalog (or `--version`) pins a
+  newer version, and a **no-op** when already up to date — then asks you to rebuild (`godot-cli build`) so
+  Godot restores + compiles the new package.
+- Behaviorally identical to the dock's `ExtensionInstaller` (the same add / update / no-op + numeric
+  version-compare rules; verified by a shared scenario set on both sides).
+
+> The catalog ships **empty** until the first Godot-MCP extension package is published, so every `<id>` is
+> currently reported as an unknown extension — there is nothing to install yet.
+
 ## Library API
 
 The package also exports a side-effect-free library (the `.` entry):
 
 ```ts
-import { openProject, runTool, setupMcp, installPlugin } from 'godot-cli';
+import { openProject, runTool, setupMcp, installPlugin, installExtension } from 'godot-cli';
+
+// The shared extension catalog + lookup helpers are exported too, so a GUI (the app)
+// can render the same list the dock + CLI install from:
+import { EXTENSIONS_CATALOG, findExtension } from 'godot-cli';
 ```
 
 Every function returns a discriminated union (`{ kind: 'success', ... }` / `{ kind: 'failure', error }`)

--- a/cli/src/commands/install-extension.ts
+++ b/cli/src/commands/install-extension.ts
@@ -54,7 +54,10 @@ export const installExtensionCommand = new Command('install-extension')
         spinner.success(`${result.packageId} is already up to date`);
         break;
       case 'no-project':
-        spinner.error('No project .csproj found');
+        // A no-project result is a kind:'success' outcome (exit 0) — use the success
+        // indicator so the spinner doesn't show a red error contradicting the exit code.
+        // The explanation is surfaced once below via ui.label('Status', result.message).
+        spinner.success('No project .csproj found — nothing to install');
         break;
     }
 

--- a/cli/src/commands/install-extension.ts
+++ b/cli/src/commands/install-extension.ts
@@ -1,0 +1,71 @@
+import { Command } from 'commander';
+import * as path from 'path';
+import * as ui from '../utils/ui.js';
+import { verbose } from '../utils/ui.js';
+import { installExtension } from '../lib/install-extension.js';
+
+interface InstallExtensionCliOptions {
+  path?: string;
+  version?: string;
+}
+
+export const installExtensionCommand = new Command('install-extension')
+  .description(
+    'Install a Godot-MCP extension into a Godot C# project: resolve the extension <id> from the shared catalog, add (or update) its <PackageReference> in the project .csproj, then rebuild to restore it. Idempotent. The project path defaults to the current directory (like install-plugin).',
+  )
+  .argument('<id>', 'Extension id to install (the package id, or the extension name)')
+  .argument('[path]', 'Path to the Godot project (defaults to the current directory)')
+  .option('--path <path>', 'Path to the Godot project')
+  .option('--version <x.y.z>', 'Override the catalog-pinned version to install')
+  .action(async (id: string, positionalPath: string | undefined, options: InstallExtensionCliOptions) => {
+    const resolvedPath = positionalPath ?? options.path ?? process.cwd();
+    const projectPath = path.resolve(resolvedPath);
+
+    ui.heading('Installing Godot-MCP extension');
+    verbose(`Extension id: ${id}`);
+    verbose(`Project path: ${projectPath}`);
+    if (options.version) verbose(`--version: ${options.version}`);
+
+    const spinner = ui.startSpinner('Installing extension...');
+    const result = await installExtension({
+      godotProjectPath: projectPath,
+      extensionId: id,
+      version: options.version,
+    });
+
+    if (result.kind === 'failure') {
+      spinner.error('Failed to install extension');
+      ui.error(result.error.message);
+      for (const warning of result.warnings) {
+        console.log('');
+        ui.warn(warning);
+      }
+      process.exit(1);
+    }
+
+    switch (result.outcome) {
+      case 'added':
+        spinner.success(`Installed ${result.packageId}`);
+        break;
+      case 'updated':
+        spinner.success(`Updated ${result.packageId} to ${result.toVersion}`);
+        break;
+      case 'already-up-to-date':
+        spinner.success(`${result.packageId} is already up to date`);
+        break;
+      case 'no-project':
+        spinner.error('No project .csproj found');
+        break;
+    }
+
+    ui.label('Status', result.message);
+    if (result.csprojPath) ui.label('Project .csproj', result.csprojPath);
+    if (result.rebuildRequired) {
+      ui.label('Next step', 'Rebuild solutions (e.g. `godot-cli build`) to restore + compile the extension.');
+    }
+
+    for (const warning of result.warnings) {
+      console.log('');
+      ui.warn(warning);
+    }
+  });

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -13,6 +13,7 @@ import { createProjectCommand } from './commands/create-project.js';
 import { closeCommand } from './commands/close.js';
 import { createUpdateCommand } from './commands/update.js';
 import { installPluginCommand } from './commands/install-plugin.js';
+import { installExtensionCommand } from './commands/install-extension.js';
 import { removePluginCommand } from './commands/remove-plugin.js';
 import { configureStyledHelp, error as uiError, setVerbose } from './utils/ui.js';
 import { checkForUpdate, isRunningViaNpx, printUpdateNotification } from './utils/update-check.js';
@@ -35,6 +36,7 @@ const subcommands = [
   configureCommand,
   createProjectCommand,
   installPluginCommand,
+  installExtensionCommand,
   openCommand,
   removePluginCommand,
   runToolCommand,

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -20,6 +20,12 @@ export { runTool, runSystemTool } from './lib/run-tool.js';
 export { setupMcp, listAgentIds } from './lib/setup-mcp.js';
 export { setupSkills } from './lib/setup-skills.js';
 export { installPlugin, removePlugin } from './lib/install-plugin.js';
+export { installExtension } from './lib/install-extension.js';
+
+// Shared extension catalog (single-sourced from addons/godot_mcp/extensions.catalog.json)
+// + its lookup helpers, so the app can render the same list the dock + CLI install from.
+export { EXTENSIONS_CATALOG, findExtension, hasVersion } from './utils/extensions-catalog.js';
+export type { ExtensionDescriptor, ExtensionTool } from './utils/extensions-catalog.js';
 
 export type {
   // Shared
@@ -75,4 +81,10 @@ export type {
   RemovePluginResult,
   RemovePluginSuccess,
   RemovePluginFailure,
+  // install-extension
+  InstallExtensionOptions,
+  InstallExtensionResult,
+  InstallExtensionSuccess,
+  InstallExtensionFailure,
+  ExtensionInstallOutcome,
 } from './lib/types.js';

--- a/cli/src/lib/install-extension.ts
+++ b/cli/src/lib/install-extension.ts
@@ -78,7 +78,6 @@ export async function installExtension(
       const message =
         'No project .csproj found at the project root — open this addon inside a Godot C# project to install extensions. ' +
         `Create one (e.g. \`godot-cli create-project --dotnet\`) and add the ${descriptor.packageId} PackageReference.`;
-      warnings.push(message);
       emitProgress(opts.onProgress, { phase: 'done', message: 'No project .csproj — nothing installed.' });
       return {
         kind: 'success',

--- a/cli/src/lib/install-extension.ts
+++ b/cli/src/lib/install-extension.ts
@@ -1,0 +1,222 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  EXTENSIONS_CATALOG,
+  findExtension,
+  hasVersion,
+  type ExtensionDescriptor,
+} from '../utils/extensions-catalog.js';
+import {
+  planExtensionInstall,
+  CsprojParseError,
+  type ExtensionInstallPlan,
+} from '../utils/extension-install.js';
+import { emitProgress } from './progress.js';
+import { requireGodotProject } from './validation.js';
+import type {
+  InstallExtensionOptions,
+  InstallExtensionResult,
+} from './types.js';
+
+/**
+ * Install (or update) a Godot-MCP extension into a consumer Godot C# project, as a
+ * REAL installer that is behaviorally identical to the in-editor dock's
+ * `ExtensionInstaller`:
+ *
+ *  1. Resolve `extensionId` to a descriptor in the SHARED catalog
+ *     (`addons/godot_mcp/extensions.catalog.json`, mirrored by `EXTENSIONS_CATALOG`).
+ *  2. Locate the consumer `.csproj` at the project root.
+ *  3. Read-modify-write a `<PackageReference Include="<packageId>" Version="<version>" />`
+ *     into it — added when absent, version-bumped only when the catalog (or `--version`)
+ *     pins a NEWER version, and a no-op when already up to date.
+ *  4. Tell the caller a rebuild is required (Godot has no programmatic restore).
+ *
+ * Library-safe: no stdout noise, no `process.exit`, no throws past the public boundary;
+ * returns a `{ kind: 'success' | 'failure' }` union. Idempotent: a re-run that finds the
+ * reference present at an equal/newer version reports `already-up-to-date` and makes no
+ * write. Mirrors `installPlugin`'s shape exactly so the app can adopt it the same way.
+ */
+export async function installExtension(
+  opts: InstallExtensionOptions,
+): Promise<InstallExtensionResult> {
+  const warnings: string[] = [];
+
+  try {
+    const validated = requireGodotProject(opts?.godotProjectPath);
+    if (!validated.ok) {
+      return {
+        kind: 'failure',
+        success: false,
+        projectGodotPath: validated.projectGodotPath,
+        warnings,
+        error: validated.error,
+      };
+    }
+    const { projectPath } = validated;
+
+    const catalog = opts.catalog ?? EXTENSIONS_CATALOG;
+    const resolved = findExtension(opts.extensionId, catalog);
+    if (resolved === null) {
+      return {
+        kind: 'failure',
+        success: false,
+        warnings,
+        error: new Error(unknownExtensionMessage(opts.extensionId, catalog)),
+      };
+    }
+
+    // Apply the optional --version override (drives both the pin written and the bump decision).
+    const descriptor = applyVersionOverride(resolved, opts.version, warnings);
+
+    emitProgress(opts.onProgress, {
+      phase: 'start',
+      message: `Installing extension ${descriptor.packageId}${hasVersion(descriptor) ? ` ${descriptor.version}` : ''} into ${projectPath}`,
+    });
+
+    const csprojPath = findConsumerCsproj(projectPath, warnings);
+    if (csprojPath === null) {
+      const message =
+        'No project .csproj found at the project root — open this addon inside a Godot C# project to install extensions. ' +
+        `Create one (e.g. \`godot-cli create-project --dotnet\`) and add the ${descriptor.packageId} PackageReference.`;
+      warnings.push(message);
+      emitProgress(opts.onProgress, { phase: 'done', message: 'No project .csproj — nothing installed.' });
+      return {
+        kind: 'success',
+        success: true,
+        outcome: 'no-project',
+        changed: false,
+        rebuildRequired: false,
+        extensionId: opts.extensionId,
+        packageId: descriptor.packageId,
+        fromVersion: null,
+        toVersion: hasVersion(descriptor) ? descriptor.version : null,
+        message,
+        warnings,
+      };
+    }
+
+    const before = fs.readFileSync(csprojPath, 'utf-8');
+    let plan: ExtensionInstallPlan;
+    try {
+      plan = planExtensionInstall(descriptor, before);
+    } catch (err: unknown) {
+      if (err instanceof CsprojParseError) {
+        return {
+          kind: 'failure',
+          success: false,
+          warnings,
+          error: new Error(`Could not edit the project .csproj: ${err.message}`),
+        };
+      }
+      throw err;
+    }
+
+    if (plan.action === 'noop') {
+      emitProgress(opts.onProgress, { phase: 'done', message: `${descriptor.packageId} is already up to date.` });
+      return {
+        kind: 'success',
+        success: true,
+        outcome: 'already-up-to-date',
+        changed: false,
+        rebuildRequired: false,
+        extensionId: opts.extensionId,
+        packageId: descriptor.packageId,
+        fromVersion: plan.fromVersion,
+        toVersion: plan.toVersion,
+        csprojPath,
+        message: `${descriptor.name} is already installed and up to date.`,
+        warnings,
+      };
+    }
+
+    fs.writeFileSync(csprojPath, plan.resultingCsproj);
+    emitProgress(opts.onProgress, {
+      phase: 'csproj-patched',
+      message: `${plan.action === 'add' ? 'Added' : 'Updated'} ${descriptor.packageId} in ${csprojPath}`,
+      csprojPath,
+    });
+    emitProgress(opts.onProgress, { phase: 'done', message: 'Extension installed — rebuild solutions to restore.' });
+
+    const message =
+      plan.action === 'add'
+        ? `Added ${descriptor.packageId}${hasVersion(descriptor) ? ` ${descriptor.version}` : ''}. Rebuild solutions to restore and compile the extension.`
+        : `Updated ${descriptor.packageId} to ${plan.toVersion}. Rebuild solutions to restore the new version.`;
+
+    return {
+      kind: 'success',
+      success: true,
+      outcome: plan.action === 'add' ? 'added' : 'updated',
+      changed: true,
+      rebuildRequired: true,
+      extensionId: opts.extensionId,
+      packageId: descriptor.packageId,
+      fromVersion: plan.fromVersion,
+      toVersion: plan.toVersion,
+      csprojPath,
+      message,
+      warnings,
+    };
+  } catch (err: unknown) {
+    return {
+      kind: 'failure',
+      success: false,
+      warnings,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}
+
+/** Return a descriptor with the `--version` override applied (empty/whitespace override is ignored). */
+function applyVersionOverride(
+  descriptor: ExtensionDescriptor,
+  version: string | undefined,
+  warnings: string[],
+): ExtensionDescriptor {
+  const v = (version ?? '').trim();
+  if (v === '') return descriptor;
+  if (descriptor.version !== null && descriptor.version !== v) {
+    warnings.push(
+      `--version ${v} overrides the catalog pin ${descriptor.packageId}@${descriptor.version} for this install.`,
+    );
+  }
+  return { ...descriptor, version: v };
+}
+
+/** A clear "unknown extension" error that lists what IS installable (or says the catalog is empty). */
+function unknownExtensionMessage(
+  id: string,
+  catalog: readonly ExtensionDescriptor[],
+): string {
+  if (catalog.length === 0) {
+    return (
+      `Unknown extension "${id}". The Godot-MCP extension catalog is currently empty ` +
+      '(no extension packages have been published yet), so there is nothing to install.'
+    );
+  }
+  const available = catalog.map((d) => d.packageId).join(', ');
+  return `Unknown extension "${id}". Available extensions: ${available}.`;
+}
+
+/**
+ * Find the consumer's `.csproj` (the one Godot compiles every `.cs` into) — the single
+ * `*.csproj` at the project root. When several exist, pick the first alphabetically and
+ * warn (they all compile into the same Godot assembly). Returns null when none exist
+ * (a GDScript-only project). Mirrors `install-plugin`'s `findConsumerCsproj`.
+ */
+function findConsumerCsproj(projectPath: string, warnings: string[]): string | null {
+  let names: string[];
+  try {
+    names = fs.readdirSync(projectPath).filter((n) => n.toLowerCase().endsWith('.csproj'));
+  } catch {
+    return null;
+  }
+  if (names.length === 0) return null;
+  names.sort();
+  if (names.length > 1) {
+    warnings.push(
+      `Multiple .csproj files found at the project root (${names.join(', ')}); patched ${names[0]}. ` +
+        'If a different one is the Godot project, add the extension PackageReference to it as well.',
+    );
+  }
+  return path.join(projectPath, names[0]);
+}

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -5,6 +5,8 @@
 //
 // No top-level side effects, no runtime deps beyond TypeScript types.
 
+import type { ExtensionDescriptor } from '../utils/extensions-catalog.js';
+
 // ---------------------------------------------------------------------------
 // Progress events
 // ---------------------------------------------------------------------------
@@ -465,3 +467,66 @@ export interface RemovePluginFailure {
 }
 
 export type RemovePluginResult = RemovePluginSuccess | RemovePluginFailure;
+
+// ---------------------------------------------------------------------------
+// install-extension
+// ---------------------------------------------------------------------------
+
+/**
+ * What `installExtension` did to the consumer `.csproj` — the CLI mirror of the dock's
+ * `ExtensionInstallOutcome`:
+ *  - `added`             — the `<PackageReference>` was newly added (rebuild required).
+ *  - `updated`           — its version was bumped up (rebuild required).
+ *  - `already-up-to-date`— present at an equal/newer version, or the descriptor has no pin (no write).
+ *  - `no-project`        — no consumer `.csproj` was found to install into (nothing written).
+ */
+export type ExtensionInstallOutcome = 'added' | 'updated' | 'already-up-to-date' | 'no-project';
+
+export interface InstallExtensionOptions {
+  /** Absolute or relative path to the Godot project root (holds `project.godot` + the consumer `.csproj`). */
+  godotProjectPath: string;
+  /** The extension `<id>` to install — matched against the catalog by `packageId` (then `name`), case-insensitive. */
+  extensionId: string;
+  /** Override the catalog's pinned version for this install (the `--version` flag). Ignored when empty. */
+  version?: string;
+  /**
+   * Catalog to resolve `extensionId` against. Defaults to the bundled `EXTENSIONS_CATALOG`
+   * (single-sourced from `addons/godot_mcp/extensions.catalog.json`). Injectable for tests.
+   */
+  catalog?: readonly ExtensionDescriptor[];
+  onProgress?: ProgressCallback;
+}
+
+export interface InstallExtensionSuccess {
+  kind: 'success';
+  success: true;
+  /** The classified outcome (added / updated / already-up-to-date / no-project). */
+  outcome: ExtensionInstallOutcome;
+  /** True when the `.csproj` was written (added or updated). */
+  changed: boolean;
+  /** True when a write happened, so the consumer must rebuild solutions (Godot has no programmatic restore). */
+  rebuildRequired: boolean;
+  /** The user-supplied id that resolved to the descriptor. */
+  extensionId: string;
+  /** The resolved descriptor's package id (the `<PackageReference Include>`). */
+  packageId: string;
+  /** Version currently referenced before this install: `null` when not installed, `''` when referenced unversioned. */
+  fromVersion: string | null;
+  /** The version this install targeted (catalog pin or `--version` override), or `null` when unpinned. */
+  toVersion: string | null;
+  /** Absolute path to the consumer `.csproj`, when one was located. */
+  csprojPath?: string;
+  /** A short human-readable status line, safe to print. */
+  message: string;
+  warnings: string[];
+}
+
+export interface InstallExtensionFailure {
+  kind: 'failure';
+  success: false;
+  projectGodotPath?: string;
+  warnings: string[];
+  error: Error;
+}
+
+export type InstallExtensionResult = InstallExtensionSuccess | InstallExtensionFailure;

--- a/cli/src/utils/extension-install.ts
+++ b/cli/src/utils/extension-install.ts
@@ -1,0 +1,254 @@
+// Pure, behaviorally-identical TS port of the dock's extension-install logic
+// (`addons/godot_mcp/Runtime/Extensions/ExtensionInstallPlanner.cs` +
+// `InstalledStateDetector.CompareVersions`). It computes the add / update / no-op
+// plan AND the resulting `.csproj` text from a descriptor + the current `.csproj`,
+// preserving every other `<PackageReference>` and unrelated XML.
+//
+// Parity contract (verified by `cli/tests/extension-install.test.ts` against the
+// SAME scenario set as `Godot-MCP.Tests/ExtensionInstallTests.cs`):
+//   - absent reference            → ADD (append; version attribute only when pinned)
+//   - present, descriptor newer   → UPDATE (bump version, honoring attr vs child form)
+//   - present, no version, pinned → UPDATE (set the descriptor's pin)
+//   - present, equal/newer        → NO-OP
+//   - descriptor unpinned, present→ NO-OP
+//   - version compare is numeric + tolerant (1.10.0 > 1.2.0; trailing 0; suffix-tolerant)
+//
+// The C# planner uses System.Xml.Linq; this uses scoped text edits (like the CLI's
+// existing `csproj-deps.ts`) so the consumer's formatting is preserved verbatim. The
+// add/update/no-op DECISION and the resulting parsed PackageReferences are identical.
+//
+// No top-level side effects; pure string transforms only.
+
+import type { ExtensionDescriptor } from './extensions-catalog.js';
+import { hasVersion } from './extensions-catalog.js';
+
+export type ExtensionInstallAction = 'add' | 'update' | 'noop';
+
+export interface ExtensionInstallPlan {
+  /** The add / update / no-op decision. */
+  action: ExtensionInstallAction;
+  /** The full `.csproj` text after applying the action (=== input for a no-op). */
+  resultingCsproj: string;
+  /** The package id the plan targets. */
+  packageId: string;
+  /** Version currently referenced: `null` when not installed; `''` when referenced without a version. */
+  fromVersion: string | null;
+  /** The descriptor's target version, or `null` when the descriptor has no pin. */
+  toVersion: string | null;
+}
+
+/** Thrown by {@link planExtensionInstall} on a genuinely unparseable `.csproj` (the lib turns it into a structured failure). */
+export class CsprojParseError extends Error {}
+
+/** Escape a string for use inside a RegExp source. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Compare two dotted numeric version strings component-by-component as integers
+ * (so `1.10.0` > `1.2.0`, unlike an ordinal string compare). A trailing pre-release
+ * / build suffix on a component (`1.0.0-rc1`) is tolerated — only the leading integer
+ * of each component is read; a non-numeric component reads as 0. Missing trailing
+ * components are treated as 0 (`1.0` === `1.0.0`). Returns >0 when `a` is newer, <0
+ * when older, 0 when equal. Exact port of C# `InstalledStateDetector.CompareVersions`.
+ */
+export function compareVersions(a: string, b: string): number {
+  const pa = splitComponents(a);
+  const pb = splitComponents(b);
+  const n = Math.max(pa.length, pb.length);
+  for (let i = 0; i < n; i++) {
+    const ca = i < pa.length ? pa[i] : 0;
+    const cb = i < pb.length ? pb[i] : 0;
+    if (ca !== cb) return ca < cb ? -1 : 1;
+  }
+  return 0;
+}
+
+function splitComponents(version: string | null | undefined): number[] {
+  if (version === null || version === undefined || version.trim() === '') return [];
+  return version
+    .trim()
+    .split('.')
+    .map((part) => leadingInt(part));
+}
+
+function leadingInt(component: string): number {
+  let end = 0;
+  while (end < component.length && component[end] >= '0' && component[end] <= '9') end++;
+  if (end === 0) return 0;
+  const value = Number.parseInt(component.slice(0, end), 10);
+  return Number.isNaN(value) ? 0 : value;
+}
+
+/**
+ * Parse every `<PackageReference>` in the `.csproj` into a `{ packageId → version }`
+ * map (ids lower-cased — NuGet ids are case-insensitive; value is the `Version`
+ * attribute, else a child `<Version>` element, else `''`). Returns an EMPTY map for
+ * empty/whitespace input. Port of C# `InstalledStateDetector.ParsePackageReferences`
+ * (the CLI never needs the bad-XML tolerance branch — the planner validates first).
+ */
+export function parsePackageReferences(csprojText: string | null | undefined): Map<string, string> {
+  const map = new Map<string, string>();
+  if (csprojText === null || csprojText === undefined || csprojText.trim() === '') return map;
+
+  const elementRe = /<PackageReference\b[^>]*?(?:\/>|>[\s\S]*?<\/PackageReference>)/gi;
+  let m: RegExpExecArray | null;
+  while ((m = elementRe.exec(csprojText)) !== null) {
+    const element = m[0];
+    const include = /\bInclude\s*=\s*"([^"]*)"/i.exec(element);
+    if (!include || include[1].trim() === '') continue;
+    map.set(include[1].trim().toLowerCase(), readElementVersion(element));
+  }
+  return map;
+}
+
+/** Read the version off a single matched `<PackageReference>` element (attribute form, else child element; `''` when unversioned). */
+function readElementVersion(element: string): string {
+  const attr = /\bVersion\s*=\s*"([^"]*)"/i.exec(element);
+  if (attr && attr[1].trim() !== '') return attr[1].trim();
+  const child = /<Version>\s*([^<]*?)\s*<\/Version>/i.exec(element);
+  if (child) return child[1].trim();
+  return '';
+}
+
+/** Match the whole `<PackageReference>` element (either attribute order, self-close or open/close) for one id. */
+function packageRefElementRegex(id: string): RegExp {
+  const escId = escapeRegExp(id);
+  return new RegExp(
+    `<PackageReference\\b[^>]*?\\bInclude\\s*=\\s*"${escId}"[^>]*?(?:/>|>[\\s\\S]*?</PackageReference>)`,
+    'i',
+  );
+}
+
+function detectIndent(text: string): string {
+  const m = text.match(/\n([ \t]*)<PackageReference\b/);
+  return m ? m[1] : '    ';
+}
+
+function detectEol(text: string): '\n' | '\r\n' {
+  const crlf = (text.match(/\r\n/g) ?? []).length;
+  const lf = (text.match(/\n/g) ?? []).length - crlf;
+  return crlf > lf ? '\r\n' : '\n';
+}
+
+function renderRef(descriptor: ExtensionDescriptor): string {
+  return hasVersion(descriptor)
+    ? `<PackageReference Include="${descriptor.packageId}" Version="${descriptor.version}" />`
+    : `<PackageReference Include="${descriptor.packageId}" />`;
+}
+
+/** Index of the `</ItemGroup>` closing the FIRST `<ItemGroup>` holding a `<PackageReference>`, or -1. */
+function findPackageReferenceItemGroupClose(text: string): number {
+  const itemGroupRe = /<ItemGroup\b[^>]*>([\s\S]*?)<\/ItemGroup>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = itemGroupRe.exec(text)) !== null) {
+    if (/<PackageReference\b/i.test(m[1])) {
+      const closeTag = '</ItemGroup>';
+      return m.index + m[0].length - closeTag.length;
+    }
+  }
+  return -1;
+}
+
+/** Append a new `<PackageReference>` for the descriptor, joining the first package ItemGroup or a fresh one. */
+function appendReference(text: string, descriptor: ExtensionDescriptor): string {
+  const indent = detectIndent(text);
+  const eol = detectEol(text);
+  const element = `${indent}${renderRef(descriptor)}`;
+
+  const pkgItemGroupClose = findPackageReferenceItemGroupClose(text);
+  if (pkgItemGroupClose !== -1) {
+    return `${text.slice(0, pkgItemGroupClose)}${element}${eol}${text.slice(pkgItemGroupClose)}`;
+  }
+
+  const groupIndent = indent.length >= 2 ? indent.slice(0, Math.floor(indent.length / 2)) : '  ';
+  const newGroup = `${groupIndent}<ItemGroup>${eol}${element}${eol}${groupIndent}</ItemGroup>${eol}`;
+  const closeIdx = text.lastIndexOf('</Project>');
+  if (closeIdx === -1) return `${text}${eol}${newGroup}`;
+  return `${text.slice(0, closeIdx)}${newGroup}${text.slice(closeIdx)}`;
+}
+
+/** Set the version on an existing element span, honoring whichever form it already uses (attribute, child element, or unversioned). */
+function setElementVersion(element: string, version: string): string {
+  // Existing Version="x" attribute → replace its value.
+  if (/\bVersion\s*=\s*"[^"]*"/i.test(element)) {
+    return element.replace(/\bVersion\s*=\s*"[^"]*"/i, `Version="${version}"`);
+  }
+  // Existing <Version>x</Version> child element → replace inner text (keep the child form).
+  if (/<Version>[\s\S]*?<\/Version>/i.test(element)) {
+    return element.replace(/<Version>[\s\S]*?<\/Version>/i, `<Version>${version}</Version>`);
+  }
+  // No version present → add a Version attribute to the open tag.
+  if (/\/>\s*$/.test(element)) {
+    // self-close: `<PackageReference Include="id" />` → `... Version="x" />`
+    return element.replace(/\s*\/>\s*$/, ` Version="${version}" />`);
+  }
+  // open/close pair with no child version: add the attribute to the open tag's first `>`.
+  return element.replace(/>/, ` Version="${version}">`);
+}
+
+/**
+ * Compute the install plan for `descriptor` against `csprojText`. Port of
+ * `ExtensionInstallPlanner.Plan`. Throws {@link CsprojParseError} only on a genuinely
+ * malformed `.csproj` (no recognizable `<Project ...>` root) — the caller maps that to
+ * a structured failure rather than corrupting the file.
+ */
+export function planExtensionInstall(
+  descriptor: ExtensionDescriptor,
+  csprojText: string,
+): ExtensionInstallPlan {
+  if (!/<Project\b[\s\S]*?>/i.test(csprojText) || !/<\/Project>/i.test(csprojText)) {
+    throw new CsprojParseError('The consumer .csproj is not valid XML; refusing to edit it.');
+  }
+
+  const elementRe = packageRefElementRegex(descriptor.packageId);
+  const match = csprojText.match(elementRe);
+
+  // --- No existing reference → ADD ---
+  if (!match) {
+    return {
+      action: 'add',
+      resultingCsproj: appendReference(csprojText, descriptor),
+      packageId: descriptor.packageId,
+      fromVersion: null,
+      toVersion: hasVersion(descriptor) ? descriptor.version : null,
+    };
+  }
+
+  const element = match[0];
+  const currentVersion = readElementVersion(element);
+
+  // Descriptor pins no version → leave the existing reference untouched.
+  if (!hasVersion(descriptor)) {
+    return {
+      action: 'noop',
+      resultingCsproj: csprojText,
+      packageId: descriptor.packageId,
+      fromVersion: currentVersion,
+      toVersion: null,
+    };
+  }
+
+  const target = descriptor.version as string;
+  const needsBump = currentVersion === '' || compareVersions(target, currentVersion) > 0;
+  if (!needsBump) {
+    return {
+      action: 'noop',
+      resultingCsproj: csprojText,
+      packageId: descriptor.packageId,
+      fromVersion: currentVersion,
+      toVersion: target,
+    };
+  }
+
+  const updatedElement = setElementVersion(element, target);
+  return {
+    action: 'update',
+    // Function replacement so any `$` in the version is never treated as a replacement pattern.
+    resultingCsproj: csprojText.replace(elementRe, () => updatedElement),
+    packageId: descriptor.packageId,
+    fromVersion: currentVersion,
+    toVersion: target,
+  };
+}

--- a/cli/src/utils/extension-install.ts
+++ b/cli/src/utils/extension-install.ts
@@ -159,7 +159,12 @@ function appendReference(text: string, descriptor: ExtensionDescriptor): string 
 
   const pkgItemGroupClose = findPackageReferenceItemGroupClose(text);
   if (pkgItemGroupClose !== -1) {
-    return `${text.slice(0, pkgItemGroupClose)}${element}${eol}${text.slice(pkgItemGroupClose)}`;
+    // Insert before the START of the `</ItemGroup>` line, not at the `<` of `</ItemGroup>`
+    // itself: slicing at `pkgItemGroupClose` would absorb the closing tag's indent into the
+    // prefix, so the appended element would inherit that indent on top of its own and
+    // `</ItemGroup>` would lose its indent. Splitting at the line start keeps both aligned.
+    const lineStart = text.lastIndexOf('\n', pkgItemGroupClose) + 1;
+    return `${text.slice(0, lineStart)}${element}${eol}${text.slice(lineStart)}`;
   }
 
   const groupIndent = indent.length >= 2 ? indent.slice(0, Math.floor(indent.length / 2)) : '  ';

--- a/cli/src/utils/extensions-catalog.ts
+++ b/cli/src/utils/extensions-catalog.ts
@@ -1,0 +1,72 @@
+// The CLI's typed mirror of the SHARED extension catalog — the single source of
+// truth `addons/godot_mcp/extensions.catalog.json` (see that file's sibling
+// `extensions.catalog.md`). It is the CLI half of the "one catalog consumed by the
+// dock, the CLI, and the app" contract: the dock parses the JSON via an embedded
+// resource (C# `GodotExtensionCatalog`); the CLI mirrors it here so the published
+// npm package stays self-contained (no runtime `../addons` dependency).
+//
+// SINGLE SOURCE OF TRUTH: this constant MUST stay byte-equivalent to the JSON. The
+// parity test `cli/tests/extensions-catalog-parity.test.ts` reads the addon JSON and
+// FAILS the build if this mirror drifts — exactly the discipline `addon-deps.ts` /
+// `addon-deps-parity.test.ts` use for the NuGet pins. Adding an extension =
+// appending an entry to BOTH the JSON and this array (the test enforces it).
+//
+// No top-level side effects; pure data + pure lookups only.
+
+/** One tool a catalog extension contributes — mirrors the JSON `tools[]` entry. */
+export interface ExtensionTool {
+  readonly name: string;
+  readonly description: string;
+}
+
+/**
+ * One installable extension — the CLI analog of the C# `GodotExtensionDescriptor`.
+ * `packageId` is the INSTALL IDENTITY (the `<PackageReference Include="...">`).
+ * `version` is `null` for a floating (unpinned) reference.
+ */
+export interface ExtensionDescriptor {
+  readonly name: string;
+  readonly description: string;
+  readonly packageId: string;
+  readonly version: string | null;
+  readonly gitUrl: string | null;
+  readonly tools: readonly ExtensionTool[];
+}
+
+/**
+ * The extension catalog, single-sourced from `addons/godot_mcp/extensions.catalog.json`.
+ * Ships EMPTY until the first Godot-MCP extension package is published on nuget.org —
+ * `install-extension <id>` then reports "unknown extension" for every id, which is the
+ * correct behavior (there is nothing to install yet). The parity test keeps this in
+ * lockstep with the JSON so adding an entry there forces an update here.
+ */
+export const EXTENSIONS_CATALOG: readonly ExtensionDescriptor[] = [
+  // (none yet — see addons/godot_mcp/extensions.catalog.json / extensions.catalog.md)
+] as const;
+
+/** True when a descriptor carries a concrete version pin (drives the up-to-date / update decision). */
+export function hasVersion(descriptor: ExtensionDescriptor): boolean {
+  return descriptor.version !== null && descriptor.version.trim() !== '';
+}
+
+/**
+ * Resolve a user-supplied `<id>` to a catalog descriptor. Matches by `packageId`
+ * first (ordinal-ignore-case, like NuGet's case-insensitive ids — the install
+ * identity), then falls back to an exact case-insensitive `name` match for
+ * convenience. Returns `null` when absent or `id` is empty.
+ */
+export function findExtension(
+  id: string | undefined | null,
+  catalog: readonly ExtensionDescriptor[] = EXTENSIONS_CATALOG,
+): ExtensionDescriptor | null {
+  if (id === undefined || id === null) return null;
+  const needle = id.trim();
+  if (needle === '') return null;
+
+  const byPackageId = catalog.find(
+    (d) => d.packageId.toLowerCase() === needle.toLowerCase(),
+  );
+  if (byPackageId) return byPackageId;
+
+  return catalog.find((d) => d.name.toLowerCase() === needle.toLowerCase()) ?? null;
+}

--- a/cli/tests/extension-install.test.ts
+++ b/cli/tests/extension-install.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest';
+import {
+  planExtensionInstall,
+  parsePackageReferences,
+  compareVersions,
+  CsprojParseError,
+} from '../src/utils/extension-install.js';
+import type { ExtensionDescriptor } from '../src/utils/extensions-catalog.js';
+
+// This suite is the CLI half of the behavioral-parity contract with the dock's
+// ExtensionInstaller / ExtensionInstallPlanner. The scenarios mirror
+// `Godot-MCP.Tests/ExtensionInstallTests.cs` 1:1 so a divergence in either
+// implementation fails a test (see addons/godot_mcp/extensions.catalog.md).
+
+// The SAME representative SDK-style consumer .csproj the C# tests use.
+const SampleCsproj = `<Project Sdk="Godot.NET.Sdk/4.3.0">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.1" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="6.7.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="Godot-MCP.Tests/**/*.cs" />
+  </ItemGroup>
+</Project>`;
+
+function descriptor(
+  packageId = 'com.IvanMurzak.Godot.MCP.ProBuilder',
+  version: string | null = '1.2.0',
+): ExtensionDescriptor {
+  return {
+    name: 'ProBuilder Tools',
+    description: 'Mesh-editing MCP tools for Godot.',
+    packageId,
+    version,
+    gitUrl: null,
+    tools: [],
+  };
+}
+
+describe('compareVersions — numeric + tolerant (parity with C# InstalledStateDetector)', () => {
+  it.each([
+    ['1.2.0', '1.2.0', 0],
+    ['1.10.0', '1.2.0', 1], // numeric, not ordinal — 10 > 2
+    ['1.2.0', '1.10.0', -1],
+    ['2.0.0', '1.9.9', 1],
+    ['1.0', '1.0.0', 0], // missing trailing component == 0
+    ['1.0.0-rc1', '1.0.0', 0], // pre-release suffix tolerated (leading int only)
+  ])('compareVersions(%s, %s) sign === %i', (a, b, expectedSign) => {
+    expect(Math.sign(compareVersions(a, b))).toBe(expectedSign);
+  });
+});
+
+describe('parsePackageReferences — attribute + child-element + unversioned forms', () => {
+  it('parses all three MSBuild forms', () => {
+    const mixed = `<Project>
+  <ItemGroup>
+    <PackageReference Include="A" Version="1.0.0" />
+    <PackageReference Include="B"><Version>2.3.4</Version></PackageReference>
+    <PackageReference Include="C" />
+  </ItemGroup>
+</Project>`;
+    const refs = parsePackageReferences(mixed);
+    expect(refs.get('a')).toBe('1.0.0');
+    expect(refs.get('b')).toBe('2.3.4');
+    expect(refs.get('c')).toBe('');
+  });
+
+  it.each([null, '', '   '])('returns empty for %j', (text) => {
+    expect(parsePackageReferences(text as string).size).toBe(0);
+  });
+
+  it('package id match is case-insensitive', () => {
+    const refs = parsePackageReferences(SampleCsproj);
+    expect(refs.get('com.ivanmurzak.mcpplugin')).toBe('6.7.0');
+  });
+});
+
+describe('planExtensionInstall — ADD', () => {
+  it('adds the reference when absent', () => {
+    const plan = planExtensionInstall(descriptor(), SampleCsproj);
+    expect(plan.action).toBe('add');
+    expect(plan.fromVersion).toBeNull();
+    expect(plan.toVersion).toBe('1.2.0');
+    expect(parsePackageReferences(plan.resultingCsproj).get('com.ivanmurzak.godot.mcp.probuilder')).toBe('1.2.0');
+  });
+
+  it('preserves existing PackageReferences and unrelated XML, joining the existing ItemGroup', () => {
+    const plan = planExtensionInstall(descriptor(), SampleCsproj);
+    const refs = parsePackageReferences(plan.resultingCsproj);
+    expect(refs.get('com.ivanmurzak.reflectornet')).toBe('5.3.1');
+    expect(refs.get('com.ivanmurzak.mcpplugin')).toBe('6.7.0');
+    expect(refs.get('com.ivanmurzak.godot.mcp.probuilder')).toBe('1.2.0');
+    // Unrelated XML survives.
+    expect(plan.resultingCsproj).toContain('<TargetFramework>net8.0</TargetFramework>');
+    expect(plan.resultingCsproj).toContain('Compile Remove="Godot-MCP.Tests/**/*.cs"');
+    // Joined the existing package ItemGroup (still exactly 2 ItemGroups).
+    expect((plan.resultingCsproj.match(/<ItemGroup\b/g) ?? []).length).toBe(2);
+  });
+
+  it('omits the Version attribute when the descriptor has no version', () => {
+    const plan = planExtensionInstall(descriptor('com.x', null), SampleCsproj);
+    expect(plan.action).toBe('add');
+    const refs = parsePackageReferences(plan.resultingCsproj);
+    expect(refs.has('com.x')).toBe(true);
+    expect(refs.get('com.x')).toBe('');
+  });
+
+  it('creates an ItemGroup when the project has no PackageReferences', () => {
+    const bare = `<Project Sdk="Godot.NET.Sdk/4.3.0">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>`;
+    const plan = planExtensionInstall(descriptor(), bare);
+    expect(plan.action).toBe('add');
+    expect(parsePackageReferences(plan.resultingCsproj).get('com.ivanmurzak.godot.mcp.probuilder')).toBe('1.2.0');
+    expect(plan.resultingCsproj).toContain('</Project>');
+  });
+});
+
+describe('planExtensionInstall — UPDATE', () => {
+  it('bumps the version when installed is lower', () => {
+    const installed = planExtensionInstall(descriptor(undefined, '1.0.0'), SampleCsproj).resultingCsproj;
+    const plan = planExtensionInstall(descriptor(undefined, '1.2.0'), installed);
+    expect(plan.action).toBe('update');
+    expect(plan.fromVersion).toBe('1.0.0');
+    expect(plan.toVersion).toBe('1.2.0');
+    const refs = parsePackageReferences(plan.resultingCsproj);
+    expect(refs.get('com.ivanmurzak.godot.mcp.probuilder')).toBe('1.2.0');
+    expect(refs.get('com.ivanmurzak.reflectornet')).toBe('5.3.1');
+    expect(refs.get('com.ivanmurzak.mcpplugin')).toBe('6.7.0');
+  });
+
+  it('updates when installed has no version but the descriptor does', () => {
+    const unversioned = `<Project Sdk="Godot.NET.Sdk/4.3.0">
+  <ItemGroup>
+    <PackageReference Include="com.IvanMurzak.Godot.MCP.ProBuilder" />
+  </ItemGroup>
+</Project>`;
+    const plan = planExtensionInstall(descriptor(undefined, '1.2.0'), unversioned);
+    expect(plan.action).toBe('update');
+    expect(parsePackageReferences(plan.resultingCsproj).get('com.ivanmurzak.godot.mcp.probuilder')).toBe('1.2.0');
+  });
+
+  it('updates the child <Version> element form in place (no new attribute)', () => {
+    const childForm = `<Project Sdk="Godot.NET.Sdk/4.3.0">
+  <ItemGroup>
+    <PackageReference Include="com.IvanMurzak.Godot.MCP.ProBuilder">
+      <Version>1.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+</Project>`;
+    const plan = planExtensionInstall(descriptor(undefined, '1.2.0'), childForm);
+    expect(plan.action).toBe('update');
+    expect(parsePackageReferences(plan.resultingCsproj).get('com.ivanmurzak.godot.mcp.probuilder')).toBe('1.2.0');
+    expect(plan.resultingCsproj).not.toContain('Version="1.2.0"');
+    expect(plan.resultingCsproj).toContain('<Version>1.2.0</Version>');
+  });
+});
+
+describe('planExtensionInstall — NO-OP', () => {
+  it('no-ops when versions are equal (byte-identical result)', () => {
+    const installed = planExtensionInstall(descriptor(undefined, '1.2.0'), SampleCsproj).resultingCsproj;
+    const plan = planExtensionInstall(descriptor(undefined, '1.2.0'), installed);
+    expect(plan.action).toBe('noop');
+    expect(plan.resultingCsproj).toBe(installed);
+  });
+
+  it('no-ops when installed is newer', () => {
+    const installed = planExtensionInstall(descriptor(undefined, '2.0.0'), SampleCsproj).resultingCsproj;
+    const plan = planExtensionInstall(descriptor(undefined, '1.2.0'), installed);
+    expect(plan.action).toBe('noop');
+  });
+
+  it('no-ops when the descriptor has no version and a reference exists', () => {
+    const installed = planExtensionInstall(descriptor(undefined, '1.0.0'), SampleCsproj).resultingCsproj;
+    const plan = planExtensionInstall(descriptor(undefined, null), installed);
+    expect(plan.action).toBe('noop');
+  });
+
+  it('throws CsprojParseError on an unparseable csproj', () => {
+    expect(() => planExtensionInstall(descriptor(), '<Project><not closed')).toThrow(CsprojParseError);
+  });
+});

--- a/cli/tests/extension-install.test.ts
+++ b/cli/tests/extension-install.test.ts
@@ -101,6 +101,20 @@ describe('planExtensionInstall — ADD', () => {
     expect((plan.resultingCsproj.match(/<ItemGroup\b/g) ?? []).length).toBe(2);
   });
 
+  it('indents the appended reference like its siblings and preserves the </ItemGroup> indent', () => {
+    const plan = planExtensionInstall(descriptor(), SampleCsproj);
+    // Regression guard for the appendReference split point: the new <PackageReference>
+    // sits at the same 4-space indent as the existing refs, and the closing </ItemGroup>
+    // keeps its own 2-space indent (slicing at `</ItemGroup>` itself used to absorb the
+    // closing tag's indent into the appended element and strip it from the closing tag).
+    // Normalize EOL so the assertion is checkout-agnostic (autocrlf).
+    expect(plan.resultingCsproj.replace(/\r\n/g, '\n')).toContain(
+      '    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="6.7.0" />\n' +
+        '    <PackageReference Include="com.IvanMurzak.Godot.MCP.ProBuilder" Version="1.2.0" />\n' +
+        '  </ItemGroup>',
+    );
+  });
+
   it('omits the Version attribute when the descriptor has no version', () => {
     const plan = planExtensionInstall(descriptor('com.x', null), SampleCsproj);
     expect(plan.action).toBe('add');

--- a/cli/tests/extensions-catalog-parity.test.ts
+++ b/cli/tests/extensions-catalog-parity.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { EXTENSIONS_CATALOG, type ExtensionDescriptor } from '../src/utils/extensions-catalog.js';
+
+// The CLI's EXTENSIONS_CATALOG mirror MUST stay byte-equivalent to the SHARED source of
+// truth `addons/godot_mcp/extensions.catalog.json` (consumed by the dock via an embedded
+// resource). If the catalog gains/changes an entry, this test fails until the mirror is
+// updated — the drift tripwire that keeps the dock + CLI + app from diverging. Same
+// discipline as addon-deps-parity.test.ts for the NuGet pins.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CATALOG_JSON = path.resolve(__dirname, '..', '..', 'addons', 'godot_mcp', 'extensions.catalog.json');
+
+interface CatalogJsonEntry {
+  name?: string;
+  description?: string;
+  packageId?: string;
+  version?: string;
+  gitUrl?: string;
+  tools?: { name?: string; description?: string }[];
+}
+
+/** Normalize a raw JSON entry to the canonical ExtensionDescriptor shape (mirrors the C# parser's mapping). */
+function normalizeJsonEntry(e: CatalogJsonEntry): ExtensionDescriptor {
+  return {
+    name: (e.name ?? '').trim(),
+    description: (e.description ?? '').trim(),
+    packageId: (e.packageId ?? '').trim(),
+    version: e.version && e.version.trim() !== '' ? e.version.trim() : null,
+    gitUrl: e.gitUrl && e.gitUrl.trim() !== '' ? e.gitUrl.trim() : null,
+    tools: (e.tools ?? [])
+      .filter((t) => t.name && t.name.trim() !== '')
+      .map((t) => ({ name: (t.name ?? '').trim(), description: (t.description ?? '').trim() })),
+  };
+}
+
+describe('extensions-catalog parity with addons/godot_mcp/extensions.catalog.json', () => {
+  it('the catalog JSON is reachable from the test (relative layout sanity)', () => {
+    expect(fs.existsSync(CATALOG_JSON)).toBe(true);
+  });
+
+  it('the TS mirror EXTENSIONS_CATALOG matches the JSON source of truth exactly', () => {
+    const raw = JSON.parse(fs.readFileSync(CATALOG_JSON, 'utf-8')) as {
+      extensions?: CatalogJsonEntry[];
+    };
+    const expected = (raw.extensions ?? [])
+      .filter((e) => e.name && e.name.trim() !== '' && e.packageId && e.packageId.trim() !== '')
+      .map(normalizeJsonEntry);
+
+    // Compare as plain objects (EXTENSIONS_CATALOG is readonly; spread to mutable for deep-equal).
+    const actual = EXTENSIONS_CATALOG.map((d) => ({
+      name: d.name,
+      description: d.description,
+      packageId: d.packageId,
+      version: d.version,
+      gitUrl: d.gitUrl,
+      tools: d.tools.map((t) => ({ name: t.name, description: t.description })),
+    }));
+
+    expect(
+      actual,
+      'cli/src/utils/extensions-catalog.ts drifted from addons/godot_mcp/extensions.catalog.json. ' +
+        'Update EXTENSIONS_CATALOG to match the JSON source of truth.',
+    ).toEqual(expected);
+  });
+});

--- a/cli/tests/install-extension-cli.test.ts
+++ b/cli/tests/install-extension-cli.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { runCliAsync } from './helpers/cli.js';
+
+const MINIMAL_PROJECT = '; Engine configuration file.\nconfig_version=5\n\n[application]\n\nconfig/name="Test"\n';
+
+describe('install-extension — CLI smoke (command wiring)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cli-ext-cli-'));
+    fs.writeFileSync(path.join(tmpDir, 'project.godot'), MINIMAL_PROJECT);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('is registered and documented in --help', async () => {
+    const { stdout, exitCode } = await runCliAsync(['--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('install-extension');
+  });
+
+  it('exits 1 with an honest empty-catalog message (no extension published yet)', async () => {
+    const { stdout, exitCode } = await runCliAsync(['install-extension', 'anything', tmpDir]);
+    // The shipped catalog is empty, so any id is unknown — and the message says so.
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('catalog is currently empty');
+  });
+
+  it('exits 1 for a non-Godot project directory', async () => {
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cli-ext-cli-empty-'));
+    try {
+      const { exitCode, stdout } = await runCliAsync(['install-extension', 'anything', empty]);
+      expect(exitCode).toBe(1);
+      expect(stdout).toContain('project.godot');
+    } finally {
+      fs.rmSync(empty, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/tests/install-extension.test.ts
+++ b/cli/tests/install-extension.test.ts
@@ -131,7 +131,10 @@ describe('installExtension — lib logic (parity with the dock ExtensionInstalle
     if (result.kind === 'success') {
       expect(result.outcome).toBe('no-project');
       expect(result.changed).toBe(false);
-      expect(result.warnings.some((w) => w.includes('.csproj'))).toBe(true);
+      // The no-project explanation is surfaced once via result.message (printed as Status),
+      // not duplicated into warnings.
+      expect(result.message).toContain('.csproj');
+      expect(result.warnings.some((w) => w.includes('.csproj'))).toBe(false);
     }
   });
 

--- a/cli/tests/install-extension.test.ts
+++ b/cli/tests/install-extension.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { installExtension } from '../src/lib/install-extension.js';
+import { parsePackageReferences } from '../src/utils/extension-install.js';
+import type { ExtensionDescriptor } from '../src/utils/extensions-catalog.js';
+
+const MINIMAL_PROJECT = '; Engine configuration file.\nconfig_version=5\n\n[application]\n\nconfig/name="Test"\n';
+
+const SampleCsproj = `<Project Sdk="Godot.NET.Sdk/4.3.0">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.1" />
+  </ItemGroup>
+</Project>`;
+
+// Injected fixture catalog (the shipped EXTENSIONS_CATALOG is empty until a package is published).
+const FIXTURE_CATALOG: readonly ExtensionDescriptor[] = [
+  {
+    name: 'ProBuilder Tools',
+    description: 'Mesh-editing MCP tools for Godot.',
+    packageId: 'com.IvanMurzak.Godot.MCP.ProBuilder',
+    version: '1.2.0',
+    gitUrl: null,
+    tools: [],
+  },
+];
+
+describe('installExtension — lib logic (parity with the dock ExtensionInstaller)', () => {
+  let tmpDir: string;
+  let csprojPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cli-ext-'));
+    fs.writeFileSync(path.join(tmpDir, 'project.godot'), MINIMAL_PROJECT);
+    csprojPath = path.join(tmpDir, 'Game.csproj');
+    fs.writeFileSync(csprojPath, SampleCsproj);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('adds the PackageReference and requests a rebuild', async () => {
+    const result = await installExtension({
+      godotProjectPath: tmpDir,
+      extensionId: 'com.IvanMurzak.Godot.MCP.ProBuilder',
+      catalog: FIXTURE_CATALOG,
+    });
+    expect(result.kind).toBe('success');
+    if (result.kind === 'success') {
+      expect(result.outcome).toBe('added');
+      expect(result.changed).toBe(true);
+      expect(result.rebuildRequired).toBe(true);
+      expect(result.packageId).toBe('com.IvanMurzak.Godot.MCP.ProBuilder');
+      expect(result.toVersion).toBe('1.2.0');
+      expect(result.message).toContain('Rebuild solutions');
+    }
+    const refs = parsePackageReferences(fs.readFileSync(csprojPath, 'utf-8'));
+    expect(refs.get('com.ivanmurzak.godot.mcp.probuilder')).toBe('1.2.0');
+    // Pre-existing reference preserved.
+    expect(refs.get('com.ivanmurzak.reflectornet')).toBe('5.3.1');
+  });
+
+  it('is idempotent — a second install reports already-up-to-date with no write', async () => {
+    await installExtension({ godotProjectPath: tmpDir, extensionId: 'com.IvanMurzak.Godot.MCP.ProBuilder', catalog: FIXTURE_CATALOG });
+    const before = fs.readFileSync(csprojPath, 'utf-8');
+    const second = await installExtension({ godotProjectPath: tmpDir, extensionId: 'com.IvanMurzak.Godot.MCP.ProBuilder', catalog: FIXTURE_CATALOG });
+    expect(second.kind).toBe('success');
+    if (second.kind === 'success') {
+      expect(second.outcome).toBe('already-up-to-date');
+      expect(second.changed).toBe(false);
+      expect(second.rebuildRequired).toBe(false);
+    }
+    expect(fs.readFileSync(csprojPath, 'utf-8')).toBe(before); // byte-identical (no write)
+  });
+
+  it('updates when the catalog pins a newer version', async () => {
+    const old: readonly ExtensionDescriptor[] = [{ ...FIXTURE_CATALOG[0], version: '1.0.0' }];
+    await installExtension({ godotProjectPath: tmpDir, extensionId: 'com.IvanMurzak.Godot.MCP.ProBuilder', catalog: old });
+    const result = await installExtension({ godotProjectPath: tmpDir, extensionId: 'com.IvanMurzak.Godot.MCP.ProBuilder', catalog: FIXTURE_CATALOG });
+    expect(result.kind).toBe('success');
+    if (result.kind === 'success') {
+      expect(result.outcome).toBe('updated');
+      expect(result.fromVersion).toBe('1.0.0');
+      expect(result.toVersion).toBe('1.2.0');
+    }
+    expect(parsePackageReferences(fs.readFileSync(csprojPath, 'utf-8')).get('com.ivanmurzak.godot.mcp.probuilder')).toBe('1.2.0');
+  });
+
+  it('resolves the extension by name (case-insensitive), not just package id', async () => {
+    const result = await installExtension({ godotProjectPath: tmpDir, extensionId: 'probuilder tools', catalog: FIXTURE_CATALOG });
+    expect(result.kind).toBe('success');
+    if (result.kind === 'success') expect(result.packageId).toBe('com.IvanMurzak.Godot.MCP.ProBuilder');
+  });
+
+  it('honors the --version override and warns about overriding the catalog pin', async () => {
+    const result = await installExtension({
+      godotProjectPath: tmpDir,
+      extensionId: 'com.IvanMurzak.Godot.MCP.ProBuilder',
+      version: '2.5.0',
+      catalog: FIXTURE_CATALOG,
+    });
+    expect(result.kind).toBe('success');
+    if (result.kind === 'success') {
+      expect(result.toVersion).toBe('2.5.0');
+      expect(result.warnings.some((w) => w.includes('overrides the catalog pin'))).toBe(true);
+    }
+    expect(parsePackageReferences(fs.readFileSync(csprojPath, 'utf-8')).get('com.ivanmurzak.godot.mcp.probuilder')).toBe('2.5.0');
+  });
+
+  it('fails with a clear error for an unknown extension id', async () => {
+    const result = await installExtension({ godotProjectPath: tmpDir, extensionId: 'com.does.not.exist', catalog: FIXTURE_CATALOG });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') expect(result.error.message).toContain('Unknown extension');
+  });
+
+  it('reports the empty catalog clearly when nothing is published', async () => {
+    const result = await installExtension({ godotProjectPath: tmpDir, extensionId: 'anything', catalog: [] });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') expect(result.error.message).toContain('catalog is currently empty');
+  });
+
+  it('returns a no-project outcome (success) when there is no consumer .csproj', async () => {
+    fs.rmSync(csprojPath);
+    const result = await installExtension({ godotProjectPath: tmpDir, extensionId: 'com.IvanMurzak.Godot.MCP.ProBuilder', catalog: FIXTURE_CATALOG });
+    expect(result.kind).toBe('success');
+    if (result.kind === 'success') {
+      expect(result.outcome).toBe('no-project');
+      expect(result.changed).toBe(false);
+      expect(result.warnings.some((w) => w.includes('.csproj'))).toBe(true);
+    }
+  });
+
+  it('returns a structured failure (never throws) for a non-Godot dir', async () => {
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cli-ext-empty-'));
+    try {
+      const result = await installExtension({ godotProjectPath: empty, extensionId: 'com.IvanMurzak.Godot.MCP.ProBuilder', catalog: FIXTURE_CATALOG });
+      expect(result.kind).toBe('failure');
+      if (result.kind === 'failure') expect(result.error.message).toContain('project.godot');
+    } finally {
+      fs.rmSync(empty, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add `godot-cli install-extension <id> [path] [--version]` — resolves `<id>` from a shared catalog and add/update/no-ops the consumer `.csproj` `<PackageReference>`, idempotently. Same logic exported as `installExtension` (parity with `installPlugin`) for the app to import.
- Define ONE shared extension catalog (`addons/godot_mcp/extensions.catalog.json`) as the single source of truth consumed by all three channels: the **dock** parses it via an embedded resource (`GodotExtensionCatalog` → `GodotExtensionRegistry`), the **CLI** mirrors it (`extensions-catalog.ts`, parity-tested), the **app** imports it from `godot-cli`.
- Behaviorally identical to the dock's `ExtensionInstaller` (add-when-absent, bump-only-upward, no-op-when-equal/newer, numeric-tolerant version compare) — the same scenario set is encoded on both the C# and TS sides.

## Test plan
- [x] Target-specific local tests passed (see profile test.md): Suite 1 `dotnet build` (0 errors), Suite 2 `dotnet test` (962 passed, incl. new `GodotExtensionCatalogTests`), Suite 2b `npm test` (364 passed, incl. `extension-install` / `install-extension` / `extensions-catalog-parity` / `install-extension-cli`).
- [x] Verified the catalog JSON is genuinely embedded in the built game assembly (dock consume path).

Closes #223