### PR TITLE
feat(connection): RFC 8628 device flow + machine credential store + zero-button boot

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -104,6 +104,17 @@
          ConnectionPanel (browser-open + token persistence), verified via the headless smoke (test.md Suite 3). -->
     <Compile Include="..\addons\godot_mcp\Editor\Connection\GodotDeviceAuthService.cs" Link="Source\GodotDeviceAuthService.cs" />
     <Compile Include="..\addons\godot_mcp\Editor\Connection\GodotDeviceAuthFlow.cs" Link="Source\GodotDeviceAuthFlow.cs" />
+    <!-- mcp-authorize PR 2 (RFC 8628 device flow + machine credential store + zero-button boot): the
+         device-flow result carrier, the ITokenRefresher impl (proactive/reactive refresh against
+         /oauth/token), and the account coordinator that owns McpPlugin 7.0's MachineCredentialStore +
+         PluginCredentialProvider (store auto-adopt, sign-in persist, refresh). All pure-managed (no Godot
+         native types, no #if TOOLS), so the store/adopt/refresh lifecycle is unit-tested here with a
+         temp-directory store + a fake HttpMessageHandler; the connection wiring (composed credential
+         provider + refresh-on-reject) lives in GodotMcpConnection.cs (#if-free but SignalR-coupled) and is
+         verified via the headless Godot smoke (test.md Suite 3). -->
+    <Compile Include="..\addons\godot_mcp\Editor\Connection\GodotDeviceAuthResult.cs" Link="Source\GodotDeviceAuthResult.cs" />
+    <Compile Include="..\addons\godot_mcp\Editor\Connection\GodotTokenRefresher.cs" Link="Source\GodotTokenRefresher.cs" />
+    <Compile Include="..\addons\godot_mcp\Editor\Connection\GodotAccountAuth.cs" Link="Source\GodotAccountAuth.cs" />
     <!-- Editor-runtime NuGet-dependency resolver. Pure-BCL (System.Runtime.Loader), no #if TOOLS,
          no Godot native types — so it is unit-testable in this plain-xUnit host. -->
     <Compile Include="..\addons\godot_mcp\Runtime\Connection\GodotMcpAssemblyResolver.cs" Link="Source\GodotMcpAssemblyResolver.cs" />

--- a/Godot-MCP.Tests/GodotAccountAuthTests.cs
+++ b/Godot-MCP.Tests/GodotAccountAuthTests.cs
@@ -1,0 +1,299 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.Godot.MCP.Connection;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Covers <see cref="GodotAccountAuth"/> — the machine-store account coordinator (mcp-authorize D12).
+    /// Verifies the three PR-2 behaviours against a temp-directory <see cref="MachineCredentialStore"/> + a
+    /// fake <see cref="HttpMessageHandler"/>: boot auto-adopt (a pre-populated store leaves the coordinator
+    /// signed in with no network I/O), sign-in persistence (the device flow's credential is written to the
+    /// store), sign-out (the store is wiped), and reactive refresh (the refresh grant rotates the stored
+    /// credential). No token is asserted into a log surface.
+    /// </summary>
+    public class GodotAccountAuthTests
+    {
+        const string AsBaseUrl = "https://ai-game.dev";
+        static readonly DateTimeOffset T0 = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        static readonly DateTime T0Dt = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        // --- Boot auto-adopt (the zero-button rule) ---
+
+        [Fact]
+        public void EmptyStore_NotSignedIn()
+        {
+            using var tmp = new TempDir();
+            using var account = MakeAccount(tmp, new ThrowingHandler());
+
+            Assert.False(account.IsSignedIn);
+        }
+
+        [Fact]
+        public async Task EmptyStore_AccessTokenProvider_ReturnsNull()
+        {
+            using var tmp = new TempDir();
+            using var account = MakeAccount(tmp, new ThrowingHandler());
+
+            var token = await account.AccessTokenProvider();
+
+            Assert.Null(token);
+        }
+
+        [Fact]
+        public async Task PrePopulatedStore_AutoAdopts_WithoutNetworkIo()
+        {
+            using var tmp = new TempDir();
+            // ExpiresAt = null → no proactive refresh is due, so the provider must return the stored token
+            // WITHOUT touching the network (the ThrowingHandler proves it).
+            Store(tmp).Write(new MachineCredentials
+            {
+                AccessToken = "stored-access",
+                RefreshToken = "stored-refresh",
+                ExpiresAt = null,
+                ServerTarget = AsBaseUrl,
+            });
+
+            using var account = MakeAccount(tmp, new ThrowingHandler());
+
+            Assert.True(account.IsSignedIn);
+            Assert.Equal("stored-access", await account.AccessTokenProvider());
+        }
+
+        // --- Sign-in persistence (device flow → machine store) ---
+
+        [Fact]
+        public async Task SignInAsync_Success_PersistsCredential_AndAnotherCoordinatorAutoAdopts()
+        {
+            using var tmp = new TempDir();
+            using var account = MakeAccount(tmp, new ThrowingHandler());
+
+            var flow = MakeFlow(new DeviceFlowHandler(
+                Authorize("USER-1", "dev-1"),
+                Token(access: "acc-1", refresh: "ref-1", expiresIn: 3600)));
+
+            var ok = await account.SignInAsync(flow, AsBaseUrl);
+
+            Assert.True(ok);
+            Assert.True(account.IsSignedIn);
+
+            var persisted = Store(tmp).Read();
+            Assert.NotNull(persisted);
+            Assert.Equal("acc-1", persisted!.AccessToken);
+            Assert.Equal("ref-1", persisted.RefreshToken);
+            Assert.Equal(AsBaseUrl, persisted.ServerTarget);
+            Assert.Equal(T0.AddSeconds(3600), persisted.ExpiresAt);
+
+            // A fresh coordinator over the SAME store auto-adopts (the once-per-machine sign-in seen by a
+            // second editor session / another engine).
+            using var account2 = MakeAccount(tmp, new ThrowingHandler());
+            Assert.True(account2.IsSignedIn);
+        }
+
+        [Fact]
+        public async Task SignInAsync_Denied_DoesNotPersist()
+        {
+            using var tmp = new TempDir();
+            using var account = MakeAccount(tmp, new ThrowingHandler());
+
+            var flow = MakeFlow(new DeviceFlowHandler(
+                Authorize("USER-1", "dev-1"),
+                Error("access_denied")));
+
+            var ok = await account.SignInAsync(flow, AsBaseUrl);
+
+            Assert.False(ok);
+            Assert.False(account.IsSignedIn);
+            Assert.False(Store(tmp).Exists);
+        }
+
+        // --- Sign-out ---
+
+        [Fact]
+        public void SignOut_WipesStore()
+        {
+            using var tmp = new TempDir();
+            Store(tmp).Write(new MachineCredentials { AccessToken = "a", RefreshToken = "r", ServerTarget = AsBaseUrl });
+
+            using var account = MakeAccount(tmp, new ThrowingHandler());
+            Assert.True(account.IsSignedIn);
+
+            account.SignOut();
+
+            Assert.False(account.IsSignedIn);
+            Assert.False(Store(tmp).Exists);
+            using var account2 = MakeAccount(tmp, new ThrowingHandler());
+            Assert.False(account2.IsSignedIn);
+        }
+
+        // --- Reactive refresh rotates the stored credential ---
+
+        [Fact]
+        public async Task RefreshAsync_RotatesStoredCredential()
+        {
+            using var tmp = new TempDir();
+            Store(tmp).Write(new MachineCredentials
+            {
+                AccessToken = "acc-old",
+                RefreshToken = "ref-old",
+                ExpiresAt = T0.AddSeconds(-10), // already expired
+                ServerTarget = AsBaseUrl,
+            });
+
+            // The refresh grant returns a fresh token pair.
+            using var account = MakeAccount(tmp, new SingleResponseHandler(
+                TokenJson(access: "acc-new", refresh: "ref-new", expiresIn: 3600)));
+
+            var refreshed = await account.RefreshAsync();
+
+            Assert.True(refreshed);
+            Assert.True(account.IsSignedIn);
+
+            var persisted = Store(tmp).Read();
+            Assert.Equal("acc-new", persisted!.AccessToken);
+            Assert.Equal("ref-new", persisted.RefreshToken);
+            // ServerTarget is preserved across a rotation (MachineCredentialStore.Rotate keeps identity fields).
+            Assert.Equal(AsBaseUrl, persisted.ServerTarget);
+        }
+
+        [Fact]
+        public async Task RefreshAsync_ServerRejects_FailsClosed_KeepsOldCredential()
+        {
+            using var tmp = new TempDir();
+            Store(tmp).Write(new MachineCredentials
+            {
+                AccessToken = "acc-old",
+                RefreshToken = "ref-old",
+                ExpiresAt = T0.AddSeconds(-10),
+                ServerTarget = AsBaseUrl,
+            });
+
+            using var account = MakeAccount(tmp, new SingleResponseHandler(
+                () => JsonResponse(HttpStatusCode.BadRequest, "{ \"error\": \"invalid_grant\" }")));
+
+            var refreshed = await account.RefreshAsync();
+
+            Assert.False(refreshed);
+        }
+
+        // --- helpers ---
+
+        static MachineCredentialStore Store(TempDir tmp) => new(tmp.Path);
+
+        static GodotAccountAuth MakeAccount(TempDir tmp, HttpMessageHandler handler)
+            => new(
+                asBaseUrlProvider: () => AsBaseUrl,
+                store: new MachineCredentialStore(tmp.Path),
+                service: new GodotDeviceAuthService(new HttpClient(handler)),
+                clock: () => T0);
+
+        static GodotDeviceAuthFlow MakeFlow(HttpMessageHandler handler)
+            => new(
+                new GodotDeviceAuthService(new HttpClient(handler)),
+                delay: (_, _) => Task.CompletedTask,
+                utcNow: () => T0Dt);
+
+        static Func<HttpResponseMessage> Authorize(string userCode, string deviceCode)
+            => () => JsonResponse(HttpStatusCode.OK, $$"""
+                {
+                  "device_code": "{{deviceCode}}",
+                  "user_code": "{{userCode}}",
+                  "verification_uri": "https://ai-game.dev/verify",
+                  "verification_uri_complete": "https://ai-game.dev/verify?code={{userCode}}",
+                  "expires_in": 600,
+                  "interval": 5
+                }
+                """);
+
+        static Func<HttpResponseMessage> Token(string access, string refresh, int expiresIn)
+            => () => JsonResponse(HttpStatusCode.OK, TokenJsonText(access, refresh, expiresIn));
+
+        static Func<HttpResponseMessage> Error(string error)
+            => () => JsonResponse(HttpStatusCode.BadRequest, $"{{ \"error\": \"{error}\" }}");
+
+        static Func<HttpResponseMessage> TokenJson(string access, string refresh, int expiresIn)
+            => () => JsonResponse(HttpStatusCode.OK, TokenJsonText(access, refresh, expiresIn));
+
+        static string TokenJsonText(string access, string refresh, int expiresIn) => $$"""
+            {
+              "access_token": "{{access}}",
+              "refresh_token": "{{refresh}}",
+              "token_type": "Bearer",
+              "expires_in": {{expiresIn}},
+              "scope": "mcp:plugin"
+            }
+            """;
+
+        static HttpResponseMessage JsonResponse(HttpStatusCode code, string json)
+            => new(code) { Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json") };
+
+        /// <summary>A unique temp directory, deleted on dispose — the isolated machine-store root per test.</summary>
+        sealed class TempDir : IDisposable
+        {
+            public string Path { get; } = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(), "godot-mcp-acct-" + Guid.NewGuid().ToString("N"));
+
+            public void Dispose()
+            {
+                try { if (Directory.Exists(Path)) Directory.Delete(Path, recursive: true); }
+                catch { /* best-effort test cleanup */ }
+            }
+        }
+
+        /// <summary>Device flow handler: first request (device_authorization) → authorize; each token POST → token.</summary>
+        sealed class DeviceFlowHandler : HttpMessageHandler
+        {
+            readonly Func<HttpResponseMessage> _authorize;
+            readonly Queue<Func<HttpResponseMessage>> _token;
+
+            public DeviceFlowHandler(Func<HttpResponseMessage> authorize, params Func<HttpResponseMessage>[] token)
+            {
+                _authorize = authorize;
+                _token = new Queue<Func<HttpResponseMessage>>(token);
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var path = request.RequestUri!.AbsolutePath;
+                var responder = path.EndsWith("/oauth/token", StringComparison.Ordinal)
+                    ? (_token.Count > 0 ? _token.Dequeue() : _token.Peek())
+                    : _authorize;
+                return Task.FromResult(responder());
+            }
+        }
+
+        /// <summary>Responds to every request (the refresh POST) with one scripted response.</summary>
+        sealed class SingleResponseHandler : HttpMessageHandler
+        {
+            readonly Func<HttpResponseMessage> _respond;
+            public SingleResponseHandler(Func<HttpResponseMessage> respond) => _respond = respond;
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+                => Task.FromResult(_respond());
+        }
+
+        /// <summary>Throws on any request — proves a code path performs no network I/O.</summary>
+        sealed class ThrowingHandler : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+                => throw new InvalidOperationException("unexpected network call: " + request.RequestUri);
+        }
+    }
+}

