### PR TITLE
feat(catalog): add Godot-AI-Dialogic extension

### DIFF
--- a/addons/godot_mcp/extensions.catalog.json
+++ b/addons/godot_mcp/extensions.catalog.json
@@ -136,6 +136,25 @@
         "repo": "bitbrain/beehave",
         "license": "MIT"
       }
+    },
+    {
+      "name": "Dialogic Tools",
+      "description": "AI MCP tools for the Godot Dialogic addon (dialogue / visual novels): create timeline and character resources, append text events, and inspect them.",
+      "packageId": "com.IvanMurzak.Godot.MCP.Dialogic",
+      "version": null,
+      "gitUrl": "https://github.com/IvanMurzak/Godot-AI-Dialogic",
+      "tools": [
+        { "name": "dialogic-defaults", "description": "Return the recommended starter timeline and character config for Dialogic authoring." },
+        { "name": "dialogic-timeline-create", "description": "Create a Dialogic timeline resource (.dtl), seeded with a first text event." },
+        { "name": "dialogic-character-create", "description": "Create a Dialogic character resource (.dch) with a display name and color." },
+        { "name": "dialogic-timeline-add-text", "description": "Append a text event (optionally with a speaker) to an existing Dialogic timeline (.dtl)." },
+        { "name": "dialogic-get", "description": "Read a Dialogic timeline (.dtl) or character (.dch) resource's config (read-only)." }
+      ],
+      "addonRequired": {
+        "name": "Dialogic",
+        "repo": "dialogic-godot/dialogic",
+        "license": "MIT"
+      }
     }
   ]
 }

--- a/cli/src/utils/extensions-catalog.ts
+++ b/cli/src/utils/extensions-catalog.ts
@@ -205,6 +205,27 @@ export const EXTENSIONS_CATALOG: readonly ExtensionDescriptor[] = [
       license: 'MIT',
     },
   },
+  {
+    name: 'Dialogic Tools',
+    description:
+      'AI MCP tools for the Godot Dialogic addon (dialogue / visual novels): create timeline and character resources, append text events, and inspect them.',
+    packageId: 'com.IvanMurzak.Godot.MCP.Dialogic',
+    version: null,
+    gitUrl: 'https://github.com/IvanMurzak/Godot-AI-Dialogic',
+    tools: [
+      { name: 'dialogic-defaults', description: 'Return the recommended starter timeline and character config for Dialogic authoring.' },
+      { name: 'dialogic-timeline-create', description: 'Create a Dialogic timeline resource (.dtl), seeded with a first text event.' },
+      { name: 'dialogic-character-create', description: 'Create a Dialogic character resource (.dch) with a display name and color.' },
+      { name: 'dialogic-timeline-add-text', description: 'Append a text event (optionally with a speaker) to an existing Dialogic timeline (.dtl).' },
+      { name: 'dialogic-get', description: "Read a Dialogic timeline (.dtl) or character (.dch) resource's config (read-only)." },
+    ],
+    addonRequired: {
+      name: 'Dialogic',
+      assetLibId: null,
+      repo: 'dialogic-godot/dialogic',
+      license: 'MIT',
+    },
+  },
 ] as const;
 
 /** True when a descriptor carries a concrete version pin (drives the up-to-date / update decision). */


### PR DESCRIPTION
Adds `com.IvanMurzak.Godot.MCP.Dialogic` (https://github.com/IvanMurzak/Godot-AI-Dialogic) to the shared extension catalog (parity-locked JSON + CLI mirror). Published 0.1.0 on nuget.org.

Class-B (addon-dependent) entry: carries an `addonRequired` block for the **Dialogic** addon (https://github.com/dialogic-godot/dialogic, MIT). The addon is NOT bundled — it is the consumer's own runtime responsibility; `addonRequired` is presentation metadata only (install logic is unchanged, the package installs by `packageId`). `assetLibId` is omitted because Dialogic is not listed in the Godot Asset Library (distributed via GitHub Releases, currently 2.x alpha).

Floating `version: null` so re-releases never need a catalog edit. Local gates green: `cli` vitest (parity + install) 365 passed, `Godot-MCP.Tests` 964 passed.