### PR TITLE
feat(connection): migrate local default port 8080 → ProjectIdentity-derived (D15)

### DIFF
--- a/Godot-MCP.Tests/GodotProjectIdentityTests.cs
+++ b/Godot-MCP.Tests/GodotProjectIdentityTests.cs
@@ -154,6 +154,56 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.True(identity.PortIsOverridden);
         }
 
+        // === Default local server host — mcp-authorize e1, PR 4 (8080 → derived-port migration) ========
+        //
+        // The plugin's connect/start default host is now http://localhost:<derived-port> — the fixed 8080
+        // literal is gone from the golden path. These pin: (1) the derived port is used when there is no
+        // override; (2) it is NOT the fixed 8080; (3) a marker portOverride wins; (4) the URL's port tracks
+        // the same golden-vector port as Derive (one derivation, no second copy of the port math).
+
+        [Theory]
+        [InlineData("C:/Games/MyGame", "http://localhost:29062")]
+        [InlineData("/home/user/MyGame", "http://localhost:24998")]
+        [InlineData("/home/user/Demo Project", "http://localhost:20832")]
+        public void ResolveDefaultLocalServerHost_UsesDerivedPort_WhenNoOverride(string projectRoot, string expectedUrl)
+        {
+            Assert.Equal(expectedUrl, GodotProjectIdentity.ResolveDefaultLocalServerHost(projectRoot, marker: null));
+        }
+
+        [Fact]
+        public void ResolveDefaultLocalServerHost_IsNotTheFixed8080_OnTheGoldenPath()
+        {
+            // The whole point of PR 4: the local default is no longer the fixed 8080 literal.
+            var url = GodotProjectIdentity.ResolveDefaultLocalServerHost("C:/Games/MyGame", marker: null);
+            Assert.Equal("http://localhost:29062", url);
+            Assert.DoesNotContain(":8080", url);
+        }
+
+        [Fact]
+        public void ResolveDefaultLocalServerHost_MarkerPortOverride_Wins()
+        {
+            var marker = new ProjectMarker { PortOverride = 25000 };
+
+            // The user's explicit portOverride always wins over the derived default (D15 precedence).
+            Assert.Equal(
+                "http://localhost:25000",
+                GodotProjectIdentity.ResolveDefaultLocalServerHost("C:/Games/MyGame", marker));
+        }
+
+        [Fact]
+        public void ResolveDefaultLocalServerHost_TracksTheDeriveGoldenVectorPort()
+        {
+            // The URL's port is exactly ProjectIdentity's derived port for the same root — golden-vector
+            // parity is inherited from Derive, and the port stays inside the shared 20000–29999 band.
+            const string root = "/home/user/MyGame";
+            var identity = GodotProjectIdentity.Derive(root, marker: null);
+
+            Assert.Equal(
+                $"http://localhost:{identity.Port}",
+                GodotProjectIdentity.ResolveDefaultLocalServerHost(root, marker: null));
+            Assert.InRange(identity.Port, ProjectIdentity.MinPort, ProjectIdentity.MaxPort);
+        }
+
         // === Project marker read/write + server-target resolution =====================================
 
         [Fact]

--- a/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
@@ -375,8 +375,8 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
             // Surface the resolved project identity (routing pin + derived local port) and the enrolled
             // server target for the operator smoke. The pin is what agent sessions route on; the derived
-            // port is wired here for PR 4's 8080 → derived-port migration but does NOT change the runtime
-            // default in this PR (the connection still uses the configured Host / 8080 default).
+            // port is now the connection's local Custom-mode default (seeded into the config by
+            // ResolveConfig → SeedDefaultLocalServerHost — mcp-authorize e1, PR 4).
             LogProjectIdentity(projectRootPath);
 
             Reflector reflector = GodotReflectorFactory.CreateDefaultReflector();
@@ -1089,7 +1089,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 return;
             _configResolved = true;
 