--- a/Godot-MCP.Tests/GodotDeviceAuthFlowTests.cs
+++ b/Godot-MCP.Tests/GodotDeviceAuthFlowTests.cs
@@ -20,38 +20,48 @@ using Xunit;
 namespace com.IvanMurzak.Godot.MCP.Tests
 {
     /// <summary>
-    /// Covers the pure-managed cloud device-code auth core (<see cref="GodotDeviceAuthFlow"/> +
+    /// Covers the pure-managed RFC 8628 device-code auth core (<see cref="GodotDeviceAuthFlow"/> +
     /// <see cref="GodotDeviceAuthService"/>) with a scripted <see cref="HttpMessageHandler"/> and an
     /// injected no-op delay + clock so the polling loop runs instantly (never the real 5s interval).
+    /// The transport is the ai-game.dev alias: <c>POST /oauth/device_authorization</c> (form
+    /// <c>client_id</c>+<c>scope</c>) then poll <c>POST /oauth/token</c> (device-code grant) → access +
+    /// rotating refresh token + expiry.
     ///
     /// <para>
-    /// SECURITY assertion threaded through the suite: the issued access token must NEVER appear in any
+    /// SECURITY assertion threaded through the suite: the issued access/refresh token must NEVER appear in any
     /// flow <see cref="GodotDeviceAuthFlow.ErrorMessage"/>, <see cref="GodotDeviceAuthFlow.UserCode"/>, or
-    /// the verification URL. The token is observable ONLY as the <c>StartAsync</c> return value.
+    /// the verification URL. The secrets are observable ONLY as the <c>AuthorizeAsync</c>/<c>StartAsync</c>
+    /// return value.
     /// </para>
     /// </summary>
     public class GodotDeviceAuthFlowTests
     {
-        const string CloudBaseUrl = "https://ai-game.dev";
+        const string AsBaseUrl = "https://ai-game.dev";
         const string AccessToken = "super-secret-access-token-value";
+        const string RefreshToken = "super-secret-refresh-token-value";
 
-        // --- Happy path: issuance + immediate token ---
+        // --- Happy path: issuance + immediate token, full credential surfaced ---
 
         [Fact]
-        public async Task StartAsync_ImmediateToken_ReachesAuthorized_AndReturnsToken()
+        public async Task AuthorizeAsync_ImmediateToken_ReachesAuthorized_AndReturnsFullCredential()
         {
             var handler = new ScriptedHandler(
                 AuthorizeOk(userCode: "WXYZ-1234"),
-                TokenOk(AccessToken));
+                TokenOk(AccessToken, RefreshToken, expiresIn: 3600));
 
             var (flow, states) = MakeFlow(handler);
 
-            var token = await flow.StartAsync(CloudBaseUrl, "Godot Editor");
+            var result = await flow.AuthorizeAsync(AsBaseUrl);
 
-            Assert.Equal(AccessToken, token);
+            Assert.NotNull(result);
+            Assert.Equal(AccessToken, result!.AccessToken);
+            Assert.Equal(RefreshToken, result.RefreshToken);
+            // FixedClock is t0 = 2026-01-01T00:00:00Z; expires_in 3600 → t0 + 1h.
+            Assert.Equal(new DateTimeOffset(2026, 1, 1, 1, 0, 0, TimeSpan.Zero), result.ExpiresAt);
+
             Assert.Equal(GodotDeviceAuthFlowState.Authorized, flow.State);
             Assert.Equal("WXYZ-1234", flow.UserCode);
-            Assert.Equal($"{CloudBaseUrl}/verify?code=WXYZ-1234", flow.VerificationUriComplete);
+            Assert.Equal($"{AsBaseUrl}/verify?code=WXYZ-1234", flow.VerificationUriComplete);
 
             // State events fire in order: Initiating -> WaitingForUser -> Polling -> Authorized.
             Assert.Equal(new[]
@@ -62,68 +72,107 @@ namespace com.IvanMurzak.Godot.MCP.Tests
                 GodotDeviceAuthFlowState.Authorized
             }, states);
 
-            AssertTokenNotLeaked(flow);
+            AssertSecretsNotLeaked(flow);
         }
 
         [Fact]
-        public async Task InitiateDeviceAuth_ParsesAllFields()
+        public async Task StartAsync_ImmediateToken_ReturnsAccessTokenOnly()
+        {
+            var handler = new ScriptedHandler(AuthorizeOk(), TokenOk(AccessToken, RefreshToken));
+            var (flow, _) = MakeFlow(handler);
+
+            var token = await flow.StartAsync(AsBaseUrl, "Godot Editor");
+
+            Assert.Equal(AccessToken, token);
+            Assert.Equal(GodotDeviceAuthFlowState.Authorized, flow.State);
+        }
+
+        // --- The RFC 8628 request shape: form-encoded client_id + scope, device-code grant ---
+
+        [Fact]
+        public async Task AuthorizeAsync_SendsRfc8628FormFields()
+        {
+            var handler = new ScriptedHandler(
+                AuthorizeOk(deviceCode: "dev-code-123"),
+                TokenOk(AccessToken, RefreshToken));
+            var (flow, _) = MakeFlow(handler);
+
+            await flow.AuthorizeAsync(AsBaseUrl);
+
+            // Authorize request: POST /oauth/device_authorization with client_id + scope=mcp:plugin.
+            var authorize = handler.Requests[0];
+            Assert.EndsWith("/oauth/device_authorization", authorize.Path);
+            Assert.Contains($"client_id={GodotDeviceAuthFlow.DefaultClientId}", authorize.Body);
+            Assert.Contains("scope=mcp%3Aplugin", authorize.Body); // "mcp:plugin" url-encoded
+
+            // Token request: POST /oauth/token with the device-code grant + same client_id + device_code.
+            var token = handler.Requests[1];
+            Assert.EndsWith("/oauth/token", token.Path);
+            Assert.Contains("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code", token.Body);
+            Assert.Contains("device_code=dev-code-123", token.Body);
+            Assert.Contains($"client_id={GodotDeviceAuthFlow.DefaultClientId}", token.Body);
+        }
+
+        [Fact]
+        public async Task RequestDeviceAuthorization_ParsesAllFields()
         {
             var handler = new ScriptedHandler(
                 AuthorizeOk(userCode: "AAAA-BBBB", deviceCode: "dev-code-123", interval: 5, expiresIn: 600),
-                TokenOk(AccessToken));
+                TokenOk(AccessToken, RefreshToken));
 
             var service = new GodotDeviceAuthService(new HttpClient(handler));
