### PR TITLE
feat(catalog): add Godot-AI-Animation extension

### DIFF
--- a/addons/godot_mcp/extensions.catalog.json
+++ b/addons/godot_mcp/extensions.catalog.json
@@ -45,6 +45,22 @@
         { "name": "navigation-link-create", "description": "Create a NavigationLink2D/NavigationLink3D node (an off-mesh connection between two points)." },
         { "name": "navigation-get", "description": "Read a navigation node's scalar config (read-only)." }
       ]
+    },
+    {
+      "name": "Animation Tools",
+      "description": "AI MCP tools for Godot AnimationPlayer: create players, libraries, and animations, add tracks, insert keyframes, and inspect them.",
+      "packageId": "com.IvanMurzak.Godot.MCP.Animation",
+      "version": null,
+      "gitUrl": "https://github.com/IvanMurzak/Godot-AI-Animation",
+      "tools": [
+        { "name": "animation-defaults", "description": "Return the recommended starter config (length, loop mode) for a new animation." },
+        { "name": "animation-player-create", "description": "Create an AnimationPlayer node in the currently edited Godot scene." },
+        { "name": "animation-library-add", "description": "Add a new empty AnimationLibrary to an existing AnimationPlayer." },
+        { "name": "animation-create", "description": "Create an Animation in an AnimationPlayer's library (auto-created when missing)." },
+        { "name": "animation-add-track", "description": "Add a value or 3D transform track to an existing Animation." },
+        { "name": "animation-insert-key", "description": "Insert a keyframe on an animation track." },
+        { "name": "animation-get", "description": "Read an AnimationPlayer's libraries, animations, and a clip's tracks (read-only)." }
+      ]
     }
   ]
 }

--- a/cli/src/utils/extensions-catalog.ts
+++ b/cli/src/utils/extensions-catalog.ts
@@ -89,6 +89,23 @@ export const EXTENSIONS_CATALOG: readonly ExtensionDescriptor[] = [
       { name: 'navigation-get', description: "Read a navigation node's scalar config (read-only)." },
     ],
   },
+  {
+    name: 'Animation Tools',
+    description:
+      'AI MCP tools for Godot AnimationPlayer: create players, libraries, and animations, add tracks, insert keyframes, and inspect them.',
+    packageId: 'com.IvanMurzak.Godot.MCP.Animation',
+    version: null,
+    gitUrl: 'https://github.com/IvanMurzak/Godot-AI-Animation',
+    tools: [
+      { name: 'animation-defaults', description: 'Return the recommended starter config (length, loop mode) for a new animation.' },
+      { name: 'animation-player-create', description: 'Create an AnimationPlayer node in the currently edited Godot scene.' },
+      { name: 'animation-library-add', description: 'Add a new empty AnimationLibrary to an existing AnimationPlayer.' },
+      { name: 'animation-create', description: "Create an Animation in an AnimationPlayer's library (auto-created when missing)." },
+      { name: 'animation-add-track', description: 'Add a value or 3D transform track to an existing Animation.' },
+      { name: 'animation-insert-key', description: 'Insert a keyframe on an animation track.' },
+      { name: 'animation-get', description: "Read an AnimationPlayer's libraries, animations, and a clip's tracks (read-only)." },
+    ],
+  },
 ] as const;
 
 /** True when a descriptor carries a concrete version pin (drives the up-to-date / update decision). */


### PR DESCRIPTION
Adds `com.IvanMurzak.Godot.MCP.Animation` (https://github.com/IvanMurzak/Godot-AI-Animation) to the shared extension catalog (parity-locked JSON + CLI mirror) as a FLOATING entry (`version: null`), so `install-extension` always tracks the latest published package version. Published 0.1.0 on nuget.org.