### PR TITLE
feat(catalog): add optional addonRequired field for Class-B extensions

### DIFF
--- a/Godot-MCP.Tests/GodotExtensionCatalogTests.cs
+++ b/Godot-MCP.Tests/GodotExtensionCatalogTests.cs
@@ -35,7 +35,13 @@ namespace com.IvanMurzak.Godot.MCP.Tests
       ""gitUrl"": ""https://github.com/IvanMurzak/Godot-MCP"",
       ""tools"": [
         { ""name"": ""probuilder-extrude"", ""description"": ""Extrude faces."" }
-      ]
+      ],
+      ""addonRequired"": {
+        ""name"": ""PhantomCamera"",
+        ""assetLibId"": ""1822"",
+        ""repo"": ""ramokz/phantom-camera"",
+        ""license"": ""MIT""
+      }
     },
     {
       ""name"": ""Floating Ext"",
@@ -64,6 +70,19 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         }
 
         [Fact]
+        public void Parse_ClassBEntry_MapsAddonRequiredBlock()
+        {
+            // CLASS-B: the optional addonRequired block round-trips its four fields and flags the descriptor.
+            var pb = GodotExtensionCatalog.Parse(PopulatedCatalog)[0];
+            Assert.True(pb.RequiresAddon);
+            Assert.NotNull(pb.AddonRequired);
+            Assert.Equal("PhantomCamera", pb.AddonRequired!.Name);
+            Assert.Equal("1822", pb.AddonRequired.AssetLibId);
+            Assert.Equal("ramokz/phantom-camera", pb.AddonRequired.Repo);
+            Assert.Equal("MIT", pb.AddonRequired.License);
+        }
+
+        [Fact]
         public void Parse_OmittedVersion_YieldsNullVersion()
         {
             var list = GodotExtensionCatalog.Parse(PopulatedCatalog);
@@ -72,6 +91,15 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Null(floating.Version);
             Assert.False(floating.HasVersion);
             Assert.Empty(floating.Tools);
+        }
+
+        [Fact]
+        public void Parse_ClassAEntry_HasNullAddonRequired()
+        {
+            // CLASS-A (no addonRequired block) → AddonRequired is null and RequiresAddon is false.
+            var floating = GodotExtensionCatalog.Parse(PopulatedCatalog)[1];
+            Assert.Null(floating.AddonRequired);
+            Assert.False(floating.RequiresAddon);
         }
 
         [Fact]

--- a/addons/godot_mcp/Runtime/Extensions/GodotExtensionCatalog.cs
+++ b/addons/godot_mcp/Runtime/Extensions/GodotExtensionCatalog.cs
@@ -89,13 +89,23 @@ namespace com.IvanMurzak.Godot.MCP.Extensions
                         .Select(t => (t!.Name!.Trim(), (t.Description ?? string.Empty).Trim()))
                         .ToArray();
 
+                // CLASS-B addon block: present only when its `name` is non-empty; absent / nameless reads as null.
+                var addonRequired = entry.AddonRequired != null && !string.IsNullOrWhiteSpace(entry.AddonRequired.Name)
+                    ? new GodotAddonRequirement(
+                        Name: entry.AddonRequired.Name!.Trim(),
+                        AssetLibId: string.IsNullOrWhiteSpace(entry.AddonRequired.AssetLibId) ? null : entry.AddonRequired.AssetLibId!.Trim(),
+                        Repo: string.IsNullOrWhiteSpace(entry.AddonRequired.Repo) ? null : entry.AddonRequired.Repo!.Trim(),
+                        License: string.IsNullOrWhiteSpace(entry.AddonRequired.License) ? null : entry.AddonRequired.License!.Trim())
+                    : null;
+
                 result.Add(new GodotExtensionDescriptor(
                     Name: entry.Name!.Trim(),
                     Description: (entry.Description ?? string.Empty).Trim(),
                     PackageId: entry.PackageId!.Trim(),
                     Version: string.IsNullOrWhiteSpace(entry.Version) ? null : entry.Version!.Trim(),
                     GitUrl: string.IsNullOrWhiteSpace(entry.GitUrl) ? null : entry.GitUrl!.Trim(),
-                    Tools: tools));
+                    Tools: tools,
+                    AddonRequired: addonRequired));
             }
 
             return result;
@@ -139,12 +149,23 @@ namespace com.IvanMurzak.Godot.MCP.Extensions
             [JsonPropertyName("version")] public string? Version { get; set; }
             [JsonPropertyName("gitUrl")] public string? GitUrl { get; set; }
             [JsonPropertyName("tools")] public List<CatalogTool?>? Tools { get; set; }
