### PR TITLE
feat(ui): surface Class-B addonRequired note + link in the Extensions panel rows

### DIFF
--- a/Godot-MCP.Tests/ExtensionsPanelTextTests.cs
+++ b/Godot-MCP.Tests/ExtensionsPanelTextTests.cs
@@ -1,0 +1,91 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Linq;
+using com.IvanMurzak.Godot.MCP.Extensions;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the pure-managed CLASS-B "requires the &lt;X&gt; addon" surfacing helpers on
+    /// <see cref="ExtensionsPanelText"/> (the note string + the AssetLib/repo link derivation the dock's
+    /// <see cref="ExtensionsPanelText"/>-driven <c>ExtensionRow</c> shows). The editor Control wiring
+    /// (<c>ExtensionRow.cs</c>, <c>#if TOOLS</c>) is verified via the headless Godot smoke (test.md Suite 3);
+    /// the text + URL logic is unit-tested here so the addon-required surfacing never silently drops.
+    /// </summary>
+    public class ExtensionsPanelTextTests
+    {
+        [Fact]
+        public void AddonRequiredNotice_IncludesTheAddonName()
+        {
+            var addon = new GodotAddonRequirement("Phantom Camera", "1822", "ramokz/phantom-camera", "MIT");
+            var notice = ExtensionsPanelText.AddonRequiredNotice(addon);
+            Assert.Contains("Phantom Camera", notice);
+            Assert.Contains("addon", notice);
+        }
+
+        [Fact]
+        public void AddonRequiredUrl_PrefersAssetLib_WhenPresent()
+        {
+            // AssetLib is the in-editor install location, so it wins over the repo when an id is known.
+            var addon = new GodotAddonRequirement("Phantom Camera", "1822", "ramokz/phantom-camera", "MIT");
+            Assert.Equal("https://godotengine.org/asset-library/asset/1822", ExtensionsPanelText.AddonRequiredUrl(addon));
+        }
+
+        [Fact]
+        public void AddonRequiredUrl_FallsBackToRepo_ExpandsBareOwnerNameToGithub()
+        {
+            // No AssetLib id (Dialogic's shape) → a bare owner/name repo is expanded to a GitHub URL.
+            var addon = new GodotAddonRequirement("Dialogic", AssetLibId: null, Repo: "dialogic-godot/dialogic", License: "MIT");
+            Assert.Equal("https://github.com/dialogic-godot/dialogic", ExtensionsPanelText.AddonRequiredUrl(addon));
+        }
+
+        [Fact]
+        public void AddonRequiredUrl_AbsoluteHttpRepo_UsedVerbatim()
+        {
+            var addon = new GodotAddonRequirement("Some Addon", AssetLibId: null, Repo: "https://example.com/some/addon", License: null);
+            Assert.Equal("https://example.com/some/addon", ExtensionsPanelText.AddonRequiredUrl(addon));
+        }
+
+        [Fact]
+        public void AddonRequiredUrl_WhitespaceAssetLib_FallsBackToRepo()
+        {
+            // A blank assetLibId must not produce ".../asset/" — it falls through to the repo.
+            var addon = new GodotAddonRequirement("Some Addon", AssetLibId: "   ", Repo: "owner/name", License: null);
+            Assert.Equal("https://github.com/owner/name", ExtensionsPanelText.AddonRequiredUrl(addon));
+        }
+
+        [Fact]
+        public void AddonRequiredUrl_NeitherAssetLibNorRepo_ReturnsNull()
+        {
+            var addon = new GodotAddonRequirement("Some Addon", AssetLibId: null, Repo: null, License: null);
+            Assert.Null(ExtensionsPanelText.AddonRequiredUrl(addon));
+        }
+
+        [Fact]
+        public void ShippedCatalog_EveryClassBExtension_SurfacesNoticeAndLink()
+        {
+            // Tie the helpers to the REAL embedded catalog: every Class-B (addon-dependent) extension that ships
+            // must yield a note naming its required addon AND a resolvable link. The shipped catalog has Class-B
+            // entries (PhantomCamera, Beehave, Dialogic, Terrain3D); assert there is at least one so this is meaningful.
+            var classB = GodotExtensionRegistry.All.Where(d => d.RequiresAddon).ToList();
+            Assert.NotEmpty(classB);
+
+            foreach (var ext in classB)
+            {
+                Assert.NotNull(ext.AddonRequired);
+                var notice = ExtensionsPanelText.AddonRequiredNotice(ext.AddonRequired!);
+                Assert.Contains(ext.AddonRequired!.Name, notice);
+                Assert.False(string.IsNullOrEmpty(ExtensionsPanelText.AddonRequiredUrl(ext.AddonRequired)));
+            }
+        }
+    }
+}

