### PR TITLE
fix: resolve all nullable build warnings in the addon (CS8618 + CS0649)

### DIFF
--- a/addons/godot_mcp/Editor/UI/Agents/AgentConfiguratorsPanel.cs
+++ b/addons/godot_mcp/Editor/UI/Agents/AgentConfiguratorsPanel.cs
@@ -49,7 +49,10 @@ namespace com.IvanMurzak.Godot.MCP.UI
     [Tool]
     public partial class AgentConfiguratorsPanel : VBoxContainer
     {
-        readonly GodotMcpConnection _connection;
+        // = null! suppresses CS8618 for the Godot-required parameterless ctor (below): Godot's hot-reload
+        // re-instantiates [Tool] scripts via new() and cannot set this readonly field; the parameterized
+        // ctor assigns the real value for the live-wired instance.
+        readonly GodotMcpConnection _connection = null!;
 
         OptionButton? _agentSelector;
         VBoxContainer? _agentView;

--- a/addons/godot_mcp/Editor/UI/ConnectionPanel.cs
+++ b/addons/godot_mcp/Editor/UI/ConnectionPanel.cs
@@ -47,7 +47,10 @@ namespace com.IvanMurzak.Godot.MCP.UI
     [Tool]
     public partial class ConnectionPanel : VBoxContainer
     {
-        readonly GodotMcpConnection _connection;
+        // = null! suppresses CS8618 for the Godot-required parameterless ctor (below): Godot's hot-reload
+        // re-instantiates [Tool] scripts via new() and cannot set this readonly field; the parameterized
+        // ctor assigns the real value for the live-wired instance.
+        readonly GodotMcpConnection _connection = null!;
 
         /// <summary>
         /// Raised after the user changes any connection setting that affects the RESOLVED MCP-client URL or token
@@ -129,7 +132,8 @@ namespace com.IvanMurzak.Godot.MCP.UI
         // lifecycle (Stopped/Starting/Running/Stopping) — the connection's own hub state is shown by the
         // Godot circle. This is the #1 "server-less client" carve-out reversal: the plugin can now HOST its
         // own server, not only connect to an external/cloud one.
-        readonly GodotMcpServerManager _serverManager;
+        // = null! suppresses CS8618 for the Godot-required parameterless ctor (see _connection above).
+        readonly GodotMcpServerManager _serverManager = null!;
         VBoxContainer _localServerRow = null!;
         Label _serverStatusLabel = null!;
         Button _serverStartStopButton = null!;

--- a/addons/godot_mcp/Editor/UI/ExtensionRow.cs
+++ b/addons/godot_mcp/Editor/UI/ExtensionRow.cs
@@ -28,9 +28,12 @@ namespace com.IvanMurzak.Godot.MCP.UI
     public partial class ExtensionRow : HBoxContainer
     {
         /// <summary>The extension descriptor this row represents.</summary>
-        public GodotExtensionDescriptor Descriptor { get; }
+        // = null! suppresses CS8618 for the Godot-required parameterless ctor (below): Godot's hot-reload
+        // re-instantiates [Tool] scripts via new() and cannot set this get-only property / readonly field;
+        // the parameterized ctor assigns the real values for the live-wired instance.
+        public GodotExtensionDescriptor Descriptor { get; } = null!;
 
-        readonly Action<GodotExtensionDescriptor> _onAction;
+        readonly Action<GodotExtensionDescriptor> _onAction = null!;
 
         Button _actionButton = null!;
 

--- a/addons/godot_mcp/Editor/UI/FeatureListWindow.cs
+++ b/addons/godot_mcp/Editor/UI/FeatureListWindow.cs
@@ -37,7 +37,10 @@ namespace com.IvanMurzak.Godot.MCP.UI
     [Tool]
     public partial class FeatureListWindow : Window
     {
-        readonly GodotMcpConnection _connection;
+        // = null! suppresses CS8618 for the Godot-required parameterless ctor (below): Godot's hot-reload
+        // re-instantiates [Tool] scripts via new() and cannot set this readonly field; the parameterized
+        // ctor assigns the real value for the live-wired instance.
+        readonly GodotMcpConnection _connection = null!;
         readonly GodotMcpFeatureKind _kind;
 
         LineEdit _searchField = null!;

--- a/addons/godot_mcp/Editor/UI/FeatureRow.cs
+++ b/addons/godot_mcp/Editor/UI/FeatureRow.cs
@@ -31,7 +31,10 @@ namespace com.IvanMurzak.Godot.MCP.UI
         public GodotMcpFeatureKind Kind { get; }
 
         readonly bool _showTokens;
-        readonly Action<GodotMcpFeatureKind> _onOpen;
+        // = null! suppresses CS8618 for the Godot-required parameterless ctor (below): Godot's hot-reload
+        // re-instantiates [Tool] scripts via new() and cannot set this readonly field; the parameterized
+        // ctor assigns the real value for the live-wired instance.
+        readonly Action<GodotMcpFeatureKind> _onOpen = null!;
 
         Label _countLabel = null!;
         Label? _tokenLabel;

--- a/addons/godot_mcp/Editor/UI/FeaturesPanel.cs
+++ b/addons/godot_mcp/Editor/UI/FeaturesPanel.cs
@@ -40,7 +40,10 @@ namespace com.IvanMurzak.Godot.MCP.UI
     [Tool]
     public partial class FeaturesPanel : VBoxContainer
     {
-        readonly GodotMcpConnection _connection;
+        // = null! suppresses CS8618 for the Godot-required parameterless ctor (below): Godot's hot-reload
+        // re-instantiates [Tool] scripts via new() and cannot set this readonly field; the parameterized
+        // ctor assigns the real value for the live-wired instance.
+        readonly GodotMcpConnection _connection = null!;
 
         FeatureRow _toolsRow = null!;
         FeatureRow _promptsRow = null!;

--- a/addons/godot_mcp/Editor/UI/SkillsPanel.cs
+++ b/addons/godot_mcp/Editor/UI/SkillsPanel.cs
@@ -44,7 +44,10 @@ namespace com.IvanMurzak.Godot.MCP.UI
     [Tool]
     public partial class SkillsPanel : VBoxContainer
     {
-        readonly GodotMcpConnection _connection;
+        // = null! suppresses CS8618 for the Godot-required parameterless ctor (below): Godot's hot-reload
+        // re-instantiates [Tool] scripts via new() and cannot set this readonly field; the parameterized
+        // ctor assigns the real value for the live-wired instance.
+        readonly GodotMcpConnection _connection = null!;
 
         VBoxContainer? _body;
         DockCheckBox? _autoGenerateToggle;

--- a/addons/godot_mcp/Runtime/GodotMcpRuntime.cs
+++ b/addons/godot_mcp/Runtime/GodotMcpRuntime.cs
@@ -235,11 +235,17 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
         /// </summary>
         static void RuntimeErrorCaptureInstall() => RuntimeErrorCapture.Install();
 
+        // CS0649 is suppressed for these two seams: they are assigned ONLY via reflection from
+        // Godot-MCP.Tests; in the addon/testbed build (no test assembly) they are never assigned, so the
+        // compiler otherwise warns "field is never assigned to". The seams (read via `_x ?? <real>`) are
+        // intentional, so suppress rather than remove.
+#pragma warning disable CS0649
         /// <summary>Test seam: overrides the capture installer in <see cref="InstallCaptureThenBuildHandle"/>. Null in production.</summary>
         internal static Action? _installForTests;
 
         /// <summary>Test seam: overrides the capture uninstaller in <see cref="InstallCaptureThenBuildHandle"/>'s rollback. Null in production.</summary>
         internal static Action? _uninstallForTests;
+#pragma warning restore CS0649
 
         /// <summary>
         /// Resolve the addon version reported in the MCP handshake from

--- a/addons/godot_mcp/Runtime/RuntimeErrorCapture.cs
+++ b/addons/godot_mcp/Runtime/RuntimeErrorCapture.cs
@@ -80,9 +80,16 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
         // are read at Install()/Uninstall() time and forwarded into the ErrorCaptureManager ctor. In production
         // all are null and the real static bridge / GD.Print run. Mirrors the
         // GodotMcpRuntime._installForTests / _uninstallForTests pattern. Internal: test-only.
+        //
+        // CS0649 is suppressed here because these seams are assigned ONLY via reflection from
+        // Godot-MCP.Tests; in the addon/testbed build (no test assembly) they are never assigned and the
+        // compiler otherwise warns "field is never assigned to". Keeping the seams (read via `_x ?? <real>`)
+        // is intentional, so suppress rather than remove.
+#pragma warning disable CS0649
         internal static Func<ScriptErrorCapture, ScriptErrorCapture?>? _bridgeInstallForTests;
         internal static Action? _bridgeUninstallForTests;
         internal static Action<string>? _logForTests;
+#pragma warning restore CS0649
 
         /// <summary>True while capture is installed (an engine logger and/or the C# fault hooks are live).</summary>
         public static bool IsInstalled


### PR DESCRIPTION
## Summary
- Clean ALL nullable build warnings in the addon to zero with NO behavior change (was 14: 9× CS8618 + 5× CS0649).
- **CS8618** — add `= null!` initializers to the readonly fields / get-only property in the `Editor/UI/` classes that have BOTH a Godot-required parameterless ctor (`[Tool]` hot-reload re-instantiation) and a real parameterized ctor: `ConnectionPanel` (`_connection`, `_serverManager`), `AgentConfiguratorsPanel`/`SkillsPanel`/`FeaturesPanel`/`FeatureListWindow` (`_connection`), `ExtensionRow` (`Descriptor`, `_onAction`), `FeatureRow` (`_onOpen`). `required` is not usable — Godot instantiates via `new()`.
- **CS0649** — wrap the reflection-assigned `internal static` test seams in `RuntimeErrorCapture` (`_bridgeInstallForTests`, `_bridgeUninstallForTests`, `_logForTests`) and `GodotMcpRuntime` (`_installForTests`, `_uninstallForTests`) in a scoped `#pragma warning disable/restore CS0649` with an explanatory comment, keeping the seams (assigned only from `Godot-MCP.Tests`, read via `_x ?? <real impl>`).

## Test plan
- [x] `dotnet build Godot-MCP.sln --configuration Debug` → 0 warnings + 0 errors (was 14 warnings).
- [x] `dotnet test Godot-MCP.Tests` → 973 passed / 0 failed.
- [x] No behavior change — pure warning-suppression / null-forgiving initializers; reused NuGet pins and addon version untouched.

Closes #244