### PR TITLE
fix: float unpinned extension installs to Version="*" (NU1015)

### DIFF
--- a/Godot-MCP.Tests/ExtensionInstallTests.cs
+++ b/Godot-MCP.Tests/ExtensionInstallTests.cs
@@ -112,15 +112,19 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         }
 
         [Fact]
-        public void Plan_Add_WithNoVersion_OmitsVersionAttribute()
+        public void Plan_Add_WithNoVersion_WritesFloatVersion()
         {
+            // Regression for #242: an unpinned (null-version) descriptor must NOT emit a versionless
+            // <PackageReference> (which fails NuGet restore with NU1015) — its "float to latest" intent
+            // is materialized as Version="*".
             var descriptor = new GodotExtensionDescriptor("X", "desc", "com.x", Version: null);
             var plan = ExtensionInstallPlanner.Plan(descriptor, SampleCsproj);
 
             Assert.Equal(ExtensionInstallAction.Add, plan.Action);
+            Assert.Equal("*", plan.ToVersion);
             var refs = InstalledStateDetector.ParsePackageReferences(plan.ResultingCsproj);
-            Assert.True(refs.ContainsKey("com.x"));
-            Assert.Equal(string.Empty, refs["com.x"]);
+            Assert.Equal("*", refs["com.x"]);
+            Assert.Contains("<PackageReference Include=\"com.x\" Version=\"*\" />", plan.ResultingCsproj);
         }
 
         [Fact]
@@ -198,6 +202,27 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Contains("<Version>1.2.0</Version>", plan.ResultingCsproj);
         }
 
+        [Fact]
+        public void Plan_SelfHeals_VersionlessReference_WhenDescriptorUnpinned()
+        {
+            // #242 self-heal: an EXISTING versionless reference + an UNPINNED descriptor → UPDATE to
+            // Version="*" (a versionless reference is NU1015-prone; the unpinned descriptor wants a float).
+            const string versionless =
+@"<Project Sdk=""Godot.NET.Sdk/4.3.0"">
+  <ItemGroup>
+    <PackageReference Include=""com.IvanMurzak.Godot.MCP.ProBuilder"" />
+  </ItemGroup>
+</Project>";
+            var plan = ExtensionInstallPlanner.Plan(
+                new GodotExtensionDescriptor("X", "d", "com.IvanMurzak.Godot.MCP.ProBuilder", Version: null), versionless);
+
+            Assert.Equal(ExtensionInstallAction.Update, plan.Action);
+            Assert.Equal(string.Empty, plan.FromVersion);
+            Assert.Equal("*", plan.ToVersion);
+            var refs = InstalledStateDetector.ParsePackageReferences(plan.ResultingCsproj);
+            Assert.Equal("*", refs["com.IvanMurzak.Godot.MCP.ProBuilder"]);
+        }
+
         // --- Planner: NO-OP ------------------------------------------------------------------------------------
 
         [Fact]
@@ -233,6 +258,9 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             var plan = ExtensionInstallPlanner.Plan(
                 new GodotExtensionDescriptor("X", "d", "com.IvanMurzak.Godot.MCP.ProBuilder", Version: null), installed);
             Assert.Equal(ExtensionInstallAction.NoOp, plan.Action);
+            // #242 invariant: an unpinned descriptor must NEVER downgrade a concrete consumer pin to "*".
+            var refs = InstalledStateDetector.ParsePackageReferences(plan.ResultingCsproj);
+            Assert.Equal("1.0.0", refs["com.IvanMurzak.Godot.MCP.ProBuilder"]);
         }
 
         [Fact]

--- a/Godot-MCP.Tests/ExtensionInstallTests.cs
+++ b/Godot-MCP.Tests/ExtensionInstallTests.cs
@@ -381,6 +381,27 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         }
 
         [Fact]