+            [JsonPropertyName("addonRequired")] public CatalogAddonRequired? AddonRequired { get; set; }
         }
 
         sealed class CatalogTool
         {
             [JsonPropertyName("name")] public string? Name { get; set; }
             [JsonPropertyName("description")] public string? Description { get; set; }
+        }
+
+        // The optional CLASS-B addon block. `assetLibId` is a JSON STRING by schema convention (e.g. "1822");
+        // keeping it a string keeps the dock + CLI mirror + parity test in lockstep with no number/string drift.
+        sealed class CatalogAddonRequired
+        {
+            [JsonPropertyName("name")] public string? Name { get; set; }
+            [JsonPropertyName("assetLibId")] public string? AssetLibId { get; set; }
+            [JsonPropertyName("repo")] public string? Repo { get; set; }
+            [JsonPropertyName("license")] public string? License { get; set; }
         }
     }
 }

--- a/addons/godot_mcp/Runtime/Extensions/GodotExtensionDescriptor.cs
+++ b/addons/godot_mcp/Runtime/Extensions/GodotExtensionDescriptor.cs
@@ -13,6 +13,23 @@ using System.Collections.Generic;
 namespace com.IvanMurzak.Godot.MCP.Extensions
 {
     /// <summary>
+    /// The third-party Godot addon a CLASS-B (addon-dependent) extension wraps — mirrors the catalog JSON
+    /// <c>addonRequired</c> block. Class-A extensions (which wrap a BUILT-IN Godot feature) carry <c>null</c>
+    /// here. It is pure presentation metadata so the dock can show "requires the <c>Name</c> addon" + a link;
+    /// it does NOT affect install logic (the extension package is still installed by its <c>PackageId</c> alone —
+    /// the addon is the consumer's own runtime responsibility, never vendored or downloaded by the installer).
+    /// </summary>
+    /// <param name="Name">The third-party addon's display name (e.g. "PhantomCamera"). Required within the block.</param>
+    /// <param name="AssetLibId">Optional Godot AssetLib id (e.g. "1822"), stored as a string.</param>
+    /// <param name="Repo">Optional upstream repository (owner/name or URL).</param>
+    /// <param name="License">Optional addon licence identifier (informational).</param>
+    public sealed record GodotAddonRequirement(
+        string Name,
+        string? AssetLibId = null,
+        string? Repo = null,
+        string? License = null);
+
+    /// <summary>
     /// One tool family the dock's "Extensions" section offers to install into the CONSUMER's Godot project. The
     /// Godot analog of Unity-MCP's <c>ExtensionData</c> (in <c>MainWindowEditor.Extensions.cs</c>), except the
     /// distribution mechanism is a NuGet <c>&lt;PackageReference&gt;</c> in the consumer's game <c>.csproj</c>
@@ -43,13 +60,19 @@ namespace com.IvanMurzak.Godot.MCP.Extensions
     /// The tool entries this extension contributes, each a <c>(Name, Description)</c> pair — shown as the
     /// extension's tool list (mirrors Unity's per-extension tool enumeration). May be empty.
     /// </param>
+    /// <param name="AddonRequired">
+    /// The third-party addon a CLASS-B extension wraps (the catalog <c>addonRequired</c> block). <c>null</c> for
+    /// Class-A extensions (which wrap a built-in Godot feature). Presentation metadata only — see
+    /// <see cref="GodotAddonRequirement"/>.
+    /// </param>
     public sealed record GodotExtensionDescriptor(
         string Name,
         string Description,
         string PackageId,
         string? Version = null,
         string? GitUrl = null,
-        IReadOnlyList<(string Name, string Description)>? Tools = null)
+        IReadOnlyList<(string Name, string Description)>? Tools = null,
+        GodotAddonRequirement? AddonRequired = null)
     {
         /// <summary>The tool entries this extension contributes, never null (an absent list reads as empty).</summary>
         public IReadOnlyList<(string Name, string Description)> Tools { get; init; }
@@ -57,5 +80,8 @@ namespace com.IvanMurzak.Godot.MCP.Extensions
 
         /// <summary>True when a concrete <see cref="Version"/> pin is present (drives the up-to-date / update decision).</summary>
         public bool HasVersion => !string.IsNullOrWhiteSpace(Version);
+
+        /// <summary>True for a CLASS-B (addon-dependent) extension — i.e. <see cref="AddonRequired"/> is present.</summary>
+        public bool RequiresAddon => AddonRequired != null;
     }
 }

