### PR TITLE
chore(cli): rename VS Code agent id 'vscode' -> 'vscode-copilot'

### DIFF
--- a/cli/src/utils/agents.ts
+++ b/cli/src/utils/agents.ts
@@ -148,7 +148,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
 
   // ── VS Code (Copilot) ────────────────────────────────────────
   {
-    id: 'vscode',
+    id: 'vscode-copilot',
     name: 'Visual Studio Code (Copilot)',
     skillsPath: '.github/skills',
     configPathDisplay: '.vscode/mcp.json',

--- a/cli/tests/setup-mcp.test.ts
+++ b/cli/tests/setup-mcp.test.ts
@@ -61,7 +61,7 @@ describe('setupMcp', () => {
     expect(ids).toContain('claude-code');
     expect(ids).toContain('claude-desktop');
     expect(ids).toContain('cursor');
-    expect(ids).toContain('vscode');
+    expect(ids).toContain('vscode-copilot');
     expect(ids).toContain('custom');
     // Ported from Unity for parity
     expect(ids).toContain('vs-copilot');
@@ -115,7 +115,7 @@ describe('setupMcp', () => {
   });
 
   it('writes a VS Code config under the "servers" body path', async () => {
-    const result = await setupMcp({ agentId: 'vscode', godotProjectPath: tmpDir, url: 'http://localhost:8080' });
+    const result = await setupMcp({ agentId: 'vscode-copilot', godotProjectPath: tmpDir, url: 'http://localhost:8080' });
     expect(result.kind).toBe('success');
     const json = JSON.parse(fs.readFileSync(path.join(tmpDir, '.vscode', 'mcp.json'), 'utf-8'));
     expect(json.servers[SERVER_NAME].url).toBe('http://localhost:8080/mcp');
@@ -275,7 +275,7 @@ describe('agent config-path resolution', () => {
     const cases: Array<[string, string[]]> = [
       ['claude-code', ['.mcp.json']],
       ['cursor', ['.cursor', 'mcp.json']],
-      ['vscode', ['.vscode', 'mcp.json']],
+      ['vscode-copilot', ['.vscode', 'mcp.json']],
       ['vs-copilot', ['.vs', 'mcp.json']],
       ['rider-junie', ['.junie', 'mcp', 'mcp.json']],
       ['gemini', ['.gemini', 'settings.json']],


### PR DESCRIPTION
## Summary
- Rename the VS Code AI-agent id in `godot-cli` from `vscode` to `vscode-copilot`, matching the `unity-mcp-cli` agent roster naming (owner directive 2026-07-09).
- Only the id string changes in `cli/src/utils/agents.ts`; the display name ("Visual Studio Code (Copilot)"), the `.vscode/mcp.json` config path, and the HTTP-transport props are unchanged.
- The `custom` agent is retained; no other agents added or removed.
- Updated the `setup-mcp` tests that asserted the id list / drove the `vscode` agent.

## Test plan
- [x] Target-specific local tests passed (see profile test.md): `npm run build` (tsc) clean; `npm test` (vitest) 398/398 pass across 35 files.
- [x] Built CLI `setup-mcp --list` shows exactly 14 ids: antigravity, claude-code, claude-desktop, cline, codex, cursor, custom, gemini, github-copilot-cli, kilo-code, open-code, rider-junie, vs-copilot, vscode-copilot (no bare `vscode`).

Scope: `cli/` only. No release/publish (handled by a separate release step).

Closes #253