### PR TITLE
feat(catalog): add Godot-AI-GridMap extension

### DIFF
--- a/addons/godot_mcp/extensions.catalog.json
+++ b/addons/godot_mcp/extensions.catalog.json
@@ -77,6 +77,22 @@
         { "name": "csg-set-operation", "description": "Set an existing CSG node's boolean operation (Union / Intersection / Subtraction)." },
         { "name": "csg-get", "description": "Read a CSG node's scalar config (read-only)." }
       ]
+    },
+    {
+      "name": "GridMap Tools",
+      "description": "AI MCP tools for Godot GridMap (3D tile-based maps): create, set/clear cells, assign a MeshLibrary, and inspect.",
+      "packageId": "com.IvanMurzak.Godot.MCP.GridMap",
+      "version": null,
+      "gitUrl": "https://github.com/IvanMurzak/Godot-AI-GridMap",
+      "tools": [
+        { "name": "gridmap-defaults", "description": "Return the recommended starter configuration for a new GridMap node." },
+        { "name": "gridmap-create", "description": "Create a GridMap node in the currently edited Godot scene." },
+        { "name": "gridmap-set-mesh-library", "description": "Assign a MeshLibrary resource to an existing GridMap node." },
+        { "name": "gridmap-set-cell", "description": "Set a single cell of a GridMap to a MeshLibrary item." },
+        { "name": "gridmap-clear-cell", "description": "Clear a single cell of a GridMap." },
+        { "name": "gridmap-clear", "description": "Clear all cells of a GridMap." },
+        { "name": "gridmap-get", "description": "Read a GridMap's scalar config (read-only)." }
+      ]
     }
   ]
 }

--- a/cli/src/utils/extensions-catalog.ts
+++ b/cli/src/utils/extensions-catalog.ts
@@ -123,6 +123,23 @@ export const EXTENSIONS_CATALOG: readonly ExtensionDescriptor[] = [
       { name: 'csg-get', description: "Read a CSG node's scalar config (read-only)." },
     ],
   },
+  {
+    name: 'GridMap Tools',
+    description:
+      'AI MCP tools for Godot GridMap (3D tile-based maps): create, set/clear cells, assign a MeshLibrary, and inspect.',
+    packageId: 'com.IvanMurzak.Godot.MCP.GridMap',
+    version: null,
+    gitUrl: 'https://github.com/IvanMurzak/Godot-AI-GridMap',
+    tools: [
+      { name: 'gridmap-defaults', description: 'Return the recommended starter configuration for a new GridMap node.' },
+      { name: 'gridmap-create', description: 'Create a GridMap node in the currently edited Godot scene.' },
+      { name: 'gridmap-set-mesh-library', description: 'Assign a MeshLibrary resource to an existing GridMap node.' },
+      { name: 'gridmap-set-cell', description: 'Set a single cell of a GridMap to a MeshLibrary item.' },
+      { name: 'gridmap-clear-cell', description: 'Clear a single cell of a GridMap.' },
+      { name: 'gridmap-clear', description: 'Clear all cells of a GridMap.' },
+      { name: 'gridmap-get', description: "Read a GridMap's scalar config (read-only)." },
+    ],
+  },
 ] as const;
 
 /** True when a descriptor carries a concrete version pin (drives the up-to-date / update decision). */


### PR DESCRIPTION
Adds `com.IvanMurzak.Godot.MCP.GridMap` (https://github.com/IvanMurzak/Godot-AI-GridMap) to the shared extension catalog (parity-locked JSON + CLI mirror). Published 0.1.0 on nuget.org. Floating `version: null` entry so re-releases need no catalog edit.