### PR TITLE
feat(cli): embed the extension catalog into the consumer .csproj on install-plugin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,12 +159,17 @@ no Godot binary.
 A consumer installs the addon by placing `addons/godot_mcp/` in their Godot C# project and enabling it in
 *Project → Project Settings → Plugins*. Because Godot compiles **every** `.cs` under the project into one
 assembly, the addon's C# only compiles if the **consumer's `.csproj` declares the same NuGet
-`PackageReference`s** the addon depends on:
+`PackageReference`s** the addon depends on — and it must **also embed the extension catalog** the addon
+reads at editor runtime:
 
 ```xml
 <ItemGroup>
   <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.1" />
   <PackageReference Include="com.IvanMurzak.McpPlugin"   Version="6.10.0" />
+</ItemGroup>
+
+<ItemGroup>
+  <EmbeddedResource Include="addons/godot_mcp/extensions.catalog.json" LogicalName="Godot-MCP.extensions.catalog.json" />
 </ItemGroup>
 ```
 
@@ -173,8 +178,18 @@ With those references present, `dotnet restore` populates the consumer's NuGet c
 runtime to locate the DLLs. **No manual DLL copying is required**; the resolver finds them in the NuGet
 global packages folder. (A consumer who prefers self-contained output can instead set
 `<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>` so the DLLs land beside the project
-assembly — strategy 1 above then covers them.) These reference instructions should be surfaced in the
-addon's user-facing README / install docs as the family grows.
+assembly — strategy 1 above then covers them.)
+
+The `<EmbeddedResource>` is as load-bearing as the pins: `GodotExtensionRegistry` loads the catalog via
+`GodotExtensionCatalog.LoadEmbedded()` → `GetManifestResourceStream("Godot-MCP.extensions.catalog.json")`
+with **no `res://` / disk / cloud fallback** (an absent resource yields an EMPTY extension list). The
+addon's own `Godot-MCP.csproj` `<EmbeddedResource>` does NOT carry into a consumer (the addon ships as
+*source*, not a NuGet package), so the consumer `.csproj` must embed it just as it must declare the pins —
+the fixed `LogicalName` makes the resource resolve identically in the addon and `Godot-MCP.Tests`
+assemblies. These reference instructions are surfaced in the addon's user-facing README install docs, and
+`godot-cli install-plugin` writes both the pins (`addAddonPackageReferences`) and the embed
+(`addAddonEmbeddedResources`) into the consumer `.csproj`, single-sourced + parity-tested against this
+csproj (`cli/src/utils/addon-deps.ts` ↔ `Godot-MCP.csproj`, `cli/tests/addon-deps-parity.test.ts`).
 
 ## Testbed runbook (headless live-verification)
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ npm install -g godot-cli
 godot-cli create-project --dotnet ./MyGodotProject
 
 # 3. Install the godot_mcp addon: downloads addons/godot_mcp/ from the matching
-#    GitHub release, adds the required NuGet packages to your .csproj, and enables
-#    the plugin in project.godot — all idempotently
+#    GitHub release, adds the required NuGet packages + the extension-catalog
+#    EmbeddedResource to your .csproj, and enables the plugin in project.godot —
+#    all idempotently
 godot-cli install-plugin ./MyGodotProject
 
 # 4. Pick an AI agent (Claude Code, Cursor, Copilot, …) and write its MCP config