-            var response = await service.InitiateDeviceAuthAsync(CloudBaseUrl, "Godot Editor");
+            var response = await service.RequestDeviceAuthorizationAsync(
+                AsBaseUrl, GodotDeviceAuthFlow.DefaultClientId, GodotDeviceAuthFlow.PluginScope);
 
             Assert.Equal("dev-code-123", response.DeviceCode);
             Assert.Equal("AAAA-BBBB", response.UserCode);
             Assert.Equal(5, response.Interval);
             Assert.Equal(600, response.ExpiresIn);
-            Assert.Equal($"{CloudBaseUrl}/verify?code=AAAA-BBBB", response.VerificationUriComplete);
+            Assert.Equal($"{AsBaseUrl}/verify?code=AAAA-BBBB", response.VerificationUriComplete);
         }
 
         // --- authorization_pending keeps polling, then succeeds ---
 
         [Fact]
-        public async Task StartAsync_PendingThenToken_KeepsPolling_ThenAuthorized()
+        public async Task AuthorizeAsync_PendingThenToken_KeepsPolling_ThenAuthorized()
         {
             var handler = new ScriptedHandler(
                 AuthorizeOk(),
                 TokenError("authorization_pending"),
                 TokenError("authorization_pending"),
-                TokenOk(AccessToken));
+                TokenOk(AccessToken, RefreshToken));
 
             var (flow, _) = MakeFlow(handler);
 
-            var token = await flow.StartAsync(CloudBaseUrl);
+            var result = await flow.AuthorizeAsync(AsBaseUrl);
 
-            Assert.Equal(AccessToken, token);
+            Assert.Equal(AccessToken, result!.AccessToken);
             Assert.Equal(GodotDeviceAuthFlowState.Authorized, flow.State);
             // 1 authorize + 3 token polls.
             Assert.Equal(4, handler.RequestCount);
-            AssertTokenNotLeaked(flow);
+            AssertSecretsNotLeaked(flow);
         }
 
         // --- slow_down backs the interval off ---
 
         [Fact]
-        public async Task StartAsync_SlowDown_BacksOffInterval()
+        public async Task AuthorizeAsync_SlowDown_BacksOffInterval()
         {
             var delays = new List<TimeSpan>();
             var handler = new ScriptedHandler(
                 AuthorizeOk(interval: 5),
                 TokenError("slow_down"),
                 TokenError("slow_down"),
-                TokenOk(AccessToken));
+                TokenOk(AccessToken, RefreshToken));
 
             var flow = new GodotDeviceAuthFlow(
                 new GodotDeviceAuthService(new HttpClient(handler)),
                 delay: (ts, _) => { delays.Add(ts); return Task.CompletedTask; },
                 utcNow: FixedClock());
 
-            var token = await flow.StartAsync(CloudBaseUrl);
+            var result = await flow.AuthorizeAsync(AsBaseUrl);
 
-            Assert.Equal(AccessToken, token);
+            Assert.Equal(AccessToken, result!.AccessToken);
             // Interval starts at 5s, +5 per slow_down (capped at 30): poll1=5, poll2=10, poll3=15.
             Assert.Equal(3, delays.Count);
             Assert.Equal(TimeSpan.FromSeconds(5), delays[0]);
@@ -132,21 +181,21 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         }
 
         [Fact]
-        public async Task StartAsync_SlowDown_IntervalCapsAtMax()
+        public async Task AuthorizeAsync_SlowDown_IntervalCapsAtMax()
         {
             var delays = new List<TimeSpan>();
             // 6 slow_downs would push 5 -> 35 uncapped; the cap holds it at 30.
             var responses = new List<Func<HttpResponseMessage>> { AuthorizeOk(interval: 5) };
             for (var i = 0; i < 6; i++)
                 responses.Add(TokenError("slow_down"));
-            responses.Add(TokenOk(AccessToken));
+            responses.Add(TokenOk(AccessToken, RefreshToken));
 
             var flow = new GodotDeviceAuthFlow(
                 new GodotDeviceAuthService(new HttpClient(new ScriptedHandler(responses.ToArray()))),
                 delay: (ts, _) => { delays.Add(ts); return Task.CompletedTask; },
                 utcNow: FixedClock());
 
-            await flow.StartAsync(CloudBaseUrl);
+            await flow.AuthorizeAsync(AsBaseUrl);
 
             Assert.Equal(TimeSpan.FromSeconds(GodotDeviceAuthFlow.MaxIntervalSeconds), delays[^1]);
             Assert.All(delays, d => Assert.True(d <= TimeSpan.FromSeconds(GodotDeviceAuthFlow.MaxIntervalSeconds)));
@@ -155,37 +204,37 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         // --- access_denied -> Failed ---
 
         [Fact]
-        public async Task StartAsync_AccessDenied_ReachesFailed()
+        public async Task AuthorizeAsync_AccessDenied_ReachesFailed()
         {
             var handler = new ScriptedHandler(AuthorizeOk(), TokenError("access_denied"));
             var (flow, _) = MakeFlow(handler);
 
-            var token = await flow.StartAsync(CloudBaseUrl);
+            var result = await flow.AuthorizeAsync(AsBaseUrl);
 
-            Assert.Null(token);
+            Assert.Null(result);
             Assert.Equal(GodotDeviceAuthFlowState.Failed, flow.State);
             Assert.False(string.IsNullOrEmpty(flow.ErrorMessage));
-            AssertTokenNotLeaked(flow);
+            AssertSecretsNotLeaked(flow);
         }
 
         // --- expired_token -> Expired ---
 
         [Fact]
-        public async Task StartAsync_ExpiredToken_ReachesExpired()
+        public async Task AuthorizeAsync_ExpiredToken_ReachesExpired()
         {
             var handler = new ScriptedHandler(AuthorizeOk(), TokenError("expired_token"));
             var (flow, _) = MakeFlow(handler);
 
-            var token = await flow.StartAsync(CloudBaseUrl);
+            var result = await flow.AuthorizeAsync(AsBaseUrl);
 
-            Assert.Null(token);
+            Assert.Null(result);
             Assert.Equal(GodotDeviceAuthFlowState.Expired, flow.State);
         }
 
         // --- deadline reached (expires_in elapses) -> Expired ---
 
         [Fact]
-        public async Task StartAsync_DeadlineElapses_ReachesExpired()
+        public async Task AuthorizeAsync_DeadlineElapses_ReachesExpired()
         {
             // expires_in = 10s; the fake clock jumps 20s on the first now() AFTER the deadline is computed,
             // so the while-loop condition is false before any poll. Pending response is present but unused.
@@ -201,9 +250,9 @@ namespace com.IvanMurzak.Godot.MCP.Tests
                 delay: (_, _) => Task.CompletedTask,
                 utcNow: clock);
 
-            var token = await flow.StartAsync(CloudBaseUrl);
+            var result = await flow.AuthorizeAsync(AsBaseUrl);
 
-            Assert.Null(token);
+            Assert.Null(result);
             Assert.Equal(GodotDeviceAuthFlowState.Expired, flow.State);
         }
 
@@ -226,17 +275,17 @@ namespace com.IvanMurzak.Godot.MCP.Tests
                 utcNow: FixedClock());
             flowRef = flow;
 
-            var token = await flow.StartAsync(CloudBaseUrl);
+            var result = await flow.AuthorizeAsync(AsBaseUrl);
 
-            Assert.Null(token);
+            Assert.Null(result);
             Assert.Equal(GodotDeviceAuthFlowState.Cancelled, flow.State);
-            AssertTokenNotLeaked(flow);
+            AssertSecretsNotLeaked(flow);
         }
 
         // --- HTTP failure on authorize -> Failed, no token in message ---
 
         [Fact]
-        public async Task StartAsync_AuthorizeHttp500_ReachesFailed_NoTokenLeak()
+        public async Task AuthorizeAsync_AuthorizeHttp500_ReachesFailed_NoTokenLeak()
         {
             var handler = new ScriptedHandler(() => new HttpResponseMessage(HttpStatusCode.InternalServerError)
             {
@@ -244,31 +293,32 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             });
             var (flow, _) = MakeFlow(handler);
 
-            var token = await flow.StartAsync(CloudBaseUrl);
+            var result = await flow.AuthorizeAsync(AsBaseUrl);
 
-            Assert.Null(token);
+            Assert.Null(result);
             Assert.Equal(GodotDeviceAuthFlowState.Failed, flow.State);
-            AssertTokenNotLeaked(flow);
+            AssertSecretsNotLeaked(flow);
         }
 
-        // --- Token is never exposed anywhere except the return value ---
+        // --- Secrets are never exposed anywhere except the return value ---
 
         [Fact]
-        public async Task StartAsync_Authorized_TokenNotInAnyStringSurface()
+        public async Task AuthorizeAsync_Authorized_SecretsNotInAnyStringSurface()
         {
-            var handler = new ScriptedHandler(AuthorizeOk(userCode: "CODE-9999"), TokenOk(AccessToken));
+            var handler = new ScriptedHandler(AuthorizeOk(userCode: "CODE-9999"), TokenOk(AccessToken, RefreshToken));
             var (flow, states) = MakeFlow(handler);
 
-            var token = await flow.StartAsync(CloudBaseUrl);
-            Assert.Equal(AccessToken, token);
+            var result = await flow.AuthorizeAsync(AsBaseUrl);
+            Assert.Equal(AccessToken, result!.AccessToken);
 
-            // Token must not appear in UserCode / VerificationUriComplete / ErrorMessage, nor in any
+            // Neither secret must appear in UserCode / VerificationUriComplete / ErrorMessage, nor in any
             // pure-managed status message the UI would render for the observed states.
-            AssertTokenNotLeaked(flow);
+            AssertSecretsNotLeaked(flow);
             foreach (var s in states)
             {
                 var msg = UI.ConnectionPanelView.CloudAuthStatusMessage(s, flow.UserCode, flow.ErrorMessage);
                 Assert.DoesNotContain(AccessToken, msg, StringComparison.Ordinal);
+                Assert.DoesNotContain(RefreshToken, msg, StringComparison.Ordinal);
             }
         }
 
