### PR TITLE
feat(extensions): add Particles Tools to the shared extension catalog

### DIFF
--- a/Godot-MCP.Tests/ExtensionInstallTests.cs
+++ b/Godot-MCP.Tests/ExtensionInstallTests.cs
@@ -49,10 +49,12 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         // --- Descriptor + registry -----------------------------------------------------------------------------
 
         [Fact]
-        public void Registry_ShipsEmpty()
+        public void Registry_ShipsCatalog()
         {
-            Assert.True(GodotExtensionRegistry.IsEmpty);
-            Assert.Empty(GodotExtensionRegistry.All);
+            // The shipped catalog now lists at least the first extension (Godot-AI-Particles).
+            Assert.False(GodotExtensionRegistry.IsEmpty);
+            Assert.NotEmpty(GodotExtensionRegistry.All);
+            Assert.NotNull(GodotExtensionRegistry.GetByPackageId("com.IvanMurzak.Godot.MCP.Particles"));
             Assert.Null(GodotExtensionRegistry.GetByPackageId("anything"));
         }
 

--- a/Godot-MCP.Tests/GodotExtensionCatalogTests.cs
+++ b/Godot-MCP.Tests/GodotExtensionCatalogTests.cs
@@ -104,8 +104,8 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         [Fact]
         public void LoadEmbedded_RoundTripsTheShippedCatalog()
         {
-            // The shipped catalog is currently empty, so this proves the embedded resource resolves + parses (an
-            // unresolved resource would ALSO return empty, so we additionally assert the resource is actually present).
+            // This proves the embedded resource resolves + parses (an unresolved resource would return empty, so we
+            // additionally assert the resource is actually present — independent of how many entries it ships).
             var assembly = typeof(GodotExtensionCatalog).Assembly;
             Assert.Contains(GodotExtensionCatalog.EmbeddedResourceName, assembly.GetManifestResourceNames());
 

--- a/addons/godot_mcp/extensions.catalog.json
+++ b/addons/godot_mcp/extensions.catalog.json
@@ -1,4 +1,19 @@
 {
   "schemaVersion": 1,
-  "extensions": []
+  "extensions": [
+    {
+      "name": "Particles Tools",
+      "description": "AI MCP tools for Godot GpuParticles (2D & 3D): create, configure, start/stop, and inspect emitters.",
+      "packageId": "com.IvanMurzak.Godot.MCP.Particles",
+      "version": "0.1.0",
+      "gitUrl": "https://github.com/IvanMurzak/Godot-AI-Particles",
+      "tools": [
+        { "name": "particles-defaults", "description": "Return the recommended starter config for a 2D/3D emitter." },
+        { "name": "particles-create", "description": "Create a GpuParticles2D/GpuParticles3D node in the edited scene." },
+        { "name": "particles-configure", "description": "Update an emitter's scalar properties (clamped to valid ranges)." },
+        { "name": "particles-set-emitting", "description": "Start or stop emission, optionally restarting first." },
+        { "name": "particles-get", "description": "Read an emitter's scalar config (read-only)." }
+      ]
+    }
+  ]
 }

--- a/addons/godot_mcp/extensions.catalog.md
+++ b/addons/godot_mcp/extensions.catalog.md
@@ -40,12 +40,14 @@ It is consumed by all THREE install channels so they can never drift:
   WITHOUT a `Version` attribute (floating / centrally-managed), and a present reference is never bumped.
 - `name`, `packageId` are REQUIRED and non-empty; entries missing either are ignored by both parsers.
 
-## Ships empty (for now)
+## Adding an extension
 
-No Godot-MCP extension package exists on nuget.org yet, so `extensions` is `[]` and the dock renders an
-honest "coming soon" placeholder. To add the first real extension once it is published: append ONE entry
-to `extensions` here — no other file changes (the dock reads it via the embedded resource; the CLI's
-parity test forces `extensions-catalog.ts` to be updated to match, which the CLI then consumes).
+The first published Godot-MCP extension is **Particles Tools**
+(`com.IvanMurzak.Godot.MCP.Particles`, https://github.com/IvanMurzak/Godot-AI-Particles). To add another
+published extension: append ONE entry to `extensions` here — the dock reads it via the embedded resource,
+and the CLI's parity test (`cli/tests/extensions-catalog-parity.test.ts`) forces the typed mirror
+`cli/src/utils/extensions-catalog.ts` to be updated to match, which the CLI then consumes. (When the
+catalog is empty the dock renders an honest "coming soon" placeholder.)
 
 ## Behavioral parity contract
 

--- a/cli/src/utils/extensions-catalog.ts
+++ b/cli/src/utils/extensions-catalog.ts
@@ -41,7 +41,21 @@ export interface ExtensionDescriptor {
  * lockstep with the JSON so adding an entry there forces an update here.
  */
 export const EXTENSIONS_CATALOG: readonly ExtensionDescriptor[] = [
-  // (none yet — see addons/godot_mcp/extensions.catalog.json / extensions.catalog.md)
+  {
+    name: 'Particles Tools',
+    description:
+      'AI MCP tools for Godot GpuParticles (2D & 3D): create, configure, start/stop, and inspect emitters.',
+    packageId: 'com.IvanMurzak.Godot.MCP.Particles',
+    version: '0.1.0',
+    gitUrl: 'https://github.com/IvanMurzak/Godot-AI-Particles',
+    tools: [
+      { name: 'particles-defaults', description: 'Return the recommended starter config for a 2D/3D emitter.' },
+      { name: 'particles-create', description: 'Create a GpuParticles2D/GpuParticles3D node in the edited scene.' },
+      { name: 'particles-configure', description: "Update an emitter's scalar properties (clamped to valid ranges)." },
+      { name: 'particles-set-emitting', description: 'Start or stop emission, optionally restarting first.' },
+      { name: 'particles-get', description: "Read an emitter's scalar config (read-only)." },
+    ],
+  },
 ] as const;
 
 /** True when a descriptor carries a concrete version pin (drives the up-to-date / update decision). */

--- a/cli/tests/install-extension-cli.test.ts
+++ b/cli/tests/install-extension-cli.test.ts
@@ -24,11 +24,13 @@ describe('install-extension — CLI smoke (command wiring)', () => {
     expect(stdout).toContain('install-extension');
   });
 
-  it('exits 1 with an honest empty-catalog message (no extension published yet)', async () => {
+  it('exits 1 for an unknown id and lists the available extensions', async () => {
     const { stdout, exitCode } = await runCliAsync(['install-extension', 'anything', tmpDir]);
-    // The shipped catalog is empty, so any id is unknown — and the message says so.
+    // The catalog now ships at least one published extension, so an unknown id is
+    // rejected with a message that lists what IS available.
     expect(exitCode).toBe(1);
-    expect(stdout).toContain('catalog is currently empty');
+    expect(stdout).toContain('Unknown extension');
+    expect(stdout).toContain('com.IvanMurzak.Godot.MCP.Particles');
   });
 
   it('exits 1 for a non-Godot project directory', async () => {


### PR DESCRIPTION
Registers the first published Godot-MCP extension — **`com.IvanMurzak.Godot.MCP.Particles` 0.1.0** ([Godot-AI-Particles](https://github.com/IvanMurzak/Godot-AI-Particles), live on nuget.org) — in the shared extension catalog so the dock, the CLI (`install-extension`), and the app all list it.

## Changes
- `addons/godot_mcp/extensions.catalog.json` — append the **Particles Tools** entry (5 tools: `particles-defaults`, `particles-create`, `particles-configure`, `particles-set-emitting`, `particles-get`).
- `cli/src/utils/extensions-catalog.ts` — mirror the entry so `extensions-catalog-parity.test.ts` deep-equals the JSON source of truth.
- `cli/tests/install-extension-cli.test.ts` — the catalog is no longer empty, so an unknown id now lists the available extensions (was asserting the empty-catalog message).
- `extensions.catalog.md` / `GodotExtensionCatalogTests.cs` — drop the stale "ships empty" wording (the embedded round-trip test is count-agnostic).

## Verification
`cd cli && npm run build && npm test` → **365 passed (32 files)**, including `extensions-catalog-parity` (TS mirror deep-equals the JSON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZ6MfPoXJr7DG3dk16j1pR