--- a/addons/godot_mcp/extensions.catalog.md
+++ b/addons/godot_mcp/extensions.catalog.md
@@ -24,7 +24,13 @@ It is consumed by all THREE install channels so they can never drift:
       "gitUrl": "https://github.com/IvanMurzak/...",       // OPTIONAL repo/docs link
       "tools": [                                           // OPTIONAL contributed-tool list
         { "name": "probuilder-extrude", "description": "Extrude faces." }
-      ]
+      ],
+      "addonRequired": {                                   // OPTIONAL — present ONLY for CLASS-B (addon-dependent) extensions
+        "name": "PhantomCamera",                           //   the third-party addon the extension wraps (display name)
+        "assetLibId": "1822",                              //   OPTIONAL Godot AssetLib id (stored as a string)
+        "repo": "ramokz/phantom-camera",                   //   OPTIONAL upstream repo (owner/name or URL)
+        "license": "MIT"                                   //   OPTIONAL addon licence (informational)
+      }
     }
   ]
 }
@@ -39,6 +45,14 @@ It is consumed by all THREE install channels so they can never drift:
   decision (numeric, component-wise compare — `1.10.0` > `1.2.0`). When absent the reference is added
   WITHOUT a `Version` attribute (floating / centrally-managed), and a present reference is never bumped.
 - `name`, `packageId` are REQUIRED and non-empty; entries missing either are ignored by both parsers.
