### PR TITLE
feat(ui): URL-only default configure path + sign-in state (mcp-authorize PR5)

### DIFF
--- a/Godot-MCP.Tests/AgentConfiguratorCredentialPolicyTests.cs
+++ b/Godot-MCP.Tests/AgentConfiguratorCredentialPolicyTests.cs
@@ -1,0 +1,177 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.Linq;
+using com.IvanMurzak.Godot.MCP.UI.Agents;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the pure-managed credential-surfacing policy of the AI-agent configurators (mcp-authorize e1 · PR 5,
+    /// design <c>06-engine-plugins.md</c>): the <see cref="AgentConfiguratorCredentialPolicy"/> decisions AND —
+    /// end-to-end through the real shared <c>com.IvanMurzak.McpPlugin.AgentConfig</c> 7.0 configurators — that the
+    /// DEFAULT (OAuth) path writes a URL-only config with no token in the file OR the rendered manual-config
+    /// command, while the "Advanced: use access token" escape hatch writes the legacy Bearer-header shape.
+    ///
+    /// <para>
+    /// The <c>#if TOOLS</c> panel/factory adapters (<c>AgentConfiguratorSettingsFactory</c> reads Godot
+    /// <c>ProjectSettings</c>; <c>AgentConfiguratorsPanel</c> / <c>ConnectionPanel</c> build live Godot Controls)
+    /// are verified via the headless Godot smoke (test.md Suite 3) — here we replicate exactly the settings the
+    /// factory builds (token / authOption via the policy) and drive the shared writer, which is pure-managed.
+    /// </para>
+    /// </summary>
+    public class AgentConfiguratorCredentialPolicyTests
+    {
+        // A representative Godot-visible configurator with a writable HTTP config file (claude-code). The pin
+        // hash is derived from this string; no filesystem access happens, so any stable value works cross-OS.
+        const string ProjectRoot = "/home/dev/projects/MyGame";
+        const string SecretToken = "SECRET_TOKEN_9f8e7d6c";
+
+        static AgentConfiguratorSettings BuildSettings(
+            HttpCredentialMode mode, string? rawConfigToken, ConnectionMode connMode = ConnectionMode.Cloud) =>
+            AgentConfiguratorSettings.CreateForHost(
+                projectRootPath: ProjectRoot,
+                executableFullPath: string.Empty,
+                port: 8080,
+                timeoutMs: 10000,
+                host: connMode == ConnectionMode.Cloud ? "https://ai-game.dev/mcp" : "http://localhost:26610",
+                token: AgentConfiguratorCredentialPolicy.ResolveSettingsToken(mode, rawConfigToken),
+                connectionMode: connMode,
+                authOption: AgentConfiguratorCredentialPolicy.ResolveSettingsAuthOption(mode),
+                serverExecutableName: "gamedev-mcp-server",
+                serverVersion: "9.0.0",
+                dockerImage: "aigamedeveloper/mcp-server");
+
+        static AiAgentConfigurator Claude()
+        {
+            var c = GodotAgentConfigurators.GetByAgentId("claude-code");
+            Assert.NotNull(c);
+            return c!;
+        }
+
+        // --- ResolveCredentialMode: default OAuth; user opt-in or a non-OAuth configurator forces AccessToken ---
+
+        [Theory]
+        [InlineData(true, false, HttpCredentialMode.Oauth)]        // OAuth-capable, default -> URL-only
+        [InlineData(true, true, HttpCredentialMode.AccessToken)]   // OAuth-capable + "Advanced" opt-in -> token
+        [InlineData(false, false, HttpCredentialMode.AccessToken)] // non-OAuth -> forced token (no default path)
+        [InlineData(false, true, HttpCredentialMode.AccessToken)]  // non-OAuth stays token regardless
+        public void ResolveCredentialMode_DefaultsToOAuth_ForcesTokenWhenNeeded(
+            bool supportsOAuth, bool useAccessToken, HttpCredentialMode expected)
+        {
+            Assert.Equal(expected, AgentConfiguratorCredentialPolicy.ResolveCredentialMode(supportsOAuth, useAccessToken));
+        }
+
+        [Theory]
+        [InlineData(true, true)]    // OAuth-capable -> the toggle is offered
+        [InlineData(false, false)]  // non-OAuth -> no toggle (the token is mandatory)
+        public void ShowAdvancedToggle_OnlyForOAuthCapable(bool supportsOAuth, bool expected)
+        {
+            Assert.Equal(expected, AgentConfiguratorCredentialPolicy.ShowAdvancedToggle(supportsOAuth));
+        }
+
+        [Theory]
+        [InlineData(true, false, false)]  // default OAuth path hides the token field
+        [InlineData(true, true, true)]    // "Advanced" opt-in reveals it
+        [InlineData(false, false, true)]  // a non-OAuth configurator always shows it
+        public void ShowAccessTokenField_TracksResolvedMode(bool supportsOAuth, bool useAccessToken, bool expected)
+        {
+            Assert.Equal(expected, AgentConfiguratorCredentialPolicy.ShowAccessTokenField(supportsOAuth, useAccessToken));
+        }
+
+        [Fact]
+        public void ResolveSettingsToken_OAuthDropsToken_AccessTokenCarriesIt()
+        {
+            // OAuth default: never carry the token, even when the connection has one stored.
+            Assert.Equal(string.Empty, AgentConfiguratorCredentialPolicy.ResolveSettingsToken(HttpCredentialMode.Oauth, SecretToken));
+            // AccessToken: carry the live token (empty when none is stored).
+            Assert.Equal(SecretToken, AgentConfiguratorCredentialPolicy.ResolveSettingsToken(HttpCredentialMode.AccessToken, SecretToken));
+            Assert.Equal(string.Empty, AgentConfiguratorCredentialPolicy.ResolveSettingsToken(HttpCredentialMode.AccessToken, null));
+        }
+
+        [Fact]
+        public void ResolveSettingsAuthOption_OAuthIsNone_AccessTokenIsRequired()
+        {
+            Assert.Equal(AuthOption.none, AgentConfiguratorCredentialPolicy.ResolveSettingsAuthOption(HttpCredentialMode.Oauth));
+            Assert.Equal(AuthOption.required, AgentConfiguratorCredentialPolicy.ResolveSettingsAuthOption(HttpCredentialMode.AccessToken));
+        }
+
+        // --- End-to-end through the real shared configurator: DEFAULT path writes URL-only (no token) ---
+
+        [Fact]
+        public void DefaultOAuthPath_WritesUrlOnlyConfig_NoTokenNoBearer()
+        {
+            var settings = BuildSettings(HttpCredentialMode.Oauth, SecretToken);
+            var config = Claude().GetHttpConfig(settings, NullLogger.Instance, HttpCredentialMode.Oauth);
+            var content = config.ExpectedFileContent ?? string.Empty;
+
+            Assert.DoesNotContain(SecretToken, content);
+            Assert.DoesNotContain("Authorization", content);
+            Assert.DoesNotContain("Bearer", content);
+            // The URL-only config still points at the project-pinned URL (the /p/<pin> path).
+            Assert.Contains("/p/", content);
+        }
+
+        [Fact]
+        public void DefaultOAuthPath_ManualConfigCommand_OmitsTheRealToken()
+        {
+            // On the default path the settings carry NO token, so no real access token appears anywhere in the
+            // rendered DTO — not in the primary config and not in the "Manual Configuration Steps" command. (In
+            // Cloud mode the shared 7.0 lib still renders a generic "Bearer <token>" PLACEHOLDER in the manual
+            // fallback — a frozen-pin artifact, driven by connectionMode=Cloud, never the real secret.)
+            var settings = BuildSettings(HttpCredentialMode.Oauth, SecretToken);
+            var description = Claude().Describe(settings, TransportMethod.streamableHttp, NullLogger.Instance);
+            var allText = string.Join("\n", description.Sections.SelectMany(s => s.Items).Select(i => i.Text ?? string.Empty));
+
+            Assert.DoesNotContain(SecretToken, allText);
+        }
+
+        [Fact]
+        public void DefaultOAuthPath_LocalMode_ManualConfigCommand_IsFullyUrlOnly()
+        {
+            // In Local (self-hosted) mode the OAuth default (authOption=none) drops the Bearer header from the
+            // manual-config command entirely — the URL-only golden path, no token surface at all.
+            var settings = BuildSettings(HttpCredentialMode.Oauth, SecretToken, ConnectionMode.Local);
+            var description = Claude().Describe(settings, TransportMethod.streamableHttp, NullLogger.Instance);
+            var allText = string.Join("\n", description.Sections.SelectMany(s => s.Items).Select(i => i.Text ?? string.Empty));
+
+            Assert.DoesNotContain(SecretToken, allText);
+            Assert.DoesNotContain("Bearer", allText);
+        }
+
+        // --- End-to-end: the "Advanced: use access token" escape hatch writes the legacy Bearer-header shape ---
+
+        [Fact]
+        public void AdvancedAccessTokenPath_WritesBearerHeaderConfig()
+        {
+            var settings = BuildSettings(HttpCredentialMode.AccessToken, SecretToken);
+            var config = Claude().GetHttpConfig(settings, NullLogger.Instance, HttpCredentialMode.AccessToken);
+            var content = config.ExpectedFileContent ?? string.Empty;
+
+            Assert.Contains(SecretToken, content);
+            Assert.Contains("Bearer", content);
+        }
+
+        [Fact]
+        public void AdvancedAccessTokenPath_ManualConfigCommand_ShowsBearerToken()
+        {
+            var settings = BuildSettings(HttpCredentialMode.AccessToken, SecretToken);
+            var description = Claude().Describe(settings, TransportMethod.streamableHttp, NullLogger.Instance);
+            var allText = string.Join("\n", description.Sections.SelectMany(s => s.Items).Select(i => i.Text ?? string.Empty));
+
+            Assert.Contains("Bearer", allText);
+            Assert.Contains(SecretToken, allText);
+        }
+    }
+}

