### PR TITLE
chore(catalog): float Godot-AI-Particles version (install latest)

### DIFF
--- a/addons/godot_mcp/extensions.catalog.json
+++ b/addons/godot_mcp/extensions.catalog.json
@@ -5,7 +5,7 @@
       "name": "Particles Tools",
       "description": "AI MCP tools for Godot GpuParticles (2D & 3D): create, configure, start/stop, and inspect emitters.",
       "packageId": "com.IvanMurzak.Godot.MCP.Particles",
-      "version": "0.1.0",
+      "version": null,
       "gitUrl": "https://github.com/IvanMurzak/Godot-AI-Particles",
       "tools": [
         { "name": "particles-defaults", "description": "Return the recommended starter config for a 2D/3D emitter." },

--- a/cli/src/utils/extensions-catalog.ts
+++ b/cli/src/utils/extensions-catalog.ts
@@ -46,7 +46,7 @@ export const EXTENSIONS_CATALOG: readonly ExtensionDescriptor[] = [
     description:
       'AI MCP tools for Godot GpuParticles (2D & 3D): create, configure, start/stop, and inspect emitters.',
     packageId: 'com.IvanMurzak.Godot.MCP.Particles',
-    version: '0.1.0',
+    version: null,
     gitUrl: 'https://github.com/IvanMurzak/Godot-AI-Particles',
     tools: [
       { name: 'particles-defaults', description: 'Return the recommended starter config for a 2D/3D emitter.' },


### PR DESCRIPTION
## What

Switch the shared extension catalog entry for `com.IvanMurzak.Godot.MCP.Particles` from a pinned `version: "0.1.0"` to a **floating `null`** version, in both parity-locked files:

- `addons/godot_mcp/extensions.catalog.json`
- `cli/src/utils/extensions-catalog.ts`

## Why

Owner decision (2026-06-28) for the per-extension Godot release profiles: catalog entries float (`version: null`), so `godot-cli install-extension` always installs the **latest** published version from nuget.org. This decouples each extension re-release from a Godot-MCP catalog-version-bump PR — extension re-release collapses to bump → OIDC publish → software pointer bump.

## Tests

- `cli`: `npm test` — 365 passed (incl. `extensions-catalog-parity` and `install-extension-cli`).
- dotnet: `dotnet test Godot-MCP.Tests` — 962 passed. No C# changes needed; the parser (`GodotExtensionCatalog`), descriptor (`HasVersion`), and install planner (`Plan_Add_WithNoVersion_OmitsVersionAttribute`) are already null-tolerant, and the catalog tests use synthetic data (the real Particles entry is only existence-checked).

## Coordination

Companion to the `software` PR that simplifies the per-extension Godot release/implement-task profiles (supersedes ai-game-dev-software#57). Auto-merge intentionally OFF for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZ6MfPoXJr7DG3dk16j1pR