@@ -293,11 +343,14 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             return () => t0;
         }
 
-        static void AssertTokenNotLeaked(GodotDeviceAuthFlow flow)
+        static void AssertSecretsNotLeaked(GodotDeviceAuthFlow flow)
         {
-            Assert.True(string.IsNullOrEmpty(flow.UserCode) || !flow.UserCode!.Contains(AccessToken, StringComparison.Ordinal));
-            Assert.True(string.IsNullOrEmpty(flow.ErrorMessage) || !flow.ErrorMessage!.Contains(AccessToken, StringComparison.Ordinal));
-            Assert.True(string.IsNullOrEmpty(flow.VerificationUriComplete) || !flow.VerificationUriComplete!.Contains(AccessToken, StringComparison.Ordinal));
+            foreach (var secret in new[] { AccessToken, RefreshToken })
+            {
+                Assert.True(string.IsNullOrEmpty(flow.UserCode) || !flow.UserCode!.Contains(secret, StringComparison.Ordinal));
+                Assert.True(string.IsNullOrEmpty(flow.ErrorMessage) || !flow.ErrorMessage!.Contains(secret, StringComparison.Ordinal));
+                Assert.True(string.IsNullOrEmpty(flow.VerificationUriComplete) || !flow.VerificationUriComplete!.Contains(secret, StringComparison.Ordinal));
+            }
         }
 
         static Func<HttpResponseMessage> AuthorizeOk(
@@ -313,9 +366,15 @@ namespace com.IvanMurzak.Godot.MCP.Tests
                 }
                 """);
 
-        static Func<HttpResponseMessage> TokenOk(string accessToken)
+        static Func<HttpResponseMessage> TokenOk(string accessToken, string refreshToken, int expiresIn = 3600)
             => () => JsonResponse(HttpStatusCode.OK, $$"""
