### PR TITLE
feat(cli): add `login` device-auth command with persisted cloud token

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -4,6 +4,7 @@
 // their own program. The runnable program lives in `index.ts` (imported by
 // `bin/godot-cli.js`).
 
+export { loginCommand } from './commands/login.js';
 export { openCommand } from './commands/open.js';
 export { runToolCommand } from './commands/run-tool.js';
 export { runSystemToolCommand } from './commands/run-system-tool.js';

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -1,0 +1,45 @@
+import { Command } from 'commander';
+import * as ui from '../utils/ui.js';
+import { verbose } from '../utils/ui.js';
+import { resolveProjectPath, DEFAULT_CLOUD_BASE_URL } from '../utils/connection.js';
+import { readCloudToken } from '../utils/credentials.js';
+import { runCloudLogin } from '../utils/cloud-login.js';
+
+interface LoginOptions {
+  path?: string;
+  baseUrl?: string;
+  force?: boolean;
+}
+
+export const loginCommand = new Command('login')
+  .description(
+    'Authenticate with the Godot-MCP cloud server (ai-game.dev) via the RFC 8628 device-authorization flow and persist the cloud token so `godot-cli open --mode Cloud` connects without a manual --token.',
+  )
+  .argument('[path]', 'Godot project path — where the token is saved (defaults to current directory)')
+  .option('--path <path>', 'Godot project path (defaults to current directory)')
+  .option('--base-url <url>', 'Override the cloud base URL (default: https://ai-game.dev)')
+  .option('--force', 'Re-authenticate even if a cloud token is already saved')
+  .action(async (positionalPath: string | undefined, options: LoginOptions) => {
+    const projectPath = resolveProjectPath(positionalPath, options);
+    verbose(`Project path: ${projectPath}`);
+
+    const baseUrl = (options.baseUrl ?? DEFAULT_CLOUD_BASE_URL).replace(/\/$/, '');
+
+    if (!options.force && readCloudToken(projectPath)) {
+      ui.success('Already authenticated with the cloud server.');
+      ui.info('Use --force to re-authenticate.');
+      return;
+    }
+
+    ui.heading('Cloud Authentication');
+    ui.label('Server', baseUrl);
+    ui.divider();
+
+    const token = await runCloudLogin(projectPath, { baseUrl });
+    if (token) {
+      ui.success('Authentication complete. Cloud token saved to .godot-mcp/credentials.json.');
+      ui.info('Run: godot-cli open --mode Cloud   (no --token needed).');
+    } else {
+      process.exit(1);
+    }
+  });

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import * as ui from '../utils/ui.js';
 import { verbose } from '../utils/ui.js';
 import { resolveProjectPath, DEFAULT_CLOUD_BASE_URL } from '../utils/connection.js';