--- a/Godot-MCP.Tests/ConnectionPanelViewTests.cs
+++ b/Godot-MCP.Tests/ConnectionPanelViewTests.cs
@@ -265,6 +265,59 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.False(ConnectionPanelView.ShowConnectionRequired(true, false, ConnectionStatus.Disconnected));
         }
 
+        // --- Cloud sign-in / account state (mcp-authorize e1 · PR 5) ---
+
+        [Fact]
+        public void CloudSignInStatusLabel_ReflectsCredentialPresence()
+        {
+            Assert.Equal(ConnectionPanelView.SignedInLabel, ConnectionPanelView.CloudSignInStatusLabel(true));
+            Assert.Equal(ConnectionPanelView.SignedOutLabel, ConnectionPanelView.CloudSignInStatusLabel(false));
+        }
+
+        [Fact]
+        public void CloudSignInStatus_TracksStoredCredential_OnTheConfig()
+        {
+            // The panel derives its signed-in state from whether a cloud credential is stored — proven here on
+            // the real GodotMcpConfig: no credential -> signed out; a stored credential -> signed in.
+            var config = new GodotMcpConfig();
+            Assert.Equal(ConnectionPanelView.SignedOutLabel,
+                ConnectionPanelView.CloudSignInStatusLabel(!string.IsNullOrEmpty(config.CloudToken)));
+
+            config.CloudToken = "cloud-jwt-abc123";
+            Assert.Equal(ConnectionPanelView.SignedInLabel,
+                ConnectionPanelView.CloudSignInStatusLabel(!string.IsNullOrEmpty(config.CloudToken)));
+        }
+
+        [Fact]
+        public void CloudSignInStatusColor_IsGreenWhenSignedIn_GrayWhenNot()
+        {
+            Assert.Equal(ConnectionPanelView.ColorConnected, ConnectionPanelView.CloudSignInStatusColor(true));
+            Assert.Equal(ConnectionPanelView.ColorDisconnected, ConnectionPanelView.CloudSignInStatusColor(false));
+            Assert.NotEqual(
+                ConnectionPanelView.CloudSignInStatusColor(true),
+                ConnectionPanelView.CloudSignInStatusColor(false));
+        }
+
+        [Theory]
+        [InlineData(true, true)]    // "Advanced: use access token" on -> the raw token field is revealed
+        [InlineData(false, false)]  // default path -> hidden
+        public void ShowCloudTokenField_OnlyUnderAdvancedOptIn(bool useAccessToken, bool expected)
+        {
+            Assert.Equal(expected, ConnectionPanelView.ShowCloudTokenField(useAccessToken));
+        }
+
+        [Fact]
+        public void ConnectionUrlLabel_FormatsPinnedUrl_EmptyWhenAbsent()
+        {
+            Assert.Equal("Connection URL: https://ai-game.dev/mcp/p/228b7b4f",
+                ConnectionPanelView.ConnectionUrlLabel("https://ai-game.dev/mcp/p/228b7b4f"));
+            Assert.Equal("Connection URL: http://localhost:26610/p/228b7b4f",
+                ConnectionPanelView.ConnectionUrlLabel("  http://localhost:26610/p/228b7b4f  "));
+            Assert.Equal(string.Empty, ConnectionPanelView.ConnectionUrlLabel(null));
+            Assert.Equal(string.Empty, ConnectionPanelView.ConnectionUrlLabel(""));
+            Assert.Equal(string.Empty, ConnectionPanelView.ConnectionUrlLabel("   "));
+        }
+
         [Fact]
         public void CustomHost_PersistsAndReloads()
         {

--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -272,6 +272,13 @@
          unit-tested upstream in MCP-Plugin-dotnet. The dock UI (AgentConfiguratorsPanel.cs) is #if TOOLS and verified
          via the headless Godot smoke (test.md Suite 3). -->
     <Compile Include="..\addons\godot_mcp\Editor\UI\Agents\GodotAgentConfigurators.cs" Link="Source\GodotAgentConfigurators.cs" />
+    <!-- Credential-surfacing policy (mcp-authorize e1 · PR 5) — pure-managed (no Godot native types, no #if TOOLS):
+         decides the HttpCredentialMode + token/authOption the shared configurator settings carry so the DEFAULT
+         configure/connection view is URL-only (native OAuth) and the "Advanced: use access token" escape hatch
+         writes the legacy Bearer shape. The #if TOOLS AgentConfiguratorSettingsFactory / AgentConfiguratorsPanel /
+         ConnectionPanel are thin adapters over it (verified via the headless Godot smoke, test.md Suite 3); the
+         decisions are unit-tested here (AgentConfiguratorCredentialPolicyTests). -->
+    <Compile Include="..\addons\godot_mcp\Editor\UI\Agents\AgentConfiguratorCredentialPolicy.cs" Link="Source\AgentConfiguratorCredentialPolicy.cs" />
     <Compile Include="..\addons\godot_mcp\Editor\UI\SkillsPathUtils.cs" Link="Source\SkillsPathUtils.cs" />
     <!-- Skills card presentation model — pure-managed (no Godot native types, no #if TOOLS): the supported/path
          resolution (SkillsPlan) the dock's Skills card renders, now sourced from the shared configurator's

--- a/addons/godot_mcp/Editor/UI/Agents/AgentConfiguratorCredentialPolicy.cs
+++ b/addons/godot_mcp/Editor/UI/Agents/AgentConfiguratorCredentialPolicy.cs
@@ -1,0 +1,91 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using AgentConfig = com.IvanMurzak.McpPlugin.AgentConfig;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.Godot.MCP.UI.Agents
+{
+    /// <summary>
+    /// Pure-managed policy for HOW an AI-agent HTTP config surfaces credentials (mcp-authorize e1 · PR 5,
+    /// design <c>06-engine-plugins.md</c> § "Config writers" / "Engine UI deltas"). The shared 7.0
+    /// config-writer already defaults to URL-only OAuth output (native OAuth, no static bearer); this decides,
+    /// per configurator + the user's "Advanced: use access token" opt-in, which
+    /// <see cref="AgentConfig.HttpCredentialMode"/> to write AND what token / auth-option to feed the shared
+    /// <see cref="AgentConfig.AgentConfiguratorSettings"/> so that:
+    /// <list type="bullet">
+    ///   <item>the DEFAULT path is URL-only — no token in the written config OR in the rendered
+    ///   "Manual Configuration Steps" command (with the device-flow machine credential store from PR 2 the
+    ///   token is no longer user-entered on the golden path — <c>AgentConfiguratorSettings.Token</c> is no
+    ///   longer required input); and</item>
+    ///   <item>the escape hatch writes the legacy Bearer-header shape (design "Flow C") for the few
+    ///   configurators that can't do MCP OAuth (<see cref="AgentConfig.AiAgentConfigurator.SupportsOAuth"/>
+    ///   == false, capability flag defaulting to true).</item>
+    /// </list>
+    ///
+    /// <para>
+    /// No Godot native types and no <c>#if TOOLS</c>, so every decision is unit-testable in the plain-xUnit
+    /// host; the <c>#if TOOLS</c> <see cref="AgentConfiguratorSettingsFactory"/> / <c>AgentConfiguratorsPanel</c>
+    /// (and the Cloud connection panel) are thin adapters over this.
+    /// </para>
+    /// </summary>
+    public static class AgentConfiguratorCredentialPolicy
+    {
+        /// <summary>The label for the "Advanced: use access token" opt-in that reveals the legacy token field.</summary>
+        public const string AdvancedUseAccessTokenLabel = "Advanced: use access token";
+
+        /// <summary>
+        /// The effective credential mode for writing an HTTP agent config. The default is
+        /// <see cref="AgentConfig.HttpCredentialMode.Oauth"/> (URL-only, native OAuth). A configurator that
+        /// cannot do MCP OAuth (<paramref name="supportsOAuth"/> == <c>false</c>) has no default path, so it
+        /// FORCES <see cref="AgentConfig.HttpCredentialMode.AccessToken"/>; otherwise the user's
+        /// <paramref name="useAccessToken"/> "Advanced" opt-in flips to AccessToken.
+        /// </summary>
+        public static AgentConfig.HttpCredentialMode ResolveCredentialMode(bool supportsOAuth, bool useAccessToken)
+            => (!supportsOAuth || useAccessToken)
+                ? AgentConfig.HttpCredentialMode.AccessToken
+                : AgentConfig.HttpCredentialMode.Oauth;
+
+        /// <summary>
+        /// Whether the "Advanced: use access token" TOGGLE is offered for a configurator. Only OAuth-capable
+        /// configurators get the toggle — a non-OAuth one has no default (OAuth) path, so its token is
+        /// mandatory and there is nothing to toggle (the field is always shown for it via
+        /// <see cref="ShowAccessTokenField"/>).
+        /// </summary>
+        public static bool ShowAdvancedToggle(bool supportsOAuth) => supportsOAuth;
+
+        /// <summary>
+        /// Whether the raw access-token field is surfaced for a configurator + preference — <c>true</c> exactly
+        /// when the resolved mode is <see cref="AgentConfig.HttpCredentialMode.AccessToken"/> (the "Advanced"
+        /// opt-in, or a non-OAuth configurator). The default OAuth path hides it.
+        /// </summary>
+        public static bool ShowAccessTokenField(bool supportsOAuth, bool useAccessToken)
+            => ResolveCredentialMode(supportsOAuth, useAccessToken) == AgentConfig.HttpCredentialMode.AccessToken;
+
+        /// <summary>
+        /// The token fed into the shared <see cref="AgentConfig.AgentConfiguratorSettings"/> for a given
+        /// <paramref name="mode"/>: only the AccessToken path carries the token; the OAuth default passes empty
+        /// so the written config AND the shared <c>Describe()</c> manual-config command are URL-only (no
+        /// <c>Authorization: Bearer</c>).
+        /// </summary>
+        public static string ResolveSettingsToken(AgentConfig.HttpCredentialMode mode, string? configToken)
+            => mode == AgentConfig.HttpCredentialMode.AccessToken ? (configToken ?? string.Empty) : string.Empty;
+
+        /// <summary>
+        /// The authorization option fed into the shared <see cref="AgentConfig.AgentConfiguratorSettings"/> for
+        /// a given <paramref name="mode"/>: <see cref="AuthOption.required"/> on the AccessToken path (so the
+        /// shared <c>Describe()</c> renders the Bearer "Manual Configuration Steps" command) and
+        /// <see cref="AuthOption.none"/> on the OAuth default (URL-only manual command). The written HTTP config
+        /// body itself is driven by the explicit <c>credentialMode</c> passed to <c>GetHttpConfig</c>, not this.
+        /// </summary>
+        public static AuthOption ResolveSettingsAuthOption(AgentConfig.HttpCredentialMode mode)
+            => mode == AgentConfig.HttpCredentialMode.AccessToken ? AuthOption.required : AuthOption.none;
+    }
+}

--- a/addons/godot_mcp/Editor/UI/Agents/AgentConfiguratorSettingsFactory.cs
+++ b/addons/godot_mcp/Editor/UI/Agents/AgentConfiguratorSettingsFactory.cs
@@ -12,7 +12,6 @@
 using com.IvanMurzak.Godot.MCP.Connection;
 using Godot;
 using AgentConfig = com.IvanMurzak.McpPlugin.AgentConfig;
-using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
 
 namespace com.IvanMurzak.Godot.MCP.UI.Agents
 {
@@ -42,10 +41,23 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents
         /// configurators emitted. Godot is a pure HTTP client (no local-server lifecycle), so the port /
         /// executable / Docker fields are populated from the addon's authoritative server identity for the
         /// shared Custom configurator's Docker hints; the HTTP-config write path never reads them.
+        ///
+        /// <para>
+        /// The <paramref name="credentialMode"/> (mcp-authorize e1 · PR 5) governs how the token surfaces:
+        /// <see cref="AgentConfig.HttpCredentialMode.Oauth"/> (the DEFAULT) yields URL-only settings — empty
+        /// token + <c>authOption=none</c> — so the written config AND the shared <c>Describe()</c>
+        /// "Manual Configuration Steps" command are URL-only; <see cref="AgentConfig.HttpCredentialMode.AccessToken"/>
+        /// carries the live token + <c>required</c> so the escape-hatch path writes the legacy Bearer-header shape.
+        /// The mapping is centralized in the pure-managed, unit-tested
+        /// <see cref="AgentConfiguratorCredentialPolicy"/>.
+        /// </para>
         /// </summary>
-        public static AgentConfig.AgentConfiguratorSettings Create(GodotMcpConfig config)
+        public static AgentConfig.AgentConfiguratorSettings Create(
+            GodotMcpConfig config,
+            AgentConfig.HttpCredentialMode credentialMode = AgentConfig.HttpCredentialMode.Oauth)
         {
-            var token = config.Token;
+            var token = AgentConfiguratorCredentialPolicy.ResolveSettingsToken(credentialMode, config.Token);
+            var authOption = AgentConfiguratorCredentialPolicy.ResolveSettingsAuthOption(credentialMode);
 
             return AgentConfig.AgentConfiguratorSettings.CreateForHost(
                 projectRootPath: ProjectRootPath,
@@ -55,7 +67,7 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents
                 host: GodotMcpConfig.ResolveMcpClientUrl(config),
                 token: token,
                 connectionMode: MapConnectionMode(config.ActiveMode),
-                authOption: MapAuthOption(config),
+                authOption: authOption,
                 serverExecutableName: GodotMcpServerView.ExecutableName,
                 serverVersion: GodotMcpServerView.ServerVersion,
                 dockerImage: DockerImage);
@@ -85,21 +97,6 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents
             => mode == GodotMcpConnectionMode.Cloud
                 ? AgentConfig.ConnectionMode.Cloud
                 : AgentConfig.ConnectionMode.Local;
-
-        /// <summary>
-        /// Map Godot's effective authorization onto the shared <see cref="AuthOption"/>. Cloud mode always
-        /// authorizes (a bearer token is sent); Custom mode follows the live
-        /// <see cref="GodotMcpConfig.ActiveAuthOption"/>.
-        /// </summary>
-        public static AuthOption MapAuthOption(GodotMcpConfig config)
-        {
-            if (config.ActiveMode == GodotMcpConnectionMode.Cloud)
-                return AuthOption.required;
-
-            return config.ActiveAuthOption == GodotMcpAuthOption.Required
-                ? AuthOption.required
-                : AuthOption.none;
-        }
     }
 }
 #endif

--- a/addons/godot_mcp/Editor/UI/Agents/AgentConfiguratorsPanel.cs
+++ b/addons/godot_mcp/Editor/UI/Agents/AgentConfiguratorsPanel.cs
@@ -74,6 +74,13 @@ namespace com.IvanMurzak.Godot.MCP.UI
         // Live state for the currently-shown configurator.
         AgentConfig.AiAgentConfigurator? _current;
 
+        // "Advanced: use access token" opt-in (mcp-authorize e1 · PR 5). Default OFF → the DEFAULT configure view
+        // is URL-only (native OAuth: no token in the written config OR the rendered manual-config command). ON →
+        // the escape-hatch path writes the legacy Bearer-header shape (design "Flow C"). Panel-wide (persists
+        // across agent switches within a session); rebuilt into each agent view via BuildAdvancedTokenToggle.
+        bool _useAccessToken;
+        DockCheckBox? _advancedTokenToggle;
+
         // Configure/Remove status-row controls + the reconfigure alert host, rebuilt per agent switch.
         Label? _statusLabel;
         Button? _configureButton;
@@ -188,6 +195,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _alertHost = null;
             _agentBody = null;
             _skillsSection = null;
+            _advancedTokenToggle = null;
 
             BuildAgentView(_current);
         }
@@ -248,6 +256,11 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
             // Skills sit ABOVE the DTO sections (Unity's containerSkills order).
             BuildSkillsSection();
+
+            // "Advanced: use access token" opt-in (mcp-authorize e1 · PR 5): with the default OFF the DTO sections
+            // below (built from `settings`, which carries no token on the OAuth path) render URL-only; toggling ON
+            // re-renders + writes the legacy Bearer shape. Sits above the config sections it governs.
+            BuildAdvancedTokenToggle(agent);
 
             // Walk the shared DTO's sections — each becomes a collapsible foldout of mapped item widgets.
             foreach (var section in description.Sections)
@@ -400,7 +413,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 return;
 
             var settings = CurrentSettings();
-            var config = agent.GetHttpConfig(settings, Logger);
+            var config = agent.GetHttpConfig(settings, Logger, CurrentCredentialMode());
 
             // --- Row 1: "Model Context Protocol (MCP)" header + right-aligned ellipsis config path. ---
             var headerRow = new HBoxContainer { Name = "McpHeaderRow", SizeFlagsHorizontal = SizeFlags.ExpandFill };
@@ -457,6 +470,65 @@ namespace com.IvanMurzak.Godot.MCP.UI
         }
 
         /// <summary>
+        /// Build the "Advanced: use access token" opt-in row (mcp-authorize e1 · PR 5) — a right-aligned checkbox
+        /// that flips the written config + the DTO's manual-config command between the DEFAULT URL-only OAuth shape
+        /// and the legacy Bearer-header shape (design "Flow C"). Offered ONLY for OAuth-capable configurators
+        /// (<see cref="AgentConfiguratorCredentialPolicy.ShowAdvancedToggle"/>): a non-OAuth configurator has no
+        /// default path — its token is mandatory — so no toggle is shown and it always renders the token shape.
+        /// </summary>
+        void BuildAdvancedTokenToggle(AgentConfig.AiAgentConfigurator agent)
+        {
+            if (_agentBody == null || !AgentConfiguratorCredentialPolicy.ShowAdvancedToggle(agent.SupportsOAuth))
+                return;
+
+            var row = new HBoxContainer { Name = "AdvancedTokenRow", SizeFlagsHorizontal = SizeFlags.ExpandFill };
+            row.Alignment = BoxContainer.AlignmentMode.Center;
+            _agentBody.AddChild(row);
+
+            var label = new Label { Name = "AdvancedTokenLabel", Text = AgentConfiguratorCredentialPolicy.AdvancedUseAccessTokenLabel };
+            DockStyle.ApplyDescription(label);
+            label.AutowrapMode = TextServer.AutowrapMode.Off;
+            row.AddChild(label);
+
+            row.AddChild(new Control { Name = "AdvancedTokenSpacer", SizeFlagsHorizontal = SizeFlags.ExpandFill });
+
+            // Object+method Callable on the checkbox instance (no delegate += into the ManagedCallable hot-reload
+            // registry) — mirrors SkillsPanel's auto-generate toggle.
+            _advancedTokenToggle = new DockCheckBox { Name = "AdvancedTokenToggle", ButtonPressed = _useAccessToken };
+            _advancedTokenToggle.BindToggled(OnAdvancedTokenToggled);
+            _advancedTokenToggle.Connect(BaseButton.SignalName.Toggled, new Callable(_advancedTokenToggle, DockCheckBox.MethodName.OnToggled));
+            row.AddChild(_advancedTokenToggle);
+        }
+
+        /// <summary>
+        /// Persist the "Advanced: use access token" opt-in in panel state and rebuild the current agent view so the
+        /// DTO's config sections (built from a fresh <see cref="CurrentSettings"/> snapshot) + the Configure write
+        /// reflect the new <see cref="AgentConfig.HttpCredentialMode"/>. No connection/config mutation — the toggle
+        /// only governs how this session's configurator UI surfaces credentials.
+        /// </summary>
+        void OnAdvancedTokenToggled(bool pressed)
+        {
+            if (_useAccessToken == pressed)
+                return;
+
+            _useAccessToken = pressed;
+
+            // Rebuild the current agent view (ShowAgent reads _useAccessToken via CurrentSettings/CurrentCredentialMode).
+            var index = _agentSelector?.GetSelectedId() ?? -1;
+            if (index >= 0)
+                ShowAgent(index);
+        }
+
+        /// <summary>
+        /// The effective <see cref="AgentConfig.HttpCredentialMode"/> for the current agent + the "Advanced: use
+        /// access token" opt-in, per the pure-managed <see cref="AgentConfiguratorCredentialPolicy"/>. Drives both
+        /// the settings snapshot (<see cref="CurrentSettings"/>) and the explicit mode passed to
+        /// <c>GetHttpConfig</c> on Configure / Remove.
+        /// </summary>
+        AgentConfig.HttpCredentialMode CurrentCredentialMode() =>
+            AgentConfiguratorCredentialPolicy.ResolveCredentialMode(_current?.SupportsOAuth ?? true, _useAccessToken);
+
+        /// <summary>
         /// Configure-button <c>pressed</c> handler (object+method Callable). Writes the addon's HTTP entry into the
         /// current agent's config file via the shared config's <c>Configure()</c> (REAL token; never logged), then
         /// re-evaluates the status + alert.
@@ -465,7 +537,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         {
             if (_current == null)
                 return;
-            var config = _current.GetHttpConfig(CurrentSettings(), Logger);
+            var config = _current.GetHttpConfig(CurrentSettings(), Logger, CurrentCredentialMode());
             config.Configure();
             RefreshStatus();
         }
@@ -475,7 +547,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
         {
             if (_current == null)
                 return;
-            var config = _current.GetHttpConfig(CurrentSettings(), Logger);
+            var config = _current.GetHttpConfig(CurrentSettings(), Logger, CurrentCredentialMode());
             config.Unconfigure();
             RefreshStatus();
         }
@@ -567,8 +639,13 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
         // --- live resolution off the connection config -------------------------------------------------------
 
-        /// <summary>A fresh shared-settings snapshot bridging the live Godot connection state (URL/token/mode/auth).</summary>
-        AgentConfig.AgentConfiguratorSettings CurrentSettings() => AgentConfiguratorSettingsFactory.Create(_connection.Config);
+        /// <summary>
+        /// A fresh shared-settings snapshot bridging the live Godot connection state (URL/token/mode/auth) for the
+        /// effective <see cref="CurrentCredentialMode"/> — URL-only on the default OAuth path, token-bearing when
+        /// the "Advanced: use access token" opt-in (or a non-OAuth configurator) is in force.
+        /// </summary>
+        AgentConfig.AgentConfiguratorSettings CurrentSettings() =>
+            AgentConfiguratorSettingsFactory.Create(_connection.Config, CurrentCredentialMode());
 
         /// <summary>The absolute project root (globalized <c>res://</c>, no trailing slash) — used to render config paths project-relative.</summary>
         string ProjectRoot => ProjectSettings.GlobalizePath("res://").TrimEnd('/');

--- a/addons/godot_mcp/Editor/UI/ConnectionPanel.cs
+++ b/addons/godot_mcp/Editor/UI/ConnectionPanel.cs
@@ -108,12 +108,23 @@ namespace com.IvanMurzak.Godot.MCP.UI
         const string AuthLabelNone = "none";
         const string AuthLabelRequired = "required";
 
-        // Cloud-mode auth section (device-code flow): masked token + Authorize/Revoke + status.
+        // Cloud-mode auth section (device-code flow). The DEFAULT view (mcp-authorize e1 · PR 5) shows a sign-in /
+        // account-state chip + the derived per-project connection URL + Authorize/Revoke — NOT a raw token field.
+        // The masked token field is hidden behind the "Advanced: use access token" opt-in (device flow / machine
+        // store from PR 2 mean the token is no longer user-entered on the golden path).
         VBoxContainer _cloudAuthRow = null!;
+        Label _cloudSignInStatus = null!;
+        Label _cloudConnectionUrl = null!;
+        DockCheckBox _cloudAdvancedToggle = null!;
+        VBoxContainer _cloudTokenLine = null!;
         LineEdit _cloudTokenField = null!;
         Button _authorizeButton = null!;
         Button _revokeButton = null!;
         Label _cloudAuthStatus = null!;
+
+        // "Advanced: use access token" opt-in for the Cloud path (default OFF → the raw masked token field is
+        // hidden; the sign-in chip conveys the account state instead).
+        bool _useCloudAccessToken;
 
         // The in-flight device-auth flow (null when none has run). Recreated per Authorize click.
         GodotDeviceAuthFlow? _deviceAuthFlow;
@@ -491,8 +502,61 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _cloudAuthRow.AddThemeConstantOverride("separation", 4);
             AddChild(_cloudAuthRow);
 
-            var cloudTokenLine = new HBoxContainer { Name = "CloudTokenLine", SizeFlagsHorizontal = SizeFlags.ExpandFill };
-            _cloudAuthRow.AddChild(cloudTokenLine);
+            // --- Row 1: sign-in / account-state chip (left) + Revoke / Authorize (right). The chip REPLACES the
+            //     raw token field on the default path (mcp-authorize e1 · PR 5): the device flow / machine store
+            //     own the credential, so the user sees signed-in / signed-out state, not a token to copy. ---
+            var accountLine = new HBoxContainer { Name = "CloudAccountLine", SizeFlagsHorizontal = SizeFlags.ExpandFill };
+            accountLine.Alignment = BoxContainer.AlignmentMode.Center;
+            _cloudAuthRow.AddChild(accountLine);
+
+            _cloudSignInStatus = new Label { Name = "CloudSignInStatus", SizeFlagsHorizontal = SizeFlags.ExpandFill };
+            DockStyle.ApplyDescription(_cloudSignInStatus);
+            _cloudSignInStatus.AutowrapMode = TextServer.AutowrapMode.Off;
+            accountLine.AddChild(_cloudSignInStatus);
+
+            _revokeButton = new Button { Name = "RevokeButton", Text = "Sign out" };
+            DockStyle.ConnectPressed(_revokeButton, this, MethodName.OnRevokeButtonPressed);
+            accountLine.AddChild(_revokeButton);
+
+            _authorizeButton = new Button { Name = "AuthorizeButton", Text = ConnectionPanelView.AuthorizeButtonText };
+            DockStyle.ConnectPressed(_authorizeButton, this, MethodName.OnAuthorizeButtonPressed);
+            accountLine.AddChild(_authorizeButton);
+
+            // --- Row 2: the derived per-project connection URL (the /p/<pin> + derived port the configurators
+            //     write — PRs 3–4). Muted; hidden when the pinned URL cannot be resolved. ---
+            _cloudConnectionUrl = new Label
+            {
+                Name = "CloudConnectionUrl",
+                AutowrapMode = TextServer.AutowrapMode.WordSmart,
+                Visible = false
+            };
+            DockStyle.ApplyDescription(_cloudConnectionUrl);
+            _cloudAuthRow.AddChild(_cloudConnectionUrl);
+
+            // --- Row 3: "Advanced: use access token" opt-in (right-aligned) — reveals the legacy masked token
+            //     field below (Row 4). Default OFF: the golden path never surfaces the raw token. ---
+            var advancedLine = new HBoxContainer { Name = "CloudAdvancedLine", SizeFlagsHorizontal = SizeFlags.ExpandFill };
+            advancedLine.Alignment = BoxContainer.AlignmentMode.Center;
+            _cloudAuthRow.AddChild(advancedLine);
+
+            var advancedLabel = new Label { Name = "CloudAdvancedLabel", Text = ConnectionPanelView.AdvancedUseAccessTokenLabel };
+            DockStyle.ApplyDescription(advancedLabel);
+            advancedLabel.AutowrapMode = TextServer.AutowrapMode.Off;
+            advancedLine.AddChild(advancedLabel);
+
+            advancedLine.AddChild(new Control { Name = "CloudAdvancedSpacer", SizeFlagsHorizontal = SizeFlags.ExpandFill });
+
+            // Object+method Callable on the checkbox instance (no delegate += into the ManagedCallable hot-reload
+            // registry) — mirrors SkillsPanel's auto-generate toggle.
+            _cloudAdvancedToggle = new DockCheckBox { Name = "CloudAdvancedToggle", ButtonPressed = _useCloudAccessToken };
+            _cloudAdvancedToggle.BindToggled(OnCloudAdvancedToggled);
+            _cloudAdvancedToggle.Connect(BaseButton.SignalName.Toggled, new Callable(_cloudAdvancedToggle, DockCheckBox.MethodName.OnToggled));
+            advancedLine.AddChild(_cloudAdvancedToggle);
+
+            // --- Row 4 (hidden by default): the masked, read-only cloud token field. Revealed only by the
+            //     "Advanced: use access token" opt-in. Never editable — set only by the device-auth flow. ---
+            _cloudTokenLine = new VBoxContainer { Name = "CloudTokenLine", SizeFlagsHorizontal = SizeFlags.ExpandFill, Visible = false };
+            _cloudAuthRow.AddChild(_cloudTokenLine);
 
             _cloudTokenField = new LineEdit
             {
@@ -504,15 +568,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 PlaceholderText = ConnectionPanelView.CloudTokenPlaceholder,
                 SizeFlagsHorizontal = SizeFlags.ExpandFill
             };
-            cloudTokenLine.AddChild(_cloudTokenField);
-
-            _revokeButton = new Button { Name = "RevokeButton", Text = "Revoke" };
-            DockStyle.ConnectPressed(_revokeButton, this, MethodName.OnRevokeButtonPressed);
-            cloudTokenLine.AddChild(_revokeButton);
-
-            _authorizeButton = new Button { Name = "AuthorizeButton", Text = ConnectionPanelView.AuthorizeButtonText };
-            DockStyle.ConnectPressed(_authorizeButton, this, MethodName.OnAuthorizeButtonPressed);
-            cloudTokenLine.AddChild(_authorizeButton);
+            _cloudTokenLine.AddChild(_cloudTokenField);
 
             _cloudAuthStatus = new Label
             {
@@ -522,6 +578,19 @@ namespace com.IvanMurzak.Godot.MCP.UI
                                 // open a large gap between the token row and the timeline in Cloud mode.
             };
             _cloudAuthRow.AddChild(_cloudAuthStatus);
+        }
+
+        /// <summary>
+        /// Toggle the "Advanced: use access token" opt-in for the Cloud path — reveal / hide the raw masked token
+        /// field (Row 4 of the cloud auth row). Panel-local UI state only; no connection/config mutation.
+        /// </summary>
+        void OnCloudAdvancedToggled(bool pressed)
+        {
+            if (_useCloudAccessToken == pressed)
+                return;
+
+            _useCloudAccessToken = pressed;
+            _cloudTokenLine.Visible = ConnectionPanelView.ShowCloudTokenField(_useCloudAccessToken);
         }
 
         /// <summary>