--- a/Godot-MCP.Tests/ExtensionsPanelTextTests.cs
+++ b/Godot-MCP.Tests/ExtensionsPanelTextTests.cs
@@ -84,7 +84,7 @@ namespace com.IvanMurzak.Godot.MCP.Tests
                 Assert.NotNull(ext.AddonRequired);
                 var notice = ExtensionsPanelText.AddonRequiredNotice(ext.AddonRequired!);
                 Assert.Contains(ext.AddonRequired!.Name, notice);
-                Assert.False(string.IsNullOrEmpty(ExtensionsPanelText.AddonRequiredUrl(ext.AddonRequired)));
+                Assert.False(string.IsNullOrEmpty(ExtensionsPanelText.AddonRequiredUrl(ext.AddonRequired!)));
             }
         }
     }

--- a/addons/godot_mcp/Editor/UI/ExtensionRow.cs
+++ b/addons/godot_mcp/Editor/UI/ExtensionRow.cs
@@ -18,7 +18,8 @@ namespace com.IvanMurzak.Godot.MCP.UI
     /// One row of the dock's <see cref="ExtensionsPanel"/> for a single <see cref="GodotExtensionDescriptor"/> —
     /// the Godot <see cref="Control"/> analog of Unity-MCP's <c>ExtensionPanel</c> row. Styled like
     /// <see cref="FeatureRow"/>'s row-top layout (flex-start, space-between): a LEFT column with the extension name
-    /// as a 16px section title over a muted, wrapping description, and a RIGHT action button whose label + skin
+    /// as a 16px section title over a muted, wrapping description (plus, for CLASS-B addon-dependent extensions, a
+    /// "requires the &lt;X&gt; addon" note + a link to that addon), and a RIGHT action button whose label + skin
     /// follow the install state — "Install" / "Update" (primary cyan), "Installed" (disabled), or "Checking…"
     /// (disabled, transient). Editor-only (<c>#if TOOLS</c>): verified via the headless Godot smoke (test.md
     /// Suite 3). Holds NO live connection-event subscriptions — its state is read synchronously by the panel.
@@ -78,6 +79,31 @@ namespace com.IvanMurzak.Godot.MCP.UI
             };
             DockStyle.ApplyDescription(descriptionLabel);
             leftColumn.AddChild(descriptionLabel);
+
+            // CLASS-B (addon-dependent) extensions surface a "requires the <X> addon" note + a link to that addon
+            // (Godot AssetLib when known, else the upstream repo). The extension package still installs by PackageId
+            // alone — the wrapped addon is the consumer's own responsibility (the note makes that explicit). CLASS-A
+            // extensions carry no AddonRequired and skip this block. The note/URL text is pure-managed + unit-tested.
+            if (Descriptor.AddonRequired != null)
+            {
+                var addonNote = new Label
+                {
+                    Name = "AddonRequiredNote",
+                    Text = ExtensionsPanelText.AddonRequiredNotice(Descriptor.AddonRequired),
+                    SizeFlagsHorizontal = SizeFlags.ExpandFill
+                };
+                DockStyle.ApplyDescription(addonNote);
+                leftColumn.AddChild(addonNote);
+
+                var addonUrl = ExtensionsPanelText.AddonRequiredUrl(Descriptor.AddonRequired);
+                if (!string.IsNullOrEmpty(addonUrl))
+                {
+                    leftColumn.AddChild(DockStyle.LinkRow($"{Descriptor.PackageId}AddonLinkRow", new[]
+                    {
+                        ("AddonRequiredLink", ExtensionsPanelText.AddonRequiredLinkText, addonUrl!)
+                    }));
+                }
+            }
 
             // --- RIGHT: the install/update/installed action button (state set via ShowState). ---
             _actionButton = new Button

--- a/addons/godot_mcp/Editor/UI/ExtensionRow.cs
+++ b/addons/godot_mcp/Editor/UI/ExtensionRow.cs
@@ -100,7 +100,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 {
                     leftColumn.AddChild(DockStyle.LinkRow($"{Descriptor.PackageId}AddonLinkRow", new[]
                     {
-                        ("AddonRequiredLink", ExtensionsPanelText.AddonRequiredLinkText, addonUrl!)
+                        ("AddonRequiredLink", ExtensionsPanelText.AddonRequiredLinkText, addonUrl)
                     }));
                 }
             }

--- a/addons/godot_mcp/Runtime/Extensions/ExtensionsPanelText.cs
+++ b/addons/godot_mcp/Runtime/Extensions/ExtensionsPanelText.cs
@@ -7,15 +7,18 @@
 └──────────────────────────────────────────────────────────────────┘
 */
 #nullable enable