-import { readCloudToken } from '../utils/credentials.js';
+import { readCloudToken, readCredentials } from '../utils/credentials.js';
 import { runCloudLogin } from '../utils/cloud-login.js';
 
 interface LoginOptions {
@@ -25,7 +25,11 @@ export const loginCommand = new Command('login')
 
     const baseUrl = (options.baseUrl ?? DEFAULT_CLOUD_BASE_URL).replace(/\/$/, '');
 
-    if (!options.force && readCloudToken(projectPath)) {
+    // Only short-circuit when a token is saved AND it was issued against the SAME
+    // base URL. Otherwise `login --base-url <other>` (without --force) would silently
+    // reuse a token minted for a different server. readCloudToken() truthy implies the
+    // credentials file parsed, so the follow-up readCredentials() cannot throw here.
+    if (!options.force && readCloudToken(projectPath) && readCredentials(projectPath)?.cloudBaseUrl === baseUrl) {
       ui.success('Already authenticated with the cloud server.');
       ui.info('Use --force to re-authenticate.');
       return;

--- a/cli/src/commands/open.ts
+++ b/cli/src/commands/open.ts
@@ -7,6 +7,7 @@ import {
   resolveProjectPath as libResolveProjectPath,
   isGodotProjectDir as libIsGodotProjectDir,
 } from '../lib/open.js';
+import { resolveOpenAuthToken } from '../utils/connection.js';
 import type { OpenProjectAuthOption, OpenProjectConnectionMode } from '../lib/types.js';
 
 export interface ResolveProjectPathResult {
@@ -103,6 +104,13 @@ export const openCommand = new Command('open')
         process.exit(1);
       }
 
+      // In Cloud mode with no explicit --token / GODOT_MCP_TOKEN, inject the
+      // token persisted by `godot-cli login` so `open --mode Cloud` auto-connects.
+      const authToken = resolveOpenAuthToken(projectPath, { token: options.token, mode: options.mode });
+      if (authToken !== undefined && options.token === undefined) {
+        verbose('Using persisted cloud token from .godot-mcp/credentials.json');
+      }
+
       const spinner = ui.startSpinner(
         options.build === false ? 'Locating Godot editor...' : 'Building C# assembly...',
       );
@@ -115,7 +123,7 @@ export const openCommand = new Command('open')
         noConnect: options.connect === false,
         url: options.url,
         cloudUrl: options.cloudUrl,
-        token: options.token,
+        token: authToken,
         auth: options.auth as OpenProjectAuthOption | undefined,
         mode: options.mode as OpenProjectConnectionMode | undefined,
         logLevel: options.logLevel,

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import { createRequire } from 'module';
 import { buildCommand } from './commands/build.js';
+import { loginCommand } from './commands/login.js';
 import { openCommand } from './commands/open.js';
 import { runToolCommand } from './commands/run-tool.js';
 import { runSystemToolCommand } from './commands/run-system-tool.js';
@@ -37,6 +38,7 @@ const subcommands = [
   createProjectCommand,
   installPluginCommand,
   installExtensionCommand,
+  loginCommand,
   openCommand,
   removePluginCommand,
   runToolCommand,

--- a/cli/src/utils/auth.ts
+++ b/cli/src/utils/auth.ts
@@ -1,0 +1,202 @@
+import { verbose } from './ui.js';
+
+// --- RFC 8628 Device Authorization Grant flow (against ai-game.dev). ---
+//
+// Ported from the sibling `unity-mcp-cli` (`cli/src/utils/auth.ts`), which is the
+// verified-working implementation against the same backend. This variant accepts
+// injectable `fetch` / `sleep` / `now` so the polling loop is fully unit-testable
+// with no live network and no real timers (see `tests/auth.test.ts`).
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface DeviceAuthorizeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete: string;
+  expires_in: number;
+  interval: number;
+}
+
+interface DeviceTokenSuccessResponse {
+  access_token: string;
+  token_type: string;
+}
+
+interface DeviceTokenErrorResponse {
+  error: string;
+  error_description?: string;
+}
+
+export type DeviceAuthResult =
+  | { success: true; accessToken: string }
+  | { success: false; reason: 'expired' | 'denied' | 'error'; message: string };
+
+export interface DeviceAuthCallbacks {
+  /** Invoked once the device+user codes are issued so the caller can display them / open a browser. */
+  onUserCode: (userCode: string, verificationUrl: string) => void;
+  /** Invoked once, right before polling begins (e.g. to start a spinner). */
+  onPolling?: () => void;
+}
+
+/** Injectable dependencies — all default to the real implementations. */
+export interface DeviceAuthDeps {
+  /** HTTP client (defaults to global `fetch`). */
+  fetchImpl?: typeof fetch;
+  /** Delay primitive (defaults to a real `setTimeout` sleep). */
+  sleepImpl?: (ms: number) => Promise<void>;
+  /** Monotonic clock in ms (defaults to `Date.now`). */
+  nowImpl?: () => number;
+  /** Floor for the poll interval in ms (defaults to 5000). */
+  minIntervalMs?: number;
+}
+
+// ─── Flow ────────────────────────────────────────────────────────────────────
+
+/**
+ * Run the RFC 8628 Device Authorization Grant flow against `baseUrl`.
+ *
+ * 1. POST `/api/auth/device/authorize` → device_code + user_code.
+ * 2. Invoke `onUserCode` so the caller can display instructions / open a browser.
+ * 3. Poll `/api/auth/device/token` until success, denial, or expiry, honoring
+ *    `authorization_pending` / `slow_down` / `access_denied` / `expired_token`.
+ */
+export async function deviceAuthFlow(
+  baseUrl: string,
+  clientLabel: string,
+  callbacks: DeviceAuthCallbacks,
+  deps: DeviceAuthDeps = {},
+): Promise<DeviceAuthResult> {
+  const doFetch = deps.fetchImpl ?? fetch;
+  const sleep = deps.sleepImpl ?? defaultSleep;
+  const now = deps.nowImpl ?? (() => Date.now());
+  const minIntervalMs = deps.minIntervalMs ?? 5000;
+
+  const authorizeUrl = `${baseUrl}/api/auth/device/authorize`;
+  verbose(`POST ${authorizeUrl}`);
+
+  const initResponse = await fetchWithTimeout(
+    doFetch,
+    authorizeUrl,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ client_label: clientLabel }),
+    },
+    30_000,
+  );
+
+  if (!initResponse.ok) {
+    const text = await initResponse.text();
+    return {
+      success: false,
+      reason: 'error',
+      message: `Failed to initiate device auth (HTTP ${initResponse.status}): ${text}`,
+    };
+  }
+
+  const auth = (await initResponse.json()) as DeviceAuthorizeResponse;
+  verbose(`Device code received, user code: ${auth.user_code}, expires in ${auth.expires_in}s`);
+
+  callbacks.onUserCode(auth.user_code, auth.verification_uri_complete);
+  callbacks.onPolling?.();
+
+  const tokenUrl = `${baseUrl}/api/auth/device/token`;
+  const deadline = now() + auth.expires_in * 1000;
+  let interval = Math.max(auth.interval * 1000, minIntervalMs);
+
+  while (now() < deadline) {
+    await sleep(interval);
+
+    if (now() >= deadline) break;
+
+    verbose(`Polling ${tokenUrl} (interval=${interval / 1000}s)`);
+
+    const pollResponse = await fetchWithTimeout(
+      doFetch,
+      tokenUrl,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          device_code: auth.device_code,
+          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        }),
+      },
+      15_000,
+    );
+
+    if (pollResponse.ok) {
+      const data = (await pollResponse.json()) as DeviceTokenSuccessResponse;
+      return { success: true, accessToken: data.access_token };
+    }
+
+    let errorData: DeviceTokenErrorResponse;
+    try {
+      errorData = (await pollResponse.json()) as DeviceTokenErrorResponse;
+    } catch {
+      return {
+        success: false,
+        reason: 'error',
+        message: `Unexpected response from token endpoint (HTTP ${pollResponse.status})`,
+      };
+    }
+    verbose(`Poll response: ${errorData.error} — ${errorData.error_description ?? ''}`);
+
+    switch (errorData.error) {
+      case 'authorization_pending':
+        break;
+
+      case 'slow_down':
+        interval = Math.min(interval + 5000, 30_000);
+        verbose(`Slowing down, new interval: ${interval / 1000}s`);
+        break;
+
+      case 'expired_token':
+        return {
+          success: false,
+          reason: 'expired',
+          message: errorData.error_description ?? 'Device code expired. Please try again.',
+        };
+
+      case 'access_denied':
+        return {
+          success: false,
+          reason: 'denied',
+          message: errorData.error_description ?? 'Authorization was denied.',
+        };
+
+      default:
+        return {
+          success: false,
+          reason: 'error',
+          message: errorData.error_description ?? `Unexpected error: ${errorData.error}`,
+        };
+    }
+  }
+
+  return {
+    success: false,
+    reason: 'expired',
+    message: 'Device code expired. Please try again.',
+  };
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchWithTimeout(
+  doFetch: typeof fetch,
+  url: string,
+  options: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await doFetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/cli/src/utils/browser.ts
+++ b/cli/src/utils/browser.ts
@@ -26,15 +26,19 @@ export function openBrowser(url: string): void {
   let cmd: string;
   let args: string[];
 
+  // Hand the platform opener the NORMALIZED serialization (`parsed.href`), not the
+  // raw input string: WHATWG parsing percent-encodes shell-hostile characters (e.g. a
+  // literal `"`), so a crafted `verification_uri` cannot inject them into `cmd /c start`.
+  const safeUrl = parsed.href;
   if (platform === 'darwin') {
     cmd = 'open';
-    args = [url];
+    args = [safeUrl];
   } else if (platform === 'win32') {
     cmd = 'cmd';
-    args = ['/c', 'start', '', url];
+    args = ['/c', 'start', '', safeUrl];
   } else {
     cmd = 'xdg-open';
-    args = [url];
+    args = [safeUrl];
   }
 
   verbose(`Opening browser: ${cmd} ${args.join(' ')}`);

--- a/cli/src/utils/browser.ts
+++ b/cli/src/utils/browser.ts
@@ -1,0 +1,30 @@
+import { execFile } from 'child_process';
+import { verbose } from './ui.js';
+
+/**
+ * Open a URL in the user's default browser.
+ * Silently ignores errors — the URL is always shown in the terminal as a fallback.
+ */
+export function openBrowser(url: string): void {
+  const platform = process.platform;
+  let cmd: string;
+  let args: string[];
+
+  if (platform === 'darwin') {
+    cmd = 'open';
+    args = [url];
+  } else if (platform === 'win32') {
+    cmd = 'cmd';
+    args = ['/c', 'start', '', url];
+  } else {
+    cmd = 'xdg-open';
+    args = [url];
+  }
+
+  verbose(`Opening browser: ${cmd} ${args.join(' ')}`);
+  execFile(cmd, args, (err) => {
+    if (err) {
+      verbose(`Failed to open browser: ${err.message}`);
+    }
+  });
+}

--- a/cli/src/utils/browser.ts
+++ b/cli/src/utils/browser.ts
@@ -6,6 +6,22 @@ import { verbose } from './ui.js';
  * Silently ignores errors — the URL is always shown in the terminal as a fallback.
  */
 export function openBrowser(url: string): void {
+  // Only open well-formed http(s) URLs. The URL comes from a device-auth server
+  // (which `--base-url` can point at an arbitrary host), so it is untrusted input;
+  // refusing any non-http(s) scheme keeps a hostile/MITM'd `verification_uri` from
+  // being handed to the platform opener (notably `cmd /c start` on Windows).
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    verbose(`Refusing to open malformed URL: ${url}`);
+    return;
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    verbose(`Refusing to open non-http(s) URL: ${url}`);
+    return;
+  }
+
   const platform = process.platform;
   let cmd: string;
   let args: string[];

--- a/cli/src/utils/cloud-login.ts
+++ b/cli/src/utils/cloud-login.ts
@@ -1,0 +1,87 @@
+import * as ui from './ui.js';
+import { DEFAULT_CLOUD_BASE_URL } from './connection.js';
+import { readCredentials, writeCredentials } from './credentials.js';
+import { deviceAuthFlow, type DeviceAuthDeps } from './auth.js';
+import { openBrowser } from './browser.js';
+
+export interface CloudLoginOptions {
+  /** Cloud base URL to authenticate against (default https://ai-game.dev). */
+  baseUrl?: string;
+  /** Client label sent to the authorize endpoint. */
+  clientLabel?: string;
+  /** Browser opener (injectable for tests; defaults to the real opener). */
+  openBrowserImpl?: (url: string) => void;
+  /** Device-flow dependency injection (fetch/sleep/clock) for tests. */
+  authDeps?: DeviceAuthDeps;
+}
+
+/**
+ * Run the cloud device-auth flow: initiate, display the user code, open the
+ * browser, poll to completion, and persist the token to the project's
+ * `.godot-mcp/credentials.json`.
+ *
+ * Returns the access token on success, or null on failure (errors are printed).
+ */
+export async function runCloudLogin(
+  projectPath: string,
+  options: CloudLoginOptions = {},
+): Promise<string | null> {
+  const baseUrl = (options.baseUrl ?? DEFAULT_CLOUD_BASE_URL).replace(/\/$/, '');
+  const clientLabel = options.clientLabel ?? 'Godot-MCP CLI';
+  const openBrowserImpl = options.openBrowserImpl ?? openBrowser;
+
+  let spinner: ReturnType<typeof ui.startSpinner> | undefined;
+
+  try {
+    const result = await deviceAuthFlow(
+      baseUrl,
+      clientLabel,
+      {
+        onUserCode: (userCode, verificationUrl) => {
+          ui.info('Open this URL to authorize:');
+          console.log();
+          console.log(`  ${verificationUrl}`);
+          console.log();
+          ui.label('Code', userCode);
+          openBrowserImpl(verificationUrl);
+        },
+        onPolling: () => {
+          spinner = ui.startSpinner('Waiting for authorization...');
+        },
+      },
+      options.authDeps,
+    );
+
+    if (result.success) {
+      spinner?.success('Authorized');
+
+      // A corrupt existing credentials file must not block a fresh login.
+      let existing = {};
+      try {
+        existing = readCredentials(projectPath) ?? {};
+      } catch {
+        existing = {};
+      }
+      writeCredentials(projectPath, {
+        ...existing,
+        cloudToken: result.accessToken,
+        cloudBaseUrl: baseUrl,
+      });
+
+      return result.accessToken;
+    }
+
+    spinner?.stop();
+    ui.error(result.message);
+    return null;
+  } catch (err) {
+    spinner?.stop();
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes('ECONNREFUSED') || message.includes('fetch failed')) {
+      ui.error(`Cannot reach cloud server at ${baseUrl}`);
+    } else {
+      ui.error(`Authentication failed: ${message}`);
+    }
+    return null;
+  }
+}

--- a/cli/src/utils/connection.ts
+++ b/cli/src/utils/connection.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { verbose } from './ui.js';
 import * as ui from './ui.js';
+import { readCloudToken } from './credentials.js';
 
 // --- Godot MCP connection constants (mirror addons/godot_mcp GodotMcpConfig). ---
 
@@ -104,15 +105,16 @@ function isCloudMode(): boolean {
  * Token priority:
  *   1. --token flag (explicit override)
  *   2. GODOT_MCP_TOKEN env
+ *   3. persisted cloud token from `.godot-mcp/credentials.json` (Cloud mode only,
+ *      written by `godot-cli login`)
  *
  * Unlike the Unity CLI, there is NO deterministic project-path→port hash:
- * the Godot plugin is a server-less client whose persisted config lives in
- * `user://` (outside the project tree), so the CLI cannot read a project-local
- * config file. Resolution is therefore env-var + cloud-default based, and
- * `--url` is the authoritative override for a local/self-hosted server.
+ * the Godot plugin is a server-less client whose live config lives in `user://`
+ * (outside the project tree). The one project-local surface the CLI DOES own is
+ * the `login`-written credentials file, consulted last so `--token`/env still win.
  */
 export function resolveConnection(
-  _projectPath: string,
+  projectPath: string,
   options: ConnectionOptions,
 ): { url: string; token: string | undefined } {
   let url: string;
@@ -137,12 +139,46 @@ export function resolveConnection(
     }
   }
 
-  const token = options.token ?? normalizeEnv(process.env[ENV_TOKEN]);
+  let token = options.token ?? normalizeEnv(process.env[ENV_TOKEN]);
   if (options.token) {
     verbose('Using explicit --token');
   } else if (token) {
     verbose(`Using ${ENV_TOKEN}`);
+  } else if (isCloudMode()) {
+    const persisted = readCloudToken(projectPath);
+    if (persisted) {
+      token = persisted;
+      verbose('Using persisted cloud token from .godot-mcp/credentials.json');
+    }
   }
 
   return { url, token };
+}
+
+/**
+ * Resolve the auth token to inject into the launched editor's environment for
+ * the `open` command. The editor inherits the CLI's environment, so a set
+ * `GODOT_MCP_TOKEN` already propagates untouched — this only needs to surface
+ * the persisted cloud token (which is NOT in the environment) when Cloud mode is
+ * selected and neither `--token` nor `GODOT_MCP_TOKEN` is present.
+ *
+ * Returns the token to pass as `openProject({ token })`, or undefined to leave
+ * `open`'s env exactly as before (explicit env var / no token).
+ */
+export function resolveOpenAuthToken(
+  projectPath: string,
+  options: { token?: string; mode?: string },
+): string | undefined {
+  if (options.token !== undefined) {
+    return options.token;
+  }
+  // An env token already reaches the editor via inheritance — don't double-inject.
+  if (normalizeEnv(process.env[ENV_TOKEN]) !== undefined) {
+    return undefined;
+  }
+  const selectedMode = options.mode ?? normalizeEnv(process.env[ENV_CONNECTION_MODE]);
+  if (selectedMode !== undefined && selectedMode.toLowerCase() === 'cloud') {
+    return readCloudToken(projectPath);
+  }
+  return undefined;
 }

--- a/cli/src/utils/credentials.ts
+++ b/cli/src/utils/credentials.ts
@@ -1,0 +1,100 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Project-local cloud credentials the CLI persists after a successful `login`.
+ *
+ * Stored SEPARATELY from `.godot-mcp/features.json` (the committable feature
+ * override list) because a bearer token must never be committed: `writeCredentials`
+ * drops a `.gitignore` alongside so `credentials.json` is ignored while the
+ * sibling `features.json` stays version-controllable.
+ *
+ * `godot-cli login` writes it; `godot-cli open --mode Cloud` (and the direct
+ * tool-call path in `connection.ts`) read the token back so no manual `--token`
+ * is needed. The addon's own live config still lives in `user://` — this file is
+ * purely the CLI's in-project pickup surface, mirroring the Unity CLI's
+ * `cloudToken` config field.
+ */
+export const CREDENTIALS_RELATIVE_PATH = '.godot-mcp/credentials.json';
+
+export interface GodotMcpCredentials {
+  /** The cloud bearer token issued by the device-authorization flow. */
+  cloudToken?: string;
+  /** The cloud base URL the token was issued against (default https://ai-game.dev). */
+  cloudBaseUrl?: string;
+  [key: string]: unknown;
+}
+
+export function getCredentialsPath(projectPath: string): string {
+  return path.join(projectPath, CREDENTIALS_RELATIVE_PATH);
+}
+
+/** Read the credentials file. Returns null when absent; throws on malformed JSON. */
+export function readCredentials(projectPath: string): GodotMcpCredentials | null {
+  const credentialsPath = getCredentialsPath(projectPath);
+  if (!fs.existsSync(credentialsPath)) {
+    return null;
+  }
+  const json = fs.readFileSync(credentialsPath, 'utf-8');
+  try {
+    return JSON.parse(json) as GodotMcpCredentials;
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      throw new SyntaxError(`Malformed JSON in credentials file: ${credentialsPath}\n${err.message}`);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Write the credentials file, creating the `.godot-mcp/` directory if needed and
+ * ensuring `credentials.json` is git-ignored so the token is never committed.
+ */
+export function writeCredentials(projectPath: string, credentials: GodotMcpCredentials): void {
+  const credentialsPath = getCredentialsPath(projectPath);
+  const dir = path.dirname(credentialsPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(credentialsPath, JSON.stringify(credentials, null, 2) + '\n');
+  ensureGitignored(dir, 'credentials.json');
+}
+
+/**
+ * Convenience reader for the persisted cloud token. Swallows a missing or
+ * malformed file (returns undefined) so a broken credentials file can never
+ * crash `open` / `run-tool`; `login` re-authenticates and overwrites it.
+ */
+export function readCloudToken(projectPath: string): string | undefined {
+  let credentials: GodotMcpCredentials | null;
+  try {
+    credentials = readCredentials(projectPath);
+  } catch {
+    return undefined;
+  }
+  const token = credentials?.cloudToken;
+  return typeof token === 'string' && token.trim().length > 0 ? token : undefined;
+}
+
+/**
+ * Ensure `<dir>/.gitignore` ignores `entry`, so the secret is not committed.
+ * Idempotent: creates the file when absent, appends the line only when missing.
+ * Best-effort — a failure here never blocks persisting the token.
+ */
+function ensureGitignored(dir: string, entry: string): void {
+  try {
+    const gitignorePath = path.join(dir, '.gitignore');
+    if (!fs.existsSync(gitignorePath)) {
+      fs.writeFileSync(gitignorePath, `${entry}\n`);
+      return;
+    }
+    const existing = fs.readFileSync(gitignorePath, 'utf-8');
+    const lines = existing.split(/\r?\n/).map((l) => l.trim());
+    if (!lines.includes(entry)) {
+      const prefix = existing.length > 0 && !existing.endsWith('\n') ? '\n' : '';
+      fs.appendFileSync(gitignorePath, `${prefix}${entry}\n`);
+    }
+  } catch {
+    // Best-effort only — never fail the login over a .gitignore write.
+  }
+}

--- a/cli/src/utils/credentials.ts
+++ b/cli/src/utils/credentials.ts
@@ -56,7 +56,15 @@ export function writeCredentials(projectPath: string, credentials: GodotMcpCrede
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true });
   }
-  fs.writeFileSync(credentialsPath, JSON.stringify(credentials, null, 2) + '\n');
+  // Owner-only perms: the file holds a raw cloud bearer token, so it must not be
+  // group/world-readable on a shared machine. `mode` only applies when the file is
+  // CREATED, so also chmod on overwrite (best-effort — no-op/again-fine on Windows).
+  fs.writeFileSync(credentialsPath, JSON.stringify(credentials, null, 2) + '\n', { mode: 0o600 });
+  try {
+    fs.chmodSync(credentialsPath, 0o600);
+  } catch {
+    // Best-effort only — never fail the login over a chmod (e.g. Windows ACLs).
+  }
   ensureGitignored(dir, 'credentials.json');
 }
 

--- a/cli/tests/auth.test.ts
+++ b/cli/tests/auth.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from 'vitest';
+import { deviceAuthFlow, type DeviceAuthDeps } from '../src/utils/auth.js';
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const AUTHORIZE_OK = {
+  device_code: 'dev-code-123',
+  user_code: 'WXYZ-1234',
+  verification_uri: 'https://ai-game.dev/device',
+  verification_uri_complete: 'https://ai-game.dev/device?code=WXYZ-1234',
+  expires_in: 900,
+  interval: 5,
+};
+
+/**
+ * Build an injectable fetch: `/authorize` returns `authorize`; every `/token`
+ * poll shifts the next queued response (defaulting to authorization_pending).
+ */
+function makeFetch(authorize: Response, polls: Response[]): typeof fetch {
+  const queue = [...polls];
+  return vi.fn(async (url: string | URL | Request) => {
+    if (String(url).endsWith('/authorize')) return authorize;
+    return queue.shift() ?? jsonResponse(400, { error: 'authorization_pending' });
+  }) as unknown as typeof fetch;
+}
+
+function deps(fetchImpl: typeof fetch, intervals: number[] = []): DeviceAuthDeps {
+  return {
+    fetchImpl,
+    sleepImpl: async (ms: number) => {
+      intervals.push(ms);
+    },
+    minIntervalMs: 10,
+  };
+}
+
+describe('deviceAuthFlow', () => {
+  it('returns the access token on immediate success', async () => {
+    const fetchImpl = makeFetch(
+      jsonResponse(200, AUTHORIZE_OK),
+      [jsonResponse(200, { access_token: 'tok-abc', token_type: 'Bearer' })],
+    );
+    const onUserCode = vi.fn();
+    const result = await deviceAuthFlow('https://ai-game.dev', 'Godot-MCP CLI', { onUserCode }, deps(fetchImpl));
+
+    expect(result).toEqual({ success: true, accessToken: 'tok-abc' });
+    expect(onUserCode).toHaveBeenCalledWith('WXYZ-1234', 'https://ai-game.dev/device?code=WXYZ-1234');
+  });
+
+  it('polls through authorization_pending until success', async () => {
+    const fetchImpl = makeFetch(jsonResponse(200, AUTHORIZE_OK), [
+      jsonResponse(400, { error: 'authorization_pending' }),
+      jsonResponse(400, { error: 'authorization_pending' }),
+      jsonResponse(200, { access_token: 'tok-final', token_type: 'Bearer' }),
+    ]);
+    const result = await deviceAuthFlow('https://ai-game.dev', 'Godot-MCP CLI', { onUserCode: vi.fn() }, deps(fetchImpl));
+    expect(result).toEqual({ success: true, accessToken: 'tok-final' });
+  });
+
+  it('honors slow_down by increasing the poll interval', async () => {
+    const intervals: number[] = [];
+    const fetchImpl = makeFetch(jsonResponse(200, AUTHORIZE_OK), [
+      jsonResponse(400, { error: 'slow_down' }),
+      jsonResponse(200, { access_token: 'tok', token_type: 'Bearer' }),
+    ]);
+    const result = await deviceAuthFlow(
+      'https://ai-game.dev',
+      'Godot-MCP CLI',
+      { onUserCode: vi.fn() },
+      deps(fetchImpl, intervals),
+    );
+    expect(result.success).toBe(true);
+    // The interval used before the 2nd poll must exceed the first (slow_down += 5s).
+    expect(intervals.length).toBe(2);
+    expect(intervals[1]).toBeGreaterThan(intervals[0]!);
+  });
+
+  it('maps access_denied to a denied result', async () => {
+    const fetchImpl = makeFetch(jsonResponse(200, AUTHORIZE_OK), [
+      jsonResponse(400, { error: 'access_denied', error_description: 'user said no' }),
+    ]);
+    const result = await deviceAuthFlow('https://ai-game.dev', 'Godot-MCP CLI', { onUserCode: vi.fn() }, deps(fetchImpl));
+    expect(result).toEqual({ success: false, reason: 'denied', message: 'user said no' });
+  });
+
+  it('maps expired_token to an expired result', async () => {
+    const fetchImpl = makeFetch(jsonResponse(200, AUTHORIZE_OK), [
+      jsonResponse(400, { error: 'expired_token' }),
+    ]);
+    const result = await deviceAuthFlow('https://ai-game.dev', 'Godot-MCP CLI', { onUserCode: vi.fn() }, deps(fetchImpl));
+    expect(result.success).toBe(false);
+    expect(result).toMatchObject({ reason: 'expired' });
+  });
+
+  it('reports an error when the authorize endpoint is not OK', async () => {
+    const fetchImpl = makeFetch(new Response('boom', { status: 503 }), []);
+    const onUserCode = vi.fn();
+    const result = await deviceAuthFlow('https://ai-game.dev', 'Godot-MCP CLI', { onUserCode }, deps(fetchImpl));
+    expect(result.success).toBe(false);
+    expect(result).toMatchObject({ reason: 'error' });
+    expect((result as { message: string }).message).toContain('503');
+    expect(onUserCode).not.toHaveBeenCalled();
+  });
+
+  it('expires without polling when the device code is already past its deadline', async () => {
+    const fetchImpl = makeFetch(jsonResponse(200, { ...AUTHORIZE_OK, expires_in: 0 }), [
+      jsonResponse(200, { access_token: 'should-not-be-used', token_type: 'Bearer' }),
+    ]);
+    const onUserCode = vi.fn();
+    const result = await deviceAuthFlow(
+      'https://ai-game.dev',
+      'Godot-MCP CLI',
+      { onUserCode },
+      { ...deps(fetchImpl), nowImpl: () => 1000 },
+    );
+    expect(result.success).toBe(false);
+    expect(result).toMatchObject({ reason: 'expired' });
+    // The user code is still surfaced even when the deadline is immediate.
+    expect(onUserCode).toHaveBeenCalledTimes(1);
+  });
+});

--- a/cli/tests/cloud-login.test.ts
+++ b/cli/tests/cloud-login.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { runCloudLogin } from '../src/utils/cloud-login.js';
+import { readCredentials, getCredentialsPath } from '../src/utils/credentials.js';
+import type { DeviceAuthDeps } from '../src/utils/auth.js';
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const AUTHORIZE_OK = {
+  device_code: 'dev-code',
+  user_code: 'CODE-1234',
+  verification_uri: 'https://example.test/device',
+  verification_uri_complete: 'https://example.test/device?code=CODE-1234',
+  expires_in: 900,
+  interval: 5,
+};
+
+function authDeps(polls: Response[]): DeviceAuthDeps {
+  const queue = [...polls];
+  return {
+    fetchImpl: vi.fn(async (url: string | URL | Request) => {
+      if (String(url).endsWith('/authorize')) return jsonResponse(200, AUTHORIZE_OK);
+      return queue.shift() ?? jsonResponse(400, { error: 'authorization_pending' });
+    }) as unknown as typeof fetch,
+    sleepImpl: async () => {},
+    minIntervalMs: 1,
+  };
+}
+
+describe('runCloudLogin', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-login-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('persists the token and returns it on success', async () => {
+    const openBrowserImpl = vi.fn();
+    const token = await runCloudLogin(tmpDir, {
+      baseUrl: 'https://example.test',
+      openBrowserImpl,
+      authDeps: authDeps([jsonResponse(200, { access_token: 'cloud-tok', token_type: 'Bearer' })]),
+    });
+
+    expect(token).toBe('cloud-tok');
+    expect(openBrowserImpl).toHaveBeenCalledWith('https://example.test/device?code=CODE-1234');
+    expect(readCredentials(tmpDir)).toEqual({ cloudToken: 'cloud-tok', cloudBaseUrl: 'https://example.test' });
+  });
+
+  it('returns null and writes nothing when authorization is denied', async () => {
+    const token = await runCloudLogin(tmpDir, {
+      baseUrl: 'https://example.test',
+      openBrowserImpl: vi.fn(),
+      authDeps: authDeps([jsonResponse(400, { error: 'access_denied' })]),
+    });
+
+    expect(token).toBeNull();
+    expect(fs.existsSync(getCredentialsPath(tmpDir))).toBe(false);
+  });
+});