-                { "access_token": "{{accessToken}}", "token_type": "Bearer" }
+                {
+                  "access_token": "{{accessToken}}",
+                  "refresh_token": "{{refreshToken}}",
+                  "token_type": "Bearer",
+                  "expires_in": {{expiresIn}},
+                  "scope": "mcp:plugin"
+                }
                 """);
 
         static Func<HttpResponseMessage> TokenError(string error)
@@ -327,9 +386,10 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             => new(code) { Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json") };
 
         /// <summary>
-        /// A test <see cref="HttpMessageHandler"/> that replays a scripted sequence of responses. The first
-        /// scripted response answers the authorize POST; each subsequent one answers a token POST. An
-        /// optional <see cref="OnTokenRequest"/> hook fires before each token response (used to cancel mid-poll).
+        /// A test <see cref="HttpMessageHandler"/> that replays a scripted sequence of responses and records
+        /// each request's path + form body. The first scripted response answers the device-authorization POST;
+        /// each subsequent one answers a token POST. An optional <see cref="OnTokenRequest"/> hook fires before
+        /// each token response (used to cancel mid-poll).
         /// </summary>
         sealed class ScriptedHandler : HttpMessageHandler
         {
@@ -342,22 +402,29 @@ namespace com.IvanMurzak.Godot.MCP.Tests
 
             public int RequestCount { get; private set; }
 
+            /// <summary>The recorded (absolute path, form body) of every request, in order.</summary>
+            public List<(string Path, string Body)> Requests { get; } = new();
+
             /// <summary>Invoked just before each token-endpoint response is produced (authorize is skipped).</summary>
             public Action? OnTokenRequest { get; set; }
 
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 RequestCount++;
 
-                var isToken = request.RequestUri!.AbsolutePath.EndsWith("/token", StringComparison.Ordinal);
+                var path = request.RequestUri!.AbsolutePath;
+                var body = request.Content != null ? await request.Content.ReadAsStringAsync(cancellationToken) : "";
+                Requests.Add((path, body));
+
+                var isToken = path.EndsWith("/oauth/token", StringComparison.Ordinal);
                 if (isToken)
                     OnTokenRequest?.Invoke();
 
                 cancellationToken.ThrowIfCancellationRequested();
 
                 var next = _responses.Count > 0 ? _responses.Dequeue() : (() => JsonResponse(HttpStatusCode.BadRequest, "{ \"error\": \"authorization_pending\" }"));
-                return Task.FromResult(next());
+                return next();
             }
         }
     }

--- a/Godot-MCP.Tests/GodotTokenRefresherTests.cs
+++ b/Godot-MCP.Tests/GodotTokenRefresherTests.cs
@@ -1,0 +1,166 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.Godot.MCP.Connection;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Covers <see cref="GodotTokenRefresher"/> — the Godot <c>ITokenRefresher</c> that exchanges a refresh
+    /// token for a fresh access token at <c>POST /oauth/token</c> (<c>grant_type=refresh_token</c>). Verifies
+    /// the success mapping (access + rotated refresh + expiry), the fail-closed behaviour (error body / HTTP
+    /// fault → <c>Failure</c>, never a fabricated token), the RFC-6749 form shape, and the server-target →
+    /// AS-base resolution (a hub <c>/mcp</c> suffix is stripped). Never asserts a token into a log surface.
+    /// </summary>
+    public class GodotTokenRefresherTests
+    {
+        const string AsBaseUrl = "https://ai-game.dev";
+        const string NewAccess = "fresh-access-token";
+        const string NewRefresh = "rotated-refresh-token";
+        static readonly DateTimeOffset T0 = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        static GodotTokenRefresher MakeRefresher(RecordingHandler handler, Func<string>? defaultBase = null)
+            => new(
+                new GodotDeviceAuthService(new HttpClient(handler)),
+                defaultBase ?? (() => AsBaseUrl),
+                clientId: GodotDeviceAuthFlow.DefaultClientId,
+                clock: () => T0);
+
+        [Fact]
+        public async Task RefreshAsync_Success_MapsAccessRefreshAndExpiry()
+        {
+            var handler = new RecordingHandler(TokenOk(NewAccess, NewRefresh, expiresIn: 3600));
+            var refresher = MakeRefresher(handler);
+
+            var result = await refresher.RefreshAsync("old-refresh", serverTarget: null);
+
+            Assert.True(result.Succeeded);
+            Assert.Equal(NewAccess, result.AccessToken);
+            Assert.Equal(NewRefresh, result.RefreshToken);
+            Assert.Equal(T0.AddSeconds(3600), result.ExpiresAt);
+        }
+
+        [Fact]
+        public async Task RefreshAsync_SendsRefreshTokenGrantForm()
+        {
+            var handler = new RecordingHandler(TokenOk(NewAccess, NewRefresh));
+            var refresher = MakeRefresher(handler);
+
+            await refresher.RefreshAsync("old-refresh", serverTarget: null);
+
+            Assert.Equal($"{AsBaseUrl}/oauth/token", handler.LastRequestUri);
+            Assert.Contains("grant_type=refresh_token", handler.LastBody);
+            Assert.Contains("refresh_token=old-refresh", handler.LastBody);
+            Assert.Contains($"client_id={GodotDeviceAuthFlow.DefaultClientId}", handler.LastBody);
+        }
+
+        [Fact]
+        public async Task RefreshAsync_ServerTargetHubUrl_StripsMcpSuffixForAsBase()
+        {
+            var handler = new RecordingHandler(TokenOk(NewAccess, NewRefresh));
+            // The default base is intentionally different, to prove serverTarget wins.
+            var refresher = MakeRefresher(handler, defaultBase: () => "https://should-not-be-used.example");
+
+            await refresher.RefreshAsync("old-refresh", serverTarget: "https://ai-game.dev/mcp");
+
+            Assert.Equal($"{AsBaseUrl}/oauth/token", handler.LastRequestUri);
+        }
+
+        [Fact]
+        public async Task RefreshAsync_NullServerTarget_UsesDefaultBase()
+        {
+            var handler = new RecordingHandler(TokenOk(NewAccess, NewRefresh));
+            var refresher = MakeRefresher(handler, defaultBase: () => "https://local-as.example");
+
+            await refresher.RefreshAsync("old-refresh", serverTarget: null);
+
+            Assert.Equal("https://local-as.example/oauth/token", handler.LastRequestUri);
+        }
+
+        [Fact]
+        public async Task RefreshAsync_ErrorBody_FailsClosedWithReason()
+        {
+            var handler = new RecordingHandler(() => JsonResponse(HttpStatusCode.BadRequest,
+                "{ \"error\": \"invalid_grant\", \"error_description\": \"refresh token expired\" }"));
+            var refresher = MakeRefresher(handler);
+
+            var result = await refresher.RefreshAsync("expired-refresh", serverTarget: null);
+
+            Assert.False(result.Succeeded);
+            Assert.Null(result.AccessToken);
+            Assert.Equal("invalid_grant", result.FailureReason);
+        }
+
+        [Fact]
+        public async Task RefreshAsync_HttpFault_FailsClosed()
+        {
+            var handler = new RecordingHandler(() => throw new HttpRequestException("connection refused"));
+            var refresher = MakeRefresher(handler);
+
+            var result = await refresher.RefreshAsync("some-refresh", serverTarget: null);
+
+            Assert.False(result.Succeeded);
+            Assert.Null(result.AccessToken);
+        }
+
+        [Fact]
+        public async Task RefreshAsync_Cancellation_Propagates()
+        {
+            var handler = new RecordingHandler(() => throw new OperationCanceledException());
+            var refresher = MakeRefresher(handler);
+
+            // A pre-canceled token makes HttpClient throw TaskCanceledException (a subclass); assert ANY
+            // OperationCanceledException so cancellation propagates rather than collapsing into a Failure.
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => refresher.RefreshAsync("some-refresh", serverTarget: null, new CancellationToken(canceled: true)));
+        }
+
+        // --- helpers ---
+
+        static Func<HttpResponseMessage> TokenOk(string accessToken, string refreshToken, int expiresIn = 3600)
+            => () => JsonResponse(HttpStatusCode.OK, $$"""
+                {
+                  "access_token": "{{accessToken}}",
+                  "refresh_token": "{{refreshToken}}",
+                  "token_type": "Bearer",
+                  "expires_in": {{expiresIn}},
+                  "scope": "mcp:plugin"
+                }
+                """);
+
+        static HttpResponseMessage JsonResponse(HttpStatusCode code, string json)
+            => new(code) { Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json") };
+
+        /// <summary>A handler that records the last request URI + body and returns (or throws) one scripted response.</summary>
+        sealed class RecordingHandler : HttpMessageHandler
+        {
+            readonly Func<HttpResponseMessage> _respond;
+
+            public RecordingHandler(Func<HttpResponseMessage> respond) => _respond = respond;
+
+            public string? LastRequestUri { get; private set; }
+            public string LastBody { get; private set; } = "";
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                LastRequestUri = request.RequestUri!.GetLeftPart(UriPartial.Path);
+                LastBody = request.Content != null ? await request.Content.ReadAsStringAsync(cancellationToken) : "";
+                return _respond();
+            }
+        }
+    }
+}

--- a/addons/godot_mcp/Editor/Connection/GodotAccountAuth.cs
+++ b/addons/godot_mcp/Editor/Connection/GodotAccountAuth.cs
@@ -1,0 +1,132 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// The Godot addon's ai-game.dev account-credential coordinator (mcp-authorize design 06, D12 — the
+    /// zero-button rule). It owns the shared machine credential store (<c>~/.ai-game-dev/credentials.json</c>)
+    /// through McpPlugin 7.0's <see cref="PluginCredentialProvider"/> and the Godot
+    /// <see cref="GodotTokenRefresher"/>, wiring the two device-flow endpoints (sign-in + refresh) into a
+    /// single seam the connection consumes.
+    ///
+    /// <para>Three behaviours:</para>
+    /// <list type="bullet">
+    ///   <item><b>Boot auto-adopt:</b> the machine store is read at construction. If a valid (or refreshable)
+    ///   credential is present the plugin is signed in with <b>zero UI interaction</b> — the connection
+    ///   presents its JWT and pairs on boot (the store is populated once per machine by a <c>godot-cli
+    ///   login</c>, an enrollment, or another engine).</item>
+    ///   <item><b>Sign-in (persist):</b> <see cref="SignInAsync"/> runs the device flow and persists the
+    ///   resulting credential into the machine store. (The in-editor "Sign in" button is wired to this by the
+    ///   ConnectionPanel UI flip in the follow-up PR; PR 2 delivers + unit-tests the capability.)</item>
+    ///   <item><b>Refresh:</b> <see cref="AccessTokenProvider"/> refreshes the token proactively before
+    ///   <c>exp</c> on every (re)connect; <see cref="RefreshAsync"/> refreshes reactively when the connection's
+    ///   3-strike authorization-rejected signal fires.</item>
+    /// </list>
+    ///
+    /// <para>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) so the whole store/adopt/refresh lifecycle is
+    /// unit-testable with a temp-directory <see cref="MachineCredentialStore"/> + a fake
+    /// <see cref="System.Net.Http.HttpMessageHandler"/>. Never logs token material.
+    /// </para>
+    /// </summary>
+    public sealed class GodotAccountAuth : IDisposable
+    {
+        readonly MachineCredentialStore _store;
+        readonly PluginCredentialProvider _provider;
+        readonly string _clientId;
+
+        /// <summary>
+        /// Construct the coordinator. <paramref name="asBaseUrlProvider"/> supplies the authorization-server
+        /// base URL for refreshes (read live so a <c>.env</c> cloud-URL override applies). The remaining
+        /// arguments are injectable seams for tests: a temp-directory <paramref name="store"/>, a fake-handler
+        /// <paramref name="service"/>, a deterministic <paramref name="clock"/>. Constructing this READS the
+        /// machine store (the auto-adopt), so a pre-existing credential leaves the coordinator
+        /// <see cref="IsSignedIn"/> immediately.
+        /// </summary>
+        public GodotAccountAuth(
+            Func<string> asBaseUrlProvider,
+            MachineCredentialStore? store = null,
+            GodotDeviceAuthService? service = null,
+            ILogger? logger = null,
+            string? clientId = null,
+            Func<DateTimeOffset>? clock = null)
+        {
+            if (asBaseUrlProvider == null)
+                throw new ArgumentNullException(nameof(asBaseUrlProvider));
+
+            _store = store ?? new MachineCredentialStore();
+            _clientId = string.IsNullOrEmpty(clientId) ? GodotDeviceAuthFlow.DefaultClientId : clientId!;
+            var refresher = new GodotTokenRefresher(
+                service ?? new GodotDeviceAuthService(), asBaseUrlProvider, _clientId, clock);
+
+            // Auto-adopt: PluginCredentialProvider reads the store at construction. No UI, no device flow.
+            _provider = new PluginCredentialProvider(_store, refresher, logger);
+        }
+
+        /// <summary>True when a usable machine-store credential is present (the zero-button signed-in state).</summary>
+        public bool IsSignedIn => _provider.IsSignedIn;
+
+        /// <summary>The account id (<c>sub</c>) the current credential resolves to, if known (diagnostic only).</summary>
+        public string? Subject => _provider.Subject;
+
+        /// <summary>
+        /// The <c>Func&lt;Task&lt;string?&gt;&gt;</c> to compose into the connection's credential provider. It
+        /// returns the current (proactively-refreshed) access token, or null when signed out — so a signed-out
+        /// machine transparently falls back to the connection's existing token resolution.
+        /// </summary>
+        public Func<Task<string?>> AccessTokenProvider => _provider.AsAccessTokenProvider();
+
+        /// <summary>
+        /// Refresh the access token now (driven by the connection's 3-strike authorization-rejected signal).
+        /// Returns true when a fresh token was persisted; false when refresh failed or is impossible (in which
+        /// case the provider has surfaced sign-in-required and the caller must NOT loop).
+        /// </summary>
+        public Task<bool> RefreshAsync(CancellationToken cancellationToken = default)
+            => _provider.RefreshAsync(cancellationToken);
+
+        /// <summary>
+        /// Run the device flow against <paramref name="asBaseUrl"/> via <paramref name="flow"/> and, on
+        /// success, persist the resulting credential into the machine store (D12). The caller owns the flow so
+        /// it can subscribe to <see cref="GodotDeviceAuthFlow.OnStateChanged"/> for the browser-open. Returns
+        /// true when a credential was adopted (signed in), false on any non-Authorized terminal state.
+        /// </summary>
+        public async Task<bool> SignInAsync(GodotDeviceAuthFlow flow, string asBaseUrl)
+        {
+            if (flow == null)
+                throw new ArgumentNullException(nameof(flow));
+
+            var result = await flow.AuthorizeAsync(asBaseUrl).ConfigureAwait(false);
+            if (result == null)
+                return false;
+
+            _provider.Adopt(new MachineCredentials
+            {
+                AccessToken = result.AccessToken,
+                RefreshToken = result.RefreshToken,
+                ExpiresAt = result.ExpiresAt,
+                ServerTarget = asBaseUrl,
+            });
+            return true;
+        }
+
+        /// <summary>Sign out: delete the stored credential and reset to signed-out.</summary>
+        public void SignOut() => _provider.SignOut();
+
+        public void Dispose() => _provider.Dispose();
+    }
+}

--- a/addons/godot_mcp/Editor/Connection/GodotDeviceAuthFlow.cs
+++ b/addons/godot_mcp/Editor/Connection/GodotDeviceAuthFlow.cs
@@ -59,6 +59,18 @@ namespace com.IvanMurzak.Godot.MCP.Connection
     /// </summary>
     public sealed class GodotDeviceAuthFlow
     {
+        /// <summary>
+        /// The public <c>client_id</c> the Godot editor plugin presents on the RFC 8628 device flow. The AS
+        /// (<c>/oauth/device_authorization</c>) requires a non-empty <c>client_id</c> but does not bind it to a
+        /// registered client; the SAME value MUST be replayed at the device-code token exchange and every
+        /// refresh (the AS rejects a mismatch with <c>invalid_grant</c>). Kept as a stable well-known
+        /// identifier so refresh continues to work across editor sessions.
+        /// </summary>
+        public const string DefaultClientId = "godot-mcp-plugin";
+
+        /// <summary>The scope the plugin requests — selects the ES256 hub JWT (<c>aud=urn:agd:hub</c>) + refresh token.</summary>
+        public const string PluginScope = "mcp:plugin";
+
         /// <summary>Minimum poll interval (seconds) the server's <c>interval</c> is clamped up to — the device-flow floor.</summary>
         public const int MinIntervalSeconds = 5;
 
@@ -107,11 +119,24 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
         /// <summary>
         /// Run the device flow against <paramref name="cloudBaseUrl"/>. Returns the issued access token on
-        /// success, or <c>null</c> on any non-Authorized terminal state. The token is the ONLY channel the
-        /// secret leaves through — it is never logged or placed in <see cref="ErrorMessage"/>. A second
-        /// call cancels any in-flight run first.
+        /// success, or <c>null</c> on any non-Authorized terminal state. This is the backward-compatible,
+        /// access-token-only projection of <see cref="AuthorizeAsync"/> (the refresh token + expiry are
+        /// dropped); the machine-store sign-in path uses <see cref="AuthorizeAsync"/> to capture them.
+        /// A second call cancels any in-flight run first. <paramref name="clientLabel"/> is retained for
+        /// call-site compatibility but is not part of the RFC 8628 request (which carries <c>client_id</c> +
+        /// <c>scope</c>, not a human label).
         /// </summary>
         public async Task<string?> StartAsync(string cloudBaseUrl, string? clientLabel = null)
+            => (await AuthorizeAsync(cloudBaseUrl).ConfigureAwait(false))?.AccessToken;
+
+        /// <summary>
+        /// Run the RFC 8628 device flow against <paramref name="asBaseUrl"/> end-to-end. Returns the full
+        /// <see cref="GodotDeviceAuthResult"/> (access token + rotating refresh token + expiry) on success, or
+        /// <c>null</c> on any non-Authorized terminal state. The secrets are the ONLY channel they leave
+        /// through — none is stored on this instance nor placed in <see cref="ErrorMessage"/>. A second call
+        /// cancels any in-flight run first.
+        /// </summary>
+        public async Task<GodotDeviceAuthResult?> AuthorizeAsync(string asBaseUrl)
         {
             Cancel();
             _cts = new CancellationTokenSource();
@@ -122,7 +147,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 SetState(GodotDeviceAuthFlowState.Initiating);
 
                 var authResponse = await _service
-                    .InitiateDeviceAuthAsync(cloudBaseUrl, clientLabel, ct)
+                    .RequestDeviceAuthorizationAsync(asBaseUrl, DefaultClientId, PluginScope, ct)
                     .ConfigureAwait(false);
 
                 UserCode = authResponse.UserCode;
@@ -140,15 +165,18 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                     await _delay(TimeSpan.FromSeconds(intervalSeconds), ct).ConfigureAwait(false);
 
                     var tokenResponse = await _service
-                        .PollDeviceTokenAsync(cloudBaseUrl, authResponse.DeviceCode, ct)
+                        .PollTokenAsync(asBaseUrl, authResponse.DeviceCode, DefaultClientId, ct)
                         .ConfigureAwait(false);
 
                     if (!string.IsNullOrEmpty(tokenResponse.AccessToken))
                     {
-                        // Reach the terminal state BEFORE returning the token, but never store the token
-                        // on this instance — it flows out only as the return value.
+                        // Reach the terminal state BEFORE returning the credential, but never store any
+                        // secret on this instance — it flows out only as the return value.
+                        var expiresAt = tokenResponse.ExpiresIn > 0
+                            ? new DateTimeOffset(_utcNow(), TimeSpan.Zero).AddSeconds(tokenResponse.ExpiresIn)
+                            : (DateTimeOffset?)null;
                         SetState(GodotDeviceAuthFlowState.Authorized);
-                        return tokenResponse.AccessToken;
+                        return new GodotDeviceAuthResult(tokenResponse.AccessToken!, tokenResponse.RefreshToken, expiresAt);
                     }
 
                     switch (tokenResponse.Error)

--- a/addons/godot_mcp/Editor/Connection/GodotDeviceAuthResult.cs
+++ b/addons/godot_mcp/Editor/Connection/GodotDeviceAuthResult.cs
@@ -1,0 +1,41 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// The credential material a successful device-authorization run produces: the ES256 access token, the
+    /// rotating refresh token, and the access token's absolute expiry. It is the ONLY channel the secrets
+    /// leave <see cref="GodotDeviceAuthFlow"/> through — a transient return value, NEVER stored on the flow
+    /// instance nor logged (the flow's <c>ErrorMessage</c>/<c>UserCode</c> stay non-secret). The caller
+    /// (<see cref="GodotAccountAuth"/>) immediately hands it to the machine credential store and lets it go
+    /// out of scope.
+    /// </summary>
+    public sealed class GodotDeviceAuthResult
+    {
+        /// <summary>The short-lived ES256 JWT access token (hub audience).</summary>
+        public string AccessToken { get; }
+
+        /// <summary>The rotating refresh token used to mint a new access token before <see cref="ExpiresAt"/>.</summary>
+        public string? RefreshToken { get; }
+
+        /// <summary>Absolute expiry of <see cref="AccessToken"/> (from the token response's <c>expires_in</c>), or null when unknown.</summary>
+        public DateTimeOffset? ExpiresAt { get; }
+
+        public GodotDeviceAuthResult(string accessToken, string? refreshToken, DateTimeOffset? expiresAt)
+        {
+            AccessToken = accessToken;
+            RefreshToken = refreshToken;
+            ExpiresAt = expiresAt;
+        }
+    }
+}

--- a/addons/godot_mcp/Editor/Connection/GodotDeviceAuthService.cs
+++ b/addons/godot_mcp/Editor/Connection/GodotDeviceAuthService.cs
@@ -9,8 +9,8 @@
 */
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
@@ -20,10 +20,26 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 {
     /// <summary>
     /// Stateless HTTP transport for the OAuth 2.0 device-authorization-grant ("device code") flow against
-    /// the cloud server's <c>/api/auth/device/*</c> endpoints. The Godot analog of Unity-MCP's
+    /// the ai-game.dev authorization server's <b>RFC 8628-conformant alias</b> — <c>/oauth/device_authorization</c>
+    /// + <c>/oauth/token</c> (mcp-authorize design 03 Flow B / 06). The Godot analog of Unity-MCP's
     /// <c>DeviceAuthService</c> — pure-managed (no Godot native types, no <c>#if TOOLS</c>), so it is
     /// unit-testable in the plain-xUnit <c>Godot-MCP.Tests</c> host with a mockable
     /// <see cref="HttpMessageHandler"/>.
+    ///
+    /// <para>
+    /// The AS surface (verified against <c>cloud/AI-Game-Dev-Server</c> <c>routers/oauth.py</c>):
+    /// <list type="bullet">
+    ///   <item><c>POST /oauth/device_authorization</c> — <c>application/x-www-form-urlencoded</c>
+    ///   <c>client_id</c> (REQUIRED) + <c>scope</c> (<c>mcp:plugin</c>) → the standard device-authorization
+    ///   document.</item>
+    ///   <item><c>POST /oauth/token</c> — the device-code URN grant (<c>grant_type</c> + <c>device_code</c> +
+    ///   <c>client_id</c>) polled until authorized, and the <c>refresh_token</c> grant. <c>scope=mcp:plugin</c>
+    ///   yields the ES256 hub JWT (<c>aud=urn:agd:hub</c>) + a rotating refresh token.</item>
+    /// </list>
+    /// The SAME <c>client_id</c> MUST be presented to the device-authorization request, the device-code token
+    /// exchange, AND every subsequent refresh — the AS binds the grant to it and rejects a mismatch with
+    /// <c>invalid_grant</c> (<c>oauth_token_service.grant_device_code</c> / <c>grant_refresh_token</c>).
+    /// </para>
     ///
     /// <para>
     /// The <see cref="HttpClient"/> is injected (default: a process-shared instance) so tests can
@@ -33,6 +49,12 @@ namespace com.IvanMurzak.Godot.MCP.Connection
     /// </summary>
     public sealed class GodotDeviceAuthService
     {
+        /// <summary>The RFC 8628 device-code grant type presented at <c>/oauth/token</c>.</summary>
+        public const string DeviceCodeGrantType = "urn:ietf:params:oauth:grant-type:device_code";
+
+        /// <summary>The refresh-token grant type presented at <c>/oauth/token</c>.</summary>
+        public const string RefreshTokenGrantType = "refresh_token";
+
         static readonly HttpClient SharedHttpClient = new();
 
         static readonly JsonSerializerOptions JsonOptions = new()
@@ -54,55 +76,82 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         }
 
         /// <summary>
-        /// POST <c>&lt;cloudBaseUrl&gt;/api/auth/device/authorize</c> with <c>{ "client_label": ... }</c>
-        /// to begin a device-authorization flow. Throws on a non-success HTTP status (the caller's flow
-        /// turns the exception into a Failed state).
+        /// POST <c>&lt;asBaseUrl&gt;/oauth/device_authorization</c> with the form
+        /// <c>client_id=&lt;clientId&gt;&amp;scope=&lt;scope&gt;</c> to begin a device-authorization flow.
+        /// Throws on a non-success HTTP status (the caller's flow turns the exception into a Failed state).
         /// </summary>
-        public async Task<DeviceAuthorizeResponse> InitiateDeviceAuthAsync(
-            string cloudBaseUrl, string? clientLabel, CancellationToken ct = default)
+        public async Task<DeviceAuthorizeResponse> RequestDeviceAuthorizationAsync(
+            string asBaseUrl, string clientId, string scope, CancellationToken ct = default)
         {
-            var body = clientLabel != null
-                ? JsonSerializer.Serialize(new { client_label = clientLabel }, JsonOptions)
-                : "{}";
-
-            using var content = new StringContent(body, Encoding.UTF8, "application/json");
+            using var content = FormContent(new Dictionary<string, string>
+            {
+                ["client_id"] = clientId,
+                ["scope"] = scope,
+            });
             using var response = await _httpClient
-                .PostAsync($"{cloudBaseUrl.TrimEnd('/')}/api/auth/device/authorize", content, ct)
+                .PostAsync($"{asBaseUrl.TrimEnd('/')}/oauth/device_authorization", content, ct)
                 .ConfigureAwait(false);
 
             response.EnsureSuccessStatusCode();
 
             var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             return JsonSerializer.Deserialize<DeviceAuthorizeResponse>(json, JsonOptions)
-                ?? throw new InvalidOperationException("Failed to deserialize device authorize response.");
+                ?? throw new InvalidOperationException("Failed to deserialize device authorization response.");
         }
 
         /// <summary>
-        /// POST <c>&lt;cloudBaseUrl&gt;/api/auth/device/token</c> with the device code + grant type to poll
-        /// for the access token. Unlike <see cref="InitiateDeviceAuthAsync"/>, this does NOT throw on a
-        /// non-2xx status: the device-flow spec carries pending/slow-down/denied as a structured
-        /// <c>error</c> body (often with a 400), so the caller inspects <see cref="DeviceTokenResponse.Error"/>.
+        /// POST <c>&lt;asBaseUrl&gt;/oauth/token</c> with the device-code grant to poll for the access token.
+        /// Unlike <see cref="RequestDeviceAuthorizationAsync"/>, this does NOT throw on a non-2xx status: the
+        /// device-flow spec carries pending/slow-down/denied as a structured RFC 6749 §5.2 <c>error</c> body
+        /// (a 400), so the caller inspects <see cref="DeviceTokenResponse.Error"/>. The <paramref name="clientId"/>
+        /// MUST equal the one presented at <see cref="RequestDeviceAuthorizationAsync"/>.
         /// </summary>
-        public async Task<DeviceTokenResponse> PollDeviceTokenAsync(
-            string cloudBaseUrl, string deviceCode, CancellationToken ct = default)
+        public async Task<DeviceTokenResponse> PollTokenAsync(
+            string asBaseUrl, string deviceCode, string clientId, CancellationToken ct = default)
         {
-            var body = JsonSerializer.Serialize(new
+            using var content = FormContent(new Dictionary<string, string>
             {
-                device_code = deviceCode,
-                grant_type = "urn:ietf:params:oauth:grant-type:device_code"
-            }, JsonOptions);
+                ["grant_type"] = DeviceCodeGrantType,
+                ["device_code"] = deviceCode,
+                ["client_id"] = clientId,
+            });
+            return await PostTokenAsync(asBaseUrl, content, ct).ConfigureAwait(false);
+        }
 
-            using var content = new StringContent(body, Encoding.UTF8, "application/json");
+        /// <summary>
+        /// POST <c>&lt;asBaseUrl&gt;/oauth/token</c> with the <c>refresh_token</c> grant to mint a fresh
+        /// access token (and possibly a rotated refresh token). Does NOT throw on a non-2xx status — a
+        /// rejected/expired refresh token surfaces as a structured RFC 6749 §5.2 error body the caller reads
+        /// via <see cref="DeviceTokenResponse.Error"/>. The <paramref name="clientId"/> MUST equal the one the
+        /// refresh token was issued under (the AS rejects a mismatch with <c>invalid_grant</c>).
+        /// </summary>
+        public async Task<DeviceTokenResponse> RefreshTokenAsync(
+            string asBaseUrl, string refreshToken, string clientId, CancellationToken ct = default)
+        {
+            using var content = FormContent(new Dictionary<string, string>
+            {
+                ["grant_type"] = RefreshTokenGrantType,
+                ["refresh_token"] = refreshToken,
+                ["client_id"] = clientId,
+            });
+            return await PostTokenAsync(asBaseUrl, content, ct).ConfigureAwait(false);
+        }
+
+        async Task<DeviceTokenResponse> PostTokenAsync(string asBaseUrl, HttpContent content, CancellationToken ct)
+        {
             using var response = await _httpClient
-                .PostAsync($"{cloudBaseUrl.TrimEnd('/')}/api/auth/device/token", content, ct)
+                .PostAsync($"{asBaseUrl.TrimEnd('/')}/oauth/token", content, ct)
                 .ConfigureAwait(false);
 
             var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             return JsonSerializer.Deserialize<DeviceTokenResponse>(json, JsonOptions)
-                ?? throw new InvalidOperationException("Failed to deserialize device token response.");
+                ?? throw new InvalidOperationException("Failed to deserialize token response.");
         }
 
-        /// <summary>Response of <c>POST /api/auth/device/authorize</c>.</summary>
+        static FormUrlEncodedContent FormContent(Dictionary<string, string> fields)
+            => new(fields);
+
+        /// <summary>Response of <c>POST /oauth/device_authorization</c> (the standard RFC 8628 document).</summary>
         public sealed class DeviceAuthorizeResponse
         {
             [JsonPropertyName("device_code")]
@@ -124,14 +173,26 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             public int Interval { get; set; }
         }
 
-        /// <summary>Response of <c>POST /api/auth/device/token</c> (success carries the token; otherwise an error).</summary>
+        /// <summary>
+        /// Response of <c>POST /oauth/token</c> (success carries the access token + rotating refresh token +
+        /// expiry; otherwise an RFC 6749 §5.2 error).
+        /// </summary>
         public sealed class DeviceTokenResponse
         {
             [JsonPropertyName("access_token")]
             public string? AccessToken { get; set; }
 
+            [JsonPropertyName("refresh_token")]
+            public string? RefreshToken { get; set; }
+
             [JsonPropertyName("token_type")]
             public string? TokenType { get; set; }
+
+            [JsonPropertyName("expires_in")]
+            public int ExpiresIn { get; set; }
+
+            [JsonPropertyName("scope")]
+            public string? Scope { get; set; }
 
             [JsonPropertyName("error")]
             public string? Error { get; set; }

--- a/addons/godot_mcp/Editor/Connection/GodotTokenRefresher.cs
+++ b/addons/godot_mcp/Editor/Connection/GodotTokenRefresher.cs
@@ -1,0 +1,107 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// Godot's implementation of McpPlugin 7.0's <see cref="ITokenRefresher"/> seam (mcp-authorize design 03
+    /// Flow B / 06): the ONE piece of the connection layer that talks to the ai-game.dev authorization server
+    /// over HTTP to exchange a refresh token for a fresh access token (<c>grant_type=refresh_token</c> at
+    /// <c>/oauth/token</c>). <see cref="PluginCredentialProvider"/> owns the machine-store credential and
+    /// invokes this both proactively (before <c>exp</c>) and reactively (on the connection's 3-strike
+    /// <c>_authorizationRejected</c> signal).
+    ///
+    /// <para>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) so it is unit-testable with a fake
+    /// <see cref="System.Net.Http.HttpMessageHandler"/>. It <b>fails closed</b> — any error (a rejected token,
+    /// an HTTP/JSON fault) returns <see cref="TokenRefreshResult.Failure"/>, never a partial or fabricated
+    /// token — and never logs token material (a surfaced <see cref="Exception.Message"/> is HTTP/JSON only).
+    /// </para>
+    /// </summary>
+    public sealed class GodotTokenRefresher : ITokenRefresher
+    {
+        readonly GodotDeviceAuthService _service;
+        readonly Func<string> _defaultAsBaseUrl;
+        readonly string _clientId;
+        readonly Func<DateTimeOffset> _clock;
+
+        /// <summary>
+        /// Construct a refresher. <paramref name="defaultAsBaseUrl"/> supplies the AS base URL when the stored
+        /// credential carries no <c>serverTarget</c> (read live so a <c>.env</c> cloud-URL override applies).
+        /// <paramref name="clientId"/> defaults to <see cref="GodotDeviceAuthFlow.DefaultClientId"/> — it MUST
+        /// match the id the refresh token was issued under. <paramref name="clock"/> is injectable for
+        /// deterministic expiry tests.
+        /// </summary>
+        public GodotTokenRefresher(
+            GodotDeviceAuthService service,
+            Func<string> defaultAsBaseUrl,
+            string? clientId = null,
+            Func<DateTimeOffset>? clock = null)
+        {
+            _service = service ?? throw new ArgumentNullException(nameof(service));
+            _defaultAsBaseUrl = defaultAsBaseUrl ?? throw new ArgumentNullException(nameof(defaultAsBaseUrl));
+            _clientId = string.IsNullOrEmpty(clientId) ? GodotDeviceAuthFlow.DefaultClientId : clientId!;
+            _clock = clock ?? (() => DateTimeOffset.UtcNow);
+        }
+
+        public async Task<TokenRefreshResult> RefreshAsync(string refreshToken, string? serverTarget, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var asBase = ResolveAsBaseUrl(serverTarget);
+                var response = await _service
+                    .RefreshTokenAsync(asBase, refreshToken, _clientId, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (!string.IsNullOrEmpty(response.AccessToken))
+                {
+                    var expiresAt = response.ExpiresIn > 0
+                        ? _clock().AddSeconds(response.ExpiresIn)
+                        : (DateTimeOffset?)null;
+                    // A null/empty RefreshToken tells the caller the AS did not rotate it (keep the old one).
+                    return TokenRefreshResult.Success(response.AccessToken!, response.RefreshToken, expiresAt);
+                }
+
+                return TokenRefreshResult.Failure(response.Error ?? "refresh failed");
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // ex.Message is an HTTP/JSON transport fault, never token material — safe to surface as the
+                // (non-secret) failure reason the provider logs.
+                return TokenRefreshResult.Failure(ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Resolve the AS base URL for the refresh POST. A stored <c>serverTarget</c> wins (an enrolled
+        /// hosted-vs-local target); a trailing <c>/mcp</c> hub path is stripped so we never POST to
+        /// <c>/mcp/oauth/token</c>. An empty target falls back to the live default (the plugin's cloud base).
+        /// </summary>
+        string ResolveAsBaseUrl(string? serverTarget)
+        {
+            if (string.IsNullOrEmpty(serverTarget))
+                return _defaultAsBaseUrl();
+
+            var trimmed = serverTarget!.TrimEnd('/');
+            if (trimmed.EndsWith("/mcp", StringComparison.OrdinalIgnoreCase))
+                trimmed = trimmed[..^"/mcp".Length];
+            return trimmed;
+        }
+    }
+}

--- a/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using com.IvanMurzak.Godot.MCP.Data;
 using com.IvanMurzak.Godot.MCP.MainThreadDispatch;
@@ -197,6 +198,23 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// </summary>
         readonly ConnectionStatusTracker _statusTracker = new();
 
+        /// <summary>
+        /// The ai-game.dev account-credential coordinator (mcp-authorize D12 — the zero-button rule). Owns the
+        /// shared machine credential store + proactive/reactive refresh; constructed once per connection so the
+        /// store auto-adopt runs at boot. Its access-token provider is composed into the Cloud-mode credential
+        /// provider by <see cref="Start"/>, and its reactive refresh is driven by the authorization-rejected
+        /// signal (<see cref="TryAccountRefreshAndReconnect"/>). Pure-managed; the store/refresh lifecycle is
+        /// unit-tested via <c>GodotAccountAuthTests</c>.
+        /// </summary>
+        readonly GodotAccountAuth _account;
+
+        /// <summary>
+        /// Re-entrancy guard for <see cref="TryAccountRefreshAndReconnect"/> (0 = idle, 1 = a refresh is in
+        /// flight) so a burst of authorization-rejected signals cannot fan out concurrent refreshes. Toggled
+        /// with <see cref="Interlocked"/> because rejections arrive off the SignalR thread.
+        /// </summary>
+        int _accountRefreshInFlight;
+
         /// <summary>The active config (resolved Host/Token/mode are read live off this).</summary>
         public GodotMcpConfig Config => _config;
 
@@ -212,11 +230,20 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         public IMcpManager? McpManager => _plugin?.McpManager;
 
         /// <summary>
-        /// The resolved cloud BASE url (no <c>/mcp</c> hub suffix) — the host the device-auth endpoints
-        /// (<c>/api/auth/device/*</c>) live on. The dock's Cloud-auth section passes this to
-        /// <see cref="GodotDeviceAuthFlow.StartAsync"/>. Read live off the config so an env override applies.
+        /// The resolved cloud BASE url (no <c>/mcp</c> hub suffix) — the ai-game.dev authorization-server host
+        /// the RFC 8628 device-flow endpoints (<c>/oauth/device_authorization</c> + <c>/oauth/token</c>) live
+        /// on. The dock's Cloud-auth section passes this to <see cref="GodotDeviceAuthFlow.StartAsync"/> and it
+        /// backs the account coordinator's refresh target. Read live off the config so an env override applies.
         /// </summary>
         public string CloudBaseUrl => GodotMcpConfig.ResolveCloudBaseUrl();
+
+        /// <summary>
+        /// The ai-game.dev account-credential coordinator (machine store + proactive/reactive refresh). Exposed
+        /// so the editor UI can drive an in-editor "Sign in" (device flow → machine store) and reflect the
+        /// signed-in state; the connection itself composes <see cref="GodotAccountAuth.AccessTokenProvider"/>
+        /// into the Cloud-mode bearer and refreshes it on the authorization-rejected signal.
+        /// </summary>
+        public GodotAccountAuth Account => _account;
 
         /// <summary>
         /// Raised when the server rejects the connection's authorization token (the reused client's
@@ -284,9 +311,14 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             GodotMcpDrainDiagnostics.Warn = GodotMcpLog.Warning;
         }
 
-        public GodotMcpConnection(GodotMcpConfig? config = null)
+        public GodotMcpConnection(GodotMcpConfig? config = null, GodotAccountAuth? account = null)
         {
             _config = config ?? new GodotMcpConfig();
+
+            // Construct the account coordinator once (auto-adopts from the machine store at boot — the
+            // zero-button rule). The AS base URL is read LIVE off the config so a `.env`/env cloud-URL override
+            // reaches refreshes. The store read is safe when absent (returns null → signed out).
+            _account = account ?? new GodotAccountAuth(asBaseUrlProvider: () => CloudBaseUrl);
         }
 
         /// <summary>
@@ -307,6 +339,23 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             // built-in defaults (the first-load "Cloud token empty / Authorize prompted / wrong agent restored"
             // bug); this lazy call covers a Start() reached without that pre-step. A no-op once already resolved.
             ResolveConfig();
+
+            // Compose the machine-store account credential into the connection's bearer resolution (D12 — the
+            // zero-button rule). In Cloud mode, when the machine store holds a credential, present its
+            // (proactively-refreshed) JWT; otherwise fall back to the config's own token resolution
+            // (CloudToken in Cloud mode / CustomToken in Custom mode, env-overridable) so a signed-out machine
+            // and every Custom-mode connection behave exactly as before. Set here (not wrapped) so a Reconnect's
+            // repeat Start() re-assigns the SAME composite rather than nesting delegates.
+            _config.CredentialProvider = async () =>
+            {
+                if (_config.ActiveMode == GodotMcpConnectionMode.Cloud && _account.IsSignedIn)
+                {
+                    var accountToken = await _account.AccessTokenProvider().ConfigureAwait(false);
+                    if (!string.IsNullOrEmpty(accountToken))
+                        return accountToken;
+                }
+                return _config.Token;
+            };
 
             Reflector reflector = GodotReflectorFactory.CreateDefaultReflector();
 
@@ -507,11 +556,65 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                         MainThreadDispatcher.Enqueue(() =>
                         {
                             if (ReferenceEquals(_plugin, plugin))
-                                AuthorizationRejected?.Invoke();
+                                RaiseAuthorizationRejected();
                         });
                     else if (ReferenceEquals(_plugin, plugin))
-                        AuthorizationRejected?.Invoke();
+                        RaiseAuthorizationRejected();
                 });
+        }
+
+        /// <summary>
+        /// Handle a confirmed-live authorization rejection: notify the dock (which may revert the Cloud-token
+        /// UI to "Authorize") AND — when signed in via the machine-store account in Cloud mode — reactively
+        /// refresh the account JWT and reconnect (design 06: refresh on the <c>_authorizationRejected</c>
+        /// signal). The account refresh is a no-op fall-through for a Custom-mode / token-field connection, so
+        /// the historical dock behavior is unchanged there.
+        /// </summary>
+        void RaiseAuthorizationRejected()
+        {
+            AuthorizationRejected?.Invoke();
+            TryAccountRefreshAndReconnect();
+        }
+
+        /// <summary>
+        /// Reactively refresh the machine-store account credential and reconnect with the fresh JWT, guarded so
+        /// a burst of rejections cannot fan out concurrent refreshes. No-op unless the account is signed in and
+        /// the live mode is Cloud. A refresh FAILURE returns false (the provider has surfaced sign-in-required)
+        /// and we do NOT reconnect — that stops a reject→refresh→reject loop; recovery is then an explicit
+        /// re-sign-in.
+        /// </summary>
+        void TryAccountRefreshAndReconnect()
+        {
+            if (!_account.IsSignedIn || _config.ActiveMode != GodotMcpConnectionMode.Cloud)
+                return;
+            if (Interlocked.CompareExchange(ref _accountRefreshInFlight, 1, 0) != 0)
+                return; // a refresh is already in flight
+
+            _ = RefreshThenReconnectAsync();
+        }
+
+        async Task RefreshThenReconnectAsync()
+        {
+            try
+            {
+                var refreshed = await _account.RefreshAsync().ConfigureAwait(false);
+                if (!refreshed)
+                    return; // sign-in-required surfaced by the provider; do not loop
+
+                // Reconnect on the editor main thread (it touches _statusTracker + raises events).
+                if (MainThreadDispatcher.Instance != null && !MainThreadDispatcher.IsMainThread)
+                    MainThreadDispatcher.Enqueue(Reconnect);
+                else
+                    Reconnect();
+            }
+            catch (Exception ex)
+            {
+                GodotMcpLog.Warning($"[Godot-MCP] account token refresh-on-reject failed: {ex.Message}");
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _accountRefreshInFlight, 0);
+            }
         }
 
         /// <summary>
@@ -1207,6 +1310,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             _authRejectedSubscription.Dispose();
             _featuresSubscription.Dispose();
             _agentsSubscription.Dispose();
+            _account.Dispose();
             DisposePlugin();
         }
 


### PR DESCRIPTION
## Summary
- Implement the ai-game.dev sign-in for the Godot addon (mcp-authorize e1, PR 2). PR 1 (#263) adopted McpPlugin 7.0.0-preview.1 + migrated `ConnectionConfig.Token` → `CredentialProvider`; this PR wires the actual device-flow sign-in.
- **RFC 8628 device flow** (`GodotDeviceAuthService`): POST `/oauth/device_authorization` (form `client_id` + `scope=mcp:plugin`) → poll `/oauth/token` (device-code grant) → ES256 access + rotating refresh token + expiry; adds the `refresh_token` grant. Same `client_id` replayed across authorize/token/refresh (verified vs `cloud/AI-Game-Dev-Server` `routers/oauth.py`).
- **Machine credential store** (`GodotAccountAuth` over McpPlugin 7.0's `MachineCredentialStore` + `PluginCredentialProvider`): persists the credential to `~/.ai-game-dev/credentials.json` (0600 POSIX / DPAPI Windows) — never in a project file / VCS. Sign-in once per machine.
- **Zero-button boot (D12)**: the connection constructs the coordinator at boot (store auto-adopt), composes its proactively-refreshed JWT into the Cloud-mode credential provider (falling back to the existing token when signed out / in Custom mode), and refreshes→reconnects on the 3-strike authorization-rejected signal. `GodotTokenRefresher` is the fail-closed refresh seam.
- `ConnectionPanel.cs` is intentionally untouched; its "Sign in" button rewire + token-field removal are the follow-up PR 5. `GodotAccountAuth.SignInAsync` is the tested seam PR 5 calls.

**Out of scope** (later PRs): instance metadata + ProjectIdentity (PR 3); 8080→derived-port migration (PR 4); config-writer URL+pin UI flip / token-field removal / `ConnectionPanel.cs` / `AgentConfiguratorsPanel.cs` (PR 5); live e2e (PR 6). No NuGet pin bump; no `plugin.cfg` bump.

## Test plan
- [x] `dotnet build Godot-MCP.sln` (.NET 8) — 0 errors.
- [x] `Godot-MCP.Tests` xUnit — 990 passed / 0 failed (+17: RFC 8628 flow shape + refresh/expiry, `GodotTokenRefresher` success/fail-closed/form-shape, `GodotAccountAuth` auto-adopt / sign-in-persist / sign-out / refresh-rotate, all against a mocked AS + temp-dir store).
- [x] `scripts/check-runtime-boundary.py` — 0 violations.
- [ ] Headless Godot smoke — deferred to CI's Godot mono addon-load matrix (the shared software-repo testbed is still pinned to McpPlugin 6.10.0, pre-7.0, so it cannot compile the 7.0 addon locally).

Closes #264