+using System;
 
 namespace com.IvanMurzak.Godot.MCP.Extensions
 {
     /// <summary>
     /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) holder for the static copy + URLs the dock's
     /// <c>ExtensionsPanel</c> shows — the header, the "coming soon" placeholder line (rendered while the
-    /// <see cref="GodotExtensionRegistry"/> is empty), and the docs / template-repo link. Kept out of the editor
-    /// guard so the strings are CI-unit-tested (mirroring <c>SupportFooterLinks</c>); the editor Control wiring is
-    /// <c>#if TOOLS</c> and verified via the headless Godot smoke (test.md Suite 3).
+    /// <see cref="GodotExtensionRegistry"/> is empty), the docs / template-repo link, and the CLASS-B
+    /// "requires the &lt;X&gt; addon" note + link derivation (<see cref="AddonRequiredNotice"/> /
+    /// <see cref="AddonRequiredUrl"/>). Kept out of the editor guard so the strings + URL logic are CI-unit-tested
+    /// (mirroring <c>SupportFooterLinks</c>); the editor Control wiring is <c>#if TOOLS</c> and verified via the
+    /// headless Godot smoke (test.md Suite 3).
     /// </summary>
     public static class ExtensionsPanelText
     {
@@ -45,5 +48,41 @@ namespace com.IvanMurzak.Godot.MCP.Extensions
         /// </summary>
         public const string NoProjectFileNotice =
             "No project .csproj found — open this addon inside a Godot C# project to install extensions.";
+
+        /// <summary>The link text shown next to a CLASS-B extension's "requires the &lt;X&gt; addon" note.</summary>
+        public const string AddonRequiredLinkText = "View addon";
+
+        /// <summary>
+        /// The "requires the &lt;Name&gt; addon" note shown under a CLASS-B (addon-dependent) extension's description
+        /// (derived from the catalog <c>addonRequired</c> metadata). The wrapped third-party addon is the consumer's
+        /// own responsibility — the installer never vendors or downloads it — so the note tells the user to add it
+        /// separately. CLASS-A extensions (which wrap a built-in Godot feature) have no <c>AddonRequired</c> and show
+        /// no such note.
+        /// </summary>
+        public static string AddonRequiredNotice(GodotAddonRequirement addon)
+            => $"Requires the {addon.Name} addon — install it in your project separately.";
+
+        /// <summary>
+        /// The best "get the required addon" link for a CLASS-B extension: the Godot AssetLib asset page when an
+        /// <see cref="GodotAddonRequirement.AssetLibId"/> is known (the in-editor install location), else the upstream
+        /// <see cref="GodotAddonRequirement.Repo"/> — a bare <c>owner/name</c> is expanded to a GitHub URL, an already
+        /// absolute <c>http(s)</c> repo is used verbatim. Returns <c>null</c> when neither is available (the row then
+        /// shows the note without a link).
+        /// </summary>
+        public static string? AddonRequiredUrl(GodotAddonRequirement addon)
+        {
+            if (!string.IsNullOrWhiteSpace(addon.AssetLibId))
+                return $"https://godotengine.org/asset-library/asset/{addon.AssetLibId!.Trim()}";
+
+            var repo = addon.Repo?.Trim();
+            if (string.IsNullOrEmpty(repo))
+                return null;
+
+            if (repo.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+                || repo.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+                return repo;
+
+            return $"https://github.com/{repo}";
+        }
     }
 }


### PR DESCRIPTION
## Summary
- The dock's **Extensions** panel already lists all 10 shipped Godot extensions with Install/Update/Installed buttons — the shared `extensions.catalog.json` was populated incrementally (PRs #226–#239), embedded into the addon assembly, and read by `GodotExtensionRegistry`, so the rows already render. This PR completes the last open DoD item of #240.
- **Class-B (addon-dependent) extensions now surface their required third-party addon.** `ExtensionRow` renders a muted "Requires the <X> addon — install it separately" note under the description plus a link to that addon (Godot AssetLib when an `assetLibId` is known, else the upstream repo) for any descriptor carrying the catalog `addonRequired` metadata.
- The note text + the AssetLib/repo URL derivation are pure-managed on `ExtensionsPanelText` (no `#if TOOLS`, no Godot native types), so they are CI-unit-tested.

## Test plan
- [x] Suite 1 — `dotnet build Godot-MCP.sln` 0 errors (CI parity).
- [x] Suite 2 — `dotnet test Godot-MCP.Tests` 971 passed / 0 failed (was 964; +7 new `ExtensionsPanelTextTests`, including a walk of the real embedded catalog asserting every Class-B extension surfaces a note + link).
- [ ] Suite 3 — live visual confirmation that the note + link render in a real Godot editor dock is **operator-pending** (the issue flagged the visual as partly manual). Headless addon-load is covered by CI's 5-version `test_godot_plugin.yml` matrix on this push.

Closes #240