@@ -246,7 +247,8 @@ Pick **one** of the following ways to get the `addons/godot_mcp/` folder into yo
 > **Fully automated (recommended for terminal workflows):**
 > [`godot-cli`](https://www.npmjs.com/package/godot-cli) `install-plugin ./MyGodotProject` does **all of
 > Step 1 and Step 2 in one command** — it downloads `addons/godot_mcp/` from the matching GitHub release,
-> adds the two NuGet packages to your `.csproj`, and enables the plugin in `project.godot`, idempotently.
+> adds the two NuGet packages **and the extension-catalog `<EmbeddedResource>`** to your `.csproj`, and
+> enables the plugin in `project.godot`, idempotently.
 > Use `--source <path>/addons/godot_mcp` to install from a local copy offline. The manual Options A–C
 > below remain for in-editor (Asset Library) and hand-managed installs.
 
@@ -280,7 +282,8 @@ directory by hand.
 After the files are in place (Options A–C), **enable** the plugin:
 **Project → Project Settings → Plugins → Godot-MCP → Enable**. (If you used the fully-automated
 [`godot-cli`](https://www.npmjs.com/package/godot-cli) `install-plugin` above, the plugin is already
-enabled and the NuGet packages are already added — skip straight to [Step 3](#step-3-install-an-ai-agent).)
+enabled and the NuGet packages + extension-catalog embed are already added — skip straight to
+[Step 3](#step-3-install-an-ai-agent).)
 On a successful load the editor Output panel prints:
 
 ```
@@ -291,15 +294,20 @@ On a successful load the editor Output panel prints:
 > first submission is approved by the Godot Asset Library moderators. Until then, use Option B (GitHub
 > Release zip) or Option C.
 
-## Step 2: Add the NuGet packages
+## Step 2: Add the NuGet packages + the extension catalog embed
 
-Add both `PackageReference`s to your project's `.csproj` (use these exact pinned versions — they must
-match the addon's `Godot-MCP.csproj`):
+Add both `PackageReference`s **and** the extension-catalog `<EmbeddedResource>` to your project's
+`.csproj` (use these exact pinned versions — they must match the addon's `Godot-MCP.csproj`):
 
 ```xml
 <ItemGroup>
   <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.1" />
   <PackageReference Include="com.IvanMurzak.McpPlugin"   Version="6.10.0" />
+</ItemGroup>
+
+<!-- Embed the extension catalog so the Extensions panel populates (else it is EMPTY). -->
+<ItemGroup>
+  <EmbeddedResource Include="addons/godot_mcp/extensions.catalog.json" LogicalName="Godot-MCP.extensions.catalog.json" />
 </ItemGroup>
 ```
 
@@ -307,6 +315,12 @@ match the addon's `Godot-MCP.csproj`):
 | --- | --- | --- |
 | [`com.IvanMurzak.ReflectorNet`](https://www.nuget.org/packages/com.IvanMurzak.ReflectorNet) | `5.3.1` | Reflection / serialization core |
 | [`com.IvanMurzak.McpPlugin`](https://www.nuget.org/packages/com.IvanMurzak.McpPlugin) | `6.10.0` | MCP plugin client (transitively pulls `McpPlugin.Common` + `ReflectorNet`; carries the shared `AgentConfig` module) |
+
+The `<EmbeddedResource>` is **as required as the NuGet pins**: the addon's pure-managed extension
+registry reads the catalog at editor runtime via `GetManifestResourceStream` (no `res://` / filesystem
+fallback), and because the addon ships as *source* its own `<EmbeddedResource>` does not carry into your
+project — so without this line your **Extensions panel is empty**. The `LogicalName` must be exactly
+`Godot-MCP.extensions.catalog.json` so the resource resolves identically to the addon's own assembly.
 
 Run `dotnet restore` so the packages land in your NuGet cache, then build. **No manual DLL copying is
 required** — at editor runtime the addon's assembly resolver locates the DLLs in your NuGet

--- a/cli/README.md
+++ b/cli/README.md
@@ -35,7 +35,7 @@ Requires Node `^20.19.0 || >=22.12.0`.
 | `setup-skills <agent> [path]` | Generate Godot-MCP skill files (a `SKILL.md`-per-tool-family) under the agent's skills path. `--list` shows each agent's skills support. |
 | `configure [path]` | List / enable / disable tools, prompts, and resources in the project-local `.godot-mcp/features.json`. |
 | `close [path]` | Gracefully stop the Godot editor running for a project (`--force` to hard-kill). |
-| `install-plugin [path]` | Install the `godot_mcp` addon end-to-end: materialize `res://addons/godot_mcp/` (download the matching GitHub release, or `--source <path>` a local copy), add the required NuGet `PackageReference`s to the project `.csproj`, and enable the plugin. Idempotent. |
+| `install-plugin [path]` | Install the `godot_mcp` addon end-to-end: materialize `res://addons/godot_mcp/` (download the matching GitHub release, or `--source <path>` a local copy), add the required NuGet `PackageReference`s + the extension-catalog `<EmbeddedResource>` to the project `.csproj`, and enable the plugin. Idempotent. |
 | `install-extension <id> [path]` | Install a Godot-MCP **extension** (an optional AI-tool-family package) into the project: resolve `<id>` from the shared catalog, add/update its `<PackageReference>` in the project `.csproj`, then rebuild to restore. Idempotent — behaviorally identical to the in-editor dock. |
 | `remove-plugin [path]` | Disable the `godot_mcp` addon in `project.godot` `[editor_plugins]` (does not delete the addon files). |
 | `update` | Check npm for a newer `godot-cli` and install it. |
@@ -137,7 +137,11 @@ It performs three steps:
    to the project's `.csproj`, idempotently — adding when missing, reconciling a stale version, and
    leaving a correct pin untouched. The versions are single-sourced from the addon's own
    `Godot-MCP.csproj` pins, so the scaffold can never drift.
-3. **Enable the plugin** in `project.godot` `[editor_plugins]`.
+3. **Embed the extension catalog** (`<EmbeddedResource Include="addons/godot_mcp/extensions.catalog.json"
+   LogicalName="Godot-MCP.extensions.catalog.json" />`) into the project's `.csproj`, idempotently. Without
+   it the addon's extension registry reads no catalog at editor runtime and the **Extensions panel is
+   empty**. Single-sourced + parity-tested against the addon csproj alongside the pins.
+4. **Enable the plugin** in `project.godot` `[editor_plugins]`.
 
 It is library-safe (returns a `{ kind: 'success' | 'failure' }` union; never throws past the public
 boundary) and idempotent — re-running on an already-installed project reports no change.

--- a/cli/README.md
+++ b/cli/README.md
@@ -126,7 +126,7 @@ godot-cli install-plugin --version 0.11.1 ./MyGodotProject     # pin a specific 
 godot-cli install-plugin --source ./Godot-MCP/addons/godot_mcp ./MyGodotProject   # offline / dev copy
 ```
 
-It performs three steps:
+It performs four steps:
 
 1. **Materialize `res://addons/godot_mcp/`.** By default it downloads `godot-mcp-addon-<version>.zip`
    over HTTPS from **github.com only** (the `IvanMurzak/Godot-MCP` release `v<version>`; the version

--- a/cli/src/commands/install-plugin.ts
+++ b/cli/src/commands/install-plugin.ts
@@ -80,6 +80,10 @@ export const installPluginCommand = new Command('install-plugin')
         .map((p) => `${p.id}@${p.version} (${p.action})`)
         .join(', ');
       ui.label('NuGet packages', summary || '(none)');
+      const embedSummary = result.csproj.embeds
+        .map((e) => `${e.logicalName} (${e.action})`)
+        .join(', ');
+      ui.label('Embedded resources', embedSummary || '(none)');
     }
 
     ui.label('project.godot', result.projectGodotPath);

--- a/cli/src/commands/install-plugin.ts
+++ b/cli/src/commands/install-plugin.ts
@@ -24,7 +24,7 @@ function cliVersion(): string {
 
 export const installPluginCommand = new Command('install-plugin')
   .description(
-    'Install the godot_mcp addon into a Godot C# project: materialize res://addons/godot_mcp/ (download the matching GitHub release, or --source a local copy), add the required NuGet PackageReferences to the project .csproj, and enable the plugin in project.godot.',
+    'Install the godot_mcp addon into a Godot C# project: materialize res://addons/godot_mcp/ (download the matching GitHub release, or --source a local copy), add the required NuGet PackageReferences and the extension-catalog <EmbeddedResource> to the project .csproj, and enable the plugin in project.godot.',
   )
   .argument('[path]', 'Path to the Godot project')
   .option('--path <path>', 'Path to the Godot project')

--- a/cli/src/lib/install-plugin.ts
+++ b/cli/src/lib/install-plugin.ts
@@ -5,7 +5,7 @@ import {
   projectGodotPath as resolveProjectGodotPath,
   togglePluginInText,
 } from '../utils/project-godot.js';
-import { addAddonPackageReferences } from '../utils/csproj-deps.js';
+import { addAddonPackageReferences, addAddonEmbeddedResources } from '../utils/csproj-deps.js';
 import { ADDON_PACKAGE_REFERENCES } from '../utils/addon-deps.js';
 import {
   addonDownloadUrl,
@@ -287,11 +287,16 @@ function extractAddonEntries(entries: ZipEntry[], projectPath: string, addonDir:
 
 /**
  * Find the consumer's `.csproj` (the one Godot compiles the addon into) and add
- * the two addon NuGet PackageReferences idempotently. The csproj is the single
- * `*.csproj` at the project root (the `--dotnet` scaffold writes
+ * the addon's NuGet PackageReferences AND the EmbeddedResource(s) it needs,
+ * idempotently and single-sourced from the addon's own pins/embeds. The csproj is
+ * the single `*.csproj` at the project root (the `--dotnet` scaffold writes
  * `<AssemblyName>.csproj` there). When there is no csproj (a GDScript-only
  * project), the patch is skipped with a warning — the addon's C# cannot compile
  * without one, but that is the consumer's project shape to fix.
+ *
+ * The EmbeddedResource is as load-bearing as the NuGet pins: without it the
+ * pure-managed `GodotExtensionRegistry` reads no embedded catalog and the consumer
+ * gets an EMPTY Extensions panel (issue #246). Both edits are applied in one write.
  */
 function patchConsumerCsproj(
   projectPath: string,
@@ -304,27 +309,34 @@ function patchConsumerCsproj(
       'No .csproj found at the project root — the godot_mcp addon is C# and needs a Godot.NET.Sdk project. ' +
         `Create one (e.g. \`godot-cli create-project --dotnet\`) and add the ${ADDON_PACKAGE_REFERENCES.map((r) => r.id).join(' + ')} PackageReferences.`,
     );
-    return { changed: false, packages: [] };
+    return { changed: false, packages: [], embeds: [] };
   }
 
   const before = fs.readFileSync(csprojPath, 'utf-8');
-  const patched = addAddonPackageReferences(before);
-  if (patched.changed) {
-    fs.writeFileSync(csprojPath, patched.text);
+  const pkgPatched = addAddonPackageReferences(before);
+  const embedPatched = addAddonEmbeddedResources(pkgPatched.text);
+  const changed = pkgPatched.changed || embedPatched.changed;
+  if (changed) {
+    fs.writeFileSync(csprojPath, embedPatched.text);
     emitProgress(onProgress, {
       phase: 'csproj-patched',
-      message: `Added addon PackageReferences to ${csprojPath}`,
+      message: `Added addon PackageReferences + EmbeddedResource to ${csprojPath}`,
       csprojPath,
     });
   }
 
   return {
     csprojPath,
-    changed: patched.changed,
-    packages: patched.changes.map((c) => ({
+    changed,
+    packages: pkgPatched.changes.map((c) => ({
       id: c.id,
       action: c.action,
       version: c.version,
+    })),
+    embeds: embedPatched.changes.map((c) => ({
+      include: c.include,
+      action: c.action,
+      logicalName: c.logicalName,
     })),
   };
 }

--- a/cli/src/lib/install-plugin.ts
+++ b/cli/src/lib/install-plugin.ts
@@ -307,7 +307,7 @@ function patchConsumerCsproj(
   if (csprojPath === null) {
     warnings.push(
       'No .csproj found at the project root — the godot_mcp addon is C# and needs a Godot.NET.Sdk project. ' +
-        `Create one (e.g. \`godot-cli create-project --dotnet\`) and add the ${ADDON_PACKAGE_REFERENCES.map((r) => r.id).join(' + ')} PackageReferences.`,
+        `Create one (e.g. \`godot-cli create-project --dotnet\`) and add the ${ADDON_PACKAGE_REFERENCES.map((r) => r.id).join(' + ')} PackageReferences + the EmbeddedResource for the extension catalog.`,
     );
     return { changed: false, packages: [], embeds: [] };
   }

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -409,14 +409,16 @@ export interface AddonMaterializeOutcome {
   sourceDir?: string;
 }
 
-/** What `install-plugin` did to the consumer `.csproj`'s PackageReferences. */
+/** What `install-plugin` did to the consumer `.csproj`'s PackageReferences + EmbeddedResources. */
 export interface CsprojPatchOutcome {
   /** Absolute path to the consumer `.csproj` that was patched, if one was found. */
   csprojPath?: string;
-  /** True when the csproj text was modified. */
+  /** True when the csproj text was modified (pins and/or embeds). */
   changed: boolean;
   /** Per-package summary: each addon pin's add / update / unchanged outcome. */
   packages: { id: string; action: 'added' | 'updated' | 'unchanged'; version: string }[];
+  /** Per-resource summary: each addon `<EmbeddedResource>`'s add / update / unchanged outcome. */
+  embeds: { include: string; action: 'added' | 'updated' | 'unchanged'; logicalName: string }[];
 }
 
 export interface InstallPluginSuccess {

--- a/cli/src/utils/addon-deps.ts
+++ b/cli/src/utils/addon-deps.ts
@@ -23,6 +23,20 @@ export interface AddonPackageReference {
 }
 
 /**
+ * A single `<EmbeddedResource>` the consumer csproj must declare so an asset the
+ * addon reads at editor runtime via `GetManifestResourceStream` is embedded into
+ * the consumer's compiled project assembly (Godot globs every `*.cs` into one
+ * assembly, but does NOT carry the addon's own `Godot-MCP.csproj` `<EmbeddedResource>`
+ * — the addon ships as source, not a NuGet package).
+ */
+export interface AddonEmbeddedResource {
+  /** The file to embed, relative to the consumer project root (the `Include=` attribute). */
+  include: string;
+  /** The manifest-resource name the addon resolves it by (the `LogicalName=` attribute). */
+  logicalName: string;
+}
+
+/**
  * The exact NuGet `PackageReference`s the consumer's project `.csproj` needs,
  * single-sourced from the addon's `Godot-MCP.csproj` pins. Order matches the
  * addon csproj (ReflectorNet first, then McpPlugin).
@@ -30,6 +44,22 @@ export interface AddonPackageReference {
 export const ADDON_PACKAGE_REFERENCES: readonly AddonPackageReference[] = [
   { id: 'com.IvanMurzak.ReflectorNet', version: '5.3.1' },
   { id: 'com.IvanMurzak.McpPlugin', version: '6.10.0' },
+] as const;
+
+/**
+ * The exact `<EmbeddedResource>`s the consumer's project `.csproj` needs, single-sourced
+ * from the addon's `Godot-MCP.csproj`. The extension catalog is read at editor runtime by
+ * the pure-managed `GodotExtensionRegistry` via `GetManifestResourceStream` (no `res://` /
+ * filesystem fallback), so without this embed a consumer that installs via `install-plugin`
+ * gets an EMPTY Extensions panel. A parity test (`cli/tests/addon-deps-parity.test.ts`)
+ * reads `Godot-MCP.csproj` and FAILS the build if these constants ever drift from the addon's
+ * own `<EmbeddedResource>` (Include path + LogicalName), mirroring the NuGet-pin tripwire.
+ */
+export const ADDON_EMBEDDED_RESOURCES: readonly AddonEmbeddedResource[] = [
+  {
+    include: 'addons/godot_mcp/extensions.catalog.json',
+    logicalName: 'Godot-MCP.extensions.catalog.json',
+  },
 ] as const;
 
 /** The resource path of the addon manifest a consumer project loads the plugin from. */

--- a/cli/src/utils/csproj-deps.ts
+++ b/cli/src/utils/csproj-deps.ts
@@ -1,4 +1,9 @@
-import { ADDON_PACKAGE_REFERENCES, type AddonPackageReference } from './addon-deps.js';
+import {
+  ADDON_PACKAGE_REFERENCES,
+  ADDON_EMBEDDED_RESOURCES,
+  type AddonPackageReference,
+  type AddonEmbeddedResource,
+} from './addon-deps.js';
 
 /**
  * Idempotently reconcile a Godot consumer `.csproj`'s `<PackageReference>`s so it
@@ -31,6 +36,20 @@ export interface CsprojPatchResult {
   changes: CsprojPatchChange[];
 }
 
+export type CsprojEmbedChange =
+  | { include: string; action: 'added'; logicalName: string }
+  | { include: string; action: 'updated'; from: string; logicalName: string }
+  | { include: string; action: 'unchanged'; logicalName: string };
+
+export interface CsprojEmbedResult {
+  /** The new csproj text (identical to input when nothing changed). */
+  text: string;
+  /** True when the text was modified. */
+  changed: boolean;
+  /** One entry per required embedded resource describing what happened to it. */
+  changes: CsprojEmbedChange[];
+}
+
 /** Escape a string for use inside a RegExp source. */
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -55,17 +74,38 @@ function packageRefRegex(id: string): RegExp {
   );
 }
 
+/**
+ * Match an existing `<EmbeddedResource ... Include="<include>" ... />` element for a
+ * specific file path, capturing the whole element (in either attribute order, and
+ * whether self-closed `/>` or an explicit `></EmbeddedResource>` pair). The
+ * `LogicalName` is extracted from the captured element text separately so the regex
+ * stays order-agnostic and tolerant of an absent `LogicalName`.
+ */
+function embeddedResourceRegex(include: string): RegExp {
+  const escInclude = escapeRegExp(include);
+  return new RegExp(
+    `<EmbeddedResource\\b[^>]*?\\bInclude\\s*=\\s*"${escInclude}"[^>]*?(?:/>|></EmbeddedResource>)`,
+    'i',
+  );
+}
+
 /** Render the canonical self-closing element for a required reference. */
 function renderRef(ref: AddonPackageReference): string {
   return `<PackageReference Include="${ref.id}" Version="${ref.version}" />`;
 }
 
+/** Render the canonical self-closing element for a required embedded resource. */
+function renderEmbed(res: AddonEmbeddedResource): string {
+  return `<EmbeddedResource Include="${res.include}" LogicalName="${res.logicalName}" />`;
+}
+
 /**
- * Detect the indentation used by the FIRST existing `<PackageReference>` (or fall
- * back to 4 spaces) so appended/inserted elements match the consumer's style.
+ * Detect the indentation used by the FIRST existing `<PackageReference>` /
+ * `<EmbeddedResource>` (or fall back to 4 spaces) so appended/inserted elements
+ * match the consumer's style.
  */
 function detectIndent(text: string): string {
-  const m = text.match(/\n([ \t]*)<PackageReference\b/);
+  const m = text.match(/\n([ \t]*)<(?:PackageReference|EmbeddedResource)\b/);
   return m ? m[1] : '    ';
 }
 
@@ -151,15 +191,108 @@ export function addAddonPackageReferences(
 }
 
 /**
+ * Idempotently reconcile a Godot consumer `.csproj`'s `<EmbeddedResource>`s so it
+ * declares exactly the addon's required embeds (see `addon-deps.ts`
+ * `ADDON_EMBEDDED_RESOURCES`). Pure (operates on csproj TEXT, never touches the
+ * filesystem) and exported for unit tests. Sibling of `addAddonPackageReferences`.
+ * Handles, idempotently:
+ *  - a project with NO `<EmbeddedResource>` ItemGroup (groups into one, else appends
+ *    a fresh `<ItemGroup>` before `</Project>`);
+ *  - a project that already embeds the resource with the right LogicalName (no change);
+ *  - a project that embeds the same Include with a DIFFERENT LogicalName (reconciles
+ *    in place);
+ * Re-running `install-plugin` therefore never duplicates the `<EmbeddedResource>`.
+ */
+export function addAddonEmbeddedResources(
+  csprojText: string,
+  requiredResources: readonly AddonEmbeddedResource[] = ADDON_EMBEDDED_RESOURCES,
+): CsprojEmbedResult {
+  const changes: CsprojEmbedChange[] = [];
+  let text = csprojText;
+  const indent = detectIndent(text);
+  const eol = detectEol(text);
+
+  // First pass: reconcile any embeds that already exist (possibly with a different
+  // LogicalName). Collect the ones still missing for the append pass.
+  const missing: AddonEmbeddedResource[] = [];
+
+  for (const res of requiredResources) {
+    const re = embeddedResourceRegex(res.include);
+    const match = text.match(re);
+    if (!match) {
+      missing.push(res);
+      continue;
+    }
+    const logicalMatch = match[0].match(/\bLogicalName\s*=\s*"([^"]*)"/i);
+    const existingLogical = logicalMatch ? logicalMatch[1] : '';
+    if (existingLogical === res.logicalName) {
+      changes.push({ include: res.include, action: 'unchanged', logicalName: res.logicalName });
+      continue;
+    }
+    // Reconcile in place: replace the whole element with the canonical embed.
+    text = text.replace(re, renderEmbed(res));
+    changes.push({ include: res.include, action: 'updated', from: existingLogical, logicalName: res.logicalName });
+  }
+
+  // Second pass: add the missing embeds. Prefer an existing <ItemGroup> that already
+  // holds an <EmbeddedResource> (group them together); else append a fresh
+  // <ItemGroup> just before </Project>. Deliberately NOT grouped with the
+  // PackageReference ItemGroup — the addon's own csproj keeps the two in separate
+  // groups, and this keeps the scaffold's layout identical.
+  if (missing.length > 0) {
+    const block = missing.map((res) => `${indent}${renderEmbed(res)}`).join(eol);
+
+    const embedItemGroupClose = findItemGroupCloseContaining(text, /<EmbeddedResource\b/i);
+    if (embedItemGroupClose !== -1) {
+      text = `${text.slice(0, embedItemGroupClose)}${block}${eol}${text.slice(embedItemGroupClose)}`;
+    } else {
+      const groupIndent = indent.length >= 2 ? indent.slice(0, Math.floor(indent.length / 2)) : '  ';
+      const newGroup = `${groupIndent}<ItemGroup>${eol}${block}${eol}${groupIndent}</ItemGroup>${eol}`;
+      const closeIdx = text.lastIndexOf('</Project>');
+      if (closeIdx === -1) {
+        text = `${text}${eol}${newGroup}`;
+      } else {
+        text = `${text.slice(0, closeIdx)}${newGroup}${text.slice(closeIdx)}`;
+      }
+    }
+
+    for (const res of missing) {
+      changes.push({ include: res.include, action: 'added', logicalName: res.logicalName });
+    }
+  }
+
+  // Restore required-order in `changes` to match `requiredResources` for stable output.
+  const orderedChanges = requiredResources
+    .map((res) => changes.find((c) => c.include === res.include))
+    .filter((c): c is CsprojEmbedChange => c !== undefined);
+
+  return {
+    text,
+    changed: orderedChanges.some((c) => c.action !== 'unchanged'),
+    changes: orderedChanges,
+  };
+}
+
+/**
  * Return the index of the `</ItemGroup>` that closes the FIRST `<ItemGroup>`
  * containing a `<PackageReference>`, or -1 when none exists. Used to group the
  * added pins with the consumer's existing package references.
  */
 function findPackageReferenceItemGroupClose(text: string): number {
+  return findItemGroupCloseContaining(text, /<PackageReference\b/i);
+}
+
+/**
+ * Return the index of the `</ItemGroup>` that closes the FIRST `<ItemGroup>` whose
+ * body matches `childTagRe`, or -1 when none exists. Used to group an added element
+ * with the consumer's existing items of the same kind. `childTagRe` MUST NOT be a
+ * global regex (a stateful `lastIndex` would corrupt the `.test` below).
+ */
+function findItemGroupCloseContaining(text: string, childTagRe: RegExp): number {
   const itemGroupRe = /<ItemGroup\b[^>]*>([\s\S]*?)<\/ItemGroup>/gi;
   let m: RegExpExecArray | null;
   while ((m = itemGroupRe.exec(text)) !== null) {
-    if (/<PackageReference\b/i.test(m[1])) {
+    if (childTagRe.test(m[1])) {
       // The close tag starts at the end of the match minus its length.
       const closeTag = '</ItemGroup>';
       return m.index + m[0].length - closeTag.length;

--- a/cli/tests/addon-deps-parity.test.ts
+++ b/cli/tests/addon-deps-parity.test.ts
@@ -26,10 +26,18 @@ function parsePins(text: string): Map<string, string> {
 /** Parse `<EmbeddedResource Include="path" LogicalName="name" />` pairs from csproj text. */
 function parseEmbeds(text: string): Map<string, string> {
   const embeds = new Map<string, string>();
-  const re = /<EmbeddedResource\b[^>]*?\bInclude\s*=\s*"([^"]+)"[^>]*?\bLogicalName\s*=\s*"([^"]+)"/gi;
+  // Match each <EmbeddedResource> element, then extract Include + LogicalName from the
+  // captured element text separately — mirrors the production `embeddedResourceRegex`
+  // approach (cli/src/utils/csproj-deps.ts) so the parser stays order-agnostic
+  // (Include / LogicalName in either attribute order).
+  const re = /<EmbeddedResource\b[^>]*?(?:\/>|><\/EmbeddedResource>)/gi;
   let m: RegExpExecArray | null;
   while ((m = re.exec(text)) !== null) {
-    embeds.set(m[1], m[2]);
+    const include = m[0].match(/\bInclude\s*=\s*"([^"]+)"/i);
+    const logicalName = m[0].match(/\bLogicalName\s*=\s*"([^"]+)"/i);
+    if (include && logicalName) {
+      embeds.set(include[1], logicalName[1]);
+    }
   }
   return embeds;
 }

--- a/cli/tests/addon-deps-parity.test.ts
+++ b/cli/tests/addon-deps-parity.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
-import { ADDON_PACKAGE_REFERENCES } from '../src/utils/addon-deps.js';
+import { ADDON_PACKAGE_REFERENCES, ADDON_EMBEDDED_RESOURCES } from '../src/utils/addon-deps.js';
 
 // The CLI's ADDON_PACKAGE_REFERENCES must single-source the addon's own reused
 // NuGet pins (Godot-MCP.csproj). If the addon bumps a pin, this test fails until
@@ -21,6 +21,17 @@ function parsePins(text: string): Map<string, string> {
     pins.set(m[1], m[2]);
   }
   return pins;
+}
+
+/** Parse `<EmbeddedResource Include="path" LogicalName="name" />` pairs from csproj text. */
+function parseEmbeds(text: string): Map<string, string> {
+  const embeds = new Map<string, string>();
+  const re = /<EmbeddedResource\b[^>]*?\bInclude\s*=\s*"([^"]+)"[^>]*?\bLogicalName\s*=\s*"([^"]+)"/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    embeds.set(m[1], m[2]);
+  }
+  return embeds;
 }
 
 describe('addon-deps parity with Godot-MCP.csproj', () => {
@@ -43,6 +54,25 @@ describe('addon-deps parity with Godot-MCP.csproj', () => {
         `CLI addon pin ${ref.id}@${ref.version} drifted from Godot-MCP.csproj ${ref.id}@${csprojVersion}. ` +
           'Update ADDON_PACKAGE_REFERENCES in cli/src/utils/addon-deps.ts to match the addon pin.',
       ).toBe(csprojVersion);
+    }
+  });
+
+  it('every CLI-written EmbeddedResource matches the addon csproj Include + LogicalName exactly', () => {
+    const text = fs.readFileSync(ADDON_CSPROJ, 'utf-8');
+    const csprojEmbeds = parseEmbeds(text);
+
+    for (const res of ADDON_EMBEDDED_RESOURCES) {
+      const csprojLogical = csprojEmbeds.get(res.include);
+      expect(
+        csprojLogical,
+        `Godot-MCP.csproj is missing an <EmbeddedResource> with Include="${res.include}"`,
+      ).toBeDefined();
+      expect(
+        res.logicalName,
+        `CLI addon embed ${res.include} (LogicalName="${res.logicalName}") drifted from ` +
+          `Godot-MCP.csproj LogicalName="${csprojLogical}". ` +
+          'Update ADDON_EMBEDDED_RESOURCES in cli/src/utils/addon-deps.ts to match the addon csproj.',
+      ).toBe(csprojLogical);
     }
   });
 });

--- a/cli/tests/csproj-deps.test.ts
+++ b/cli/tests/csproj-deps.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { addAddonPackageReferences } from '../src/utils/csproj-deps.js';
-import { ADDON_PACKAGE_REFERENCES } from '../src/utils/addon-deps.js';
+import { addAddonPackageReferences, addAddonEmbeddedResources } from '../src/utils/csproj-deps.js';
+import { ADDON_PACKAGE_REFERENCES, ADDON_EMBEDDED_RESOURCES } from '../src/utils/addon-deps.js';
 
 const REFLECTOR = ADDON_PACKAGE_REFERENCES[0];
 const MCP = ADDON_PACKAGE_REFERENCES[1];
+const CATALOG = ADDON_EMBEDDED_RESOURCES[0];
 
 const FRESH_CSPROJ = `<Project Sdk="Godot.NET.Sdk/4.3.0">
 
@@ -125,3 +126,100 @@ describe('addAddonPackageReferences — existing ItemGroup with package refs', (
     expect(text).toContain(MCP.id);
   });
 });
+
+const FRESH_CSPROJ_EMBED = `<Project Sdk="Godot.NET.Sdk/4.3.0">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>MyGame</RootNamespace>
+  </PropertyGroup>
+
+</Project>
+`;
+
+const EXPECTED_EMBED = `<EmbeddedResource Include="${CATALOG.include}" LogicalName="${CATALOG.logicalName}" />`;
+
+describe('addAddonEmbeddedResources — fresh csproj (no EmbeddedResource)', () => {
+  it('appends a new ItemGroup with the catalog embed before </Project>', () => {
+    const { text, changed, changes } = addAddonEmbeddedResources(FRESH_CSPROJ_EMBED);
+    expect(changed).toBe(true);
+    expect(text).toContain(EXPECTED_EMBED);
+    expect(text.indexOf('<EmbeddedResource')).toBeLessThan(text.indexOf('</Project>'));
+    expect(changes.every((c) => c.action === 'added')).toBe(true);
+    // Still valid-looking XML: exactly one </Project>.
+    expect(text.match(/<\/Project>/g)?.length).toBe(1);
+  });
+
+  it('is idempotent — re-running does not duplicate the <EmbeddedResource>', () => {
+    const once = addAddonEmbeddedResources(FRESH_CSPROJ_EMBED).text;
+    const twice = addAddonEmbeddedResources(once);
+    expect(twice.changed).toBe(false);
+    expect(twice.text).toBe(once);
+    expect(twice.changes.every((c) => c.action === 'unchanged')).toBe(true);
+    // Exactly one occurrence of the embed Include — no duplication.
+    expect(once.match(new RegExp(escapeRe(CATALOG.include), 'g'))?.length).toBe(1);
+  });
+});
+
+describe('addAddonEmbeddedResources — different LogicalName present (reconcile)', () => {
+  it('rewrites a wrong LogicalName in place to the canonical one', () => {
+    const wrong = `<Project Sdk="Godot.NET.Sdk/4.3.0">
+  <ItemGroup>
+    <EmbeddedResource Include="${CATALOG.include}" LogicalName="Stale.Name.json" />
+  </ItemGroup>
+</Project>
+`;
+    const { text, changed, changes } = addAddonEmbeddedResources(wrong);
+    expect(changed).toBe(true);
+    expect(text).not.toContain('Stale.Name.json');
+    expect(text).toContain(EXPECTED_EMBED);
+    const change = changes.find((c) => c.include === CATALOG.include);
+    expect(change?.action).toBe('updated');
+    if (change?.action === 'updated') {
+      expect(change.from).toBe('Stale.Name.json');
+    }
+    // No duplicate Include.
+    expect(text.match(new RegExp(escapeRe(CATALOG.include), 'g'))?.length).toBe(1);
+  });
+});
+
+describe('addAddonEmbeddedResources — existing EmbeddedResource ItemGroup', () => {
+  it('groups the catalog embed into the existing EmbeddedResource ItemGroup', () => {
+    const existing = `<Project Sdk="Godot.NET.Sdk/4.3.0">
+  <ItemGroup>
+    <EmbeddedResource Include="data/other.json" LogicalName="Other.json" />
+  </ItemGroup>
+</Project>
+`;
+    const { text, changed } = addAddonEmbeddedResources(existing);
+    expect(changed).toBe(true);
+    // Only one ItemGroup — the catalog embed joined the existing embed group.
+    expect(text.match(/<ItemGroup>/g)?.length).toBe(1);
+    expect(text).toContain('data/other.json');
+    expect(text).toContain(EXPECTED_EMBED);
+  });
+});
+
+describe('addAddonPackageReferences + addAddonEmbeddedResources — combined scaffold', () => {
+  it('produces a csproj with both the pins and the embed in separate ItemGroups', () => {
+    const pkg = addAddonPackageReferences(FRESH_CSPROJ_EMBED);
+    const both = addAddonEmbeddedResources(pkg.text);
+    expect(both.text).toContain(REFLECTOR.id);
+    expect(both.text).toContain(MCP.id);
+    expect(both.text).toContain(EXPECTED_EMBED);
+    // Two ItemGroups: one for the pins, one for the embed (matching the addon csproj layout).
+    expect(both.text.match(/<ItemGroup>/g)?.length).toBe(2);
+    expect(both.text.match(/<\/Project>/g)?.length).toBe(1);
+    // Re-running both passes is a no-op.
+    const pkg2 = addAddonPackageReferences(both.text);
+    const both2 = addAddonEmbeddedResources(pkg2.text);
+    expect(pkg2.changed).toBe(false);
+    expect(both2.changed).toBe(false);
+    expect(both2.text).toBe(both.text);
+  });
+});
+
+/** Escape a string for use inside a RegExp (test-local helper). */
+function escapeRe(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/cli/tests/install-plugin-installer.test.ts
+++ b/cli/tests/install-plugin-installer.test.ts
@@ -5,7 +5,7 @@ import * as os from 'os';
 import * as zlib from 'zlib';
 import { installPlugin } from '../src/lib/install-plugin.js';
 import { GODOT_MCP_PLUGIN_PATH, parseEnabledPlugins } from '../src/utils/project-godot.js';
-import { ADDON_PACKAGE_REFERENCES } from '../src/utils/addon-deps.js';
+import { ADDON_PACKAGE_REFERENCES, ADDON_EMBEDDED_RESOURCES } from '../src/utils/addon-deps.js';
 
 const MINIMAL_PROJECT = '; Engine configuration file.\nconfig_version=5\n\n[application]\n\nconfig/name="Test"\n';
 const CSPROJ = `<Project Sdk="Godot.NET.Sdk/4.3.0">
@@ -118,6 +118,12 @@ describe('installPlugin — download path (mocked fetch)', () => {
       expect(csprojText).toContain(`Include="${ref.id}" Version="${ref.version}"`);
     }
 
+    // csproj also embeds the extension catalog (else the Extensions panel is empty — issue #246)
+    for (const res of ADDON_EMBEDDED_RESOURCES) {
+      expect(csprojText).toContain(`Include="${res.include}" LogicalName="${res.logicalName}"`);
+      expect(result.csproj.embeds.find((e) => e.include === res.include)?.action).toBe('added');
+    }
+
     // plugin enabled
     expect(result.enabledPlugins).toContain(GODOT_MCP_PLUGIN_PATH);
     expect(parseEnabledPlugins(fs.readFileSync(path.join(tmp, 'project.godot'), 'utf-8'))).toContain(
@@ -185,8 +191,15 @@ describe('installPlugin — download path (mocked fetch)', () => {
     expect(second.kind).toBe('success');
     if (second.kind === 'success') {
       expect(second.changed).toBe(false); // plugin already enabled
-      expect(second.csproj.changed).toBe(false); // pins already present
+      expect(second.csproj.changed).toBe(false); // pins + embed already present
       expect(second.csproj.packages.every((p) => p.action === 'unchanged')).toBe(true);
+      expect(second.csproj.embeds.every((e) => e.action === 'unchanged')).toBe(true);
+      // The embed appears exactly once — idempotent re-install never duplicates it.
+      const csprojText = fs.readFileSync(path.join(tmp, 'MyGame.csproj'), 'utf-8');
+      for (const res of ADDON_EMBEDDED_RESOURCES) {
+        const occurrences = csprojText.split(`Include="${res.include}"`).length - 1;
+        expect(occurrences).toBe(1);
+      }
     }
   });
 });

--- a/cli/tests/install-plugin-installer.test.ts
+++ b/cli/tests/install-plugin-installer.test.ts
@@ -256,6 +256,12 @@ describe('installPlugin — --source local copy', () => {
       expect(fs.existsSync(path.join(tmp, 'addons', 'godot_mcp', 'plugin.cfg'))).toBe(true);
       expect(fs.existsSync(path.join(tmp, 'addons', 'godot_mcp', 'Editor', 'GodotMcpPlugin.cs'))).toBe(true);
       expect(result.csproj.changed).toBe(true);
+      // csproj also embeds the extension catalog (else the Extensions panel is empty — issue #246)
+      const csprojText = fs.readFileSync(path.join(tmp, 'MyGame.csproj'), 'utf-8');
+      for (const res of ADDON_EMBEDDED_RESOURCES) {
+        expect(csprojText).toContain(`Include="${res.include}" LogicalName="${res.logicalName}"`);
+        expect(result.csproj.embeds.find((e) => e.include === res.include)?.action).toBe('added');
+      }
       expect(result.enabledPlugins).toContain(GODOT_MCP_PLUGIN_PATH);
     }
   });
@@ -290,6 +296,12 @@ describe('installPlugin — skipMaterialize', () => {
       if (result.kind === 'success') {
         expect(result.materialize.source).toBe('skipped');
         expect(result.csproj.changed).toBe(true);
+        // csproj also embeds the extension catalog (else the Extensions panel is empty — issue #246)
+        const csprojText = fs.readFileSync(path.join(tmp, 'MyGame.csproj'), 'utf-8');
+        for (const res of ADDON_EMBEDDED_RESOURCES) {
+          expect(csprojText).toContain(`Include="${res.include}" LogicalName="${res.logicalName}"`);
+          expect(result.csproj.embeds.find((e) => e.include === res.include)?.action).toBe('added');
+        }
         // warns about the absent addon files
         expect(result.warnings.some((w) => w.includes('plugin.cfg'))).toBe(true);
       }


### PR DESCRIPTION
## Summary
- `install-plugin` now writes the extension-catalog `<EmbeddedResource>` into the consumer `.csproj` alongside the two NuGet pins, so a from-scratch terminal install no longer yields an EMPTY Extensions panel (the registry reads the catalog via `GetManifestResourceStream` with no `res://`/disk/cloud fallback, and the addon's own embed does not carry into a source-shipped consumer).
- Single-sourced as `ADDON_EMBEDDED_RESOURCES` (sibling of `ADDON_PACKAGE_REFERENCES`), parity-tested against `Godot-MCP.csproj`'s `<EmbeddedResource>` (Include + LogicalName).
- New `addAddonEmbeddedResources` csproj patcher (sibling of `addAddonPackageReferences`), idempotent — re-running never duplicates the embed; pins and embed each land in their own `<ItemGroup>` matching the addon csproj layout.
- Consumer-install docs updated (README Step 2, CLAUDE.md Consumer-install story, cli/README.md).

## Test plan
- [x] CLI build green (`npm run build`)
- [x] vitest green — 373 passed (was 328), incl. new parity (`<EmbeddedResource>` ↔ csproj) + `addAddonEmbeddedResources` unit tests + install-plugin embed-on-install / idempotent-on-reinstall assertions

Closes #246