-            // PRECEDENCE: process env > .env file > persisted config > project marker > built-in default.
+            // PRECEDENCE: process env > .env file > persisted config > project marker > derived-port default.
             // 0) Seed the ENROLLED server target from the project marker FIRST (the lowest layer above the
             //    built-in defaults). A CLI `install-plugin --enroll` (or a hand-written marker) records the
             //    hosted-vs-local target in `<project>/.ai-game-dev/project.json`; applying it before the
@@ -1108,6 +1108,16 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             //    still wins because GodotMcpConfig reads it live on every Host/Token/ActiveMode access —
             //    see GodotMcpEnvFile's precedence note.
             ApplyProjectEnvFile();
+
+            // 3) DERIVED-PORT DEFAULT (lowest precedence): when NO layer above chose an explicit local
+            //    Custom host — the host is still the fixed `GodotMcpConfig.DefaultCustomHost` baseline —
+            //    replace it with the project's ProjectIdentity-derived local server URL (mcp-authorize e1,
+            //    PR 4 — the 8080 → derived-port migration, design 06 · D15). Gated on "still the baseline",
+            //    so an enrolled serverTarget / persisted host / `.env` host / live process-env host all win
+            //    untouched; a marker `portOverride` is honored inside the derivation. This is what flips the
+            //    local default from the fixed 8080 to the deterministic per-project port on the golden boot
+            //    path (both the plugin's own connect and the local-server start read this host).
+            SeedDefaultLocalServerHost();
         }
 
         /// <summary>
@@ -1149,7 +1159,8 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// <c>res://</c> path resolution; the marker read + the target→mode mapping are the pure-managed,
         /// unit-tested <see cref="GodotProjectIdentity.ResolveServerTarget"/>. A missing/empty marker (the
         /// common case) is a silent no-op, so existing connection behavior is unchanged. This wires the
-        /// server-target resolution only — it does NOT change the local default port (PR 4).
+        /// server-target resolution only; the local default port is seeded separately by
+        /// <see cref="SeedDefaultLocalServerHost"/> (mcp-authorize e1, PR 4).
         /// </summary>
         void ApplyProjectMarker()
         {
@@ -1178,6 +1189,47 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
             GodotMcpLog.Info(
                 $"[Godot-MCP] project marker enrolled server target '{resolution.Value.ServerTarget}' -> mode={resolution.Value.Mode}.");
+        }
+
+        /// <summary>
+        /// Seed <see cref="_config"/>'s Custom-mode host with the project's ProjectIdentity-derived local
+        /// server URL (mcp-authorize e1, PR 4 — the 8080 → derived-port migration, design 06 · D15) — but
+        /// ONLY when no config layer above chose an explicit local host, i.e. the host is still the fixed
+        /// <see cref="GodotMcpConfig.DefaultCustomHost"/> baseline. This is the lowest-precedence "fill in
+        /// the default" step, called LAST in <see cref="ResolveConfig"/>: an enrolled marker serverTarget, a
+        /// persisted host, a <c>.env</c> host, or a live process-env host all leave a non-baseline value
+        /// here and so win untouched. The port precedence inside the derivation is marker <c>portOverride</c>
+        /// → the deterministic hash-derived port; there is no 8080 fallback on this golden path. Both the
+        /// plugin's own connect (the <c>Host</c> getter) and the local-server START (the connection panel's
+        /// <c>ResolveCustomHost()</c> read) consume this host, so both use the derived port. The only Godot
+        /// dependency is the res:// project-root resolution; the URL derivation is the pure-managed,
+        /// unit-tested <see cref="GodotProjectIdentity.ResolveDefaultLocalServerHost"/>. A project root that
+        /// fails to resolve leaves the baseline in place (a degenerate non-editor path). Never throws.
+        /// </summary>
+        void SeedDefaultLocalServerHost()
+        {
+            // Respect any explicit local host chosen by a higher-precedence layer (enrolled serverTarget,
+            // persisted config, or .env). Only the untouched built-in baseline is replaced; a live
+            // process-env GODOT_MCP_HOST still wins regardless (the getter applies it over this field).
+            var current = GodotMcpConfig.NormalizeUrl(_config.CustomHost);
+            if (!string.IsNullOrEmpty(current) && current != GodotMcpConfig.DefaultCustomHost)
+                return;
+
+            var projectRoot = ResolveProjectRootPath();
+            if (string.IsNullOrEmpty(projectRoot))
+                return;
+
+            try
+            {
+                var marker = ProjectMarker.Read(projectRoot);
+                _config.CustomHost = GodotProjectIdentity.ResolveDefaultLocalServerHost(projectRoot, marker);
+                GodotMcpLog.Info(
+                    $"[Godot-MCP] local server default port -> ProjectIdentity-derived host {_config.CustomHost}.");
+            }
+            catch (Exception ex)
+            {
+                GodotMcpLog.Warning($"[Godot-MCP] could not seed derived local server host: {ex.Message}");
+            }
         }
 
         /// <summary>
