### PR TITLE
feat(catalog): add Godot-AI-Terrain3D extension

### DIFF
--- a/addons/godot_mcp/extensions.catalog.json
+++ b/addons/godot_mcp/extensions.catalog.json
@@ -155,6 +155,27 @@
         "repo": "dialogic-godot/dialogic",
         "license": "MIT"
       }
+    },
+    {
+      "name": "Terrain3D Tools",
+      "description": "AI MCP tools for the Godot Terrain3D addon (TokisanGames heightmap terrain): create terrains, set the data directory, region size, and material, and inspect them.",
+      "packageId": "com.IvanMurzak.Godot.MCP.Terrain3D",
+      "version": null,
+      "gitUrl": "https://github.com/IvanMurzak/Godot-AI-Terrain3D",
+      "tools": [
+        { "name": "terrain3d-defaults", "description": "Return the recommended starter config (region size, mesh LODs, mesh size, vertex spacing, data directory) for a Terrain3D node." },
+        { "name": "terrain3d-create", "description": "Create a Terrain3D node in the currently edited Godot scene (requires the Terrain3D addon)." },
+        { "name": "terrain3d-set-data-directory", "description": "Set an existing Terrain3D node's res:// data directory (where region data persists)." },
+        { "name": "terrain3d-set-region-size", "description": "Set an existing Terrain3D node's region size (snapped to a valid Terrain3D size)." },
+        { "name": "terrain3d-set-material", "description": "Assign a Terrain3DMaterial to an existing Terrain3D node (created when missing)." },
+        { "name": "terrain3d-get", "description": "Read a Terrain3D node's scalar config (read-only)." }
+      ],
+      "addonRequired": {
+        "name": "Terrain3D",
+        "assetLibId": "3892",
+        "repo": "TokisanGames/Terrain3D",
+        "license": "MIT"
+      }
     }
   ]
 }

--- a/cli/src/utils/extensions-catalog.ts
+++ b/cli/src/utils/extensions-catalog.ts
@@ -226,6 +226,28 @@ export const EXTENSIONS_CATALOG: readonly ExtensionDescriptor[] = [
       license: 'MIT',
     },
   },
+  {
+    name: 'Terrain3D Tools',
+    description:
+      'AI MCP tools for the Godot Terrain3D addon (TokisanGames heightmap terrain): create terrains, set the data directory, region size, and material, and inspect them.',
+    packageId: 'com.IvanMurzak.Godot.MCP.Terrain3D',
+    version: null,
+    gitUrl: 'https://github.com/IvanMurzak/Godot-AI-Terrain3D',
+    tools: [
+      { name: 'terrain3d-defaults', description: 'Return the recommended starter config (region size, mesh LODs, mesh size, vertex spacing, data directory) for a Terrain3D node.' },
+      { name: 'terrain3d-create', description: 'Create a Terrain3D node in the currently edited Godot scene (requires the Terrain3D addon).' },
+      { name: 'terrain3d-set-data-directory', description: "Set an existing Terrain3D node's res:// data directory (where region data persists)." },
+      { name: 'terrain3d-set-region-size', description: "Set an existing Terrain3D node's region size (snapped to a valid Terrain3D size)." },
+      { name: 'terrain3d-set-material', description: 'Assign a Terrain3DMaterial to an existing Terrain3D node (created when missing).' },
+      { name: 'terrain3d-get', description: "Read a Terrain3D node's scalar config (read-only)." },
+    ],
+    addonRequired: {
+      name: 'Terrain3D',
+      assetLibId: '3892',
+      repo: 'TokisanGames/Terrain3D',
+      license: 'MIT',
+    },
+  },
 ] as const;
 
 /** True when a descriptor carries a concrete version pin (drives the up-to-date / update decision). */


### PR DESCRIPTION
Adds `com.IvanMurzak.Godot.MCP.Terrain3D` (https://github.com/IvanMurzak/Godot-AI-Terrain3D) to the shared extension catalog (parity-locked JSON + CLI mirror). Published 0.1.0 on nuget.org.

Class B (addon-dependent): carries an `addonRequired` block — Terrain3D by TokisanGames (AssetLib id 3892, MIT). Terrain3D is **NOT bundled/vendored**; the package installs by `packageId` alone and the addon is the consumer's own runtime responsibility (presentation metadata only).

Local proof (worktree): `cd cli && npm ci && npm test` -> 365 passed (parity + install); `dotnet test Godot-MCP.Tests` -> 964 passed (catalog round-trip).