+- `addonRequired` is OPTIONAL and **absent for Class-A extensions** (those wrap a BUILT-IN Godot feature
+  and need no third-party addon). It is present only for **Class-B (addon-dependent)** extensions, which
+  wrap a community addon the consumer must install themselves (e.g. PhantomCamera, Terrain3D). It is pure
+  **presentation metadata** — the dock/app/CLI surface "requires the `<name>` addon" + a link — and does
+  **not** affect install logic (the extension package is still installed by `packageId` alone; the addon is
+  never vendored or downloaded by the installer, it is the consumer's own runtime responsibility). Its
+  `name` is REQUIRED within the block (a block missing it is dropped → reads as absent); `assetLibId` (the
+  Godot AssetLib id, a string), `repo`, and `license` are optional. Both parsers tolerate it being absent.
 
 ## Adding an extension
 

--- a/cli/src/utils/extensions-catalog.ts
+++ b/cli/src/utils/extensions-catalog.ts
@@ -20,9 +20,28 @@ export interface ExtensionTool {
 }
 
 /**
+ * The third-party Godot addon a CLASS-B extension wraps — mirrors the JSON
+ * `addonRequired` block. Class-A extensions (which wrap a BUILT-IN Godot feature)
+ * OMIT this entirely (`addonRequired` is absent / `undefined`). When present it is
+ * pure presentation metadata so the dock/app/CLI can surface "requires the <name>
+ * addon" + a link; it does NOT affect install logic (the package is still installed
+ * by `packageId` alone — the addon is the consumer's own runtime responsibility).
+ * `name` is the anchor; `assetLibId` (the Godot AssetLib id, stored as a string),
+ * `repo`, and `license` are optional.
+ */
+export interface ExtensionAddonRequirement {
+  readonly name: string;
+  readonly assetLibId: string | null;
+  readonly repo: string | null;
+  readonly license: string | null;
+}
+
+/**
  * One installable extension — the CLI analog of the C# `GodotExtensionDescriptor`.
  * `packageId` is the INSTALL IDENTITY (the `<PackageReference Include="...">`).
  * `version` is `null` for a floating (unpinned) reference.
+ * `addonRequired` is present ONLY for CLASS-B (addon-dependent) extensions; Class-A
+ * entries omit it.
  */
 export interface ExtensionDescriptor {
   readonly name: string;
@@ -31,6 +50,7 @@ export interface ExtensionDescriptor {
   readonly version: string | null;
   readonly gitUrl: string | null;
   readonly tools: readonly ExtensionTool[];
+  readonly addonRequired?: ExtensionAddonRequirement | null;
 }
 
 /**

--- a/cli/tests/extensions-catalog-parity.test.ts
+++ b/cli/tests/extensions-catalog-parity.test.ts
@@ -12,6 +12,13 @@ import { EXTENSIONS_CATALOG, type ExtensionDescriptor } from '../src/utils/exten
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CATALOG_JSON = path.resolve(__dirname, '..', '..', 'addons', 'godot_mcp', 'extensions.catalog.json');
 
+interface CatalogJsonAddonRequired {
+  name?: string;
+  assetLibId?: string | number;
+  repo?: string;
+  license?: string;
+}
+
 interface CatalogJsonEntry {
   name?: string;
   description?: string;
@@ -19,6 +26,25 @@ interface CatalogJsonEntry {
   version?: string;
   gitUrl?: string;
   tools?: { name?: string; description?: string }[];
+  addonRequired?: CatalogJsonAddonRequired;
+}
+
+/** Trim a string-or-number-or-absent field to a non-empty string, else null (assetLibId may be a JSON number). */
+function trimOrNull(v: string | number | undefined): string | null {
+  if (v === undefined || v === null) return null;
+  const s = String(v).trim();
+  return s === '' ? null : s;
+}
+
+/** Normalize the optional CLASS-B `addonRequired` block; absent / nameless → null (mirrors the C# parser's drop rule). */
+function normalizeAddonRequired(a: CatalogJsonAddonRequired | undefined) {
+  if (!a || !a.name || a.name.trim() === '') return null;
+  return {
+    name: a.name.trim(),
+    assetLibId: trimOrNull(a.assetLibId),
+    repo: trimOrNull(a.repo),
+    license: trimOrNull(a.license),
+  };
 }
 
 /** Normalize a raw JSON entry to the canonical ExtensionDescriptor shape (mirrors the C# parser's mapping). */
@@ -32,6 +58,7 @@ function normalizeJsonEntry(e: CatalogJsonEntry): ExtensionDescriptor {
     tools: (e.tools ?? [])
       .filter((t) => t.name && t.name.trim() !== '')
       .map((t) => ({ name: (t.name ?? '').trim(), description: (t.description ?? '').trim() })),
+    addonRequired: normalizeAddonRequired(e.addonRequired),
   };
 }
 
@@ -56,6 +83,16 @@ describe('extensions-catalog parity with addons/godot_mcp/extensions.catalog.jso
       version: d.version,
       gitUrl: d.gitUrl,
       tools: d.tools.map((t) => ({ name: t.name, description: t.description })),
+      // Class-A entries omit addonRequired (undefined) — coalesce to null so they match the JSON side,
+      // which normalizes an absent block to null. A Class-B entry carries the {name, assetLibId, repo, license} block.
+      addonRequired: d.addonRequired
+        ? {
+            name: d.addonRequired.name,
+            assetLibId: d.addonRequired.assetLibId,
+            repo: d.addonRequired.repo,
+            license: d.addonRequired.license,
+          }
+        : null,
     }));
 
     expect(


### PR DESCRIPTION
## What

Adds an OPTIONAL `addonRequired { name, assetLibId, repo, license }` block to the shared extension catalog so the dock / app / CLI can surface "requires the *X* addon" + a link for **Class-B (addon-dependent)** Godot-MCP extensions (those that wrap a third-party community addon — PhantomCamera, Terrain3D, Dialogic, …).

This is the catalog-schema half of the Class-B extension architecture (design note `2026-06-28-godot-class-b-extensions-architecture.md` §5, open question #3).

## Scope / safety

- **Presentation metadata only.** Install logic is UNCHANGED — the extension package is still installed by `packageId` alone; the third-party addon is never vendored or downloaded by the installer (it stays the consumer's own runtime responsibility).
- **Absent for Class-A.** All 6 current catalog entries (Particles, Tilemap, Navigation, Animation, CSG, GridMap) are byte-unchanged — `addonRequired` is optional and omitted for built-in-feature extensions.
- `assetLibId` is stored as a **string** (`"1822"`) to keep the JSON, the CLI mirror, and the dock parser in lockstep with no number/string drift.

## Changes

- `addons/godot_mcp/extensions.catalog.md` — document the optional block.
- `cli/src/utils/extensions-catalog.ts` — `ExtensionAddonRequirement` interface + optional `addonRequired` field on `ExtensionDescriptor`.
- `cli/tests/extensions-catalog-parity.test.ts` — thread `addonRequired` through normalization (absent → null on both sides) so the parity tripwire keeps the dock + CLI in lockstep.
- `addons/godot_mcp/Runtime/Extensions/GodotExtensionDescriptor.cs` — `GodotAddonRequirement` record + optional `AddonRequired` param + `RequiresAddon` flag.
- `addons/godot_mcp/Runtime/Extensions/GodotExtensionCatalog.cs` — `addonRequired` JSON DTO + tolerant mapping (a nameless block reads as absent).
- `Godot-MCP.Tests/GodotExtensionCatalogTests.cs` — cover the present (Class-B) and absent (Class-A) cases.

## Validation

- `cd cli && npm test` → 365 passed (32 files), incl. the parity test; `tsc` clean.
- `dotnet test Godot-MCP.Tests` → 964 passed.

Auto-merge intentionally **off** — for TD review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZ6MfPoXJr7DG3dk16j1pR