### PR TITLE
chore(release): bump version to 0.16.1 (re-publish godot-cli via release.yml)

### DIFF
--- a/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
@@ -65,7 +65,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// drift if you forget). The live, parsed value in <see cref="PluginVersion"/> is the source of
         /// truth; <see cref="ResolvePluginVersion"/> emits a warning whenever it has to fall back here.
         /// </summary>
-        const string FallbackPluginVersion = "0.16.0";
+        const string FallbackPluginVersion = "0.16.1";
 
         /// <summary>
         /// Plugin version reported to the server in the MCP handshake. Resolved ONCE from

--- a/addons/godot_mcp/Runtime/GodotMcpRuntime.cs
+++ b/addons/godot_mcp/Runtime/GodotMcpRuntime.cs
@@ -280,7 +280,7 @@ namespace com.IvanMurzak.Godot.MCP.Runtime
         /// <c>version=</c> (the live parsed value above is the source of truth; this is only the degraded
         /// fallback). Mirrors <c>GodotMcpConnection.FallbackPluginVersion</c>.
         /// </summary>
-        const string FallbackPluginVersion = "0.16.0";
+        const string FallbackPluginVersion = "0.16.1";
 
         /// <summary>
         /// Ensure a <see cref="MainThreadDispatcher"/> Node exists in the running game's

--- a/addons/godot_mcp/plugin.cfg
+++ b/addons/godot_mcp/plugin.cfg
@@ -3,5 +3,5 @@
 name="Godot-MCP"
 description="Model Context Protocol (MCP) integration for the Godot Editor. AI tools in C#, cloud-connected to ai-game.dev."
 author="Ivan Murzak"
-version="0.16.0"
+version="0.16.1"
 script="Editor/GodotMcpPlugin.cs"

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "godot-cli",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "godot-cli",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.6.2",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "godot-cli",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Cross-platform CLI tool for Godot-MCP (Skills & MCP). Resolves and launches the Godot editor with MCP connection env vars, runs MCP/system tools over HTTP, probes server health, configures AI agents (Claude Code, Cursor, VS Code, …), and enables/disables the godot_mcp addon. Works with Claude Code, Cursor, Copilot, and any MCP client.",
   "type": "module",
   "main": "dist/lib.js",

--- a/docs/assetlib/SUBMISSION.md
+++ b/docs/assetlib/SUBMISSION.md
@@ -25,11 +25,11 @@ this file is just the field values. Keep it in sync whenever any field changes.
 | **Asset name** | `Godot-MCP` |
 | **Category** | `Tools` (an Addon-side category — categories are split into Addons / Projects, and picking an Addon category is what makes this entry an Addon and surfaces it in the in-editor *AssetLib* tab; there is no separate "Type" field) |
 | **Godot version** | `4.3` (lowest supported; the addon also runs on 4.4 / 4.5 — a single entry cannot carry multiple engine versions, so each version it should advertise needs its own resubmission) |
-| **Version** | `0.16.0` (must match `addons/godot_mcp/plugin.cfg` `version=` and the `v0.16.0` tag) |
+| **Version** | `0.16.1` (must match `addons/godot_mcp/plugin.cfg` `version=` and the `v0.16.1` tag) |
 | **Repository host** | `GitHub` |
 | **Repository URL** | `https://github.com/IvanMurzak/Godot-MCP` |
 | **Issues URL** | `https://github.com/IvanMurzak/Godot-MCP/issues` |
-| **Download Commit** | the commit hash the `v0.16.0` tag points at — get it with `git rev-list -n1 v0.16.0` (a hash, not the tag name) |
+| **Download Commit** | the commit hash the `v0.16.1` tag points at — get it with `git rev-list -n1 v0.16.1` (a hash, not the tag name) |
 | **License** | `Apache-2.0` |
 | **Icon URL** | `https://raw.githubusercontent.com/IvanMurzak/Godot-MCP/main/addons/godot_mcp/icon.png` (square 512×512 PNG; AssetLib requires square PNG/JPG ≥ 128×128 — SVG is not accepted) |
 


### PR DESCRIPTION
0.16.0's npm publish failed twice — npm 12.0.0 provenance/sigstore regression (fixed by #257's npm@11 pin), then a masked E404 (deploy `workflow_dispatch` OIDC `workflow_ref` ≠ the Trusted Publisher's `release.yml`). v0.16.0's tag exists so it can't re-trigger. **0.16.1** re-runs the full release via the authorized `release.yml` path with the npm@11 fix on main → publishes **godot-cli@0.16.1** (same vscode-copilot rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)