+        public void Installer_Add_Unpinned_MessageContainsFloatMarker()
+        {
+            // #242 parity with the CLI lib test (install-extension.test.ts): an UNPINNED (null-version)
+            // descriptor's Add must surface the "*" float marker actually written to the .csproj — proving
+            // the installer's message path reports plan.ToVersion ("*"), not an empty version. Guards against
+            // a regression in the `string.IsNullOrEmpty(plan.ToVersion)` branch (ExtensionInstaller.cs)
+            // silently dropping "*" from the status line.
+            var file = new FakeProjectFile(SampleCsproj);
+            var result = ExtensionInstaller.Install(
+                new GodotExtensionDescriptor("X", "desc", "com.x", Version: null), file);
+
+            Assert.Equal(ExtensionInstallOutcome.Added, result.Outcome);
+            Assert.True(result.RebuildRequired);
+            Assert.Equal(1, file.Writes);
+            Assert.Contains("*", result.Message);
+
+            // The reference was written with the float marker.
+            Assert.Equal("*", InstalledStateDetector.ParsePackageReferences(file.Read())["com.x"]);
+        }
+
+        [Fact]
         public void Installer_NoOp_DoesNotWrite()
         {
             var installed = ExtensionInstallPlanner.Plan(Descriptor(Version: "1.2.0"), SampleCsproj).ResultingCsproj;

--- a/addons/godot_mcp/Runtime/Extensions/ExtensionInstallPlanner.cs
+++ b/addons/godot_mcp/Runtime/Extensions/ExtensionInstallPlanner.cs
@@ -37,7 +37,7 @@ namespace com.IvanMurzak.Godot.MCP.Extensions
     /// <param name="ResultingCsproj">The full <c>.csproj</c> text after applying the action (== original for no-op).</param>
     /// <param name="PackageId">The package id the plan targets (echoed for the UI / status line).</param>
     /// <param name="FromVersion">The version currently referenced (null when not installed; empty string when referenced without a version).</param>
-    /// <param name="ToVersion">The descriptor's target version (null when the descriptor has no version pin).</param>
+    /// <param name="ToVersion">The version the plan writes: the descriptor's pin when set, <c>"*"</c> (the float marker) when unpinned and a reference is added or self-healed, null only on a no-op.</param>
     public sealed record ExtensionInstallPlan(
         ExtensionInstallAction Action,
         string ResultingCsproj,

--- a/addons/godot_mcp/Runtime/Extensions/ExtensionInstallPlanner.cs
+++ b/addons/godot_mcp/Runtime/Extensions/ExtensionInstallPlanner.cs
@@ -140,7 +140,9 @@ namespace com.IvanMurzak.Godot.MCP.Extensions
                 // SELF-HEAL: an existing reference with NO version is NU1015-prone — upgrade it to "*".
                 // But NEVER downgrade a concrete consumer pin (or an existing "*") to "*": leave any
                 // already-versioned reference untouched (no-op), since the consumer's pin is authoritative.
-                if (string.IsNullOrEmpty(currentVersion))
+                // ReadReferenceVersion never returns null (falls back to string.Empty), so an empty-string
+                // check is exact — mirrors the TS port's `currentVersion === ''`.
+                if (currentVersion.Length == 0)
                 {
                     SetReferenceVersion(existing, FloatVersion);
                     return new ExtensionInstallPlan(
@@ -156,7 +158,7 @@ namespace com.IvanMurzak.Godot.MCP.Extensions
             }
 
             var target = descriptor.Version!;
-            var needsBump = string.IsNullOrEmpty(currentVersion)
+            var needsBump = currentVersion.Length == 0
                 || InstalledStateDetector.CompareVersions(target, currentVersion) > 0;
 
             if (!needsBump)

--- a/addons/godot_mcp/Runtime/Extensions/ExtensionInstallPlanner.cs
+++ b/addons/godot_mcp/Runtime/Extensions/ExtensionInstallPlanner.cs
@@ -69,14 +69,26 @@ namespace com.IvanMurzak.Godot.MCP.Extensions
     public static class ExtensionInstallPlanner
     {
         /// <summary>
+        /// The MSBuild floating-version marker (<c>"*"</c>) written for an UNPINNED (null/empty-version)
+        /// descriptor. A versionless <c>&lt;PackageReference Include="x" /&gt;</c> fails NuGet restore with
+        /// <c>NU1015</c>, so an unpinned descriptor's "float to latest" intent is materialized as
+        /// <c>Version="*"</c> — a valid floating reference. Mirrored by the TS planner's <c>FLOAT_VERSION</c>.
+        /// </summary>
+        public const string FloatVersion = "*";
+
+        /// <summary>
         /// Compute the install plan for <paramref name="descriptor"/> against <paramref name="csprojText"/>.
         /// <list type="bullet">
-        ///   <item>No reference present → <see cref="ExtensionInstallAction.Add"/> (append a new one).</item>
+        ///   <item>No reference present → <see cref="ExtensionInstallAction.Add"/> (append <c>Version="&lt;pin&gt;"</c> when pinned, else <c>Version="*"</c> for an unpinned/floating descriptor).</item>
         ///   <item>
         ///     Reference present but older than the descriptor's pinned version (or present with no version while the
         ///     descriptor pins one) → <see cref="ExtensionInstallAction.Update"/> (set the <c>Version</c> attribute).
         ///   </item>
-        ///   <item>Reference present and already up to date (or descriptor has no version pin) → <see cref="ExtensionInstallAction.NoOp"/>.</item>
+        ///   <item>
+        ///     Reference present with NO version while the descriptor is unpinned → <see cref="ExtensionInstallAction.Update"/>
+        ///     (SELF-HEAL the NU1015-prone versionless reference up to <c>Version="*"</c>).
+        ///   </item>
+        ///   <item>Reference present and already up to date, or unpinned descriptor against an already-versioned reference (never downgrade a concrete pin to <c>"*"</c>) → <see cref="ExtensionInstallAction.NoOp"/>.</item>
         /// </list>
         /// Throws <see cref="ArgumentException"/> only on a genuinely unparseable <c>.csproj</c> (the editor surfaces
         /// that as an error rather than silently corrupting the project file — distinct from the DETECTOR, which
@@ -116,15 +128,29 @@ namespace com.IvanMurzak.Godot.MCP.Extensions
                     Serialize(doc),
                     descriptor.PackageId,
                     FromVersion: null,
-                    ToVersion: descriptor.HasVersion ? descriptor.Version : null);
+                    ToVersion: descriptor.HasVersion ? descriptor.Version : FloatVersion);
             }
 
             // --- Existing reference → decide UPDATE vs NO-OP ---
             var currentVersion = ReadReferenceVersion(existing);
 
-            // Descriptor pins no version → leave the existing reference untouched (no target to compare to).
+            // Descriptor pins no version → it wants a FLOATING reference (Version="*").
             if (!descriptor.HasVersion)
             {
+                // SELF-HEAL: an existing reference with NO version is NU1015-prone — upgrade it to "*".
+                // But NEVER downgrade a concrete consumer pin (or an existing "*") to "*": leave any
+                // already-versioned reference untouched (no-op), since the consumer's pin is authoritative.
+                if (string.IsNullOrEmpty(currentVersion))
+                {
+                    SetReferenceVersion(existing, FloatVersion);
+                    return new ExtensionInstallPlan(
+                        ExtensionInstallAction.Update,
+                        Serialize(doc),
+                        descriptor.PackageId,
+                        currentVersion,
+                        FloatVersion);
+                }
+
                 return new ExtensionInstallPlan(
                     ExtensionInstallAction.NoOp, csprojText, descriptor.PackageId, currentVersion, ToVersion: null);
             }
@@ -186,8 +212,9 @@ namespace com.IvanMurzak.Godot.MCP.Extensions
 
             var reference = new XElement(ns + "PackageReference",
                 new XAttribute("Include", descriptor.PackageId));
-            if (descriptor.HasVersion)
-                reference.SetAttributeValue("Version", descriptor.Version);
+            // Always emit a Version: the descriptor's pin when set, else the "*" float marker. A versionless
+            // reference fails NuGet restore with NU1015 (the bug this planner is hardened against).
+            reference.SetAttributeValue("Version", descriptor.HasVersion ? descriptor.Version : FloatVersion);
 
             var targetGroup = doc.Descendants()
                 .FirstOrDefault(e => e.Name.LocalName == "ItemGroup"

--- a/addons/godot_mcp/Runtime/Extensions/ExtensionInstaller.cs
+++ b/addons/godot_mcp/Runtime/Extensions/ExtensionInstaller.cs
@@ -104,7 +104,9 @@ namespace com.IvanMurzak.Godot.MCP.Extensions
                 ? new ExtensionInstallResult(
                     ExtensionInstallOutcome.Added,
                     $"Added {descriptor.PackageId}"
-                        + (descriptor.HasVersion ? $" {descriptor.Version}" : string.Empty)
+                        // Report the version actually written (the pin, or the "*" float marker), not the
+                        // descriptor's pin presence — an unpinned add now writes Version="*".
+                        + (string.IsNullOrEmpty(plan.ToVersion) ? string.Empty : $" {plan.ToVersion}")
                         + ". Rebuild solutions to restore and compile the extension.",
                     RebuildRequired: true)
                 : new ExtensionInstallResult(

--- a/cli/src/lib/install-extension.ts
+++ b/cli/src/lib/install-extension.ts
@@ -138,7 +138,9 @@ export async function installExtension(
 
     const message =
       plan.action === 'add'
-        ? `Added ${descriptor.packageId}${hasVersion(descriptor) ? ` ${descriptor.version}` : ''}. Rebuild solutions to restore and compile the extension.`
+        ? // Report the version actually written (the pin, or the "*" float marker), not the descriptor's
+          // pin presence — an unpinned add now writes Version="*".
+          `Added ${descriptor.packageId}${plan.toVersion ? ` ${plan.toVersion}` : ''}. Rebuild solutions to restore and compile the extension.`
         : `Updated ${descriptor.packageId} to ${plan.toVersion}. Rebuild solutions to restore the new version.`;
 
     return {

--- a/cli/src/utils/extension-install.ts
+++ b/cli/src/utils/extension-install.ts
@@ -6,12 +6,17 @@
 //
 // Parity contract (verified by `cli/tests/extension-install.test.ts` against the
 // SAME scenario set as `Godot-MCP.Tests/ExtensionInstallTests.cs`):
-//   - absent reference            → ADD (append; version attribute only when pinned)
-//   - present, descriptor newer   → UPDATE (bump version, honoring attr vs child form)
-//   - present, no version, pinned → UPDATE (set the descriptor's pin)
-//   - present, equal/newer        → NO-OP
-//   - descriptor unpinned, present→ NO-OP
+//   - absent reference              → ADD (append; Version="<pin>" when pinned, Version="*" when unpinned/floating)
+//   - present, descriptor newer     → UPDATE (bump version, honoring attr vs child form)
+//   - present, no version, pinned   → UPDATE (set the descriptor's pin)
+//   - present, no version, unpinned → UPDATE (SELF-HEAL the NU1015-prone versionless reference to Version="*")
+//   - present, equal/newer          → NO-OP
+//   - descriptor unpinned, present with a version → NO-OP (never downgrade a concrete pin to "*")
 //   - version compare is numeric + tolerant (1.10.0 > 1.2.0; trailing 0; suffix-tolerant)
+//
+// A versionless `<PackageReference Include="x" />` fails NuGet restore with NU1015, so an
+// unpinned (null-version) descriptor's "float to latest" intent is materialized as
+// `Version="*"` — mirroring the C# planner's `FloatVersion` constant byte-for-byte.
 //
 // The C# planner uses System.Xml.Linq; this uses scoped text edits (like the CLI's
 // existing `csproj-deps.ts`) so the consumer's formatting is preserved verbatim. The
@@ -23,6 +28,13 @@ import type { ExtensionDescriptor } from './extensions-catalog.js';
 import { hasVersion } from './extensions-catalog.js';
 
 export type ExtensionInstallAction = 'add' | 'update' | 'noop';
+
+/**
+ * The MSBuild floating-version marker written for an UNPINNED (null/empty-version) descriptor.
+ * A versionless `<PackageReference Include="x" />` fails NuGet restore with NU1015, so the
+ * "float to latest" intent is materialized as `Version="*"`. Mirrors C# `ExtensionInstallPlanner.FloatVersion`.
+ */
+export const FLOAT_VERSION = '*';
 
 export interface ExtensionInstallPlan {
   /** The add / update / no-op decision. */
@@ -133,9 +145,10 @@ function detectEol(text: string): '\n' | '\r\n' {
 }
 
 function renderRef(descriptor: ExtensionDescriptor): string {
-  return hasVersion(descriptor)
-    ? `<PackageReference Include="${descriptor.packageId}" Version="${descriptor.version}" />`
-    : `<PackageReference Include="${descriptor.packageId}" />`;
+  // Always emit a Version: the descriptor's pin when set, else the "*" float marker. A versionless
+  // reference fails NuGet restore with NU1015. Byte-equal to the C# planner's AppendPackageReference.
+  const version = hasVersion(descriptor) ? descriptor.version : FLOAT_VERSION;
+  return `<PackageReference Include="${descriptor.packageId}" Version="${version}" />`;
 }
 
 /** Index of the `</ItemGroup>` closing the FIRST `<ItemGroup>` holding a `<PackageReference>`, or -1. */
@@ -217,15 +230,30 @@ export function planExtensionInstall(
       resultingCsproj: appendReference(csprojText, descriptor),
       packageId: descriptor.packageId,
       fromVersion: null,
-      toVersion: hasVersion(descriptor) ? descriptor.version : null,
+      toVersion: hasVersion(descriptor) ? descriptor.version : FLOAT_VERSION,
     };
   }
 
   const element = match[0];
   const currentVersion = readElementVersion(element);
 
-  // Descriptor pins no version → leave the existing reference untouched.
+  // Descriptor pins no version → it wants a FLOATING reference (Version="*").
   if (!hasVersion(descriptor)) {
+    // SELF-HEAL: an existing reference with NO version is NU1015-prone — upgrade it to "*".
+    // But NEVER downgrade a concrete consumer pin (or an existing "*") to "*": leave any
+    // already-versioned reference untouched (no-op), since the consumer's pin is authoritative.
+    if (currentVersion === '') {
+      const healedElement = setElementVersion(element, FLOAT_VERSION);
+      return {
+        action: 'update',
+        // Function replacement so any `$` in the marker is never treated as a replacement pattern.
+        resultingCsproj: csprojText.replace(elementRe, () => healedElement),
+        packageId: descriptor.packageId,
+        fromVersion: currentVersion,
+        toVersion: FLOAT_VERSION,
+      };
+    }
+
     return {
       action: 'noop',
       resultingCsproj: csprojText,

--- a/cli/src/utils/extension-install.ts
+++ b/cli/src/utils/extension-install.ts
@@ -45,7 +45,7 @@ export interface ExtensionInstallPlan {
   packageId: string;
   /** Version currently referenced: `null` when not installed; `''` when referenced without a version. */
   fromVersion: string | null;
-  /** The descriptor's target version, or `null` when the descriptor has no pin. */
+  /** The version the plan writes: the descriptor's pin when set, `"*"` (the float marker) when unpinned and a reference is added or self-healed, `null` only on a no-op. */
   toVersion: string | null;
 }
 

--- a/cli/tests/extension-install.test.ts
+++ b/cli/tests/extension-install.test.ts
@@ -115,12 +115,15 @@ describe('planExtensionInstall — ADD', () => {
     );
   });
 
-  it('omits the Version attribute when the descriptor has no version', () => {
+  it('writes Version="*" when the descriptor has no version (NU1015 float — #242)', () => {
+    // Regression for #242: an unpinned (null-version) descriptor must NOT emit a versionless
+    // <PackageReference> (which fails NuGet restore with NU1015) — it floats to "*".
     const plan = planExtensionInstall(descriptor('com.x', null), SampleCsproj);
     expect(plan.action).toBe('add');
+    expect(plan.toVersion).toBe('*');
     const refs = parsePackageReferences(plan.resultingCsproj);
-    expect(refs.has('com.x')).toBe(true);
-    expect(refs.get('com.x')).toBe('');
+    expect(refs.get('com.x')).toBe('*');
+    expect(plan.resultingCsproj).toContain('<PackageReference Include="com.x" Version="*" />');
   });
 
   it('creates an ItemGroup when the project has no PackageReferences', () => {
@@ -160,6 +163,19 @@ describe('planExtensionInstall — UPDATE', () => {
     expect(parsePackageReferences(plan.resultingCsproj).get('com.ivanmurzak.godot.mcp.probuilder')).toBe('1.2.0');
   });
 
+  it('self-heals a versionless reference to Version="*" when the descriptor is unpinned (#242)', () => {
+    const versionless = `<Project Sdk="Godot.NET.Sdk/4.3.0">
+  <ItemGroup>
+    <PackageReference Include="com.IvanMurzak.Godot.MCP.ProBuilder" />
+  </ItemGroup>
+</Project>`;
+    const plan = planExtensionInstall(descriptor(undefined, null), versionless);
+    expect(plan.action).toBe('update');
+    expect(plan.fromVersion).toBe('');
+    expect(plan.toVersion).toBe('*');
+    expect(parsePackageReferences(plan.resultingCsproj).get('com.ivanmurzak.godot.mcp.probuilder')).toBe('*');
+  });
+
   it('updates the child <Version> element form in place (no new attribute)', () => {
     const childForm = `<Project Sdk="Godot.NET.Sdk/4.3.0">
   <ItemGroup>
@@ -190,10 +206,12 @@ describe('planExtensionInstall — NO-OP', () => {
     expect(plan.action).toBe('noop');
   });
 
-  it('no-ops when the descriptor has no version and a reference exists', () => {
+  it('no-ops when the descriptor has no version and a concrete pin exists (never downgrades to "*" — #242)', () => {
     const installed = planExtensionInstall(descriptor(undefined, '1.0.0'), SampleCsproj).resultingCsproj;
     const plan = planExtensionInstall(descriptor(undefined, null), installed);
     expect(plan.action).toBe('noop');
+    // An unpinned descriptor must NEVER downgrade a concrete consumer pin to "*".
+    expect(parsePackageReferences(plan.resultingCsproj).get('com.ivanmurzak.godot.mcp.probuilder')).toBe('1.0.0');
   });
 
   it('throws CsprojParseError on an unparseable csproj', () => {

--- a/cli/tests/install-extension.test.ts
+++ b/cli/tests/install-extension.test.ts
@@ -65,6 +65,37 @@ describe('installExtension — lib logic (parity with the dock ExtensionInstalle
     expect(refs.get('com.ivanmurzak.reflectornet')).toBe('5.3.1');
   });
 
+  it('writes Version="*" for an unpinned (null-version) catalog entry — the shipped catalog case (#242)', async () => {
+    // The shipped EXTENSIONS_CATALOG ships every entry with version: null. Before #242 this produced a
+    // versionless <PackageReference>, which fails the consumer's `dotnet build` with NU1015. It must float to "*".
+    const floatCatalog: readonly ExtensionDescriptor[] = [{ ...FIXTURE_CATALOG[0], version: null }];
+    const result = await installExtension({
+      godotProjectPath: tmpDir,
+      extensionId: 'com.IvanMurzak.Godot.MCP.ProBuilder',
+      catalog: floatCatalog,
+    });
+    expect(result.kind).toBe('success');
+    if (result.kind === 'success') {
+      expect(result.outcome).toBe('added');
+      expect(result.toVersion).toBe('*');
+      expect(result.message).toContain('*');
+    }
+    const csproj = fs.readFileSync(csprojPath, 'utf-8');
+    expect(csproj).toContain('<PackageReference Include="com.IvanMurzak.Godot.MCP.ProBuilder" Version="*" />');
+    expect(parsePackageReferences(csproj).get('com.ivanmurzak.godot.mcp.probuilder')).toBe('*');
+
+    // Idempotent: a second unpinned install over the now-floating reference is a no-op (never re-touches "*").
+    const before = fs.readFileSync(csprojPath, 'utf-8');
+    const second = await installExtension({
+      godotProjectPath: tmpDir,
+      extensionId: 'com.IvanMurzak.Godot.MCP.ProBuilder',
+      catalog: floatCatalog,
+    });
+    expect(second.kind).toBe('success');
+    if (second.kind === 'success') expect(second.outcome).toBe('already-up-to-date');
+    expect(fs.readFileSync(csprojPath, 'utf-8')).toBe(before);
+  });
+
   it('is idempotent — a second install reports already-up-to-date with no write', async () => {
     await installExtension({ godotProjectPath: tmpDir, extensionId: 'com.IvanMurzak.Godot.MCP.ProBuilder', catalog: FIXTURE_CATALOG });
     const before = fs.readFileSync(csprojPath, 'utf-8');


### PR DESCRIPTION
## Summary
- An unpinned (catalog `version: null`) extension install previously emitted a versionless `<PackageReference Include="..." />`, which fails the consumer's `dotnet build` with **NU1015**. It now materializes the "float to latest" intent as `Version="*"`.
- Fixed in the C# source-of-truth `ExtensionInstallPlanner` (ADD now always writes a version; existing **versionless** references self-heal up to `*`; a concrete consumer pin is **never** downgraded to `*`) and its byte-equal TS port (`extension-install.ts` `renderRef`/`planExtensionInstall`).
- Updated the parity tests (C# `ExtensionInstallTests` ↔ TS `extension-install.test.ts`), the install-extension lib's float-catalog test, the parity-contract comment block, and the add/install summary message to report the actual written version.

## Test plan
- [x] Suite 1 — `dotnet build Godot-MCP.sln` (0 errors)
- [x] Suite 2 — `dotnet test Godot-MCP.Tests` (972 passed, 0 failed)
- [x] Suite 2b — `cd cli && npm run build && npm test` (367 vitest tests passed, 32 files)

Closes #242