@@ -927,8 +996,24 @@ namespace com.IvanMurzak.Godot.MCP.UI
             var token = _connection.Config.CloudToken;
             var hasToken = !string.IsNullOrEmpty(token);
 
-            // Empty text → the masked LineEdit shows its PlaceholderText ("Token — press Authorize").
+            // Sign-in / account-state chip (the default-path replacement for the raw token field): signed-in when a
+            // cloud credential is stored (from the device flow / machine store), signed-out otherwise.
+            _cloudSignInStatus.Text = ConnectionPanelView.CloudSignInStatusLabel(hasToken);
+            _cloudSignInStatus.AddThemeColorOverride("font_color", DockStyle.Rgb(ConnectionPanelView.CloudSignInStatusColor(hasToken)));
+
+            // Derived per-project connection URL (the /p/<pin> + derived port a configurator writes — PRs 3–4).
+            // Built from the shared settings' pinned URL; hidden when it can't be resolved.
+            var pinnedUrl = Agents.AgentConfiguratorSettingsFactory.Create(_connection.Config).PinnedHttpUrl;
+            var urlText = ConnectionPanelView.ConnectionUrlLabel(pinnedUrl);
+            _cloudConnectionUrl.Text = urlText;
+            _cloudConnectionUrl.Visible = !string.IsNullOrEmpty(urlText);
+
+            // Advanced (masked) token field — carries the stored token, shown only under the "Advanced: use access
+            // token" opt-in. Empty text → the masked LineEdit shows its PlaceholderText ("Token — press Authorize").
             _cloudTokenField.Text = hasToken ? token! : string.Empty;
