### PR TITLE
feat(catalog): add Godot-AI-PhantomCamera extension

### DIFF
--- a/addons/godot_mcp/extensions.catalog.json
+++ b/addons/godot_mcp/extensions.catalog.json
@@ -93,6 +93,28 @@
         { "name": "gridmap-clear", "description": "Clear all cells of a GridMap." },
         { "name": "gridmap-get", "description": "Read a GridMap's scalar config (read-only)." }
       ]
+    },
+    {
+      "name": "PhantomCamera Tools",
+      "description": "AI MCP tools for the Godot Phantom Camera addon (Cinemachine-style virtual cameras): create hosts and cameras, set follow/look-at targets and priority, and inspect them.",
+      "packageId": "com.IvanMurzak.Godot.MCP.PhantomCamera",
+      "version": null,
+      "gitUrl": "https://github.com/IvanMurzak/Godot-AI-PhantomCamera",
+      "tools": [
+        { "name": "phantomcamera-defaults", "description": "Return the recommended starter config (priority, follow/look-at mode, damping) for a Phantom Camera." },
+        { "name": "phantomcamera-host-create", "description": "Ensure a PhantomCameraHost exists under a Camera3D in the edited scene (required by the addon)." },
+        { "name": "phantomcamera-create", "description": "Create a PhantomCamera3D node (a virtual camera) in the currently edited Godot scene." },
+        { "name": "phantomcamera-set-follow", "description": "Set an existing PhantomCamera3D's follow mode and/or follow target." },
+        { "name": "phantomcamera-set-look-at", "description": "Set an existing PhantomCamera3D's look-at mode and/or look-at target." },
+        { "name": "phantomcamera-set-priority", "description": "Set an existing PhantomCamera3D's priority (higher wins; raising it switches the active camera)." },
+        { "name": "phantomcamera-get", "description": "Read an existing PhantomCamera3D's scalar config (read-only)." }
+      ],
+      "addonRequired": {
+        "name": "Phantom Camera",
+        "assetLibId": "1822",
+        "repo": "ramokz/phantom-camera",
+        "license": "MIT"
+      }
     }
   ]
 }

--- a/cli/src/utils/extensions-catalog.ts
+++ b/cli/src/utils/extensions-catalog.ts
@@ -160,6 +160,29 @@ export const EXTENSIONS_CATALOG: readonly ExtensionDescriptor[] = [
       { name: 'gridmap-get', description: "Read a GridMap's scalar config (read-only)." },
     ],
   },
+  {
+    name: 'PhantomCamera Tools',
+    description:
+      'AI MCP tools for the Godot Phantom Camera addon (Cinemachine-style virtual cameras): create hosts and cameras, set follow/look-at targets and priority, and inspect them.',
+    packageId: 'com.IvanMurzak.Godot.MCP.PhantomCamera',
+    version: null,
+    gitUrl: 'https://github.com/IvanMurzak/Godot-AI-PhantomCamera',
+    tools: [
+      { name: 'phantomcamera-defaults', description: 'Return the recommended starter config (priority, follow/look-at mode, damping) for a Phantom Camera.' },
+      { name: 'phantomcamera-host-create', description: 'Ensure a PhantomCameraHost exists under a Camera3D in the edited scene (required by the addon).' },
+      { name: 'phantomcamera-create', description: 'Create a PhantomCamera3D node (a virtual camera) in the currently edited Godot scene.' },
+      { name: 'phantomcamera-set-follow', description: "Set an existing PhantomCamera3D's follow mode and/or follow target." },
+      { name: 'phantomcamera-set-look-at', description: "Set an existing PhantomCamera3D's look-at mode and/or look-at target." },
+      { name: 'phantomcamera-set-priority', description: "Set an existing PhantomCamera3D's priority (higher wins; raising it switches the active camera)." },
+      { name: 'phantomcamera-get', description: "Read an existing PhantomCamera3D's scalar config (read-only)." },
+    ],
+    addonRequired: {
+      name: 'Phantom Camera',
+      assetLibId: '1822',
+      repo: 'ramokz/phantom-camera',
+      license: 'MIT',
+    },
+  },
 ] as const;
 
 /** True when a descriptor carries a concrete version pin (drives the up-to-date / update decision). */


### PR DESCRIPTION
Adds `com.IvanMurzak.Godot.MCP.PhantomCamera` (https://github.com/IvanMurzak/Godot-AI-PhantomCamera) to the shared extension catalog (parity-locked JSON + CLI mirror). Published 0.1.0 on nuget.org.

This is the first **Class-B** (addon-dependent) catalog entry: it carries an `addonRequired` block for the community **Phantom Camera** addon (AssetLib id 1822, ramokz/phantom-camera, MIT) — presentation metadata only; install logic is unchanged (the package installs by `packageId` alone). Seven `phantomcamera-*` tools listed, version floating (`null`).

Verified locally: CLI vitest (365 passed, incl. catalog parity) + Godot-MCP.Tests dotnet (964 passed, incl. catalog round-trip).