### PR TITLE
feat(connection): instance-metadata handshake + ProjectIdentity/ProjectMarker wiring

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -62,6 +62,13 @@
          instantiates the SignalR client; it is verified via the headless Godot smoke, not here. -->
     <Compile Include="..\addons\godot_mcp\Runtime\GodotMcpEnv.cs" Link="Source\GodotMcpEnv.cs" />
     <Compile Include="..\addons\godot_mcp\Runtime\Connection\GodotMcpConfig.cs" Link="Source\GodotMcpConfig.cs" />
+    <!-- Project-identity wiring (mcp-authorize e1, PR 3): the instance-metadata handshake builder,
+         ProjectIdentity (pin + derived port) resolution, and the marker serverTarget → connection-mode
+         mapping. Pure-managed adapter over McpPlugin 7.0's ConnectionInstanceMetadata / ProjectIdentity /
+         ProjectMarker (no Godot native types, no #if TOOLS); the Godot project-root/name resolution lives
+         in GodotMcpConnection.cs (verified via the headless smoke). Unit-tested in GodotProjectIdentityTests
+         (golden-vector parity, handshake payload, marker read/write). -->
+    <Compile Include="..\addons\godot_mcp\Runtime\Connection\GodotProjectIdentity.cs" Link="Source\GodotProjectIdentity.cs" />
     <!-- Project-root `.env` loader: pure-managed parser + precedence applier (no Godot native types,
          no #if TOOLS). The editor wiring (ProjectSettings.GlobalizePath) lives in GodotMcpConnection.cs
          (#if TOOLS), verified via the headless smoke; the parse/apply core is unit-tested here. -->

--- a/Godot-MCP.Tests/GodotProjectIdentityTests.cs
+++ b/Godot-MCP.Tests/GodotProjectIdentityTests.cs
@@ -1,0 +1,244 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using com.IvanMurzak.Godot.MCP.Connection;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the mcp-authorize e1 (PR 3) project-identity wiring: the instance-metadata handshake
+    /// payload, the <see cref="ProjectIdentity"/> derivation (golden-vector parity — the pin + derived
+    /// port MUST match the committed cross-language vectors byte-for-byte), and the project-marker
+    /// read/write + <c>serverTarget</c> → connection-mode resolution. All pure-managed over McpPlugin
+    /// 7.0's shared primitives (no Godot native types, no <c>#if TOOLS</c>), so they run in the plain
+    /// xUnit host on the Linux CI runner. The editor-side Godot project-root/name resolution lives in
+    /// <c>GodotMcpConnection</c> and is verified via the headless smoke (test.md Suite 3).
+    /// </summary>
+    public class GodotProjectIdentityTests
+    {
+        // === Instance-metadata handshake payload (design 04) =========================================
+
+        [Fact]
+        public void BuildInstanceMetadata_StampsGodotEngine_AndCarriesTheSuppliedFields()
+        {
+            var meta = GodotProjectIdentity.BuildInstanceMetadata(
+                projectRoot: "C:/Games/MyGame",
+                projectName: "MyGame",
+                instanceId: "11111111-2222-3333-4444-555555555555",
+                machineName: "DESKTOP-X");
+
+            Assert.Equal("godot", meta.Engine);
+            Assert.Equal("MyGame", meta.ProjectName);
+            Assert.Equal("11111111-2222-3333-4444-555555555555", meta.InstanceId);
+            Assert.Equal("DESKTOP-X", meta.MachineName);
+        }
+
+        [Fact]
+        public void BuildInstanceMetadata_ProjectPathHash_IsTheStablePinSource()
+        {
+            var meta = GodotProjectIdentity.BuildInstanceMetadata(
+                "C:/Games/MyGame", "MyGame", "id", "host");
+
+            // The metadata hash is exactly the ProjectIdentity project-path hash (same normalization),
+            // and the routing pin is its first 8 hex chars (design 04 — "pin = first 8 hex of the
+            // ProjectIdentity SHA256"). This is what ties an agent session's pin to this instance.
+            Assert.Equal(ProjectIdentity.DeriveProjectPathHash("C:/Games/MyGame"), meta.ProjectPathHash);
+            Assert.Equal(64, meta.ProjectPathHash.Length);
+            Assert.Equal(ProjectIdentity.DerivePin("C:/Games/MyGame"), meta.ProjectPathHash.Substring(0, 8));
+        }
+
+        [Fact]
+        public void BuildInstanceMetadata_ToQuery_CarriesTheFiveHandshakeKeys()
+        {
+            var meta = GodotProjectIdentity.BuildInstanceMetadata(
+                "C:/Games/MyGame", "MyGame", "the-instance-id", "DESKTOP-X");
+
+            var query = meta.ToQuery();
+
+            Assert.Equal("the-instance-id", query["instance_id"]);
+            Assert.Equal("godot", query["engine"]);
+            Assert.Equal("MyGame", query["project_name"]);
+            Assert.Equal(meta.ProjectPathHash, query["project_path_hash"]);
+            Assert.Equal("DESKTOP-X", query["machine_name"]);
+        }
+
+        [Fact]
+        public void BuildInstanceMetadata_AppendToUrl_UsesTheRightQuerySeparator()
+        {
+            var meta = GodotProjectIdentity.BuildInstanceMetadata(
+                "C:/Games/MyGame", "MyGame", "id", "host");
+
+            // A query-less URL gets a '?'; a URL that already has a query gets an '&'. Either way the
+            // five handshake params are appended (the client encodes the metadata into the hub URL).
+            Assert.Contains("?instance_id=id&", meta.AppendToUrl("https://ai-game.dev/mcp"));
+            Assert.Contains("&instance_id=id&", meta.AppendToUrl("http://localhost:8080/hub/mcp-server?x=1"));
+        }
+
+        [Fact]
+        public void SessionInstanceId_IsAStableNonEmptyGuidForTheSession()
+        {
+            Assert.False(string.IsNullOrWhiteSpace(GodotProjectIdentity.SessionInstanceId));
+            Assert.True(Guid.TryParse(GodotProjectIdentity.SessionInstanceId, out _));
+            // Stable within the session (same value on repeated reads — minted once per loaded assembly).
+            Assert.Equal(GodotProjectIdentity.SessionInstanceId, GodotProjectIdentity.SessionInstanceId);
+        }
+
+        // === ProjectIdentity derivation — golden-vector parity =======================================
+        //
+        // These pin the committed cross-language vectors. The derivation is McpPlugin 7.0's canonical
+        // ProjectIdentity (Normalize = trim trailing separators + ToLowerInvariant, NO separator
+        // conversion; SHA256; pin = first 8 hex; port = MinPort + LE-uint32(hash) % PortRange). If a
+        // McpPlugin bump ever changes the math, these fail — that is the intended tripwire (the Godot
+        // pin/port must stay byte-identical to the Unity/CLI derivation).
+
+        [Theory]
+        [InlineData("C:/Games/MyGame", "360f52fb", 29062)]
+        [InlineData("/home/user/MyGame", "465fe842", 24998)]
+        [InlineData("/home/user/Demo Project", "705ccffb", 20832)]
+        public void Derive_MatchesGoldenVectors(string projectRoot, string expectedPin, int expectedPort)
+        {
+            var identity = GodotProjectIdentity.Derive(projectRoot, marker: null);
+
+            Assert.Equal(expectedPin, identity.Pin);
+            Assert.Equal(expectedPort, identity.Port);
+            Assert.False(identity.PortIsOverridden);
+            // The derived port always lands in the shared 20000–29999 band (D14/D15).
+            Assert.InRange(identity.Port, ProjectIdentity.MinPort, ProjectIdentity.MaxPort);
+        }
+
+        [Theory]
+        [InlineData("C:/Games/MyGame/")] // trailing separator trimmed
+        [InlineData("c:/games/mygame")]  // ToLowerInvariant
+        [InlineData("C:/Games/MyGame")]  // canonical
+        public void Derive_IsTrailingSlashAndCaseInsensitive(string projectRoot)
+        {
+            var identity = GodotProjectIdentity.Derive(projectRoot, marker: null);
+
+            Assert.Equal("360f52fb", identity.Pin);
+            Assert.Equal(29062, identity.Port);
+        }
+
+        [Fact]
+        public void Derive_DoesNotConvertSeparators_SoBackslashDiffersFromForwardSlash()
+        {
+            // The normalization ToLowerInvariant-s but does NOT convert '\' <-> '/', so a backslash path
+            // and its forward-slash twin hash differently. Godot globalizes res:// to forward slashes, so
+            // the forward-slash vector above is the one the plugin actually produces; this pins the rule.
+            var forward = GodotProjectIdentity.Derive("C:/Games/MyGame", marker: null);
+            var backslash = GodotProjectIdentity.Derive(@"C:\Games\MyGame", marker: null);
+
+            Assert.NotEqual(forward.Pin, backslash.Pin);
+        }
+
+        [Fact]
+        public void Derive_HonorsMarkerPortOverride_ButKeepsThePin()
+        {
+            var marker = new ProjectMarker { PortOverride = 25000 };
+
+            var identity = GodotProjectIdentity.Derive("C:/Games/MyGame", marker);
+
+            Assert.Equal("360f52fb", identity.Pin);      // pin is path-derived, unaffected by the override
+            Assert.Equal(25000, identity.Port);          // port comes from the marker override
+            Assert.True(identity.PortIsOverridden);
+        }
+
+        // === Project marker read/write + server-target resolution =====================================
+
+        [Fact]
+        public void ProjectMarker_RoundTrips_ServerTargetAndPortOverride()
+        {
+            using var dir = new TempDir();
+
+            new ProjectMarker { ServerTarget = "https://ai-game.dev", PortOverride = 24242 }.Write(dir.Path);
+
+            // The marker lands at <project>/.ai-game-dev/project.json (design 06).
+            Assert.True(File.Exists(ProjectMarker.PathFor(dir.Path)));
+            Assert.True(File.Exists(Path.Combine(dir.Path, ".ai-game-dev", "project.json")));
+
+            var read = ProjectMarker.Read(dir.Path);
+            Assert.NotNull(read);
+            Assert.Equal("https://ai-game.dev", read!.ServerTarget);
+            Assert.Equal(24242, read.PortOverride);
+
+            // The marker portOverride flows through the identity derivation.
+            var identity = GodotProjectIdentity.Derive(dir.Path, read);
+            Assert.Equal(24242, identity.Port);
+            Assert.True(identity.PortIsOverridden);
+        }
+
+        [Fact]
+        public void ProjectMarker_Read_ReturnsNull_WhenAbsent()
+        {
+            using var dir = new TempDir();
+
+            Assert.Null(ProjectMarker.Read(dir.Path));
+            // An absent marker resolves to no server-target decision → caller keeps its own config.
+            Assert.Null(GodotProjectIdentity.ResolveServerTarget(ProjectMarker.Read(dir.Path)));
+        }
+
+        [Fact]
+        public void ResolveServerTarget_MapsLoopbackToCustom_AndHostedToCloud()
+        {
+            var local = GodotProjectIdentity.ResolveServerTarget(
+                new ProjectMarker { ServerTarget = "http://localhost:20000" });
+            Assert.NotNull(local);
+            Assert.Equal(GodotMcpConnectionMode.Custom, local!.Value.Mode);
+            Assert.Equal("http://localhost:20000", local.Value.CustomHost);
+
+            var hosted = GodotProjectIdentity.ResolveServerTarget(
+                new ProjectMarker { ServerTarget = "https://ai-game.dev" });
+            Assert.NotNull(hosted);
+            Assert.Equal(GodotMcpConnectionMode.Cloud, hosted!.Value.Mode);
+            Assert.Null(hosted.Value.CustomHost);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("not-a-url")]
+        [InlineData("ftp://example.com")]
+        public void ResolveServerTarget_ReturnsNull_ForMissingOrInvalidTargets(string? serverTarget)
+        {
+            Assert.Null(GodotProjectIdentity.ResolveServerTarget(
+                new ProjectMarker { ServerTarget = serverTarget }));
+        }
+
+        [Fact]
+        public void ResolveServerTarget_ReturnsNull_ForNullMarker()
+        {
+            Assert.Null(GodotProjectIdentity.ResolveServerTarget(marker: null));
+        }
+
+        /// <summary>Self-cleaning temp directory for the marker round-trip tests.</summary>
+        sealed class TempDir : IDisposable
+        {
+            public string Path { get; }
+
+            public TempDir()
+            {
+                Path = System.IO.Path.Combine(
+                    System.IO.Path.GetTempPath(), "godot-mcp-marker-" + Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(Path);
+            }
+
+            public void Dispose()
+            {
+                try { Directory.Delete(Path, recursive: true); }
+                catch { /* best-effort cleanup */ }
+            }
+        }
+    }
+}

--- a/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
@@ -21,6 +21,7 @@ using com.IvanMurzak.Godot.MCP.Tools;
 using com.IvanMurzak.Godot.MCP.UI;
 using com.IvanMurzak.Godot.MCP.UI.Agents;
 using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.AgentConfig;
 using com.IvanMurzak.ReflectorNet;
 using Godot;
 using Microsoft.AspNetCore.SignalR.Client;
@@ -356,6 +357,27 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 }
                 return _config.Token;
             };
+
+            // Instance-metadata handshake (design 04 — mcp-authorize e1, PR 3). Identify THIS editor
+            // session to the server so it can route/dedup by account + project + instance instead of by
+            // token-string equality. Set on the config the SignalR client reads at connect — the client
+            // appends {instance_id, engine, project_name, project_path_hash, machine_name} to the hub URL
+            // via ConnectionInstanceMetadata. The InstanceId is minted once per editor session
+            // (GodotProjectIdentity.SessionInstanceId); the project-path-hash (and its first-8 routing
+            // pin) is derived from the SAME normalized project root a configurator hashes, so an agent
+            // session launched in this project folder routes strictly to this instance.
+            var projectRootPath = ResolveProjectRootPath();
+            _config.InstanceMetadata = GodotProjectIdentity.BuildInstanceMetadata(
+                projectRootPath,
+                ResolveProjectName(),
+                GodotProjectIdentity.SessionInstanceId,
+                System.Environment.MachineName);
+
+            // Surface the resolved project identity (routing pin + derived local port) and the enrolled
+            // server target for the operator smoke. The pin is what agent sessions route on; the derived
+            // port is wired here for PR 4's 8080 → derived-port migration but does NOT change the runtime
+            // default in this PR (the connection still uses the configured Host / 8080 default).
+            LogProjectIdentity(projectRootPath);
 
             Reflector reflector = GodotReflectorFactory.CreateDefaultReflector();
 
@@ -1067,9 +1089,17 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 return;
             _configResolved = true;
 
-            // PRECEDENCE: process env > .env file > persisted config > built-in default.
-            // 1) Seed the SERIALIZED-config layer first (lowest layer above the built-in defaults), so the
-            //    .env and live process-env layers below override it — never the other way around.
+            // PRECEDENCE: process env > .env file > persisted config > project marker > built-in default.
+            // 0) Seed the ENROLLED server target from the project marker FIRST (the lowest layer above the
+            //    built-in defaults). A CLI `install-plugin --enroll` (or a hand-written marker) records the
+            //    hosted-vs-local target in `<project>/.ai-game-dev/project.json`; applying it before the
+            //    persisted / .env / process-env layers means every explicit user choice below still wins,
+            //    while a fresh enrolled project with no other config boots pointed at the right hub. A
+            //    missing marker (the common case) is a no-op, so existing behavior is unchanged.
+            ApplyProjectMarker();
+
+            // 1) Seed the SERIALIZED-config layer next (above the marker), so the .env and live process-env
+            //    layers below override it — never the other way around.
             ApplyPersistedConfig();
 
             // 2) Layer the project-root `.env` BENEATH the live process-env overrides the config already
@@ -1106,6 +1136,124 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
             GodotMcpEnvFile.Apply(_config, values);
             GodotMcpLog.Info($"[Godot-MCP] applied {values.Count} setting(s) from project .env ({envPath}).");
+        }
+
+        /// <summary>
+        /// Apply the project marker's enrolled server target (<c>&lt;project&gt;/.ai-game-dev/project.json</c>
+        /// → <see cref="ProjectMarker.ServerTarget"/>) as the lowest config layer (mcp-authorize e1, PR 3 —
+        /// design 06 / 09 · 1A). When the marker names a valid target, a loopback URL selects
+        /// <see cref="GodotMcpConnectionMode.Custom"/> pointed at that host and any other http(s) URL selects
+        /// <see cref="GodotMcpConnectionMode.Cloud"/> (hosted), so an enrolled project "boots pointed at the
+        /// right hub" without any editor interaction. Applied BEFORE the persisted / .env / process-env
+        /// layers, so every explicit user choice still overrides it. The Godot dependency is only the
+        /// <c>res://</c> path resolution; the marker read + the target→mode mapping are the pure-managed,
+        /// unit-tested <see cref="GodotProjectIdentity.ResolveServerTarget"/>. A missing/empty marker (the
+        /// common case) is a silent no-op, so existing connection behavior is unchanged. This wires the
+        /// server-target resolution only — it does NOT change the local default port (PR 4).
+        /// </summary>
+        void ApplyProjectMarker()
+        {
+            var projectRoot = ResolveProjectRootPath();
+            if (string.IsNullOrEmpty(projectRoot))
+                return;
+
+            ProjectMarker? marker;
+            try
+            {
+                marker = ProjectMarker.Read(projectRoot);
+            }
+            catch (Exception ex)
+            {
+                GodotMcpLog.Warning($"[Godot-MCP] could not read project marker: {ex.Message}");
+                return;
+            }
+
+            var resolution = GodotProjectIdentity.ResolveServerTarget(marker);
+            if (resolution == null)
+                return;
+
+            _config.ConnectionMode = resolution.Value.Mode;
+            if (resolution.Value.Mode == GodotMcpConnectionMode.Custom && !string.IsNullOrEmpty(resolution.Value.CustomHost))
+                _config.CustomHost = resolution.Value.CustomHost!;
+
+            GodotMcpLog.Info(
+                $"[Godot-MCP] project marker enrolled server target '{resolution.Value.ServerTarget}' -> mode={resolution.Value.Mode}.");
+        }
+
+        /// <summary>
+        /// The absolute, native project-root path (<c>res://</c> globalized, trailing separator trimmed) —
+        /// the string hashed into the instance metadata's <c>ProjectPathHash</c> and the routing pin, and
+        /// the project marker's directory. The only Godot dependency of the identity path; returns empty on
+        /// a resolution failure so a boot never throws here (callers treat empty as "no identity available").
+        /// </summary>
+        static string ResolveProjectRootPath()
+        {
+            try
+            {
+                return ProjectSettings.GlobalizePath("res://").TrimEnd('/');
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// The human-facing project name reported in the instance metadata — Godot's
+        /// <c>application/config/name</c> setting, falling back to the project directory name and finally a
+        /// fixed literal. Never throws (a name lookup must not break the boot path).
+        /// </summary>
+        static string ResolveProjectName()
+        {
+            try
+            {
+                var name = ProjectSettings.GetSetting("application/config/name").AsString();
+                if (!string.IsNullOrWhiteSpace(name))
+                    return name.Trim();
+            }
+            catch
+            {
+                // Fall through to the directory-name fallback.
+            }
+
+            try
+            {
+                var dir = System.IO.Path.GetFileName(ResolveProjectRootPath());
+                if (!string.IsNullOrWhiteSpace(dir))
+                    return dir;
+            }
+            catch
+            {
+                // Fall through to the literal fallback.
+            }
+
+            return "godot-project";
+        }
+
+        /// <summary>
+        /// Log the resolved <see cref="ProjectIdentity"/> (routing pin + derived local port, honoring a
+        /// marker <c>portOverride</c>) and the enrolled server target for the operator smoke — a build-green
+        /// boot line proving the identity wiring resolves. Diagnostics only: the derived port is surfaced
+        /// for PR 4's local-port migration but is NOT applied to the runtime connection here. Never throws.
+        /// </summary>
+        void LogProjectIdentity(string projectRoot)
+        {
+            if (string.IsNullOrEmpty(projectRoot))
+                return;
+
+            try
+            {
+                var marker = ProjectMarker.Read(projectRoot);
+                var identity = GodotProjectIdentity.Derive(projectRoot, marker);
+                var target = GodotProjectIdentity.ResolveServerTarget(marker);
+                GodotMcpLog.Info(
+                    $"[Godot-MCP] project identity: pin={identity.Pin} derivedPort={identity.Port} " +
+                    $"(portOverridden={identity.PortIsOverridden}); enrolled serverTarget={target?.ServerTarget ?? "<none>"}.");
+            }
+            catch (Exception ex)
+            {
+                GodotMcpLog.Warning($"[Godot-MCP] could not resolve project identity: {ex.Message}");
+            }
         }
 
         /// <summary>

--- a/addons/godot_mcp/Runtime/Connection/GodotProjectIdentity.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotProjectIdentity.cs
@@ -1,0 +1,119 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// Godot-side wiring of the shared McpPlugin 7.0 project-identity primitives (mcp-authorize e1,
+    /// PR 3 — design <c>04-pairing-and-routing.md</c> / <c>06-engine-plugins.md</c>). This is a thin,
+    /// pure-managed adapter over the library's canonical derivation — it deliberately does NOT
+    /// reimplement any hashing / port math, so the pin and derived port match the committed golden
+    /// vectors byte-for-byte (the derivation lives in <see cref="ProjectIdentity"/>; this only supplies
+    /// the Godot <c>engine</c> tag and the resolution glue). No Godot native types and no
+    /// <c>#if TOOLS</c>, so the whole surface is unit-testable in the plain-xUnit host; the Godot
+    /// project-root / project-name resolution stays in <see cref="GodotMcpConnection"/> (verified via
+    /// the headless smoke).
+    ///
+    /// <para>
+    /// Three seams live here:
+    /// <list type="bullet">
+    ///   <item><b>Handshake payload</b> — <see cref="BuildInstanceMetadata"/> builds the
+    ///   <see cref="ConnectionInstanceMetadata"/> the SignalR client sends on connect so the server can
+    ///   route/dedup by account + project + instance (design 04).</item>
+    ///   <item><b>ProjectIdentity</b> — <see cref="Derive"/> resolves the project's <c>{pin, port}</c>
+    ///   (honoring a marker <c>portOverride</c>). This PR wires the derived-port <em>value</em>; it does
+    ///   NOT change the local default port (still <c>8080</c> — that migration is PR 4).</item>
+    ///   <item><b>Server-target resolution</b> — <see cref="ResolveServerTarget"/> maps the project
+    ///   marker's enrolled <c>serverTarget</c> to a connection decision so the plugin boots pointed at
+    ///   the right hub (hosted vs local; design 06 / 09 · 1A).</item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    public static class GodotProjectIdentity
+    {
+        /// <summary>
+        /// The engine tag stamped into the instance metadata (design 04 — <c>"unity" | "godot" |
+        /// "unreal"</c>). The server's account registry keys the instance on this + project-path-hash +
+        /// machine name.
+        /// </summary>
+        public const string Engine = "godot";
+
+        /// <summary>
+        /// The instance id minted once per editor session (design 04 — a GUID per editor session). Sent
+        /// in the handshake so the server can dedup a reconnect of the same editor without orphaning the
+        /// prior entry. Stable for the life of the loaded addon assembly; a fresh editor session (or a
+        /// C# hot-reload that reloads this assembly) mints a new one — the server evicts the stale entry
+        /// after the SignalR client-timeout (design 04 "Dedup").
+        /// </summary>
+        public static readonly string SessionInstanceId = Guid.NewGuid().ToString();
+
+        /// <summary>
+        /// Build the connection instance metadata for the hub handshake. A thin forward to
+        /// <see cref="ConnectionInstanceMetadata.Create"/> that fixes the engine tag to
+        /// <see cref="Engine"/> and centralizes the argument order; the library computes the stable
+        /// <c>ProjectPathHash</c> (SHA256 of the normalized project root — the pin is its first 8 hex).
+        /// Null inputs degrade to safe empties / the session id so a partial boot never throws here.
+        /// </summary>
+        /// <param name="projectRoot">The project root the server hashes into <c>ProjectPathHash</c> —
+        /// the same normalized path the configurator hashes into the routing pin, so an agent session in
+        /// this project folder routes strictly to this instance.</param>
+        /// <param name="projectName">Human-facing project name (e.g. Godot <c>application/config/name</c>).</param>
+        /// <param name="instanceId">Per-session instance id (normally <see cref="SessionInstanceId"/>).</param>
+        /// <param name="machineName">Host machine name (audit / cross-machine disambiguation).</param>
+        public static ConnectionInstanceMetadata BuildInstanceMetadata(
+            string projectRoot,
+            string projectName,
+            string instanceId,
+            string machineName)
+            => ConnectionInstanceMetadata.Create(
+                engine: Engine,
+                projectName: projectName ?? string.Empty,
+                projectRootPath: projectRoot ?? string.Empty,
+                instanceId: string.IsNullOrEmpty(instanceId) ? SessionInstanceId : instanceId,
+                machineName: machineName ?? string.Empty);
+
+        /// <summary>
+        /// Resolve the project's <see cref="ProjectIdentity"/> (<c>{pin, port}</c>) from its root,
+        /// consulting the marker's <c>portOverride</c> when a marker is present (the
+        /// <see cref="ProjectMarker"/> overload) and otherwise deriving the default port. The derivation
+        /// itself is the library's golden-vector-pinned canonical math — this only picks the right
+        /// overload. The returned port is NOT applied to the live connection in this PR (the 8080 →
+        /// derived-port migration is PR 4); it is surfaced for diagnostics + PR-4 consumption.
+        /// </summary>
+        public static ProjectIdentity Derive(string projectRoot, ProjectMarker? marker)
+            => marker != null
+                ? ProjectIdentity.Derive(projectRoot, marker)
+                : ProjectIdentity.Derive(projectRoot, (int?)null);
+
+        /// <summary>
+        /// Resolve the enrolled server target from the project marker into a connection decision, or
+        /// <c>null</c> when the marker is absent / carries no valid <c>serverTarget</c> (the common case —
+        /// then the caller keeps its existing Cloud/Custom resolution untouched). A loopback target maps
+        /// to <see cref="GodotMcpConnectionMode.Custom"/> pointed at that host; any other valid http(s)
+        /// target maps to <see cref="GodotMcpConnectionMode.Cloud"/> (hosted). Pure — the loopback / URL
+        /// predicates are the same ones <see cref="GodotMcpConfig"/> uses, so a marker and a manual
+        /// custom-host entry classify identically.
+        /// </summary>
+        public static (GodotMcpConnectionMode Mode, string? CustomHost, string ServerTarget)? ResolveServerTarget(ProjectMarker? marker)
+        {
+            var target = GodotMcpConfig.NormalizeUrl(marker?.ServerTarget);
+            if (string.IsNullOrEmpty(target) || !GodotMcpConfig.IsValidHttpUrl(target!))
+                return null;
+
+            return GodotMcpConfig.IsLoopbackUrl(target)
+                ? (GodotMcpConnectionMode.Custom, target, target!)
+                : (GodotMcpConnectionMode.Cloud, (string?)null, target!);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
mcp-authorize e1, **PR 3 of the chain**. Wires the connection identity/handshake on top of PR 1
(#263, McpPlugin 7.0 adoption) and PR 2 (#265, RFC 8628 device flow + machine store + zero-button boot).

- **Instance-metadata handshake (design 04).** Mint an `InstanceId` once per editor session and set
  `ConnectionConfig.InstanceMetadata = ConnectionInstanceMetadata.Create("godot", projectName,
  projectRoot, instanceId, machineName)` before connect, so the server receives `{instance_id, engine,
  project_name, project_path_hash, machine_name}` in the hub handshake and can route/dedup by account +
  project + instance instead of token-string equality. The `project_path_hash` (and its first-8 routing
  pin) is derived from the same normalized project root a configurator hashes.
- **ProjectIdentity + ProjectMarker wiring (design 06 / 09 · 1A).** New pure-managed
  `GodotProjectIdentity` adapter over McpPlugin 7.0's `ProjectIdentity` (pin + derived port,
  golden-vector-pinned) and `ProjectMarker`. `ResolveConfig` now reads the project marker
  (`<project>/.ai-game-dev/project.json`) as the **lowest** config layer and resolves the enrolled
  `serverTarget` (loopback → Custom host, hosted → Cloud) so an enrolled project boots pointed at the
  right hub with no editor interaction. Every explicit user config (persisted / `.env` / process-env)
  still overrides it; a missing marker (the common case) is a no-op.
- **Scope fence.** This wires the pin + server-target resolution and surfaces the derived port
  (diagnostics/log), but does **NOT** change the local default port (the 8080 → derived-port migration is
  PR 4) and does **NOT** touch the config-writer / UI (`ConnectionPanel.cs` / `AgentConfiguratorsPanel.cs`
  — PR 5) or run a full 9.0-server e2e (PR 6). `ConnectionInstanceMetadata` carries no engine/plugin
  version fields (those already ride the existing McpPlugin version handshake).

## Test plan
- [x] `dotnet build Godot-MCP.sln` (.NET 8) — 0 errors.
- [x] `Godot-MCP.Tests` xUnit — **1012 passed / 0 failed** (+22 new: handshake payload, ProjectIdentity
      golden vectors incl. trailing-slash/case invariance + no-separator-conversion + marker-portOverride
      precedence, marker read/write + serverTarget→mode mapping).
- [x] `runtime/editor boundary` guard holds (81 Runtime/ files, 0 violations).
- [ ] Live-editor / headless smoke: the local software testbed csproj is pinned to McpPlugin 6.10.0
      (pre-existing lockstep lag behind the addon's 7.0.0-preview.1), so it cannot compile the 7.0-consuming
      addon locally — CI's five Godot mono addon-load matrices (`test-godot-4-3..4-7`) boot-verify the real
      addon on this commit.

Closes #266