+            _cloudTokenLine.Visible = ConnectionPanelView.ShowCloudTokenField(_useCloudAccessToken);
+
+            // "Sign out" (Revoke) only when a credential is stored.
             _revokeButton.Visible = hasToken;
         }
 

--- a/addons/godot_mcp/Editor/UI/ConnectionPanelView.cs
+++ b/addons/godot_mcp/Editor/UI/ConnectionPanelView.cs
@@ -161,6 +161,43 @@ namespace com.IvanMurzak.Godot.MCP.UI
         public static string CloudAuthButtonText(GodotDeviceAuthFlowState state) =>
             GodotDeviceAuthFlow.IsRunning(state) ? AuthorizeButtonCancelText : AuthorizeButtonText;
 
+        // --- Cloud sign-in / account state (mcp-authorize e1 · PR 5, design 06/09). Pure-managed, unit-tested. ---
+
+        /// <summary>Account-state chip text shown when a cloud credential is stored (signed in via the device flow / machine store).</summary>
+        public const string SignedInLabel = "Signed in to ai-game.dev";
+
+        /// <summary>Account-state chip text shown when no cloud credential is stored (the default path prompts sign-in, not a raw token).</summary>
+        public const string SignedOutLabel = "Not signed in — sign in to ai-game.dev";
+
+        /// <summary>
+        /// The Cloud account-state chip text, driven by whether a cloud credential is stored (the device-flow /
+        /// machine-store sign-in state from PR 2). With the machine credential store the token is no longer a
+        /// user-entered field on the golden path — the plugin surfaces this signed-in / signed-out state instead.
+        /// </summary>
+        public static string CloudSignInStatusLabel(bool signedIn) => signedIn ? SignedInLabel : SignedOutLabel;
+
+        /// <summary>The Cloud account-state chip colour: green when signed in, gray when not (reuses the status-dot palette).</summary>
+        public static (float R, float G, float B) CloudSignInStatusColor(bool signedIn) =>
+            signedIn ? ColorConnected : ColorDisconnected;
+
+        /// <summary>The "Advanced: use access token" opt-in label — reveals the legacy masked token field on the Cloud path.</summary>
+        public const string AdvancedUseAccessTokenLabel = "Advanced: use access token";
+
+        /// <summary>
+        /// Whether the raw (masked) cloud access-token field is shown in the connection view. The default
+        /// (device-flow / OAuth) path HIDES it — the sign-in chip conveys the state instead — and it is revealed
+        /// only when the user opts into the legacy access-token affordance (<paramref name="useAccessToken"/>).
+        /// </summary>
+        public static bool ShowCloudTokenField(bool useAccessToken) => useAccessToken;
+
+        /// <summary>
+        /// The derived per-project connection-URL line ("Connection URL: &lt;url&gt;") for the pinned project URL
+        /// the shared configurator writes (the <c>/p/&lt;pin&gt;</c> path segment + derived port from PRs 3–4). A
+        /// null / whitespace <paramref name="pinnedUrl"/> yields the empty string so the editor collapses the row.
+        /// </summary>
+        public static string ConnectionUrlLabel(string? pinnedUrl) =>
+            string.IsNullOrWhiteSpace(pinnedUrl) ? string.Empty : $"Connection URL: {pinnedUrl!.Trim()}";
+
         // --- Vertical timeline (Godot -> MCP server -> AI agent) presentation (pure-managed, unit-tested). ---
 
         /// <summary>