@@ -1233,8 +1285,9 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// <summary>
         /// Log the resolved <see cref="ProjectIdentity"/> (routing pin + derived local port, honoring a
         /// marker <c>portOverride</c>) and the enrolled server target for the operator smoke — a build-green
-        /// boot line proving the identity wiring resolves. Diagnostics only: the derived port is surfaced
-        /// for PR 4's local-port migration but is NOT applied to the runtime connection here. Never throws.
+        /// boot line proving the identity wiring resolves. Diagnostics only; the derived port is applied to
+        /// the connection separately by <see cref="SeedDefaultLocalServerHost"/> (mcp-authorize e1, PR 4).
+        /// Never throws.
         /// </summary>
         void LogProjectIdentity(string projectRoot)
         {

--- a/addons/godot_mcp/Runtime/Connection/GodotProjectIdentity.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotProjectIdentity.cs
@@ -32,8 +32,9 @@ namespace com.IvanMurzak.Godot.MCP.Connection
     ///   <see cref="ConnectionInstanceMetadata"/> the SignalR client sends on connect so the server can
     ///   route/dedup by account + project + instance (design 04).</item>
     ///   <item><b>ProjectIdentity</b> — <see cref="Derive"/> resolves the project's <c>{pin, port}</c>
-    ///   (honoring a marker <c>portOverride</c>). This PR wires the derived-port <em>value</em>; it does
-    ///   NOT change the local default port (still <c>8080</c> — that migration is PR 4).</item>
+    ///   (honoring a marker <c>portOverride</c>), and <see cref="ResolveDefaultLocalServerHost"/> turns
+    ///   that into the default local Custom-mode server URL (<c>http://localhost:&lt;port&gt;</c>) — the
+    ///   mcp-authorize e1 · PR 4 replacement for the fixed <c>8080</c> local default (design 06 · D15).</item>
     ///   <item><b>Server-target resolution</b> — <see cref="ResolveServerTarget"/> maps the project
     ///   marker's enrolled <c>serverTarget</c> to a connection decision so the plugin boots pointed at
     ///   the right hub (hosted vs local; design 06 / 09 · 1A).</item>
@@ -88,13 +89,32 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// consulting the marker's <c>portOverride</c> when a marker is present (the
         /// <see cref="ProjectMarker"/> overload) and otherwise deriving the default port. The derivation
         /// itself is the library's golden-vector-pinned canonical math — this only picks the right
-        /// overload. The returned port is NOT applied to the live connection in this PR (the 8080 →
-        /// derived-port migration is PR 4); it is surfaced for diagnostics + PR-4 consumption.
+        /// overload. The resolved port is the local Custom-mode server default (see
+        /// <see cref="ResolveDefaultLocalServerHost"/>): a marker <c>portOverride</c> wins, else the
+        /// deterministic hash-derived port (mcp-authorize e1 · PR 4 — the 8080 → derived-port migration).
         /// </summary>
         public static ProjectIdentity Derive(string projectRoot, ProjectMarker? marker)
             => marker != null
                 ? ProjectIdentity.Derive(projectRoot, marker)
                 : ProjectIdentity.Derive(projectRoot, (int?)null);
+
+        /// <summary>
+        /// The loopback scheme+host every local Custom-mode server URL is built on. The port is appended
+        /// by <see cref="ResolveDefaultLocalServerHost"/>; there is no fixed default port baked in here
+        /// (mcp-authorize e1 · PR 4 retired the <c>8080</c> literal on the connect path).
+        /// </summary>
+        public const string LocalLoopbackHost = "http://localhost";
+
+        /// <summary>
+        /// Resolve the DEFAULT local Custom-mode server URL for <paramref name="projectRoot"/> — the
+        /// mcp-authorize e1 · PR 4 replacement for the fixed <c>http://localhost:8080</c> default (design
+        /// 06 · D15). The port precedence is: the project marker's explicit user <c>portOverride</c> (when
+        /// present it always wins) → the deterministic <see cref="ProjectIdentity"/> hash-derived port.
+        /// There is NO hardcoded 8080 fallback. Deterministic and probe-free — the same project path always
+        /// yields the same URL, so it matches the pin/port a configurator writes for the same root.
+        /// </summary>
+        public static string ResolveDefaultLocalServerHost(string projectRoot, ProjectMarker? marker)
+            => $"{LocalLoopbackHost}:{Derive(projectRoot, marker).Port}";
 
         /// <summary>
         /// Resolve the enrolled server target from the project marker into a connection decision, or


### PR DESCRIPTION
## Summary
mcp-authorize e1, **PR 4 of the chain**. Flips the addon's local Custom-mode default server port from the
fixed `8080` to the deterministic **ProjectIdentity-derived** per-project port (design 06 · D15), building on
PR 1 (#262), PR 2 (#264), and PR 3 (#266 — which wired the derived-port *value* + surfaced it for diagnostics
but explicitly deferred this runtime flip to PR 4).

- **New pure-managed seam.** `GodotProjectIdentity.ResolveDefaultLocalServerHost(projectRoot, marker)` →
  `http://localhost:<port>`, where the port is the marker `portOverride` (always wins) → the golden-vector
  hash-derived port. No 8080 fallback; golden-vector parity is inherited from `Derive` (one derivation, no
  second copy of the port math).
- **Applied at the connection default layer.** `GodotMcpConnection.ResolveConfig()` seeds it into
  `GodotMcpConfig.CustomHost` as the **lowest-precedence** step, gated on "the host is still the built-in
  `DefaultCustomHost` baseline" — so an enrolled marker `serverTarget`, a persisted host, a `.env` host, or a
  live process-env `GODOT_MCP_HOST` all still win untouched. Both the plugin's own connect (`Host` getter)
  and the local-server **start** (the panel's `ResolveCustomHost()` read) consume `CustomHost`, so both pick
  up the derived port with no UI change.
- Stale "PR 4 / not applied" doc comments updated now that the migration has landed.

## Scope fence
Flips the local default port only. Does **NOT** touch the config-writer / UI (`ConnectionPanel.cs` /
`AgentConfiguratorsPanel.cs` / `AgentConfiguratorSettingsFactory.cs` — PR 5) and does **NOT** run enroll
redemption or a full live 9.0-server e2e (PR 6). No NuGet-pin or `plugin.cfg` version bump.

## Test plan
- [x] `dotnet build Godot-MCP.sln` (.NET 8) — 0 errors, 0 warnings.
- [x] `Godot-MCP.Tests` xUnit — **1018 passed / 0 failed** (+6 new `ResolveDefaultLocalServerHost` cases:
      derived default used when no override, is NOT the fixed 8080, marker `portOverride` wins, golden-vector
      port parity).
- [ ] Live-editor / headless smoke: the local software testbed csproj is pinned to McpPlugin 6.10.0
      (pre-existing lockstep lag behind the addon's 7.0.0-preview.1), so it cannot compile the 7.0-consuming
      addon locally — the same constraint PR 3 documented. CI's five Godot mono addon-load / dock-reload /
      e2e-install / runtime-harness matrices boot-verify the real addon on this commit; the change is
      pure-managed (unit-tested) with no new Godot-native surface.

Closes #268