--- a/cli/tests/connection.test.ts
+++ b/cli/tests/connection.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
 import {
   resolveConnection,
+  resolveOpenAuthToken,
   CLOUD_MCP_URL,
   DEFAULT_CLOUD_BASE_URL,
   DEFAULT_CUSTOM_HOST,
@@ -9,6 +13,7 @@ import {
   ENV_TOKEN,
   ENV_CONNECTION_MODE,
 } from '../src/utils/connection.js';
+import { writeCredentials } from '../src/utils/credentials.js';
 
 describe('resolveConnection', () => {
   const saved: Record<string, string | undefined> = {};
@@ -66,5 +71,89 @@ describe('resolveConnection', () => {
 
   it('exposes the cloud MCP-client URL constant as <base>/mcp', () => {
     expect(CLOUD_MCP_URL).toBe(`${DEFAULT_CLOUD_BASE_URL}/mcp`);
+  });
+});
+
+describe('resolveConnection — persisted cloud token fallback', () => {
+  const saved: Record<string, string | undefined> = {};
+  const ENV_KEYS = [ENV_HOST, ENV_CLOUD_URL, ENV_TOKEN, ENV_CONNECTION_MODE];
+  let tmpDir: string;
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-conn-'));
+    writeCredentials(tmpDir, { cloudToken: 'persisted-tok', cloudBaseUrl: DEFAULT_CLOUD_BASE_URL });
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('falls back to the persisted cloud token in Cloud mode when no --token / env token', () => {
+    process.env[ENV_CONNECTION_MODE] = 'Cloud';
+    expect(resolveConnection(tmpDir, {}).token).toBe('persisted-tok');
+  });
+
+  it('does NOT use the persisted token outside Cloud mode', () => {
+    expect(resolveConnection(tmpDir, {}).token).toBeUndefined();
+  });
+
+  it('lets --token and GODOT_MCP_TOKEN win over the persisted token', () => {
+    process.env[ENV_CONNECTION_MODE] = 'Cloud';
+    expect(resolveConnection(tmpDir, { token: 'flag-tok' }).token).toBe('flag-tok');
+    process.env[ENV_TOKEN] = 'env-tok';
+    expect(resolveConnection(tmpDir, {}).token).toBe('env-tok');
+  });
+});
+
+describe('resolveOpenAuthToken', () => {
+  const saved: Record<string, string | undefined> = {};
+  const ENV_KEYS = [ENV_TOKEN, ENV_CONNECTION_MODE];
+  let tmpDir: string;
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-open-'));
+    writeCredentials(tmpDir, { cloudToken: 'persisted-tok' });
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns an explicit --token verbatim', () => {
+    expect(resolveOpenAuthToken(tmpDir, { token: 'flag-tok', mode: 'Cloud' })).toBe('flag-tok');
+  });
+
+  it('returns undefined when GODOT_MCP_TOKEN is set (env propagates naturally)', () => {
+    process.env[ENV_TOKEN] = 'env-tok';
+    expect(resolveOpenAuthToken(tmpDir, { mode: 'Cloud' })).toBeUndefined();
+  });
+
+  it('returns the persisted cloud token when --mode Cloud and no token', () => {
+    expect(resolveOpenAuthToken(tmpDir, { mode: 'Cloud' })).toBe('persisted-tok');
+  });
+
+  it('honors GODOT_MCP_CONNECTION_MODE=Cloud when --mode is absent', () => {
+    process.env[ENV_CONNECTION_MODE] = 'Cloud';
+    expect(resolveOpenAuthToken(tmpDir, {})).toBe('persisted-tok');
+  });
+
+  it('returns undefined in Custom mode', () => {
+    expect(resolveOpenAuthToken(tmpDir, { mode: 'Custom' })).toBeUndefined();
   });
 });

--- a/cli/tests/credentials.test.ts
+++ b/cli/tests/credentials.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  getCredentialsPath,
+  readCredentials,
+  writeCredentials,
+  readCloudToken,
+} from '../src/utils/credentials.js';
+
+describe('credentials', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-cred-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('credentials path is project-local .godot-mcp/credentials.json', () => {
+    expect(getCredentialsPath(tmpDir)).toBe(path.join(tmpDir, '.godot-mcp', 'credentials.json'));
+  });
+
+  it('returns null when no credentials file exists', () => {
+    expect(readCredentials(tmpDir)).toBeNull();
+  });
+
+  it('round-trips written credentials', () => {
+    writeCredentials(tmpDir, { cloudToken: 'tok-1', cloudBaseUrl: 'https://ai-game.dev' });
+    expect(readCredentials(tmpDir)).toEqual({ cloudToken: 'tok-1', cloudBaseUrl: 'https://ai-game.dev' });
+  });
+
+  it('readCloudToken returns the persisted token', () => {
+    writeCredentials(tmpDir, { cloudToken: 'tok-2' });
+    expect(readCloudToken(tmpDir)).toBe('tok-2');
+  });
+
+  it('readCloudToken returns undefined when absent, empty, or malformed', () => {
+    expect(readCloudToken(tmpDir)).toBeUndefined();
+
+    writeCredentials(tmpDir, { cloudToken: '   ' });
+    expect(readCloudToken(tmpDir)).toBeUndefined();
+
+    fs.writeFileSync(getCredentialsPath(tmpDir), '{ not json');
+    expect(readCloudToken(tmpDir)).toBeUndefined();
+  });
+
+  it('readCredentials throws on malformed JSON', () => {
+    fs.mkdirSync(path.join(tmpDir, '.godot-mcp'), { recursive: true });
+    fs.writeFileSync(getCredentialsPath(tmpDir), '{ not json');
+    expect(() => readCredentials(tmpDir)).toThrow(/Malformed JSON/);
+  });
+
+  it('writeCredentials git-ignores credentials.json (idempotently, without clobbering)', () => {
+    writeCredentials(tmpDir, { cloudToken: 'tok' });
+    const gitignorePath = path.join(tmpDir, '.godot-mcp', '.gitignore');
+    expect(fs.existsSync(gitignorePath)).toBe(true);
+    expect(fs.readFileSync(gitignorePath, 'utf-8')).toContain('credentials.json');
+
+    // A second write must not duplicate the entry.
+    writeCredentials(tmpDir, { cloudToken: 'tok2' });
+    const occurrences = fs
+      .readFileSync(gitignorePath, 'utf-8')
+      .split(/\r?\n/)
+      .filter((l) => l.trim() === 'credentials.json').length;
+    expect(occurrences).toBe(1);
+  });
+
+  it('writeCredentials preserves pre-existing .gitignore entries', () => {
+    const dir = path.join(tmpDir, '.godot-mcp');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, '.gitignore'), 'features-local.json\n');
+    writeCredentials(tmpDir, { cloudToken: 'tok' });
+    const content = fs.readFileSync(path.join(dir, '.gitignore'), 'utf-8');
+    expect(content).toContain('features-local.json');
+    expect(content).toContain('credentials.json');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `godot-cli login [path]` — runs the RFC 8628 device-authorization flow against ai-game.dev and persists the cloud token to a project-local, git-ignored `.godot-mcp/credentials.json`.
- `godot-cli open --mode Cloud` (and the direct tool-call path) now read that persisted token back, so `login` → `open --mode Cloud` needs no manual `--token`. `--token` / `GODOT_MCP_TOKEN` still win.
- Ported the device flow from `unity-mcp-cli` (no new runtime dependency); injectable fetch/clock make it fully unit-testable with no live network.

## Test plan
- [x] Target-specific local tests passed (see profile test.md): `cd cli && npm run build && npm test` → build clean, 398/398 vitest pass (15 new tests across auth / credentials / cloud-login / connection).

Closes #250