### PR DESCRIPTION
## Summary

The editor UI surface for the new device-flow auth model (mcp-authorize e1, PR 5 of ~6). PRs 1–4 already landed on `main` (7.0 adoption #262, device flow + machine store + zero-button boot #264, instance-metadata handshake + ProjectIdentity/marker #266, 8080→derived-port migration #268). The shared `McpPlugin.AgentConfig` 7.0 writer already defaults to URL-only (`HttpCredentialMode.Oauth`); this flips the Godot dock onto it.

- **Default configure/connection view is URL-only** — no raw access token in the written config or the "Manual Configuration Steps" command. `AgentConfiguratorSettingsFactory.Create` now takes a credential mode; the pure-managed `AgentConfiguratorCredentialPolicy` maps the OAuth default to an empty token + `authOption=none`.
- **"Advanced: use access token"** escape hatch (capability flag `AiAgentConfigurator.SupportsOAuth`, default true) reveals the legacy masked token field and writes the `HttpCredentialMode.AccessToken` (Bearer-header) shape — Flow C for clients that can't do MCP OAuth.
- **Sign-in / account-state indicator** + the derived per-project connection URL (`/p/<pin>`) replace the raw token field in the Cloud connection view.
- Connection/credential core (device flow, machine store, handshake, marker, port) untouched — done in PRs 2–4.

## Test plan

- [x] `dotnet build Godot-MCP.sln` (.NET 8) — 0 errors.
- [x] `Godot-MCP.Tests` xUnit — 1040 passed / 0 failed, incl. new `AgentConfiguratorCredentialPolicyTests` (default writes URL-only, no token; Advanced writes Bearer — driven end-to-end through the real shared configurator) and `ConnectionPanelView` sign-in/URL/toggle assertions.
- [x] `runtime/editor boundary` guard — 0 violations.
- [ ] Five-version Godot mono CI matrices (addon-load / dock-reload / e2e-install / runtime-harness).
- Live-editor behavioral check pending CI/operator: the local headless smoke is infeasible while the testbed NuGet pin (`McpPlugin` 6.11.0) trails the addon's 7.0.0-preview.1 (see `test.md` Suite 3).

Closes #270