### PR TITLE
feat(cli): login -> shared machine credential store + ProjectIdentity port (mcp-authorize e2, PR 1/2)

### DIFF
--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -1,35 +1,42 @@
 import { Command } from 'commander';
+import * as fs from 'fs';
+import * as path from 'path';
 import * as ui from '../utils/ui.js';
 import { verbose } from '../utils/ui.js';
-import { resolveProjectPath, DEFAULT_CLOUD_BASE_URL } from '../utils/connection.js';
-import { readCloudToken, readCredentials } from '../utils/credentials.js';
-import { runCloudLogin } from '../utils/cloud-login.js';
+import { DEFAULT_CLOUD_BASE_URL } from '../utils/connection.js';
+import { readCredentials } from '../utils/credentials.js';
+import { readMachineCredentials, getMachineCredentialsPath } from '../utils/machine-credentials.js';
+import { runCloudLogin, type CredentialSink } from '../utils/cloud-login.js';
 
 interface LoginOptions {
   path?: string;
+  project?: string;
   baseUrl?: string;
   force?: boolean;
 }
 
 export const loginCommand = new Command('login')
   .description(
-    'Authenticate with the Godot-MCP cloud server (ai-game.dev) via the RFC 8628 device-authorization flow and persist the cloud token so `godot-cli open --mode Cloud` connects without a manual --token.',
+    'Authenticate with the Godot-MCP cloud server (ai-game.dev) via the RFC 8628 device-authorization flow. ' +
+      'By default the credential is saved to the shared machine store (~/.ai-game-dev/credentials.json, 0600 / ' +
+      'DPAPI) so you sign in once per machine and the editor plugin auto-adopts it. Use --project <path> to keep ' +
+      'a per-project credential (project-local .godot-mcp/credentials.json, gitignored) instead.',
   )
-  .argument('[path]', 'Godot project path — where the token is saved (defaults to current directory)')
-  .option('--path <path>', 'Godot project path (defaults to current directory)')
+  .argument('[path]', 'Project path for a per-project credential override (alias of --project). Omit for the machine store.')
+  .option('--project <path>', 'Save a per-project credential under <path>/.godot-mcp/ instead of the machine store')
+  .option('--path <path>', 'Alias of --project (kept for backward compatibility)')
   .option('--base-url <url>', 'Override the cloud base URL (default: https://ai-game.dev)')
-  .option('--force', 'Re-authenticate even if a cloud token is already saved')
+  .option('--force', 'Re-authenticate even if a credential is already saved')
   .action(async (positionalPath: string | undefined, options: LoginOptions) => {
-    const projectPath = resolveProjectPath(positionalPath, options);
-    verbose(`Project path: ${projectPath}`);
-
     const baseUrl = (options.baseUrl ?? DEFAULT_CLOUD_BASE_URL).replace(/\/$/, '');
 
-    // Only short-circuit when a token is saved AND it was issued against the SAME
-    // base URL. Otherwise `login --base-url <other>` (without --force) would silently
-    // reuse a token minted for a different server. readCloudToken() truthy implies the
-    // credentials file parsed, so the follow-up readCredentials() cannot throw here.
-    if (!options.force && readCloudToken(projectPath) && readCredentials(projectPath)?.cloudBaseUrl === baseUrl) {
+    const { sink, savedLocationLabel } = resolveSink(positionalPath, options);
+    verbose(`Credential store: ${savedLocationLabel}`);
+
+    // Only short-circuit when a credential is saved in the SAME store AND it was issued against the
+    // SAME base URL. Otherwise `login --base-url <other>` (without --force) would silently reuse a
+    // credential minted for a different server.
+    if (!options.force && isAlreadyAuthenticated(sink, baseUrl)) {
       ui.success('Already authenticated with the cloud server.');
       ui.info('Use --force to re-authenticate.');
       return;
@@ -39,11 +46,47 @@ export const loginCommand = new Command('login')
     ui.label('Server', baseUrl);
     ui.divider();
 
-    const token = await runCloudLogin(projectPath, { baseUrl });
+    const token = await runCloudLogin({ baseUrl, sink });
     if (token) {
-      ui.success('Authentication complete. Cloud token saved to .godot-mcp/credentials.json.');
+      ui.success(`Authentication complete. Cloud token saved to ${savedLocationLabel}.`);
       ui.info('Run: godot-cli open --mode Cloud   (no --token needed).');
     } else {
       process.exit(1);
     }
   });
+
+/**
+ * Resolve where the credential should be stored. A project override (via --project, the legacy
+ * --path, or the positional arg) selects the project-local store; otherwise the shared machine store.
+ */
+function resolveSink(
+  positionalPath: string | undefined,
+  options: LoginOptions,
+): { sink: CredentialSink; savedLocationLabel: string } {
+  const overrideRaw = options.project ?? options.path ?? positionalPath;
+  if (overrideRaw !== undefined) {
+    const projectPath = path.resolve(overrideRaw);
+    if (!fs.existsSync(projectPath)) {
+      ui.error(`Project path does not exist: ${projectPath}`);
+      process.exit(1);
+    }
+    return {
+      sink: { kind: 'project', projectPath },
+      savedLocationLabel: path.join(projectPath, '.godot-mcp', 'credentials.json'),
+    };
+  }
+  return { sink: { kind: 'machine' }, savedLocationLabel: getMachineCredentialsPath() };
+}
+
+function isAlreadyAuthenticated(sink: CredentialSink, baseUrl: string): boolean {
+  try {
+    if (sink.kind === 'project') {
+      const creds = readCredentials(sink.projectPath);
+      return !!creds?.cloudToken && creds.cloudBaseUrl === baseUrl;
+    }
+    const creds = readMachineCredentials(sink.storeBaseDir);
+    return !!creds?.accessToken && creds.serverTarget === baseUrl;
+  } catch {
+    return false;
+  }
+}

--- a/cli/src/utils/cloud-login.ts
+++ b/cli/src/utils/cloud-login.ts
@@ -1,8 +1,22 @@
 import * as ui from './ui.js';
 import { DEFAULT_CLOUD_BASE_URL } from './connection.js';
 import { readCredentials, writeCredentials } from './credentials.js';
+import { readMachineCredentials, writeMachineCredentials } from './machine-credentials.js';
 import { deviceAuthFlow, type DeviceAuthDeps } from './auth.js';
 import { openBrowser } from './browser.js';
+
+/**
+ * Where a successful `login` persists the credential.
+ *
+ * - `machine` (the default) → the shared per-machine store `~/.ai-game-dev/credentials.json`
+ *   (0600 on POSIX / DPAPI on Windows), so the engine plugin auto-adopts it — sign in once per
+ *   machine (design 06 · D12). `storeBaseDir` overrides the store directory (tests only).
+ * - `project` → the legacy project-local override `<projectPath>/.godot-mcp/credentials.json`
+ *   (gitignored), kept for per-project accounts (the `--project` flag).
+ */
+export type CredentialSink =
+  | { kind: 'machine'; storeBaseDir?: string }
+  | { kind: 'project'; projectPath: string };
 
 export interface CloudLoginOptions {
   /** Cloud base URL to authenticate against (default https://ai-game.dev). */
@@ -13,22 +27,22 @@ export interface CloudLoginOptions {
   openBrowserImpl?: (url: string) => void;
   /** Device-flow dependency injection (fetch/sleep/clock) for tests. */
   authDeps?: DeviceAuthDeps;
+  /** Where to persist the credential. Defaults to the shared machine store. */
+  sink?: CredentialSink;
 }
 
 /**
- * Run the cloud device-auth flow: initiate, display the user code, open the
- * browser, poll to completion, and persist the token to the project's
- * `.godot-mcp/credentials.json`.
+ * Run the cloud device-auth flow: initiate, display the user code, open the browser, poll to
+ * completion, and persist the token to the resolved {@link CredentialSink} (the shared machine store
+ * by default; the project-local override when `--project` is used).
  *
  * Returns the access token on success, or null on failure (errors are printed).
  */
-export async function runCloudLogin(
-  projectPath: string,
-  options: CloudLoginOptions = {},
-): Promise<string | null> {
+export async function runCloudLogin(options: CloudLoginOptions = {}): Promise<string | null> {
   const baseUrl = (options.baseUrl ?? DEFAULT_CLOUD_BASE_URL).replace(/\/$/, '');
   const clientLabel = options.clientLabel ?? 'Godot-MCP CLI';
   const openBrowserImpl = options.openBrowserImpl ?? openBrowser;
+  const sink: CredentialSink = options.sink ?? { kind: 'machine' };
 
   let spinner: ReturnType<typeof ui.startSpinner> | undefined;
 
@@ -54,20 +68,7 @@ export async function runCloudLogin(
 
     if (result.success) {
       spinner?.success('Authorized');
-
-      // A corrupt existing credentials file must not block a fresh login.
-      let existing = {};
-      try {
-        existing = readCredentials(projectPath) ?? {};
-      } catch {
-        existing = {};
-      }
-      writeCredentials(projectPath, {
-        ...existing,
-        cloudToken: result.accessToken,
-        cloudBaseUrl: baseUrl,
-      });
-
+      persistCredential(sink, result.accessToken, baseUrl);
       return result.accessToken;
     }
 
@@ -84,4 +85,40 @@ export async function runCloudLogin(
     }
     return null;
   }
+}
+
+function persistCredential(sink: CredentialSink, accessToken: string, baseUrl: string): void {
+  if (sink.kind === 'project') {
+    // A corrupt existing credentials file must not block a fresh login.
+    let existing = {};
+    try {
+      existing = readCredentials(sink.projectPath) ?? {};
+    } catch {
+      existing = {};
+    }
+    writeCredentials(sink.projectPath, {
+      ...existing,
+      cloudToken: accessToken,
+      cloudBaseUrl: baseUrl,
+    });
+    return;
+  }
+
+  // Machine store: preserve any stored identity/refresh fields, replacing the token material and
+  // recording the server target the credential was issued for.
+  let existing = {};
+  try {
+    existing = readMachineCredentials(sink.storeBaseDir) ?? {};
+  } catch {
+    existing = {};
+  }
+  writeMachineCredentials(
+    {
+      ...existing,
+      version: 1,
+      accessToken,
+      serverTarget: baseUrl,
+    },
+    sink.storeBaseDir,
+  );
 }

--- a/cli/src/utils/connection.ts
+++ b/cli/src/utils/connection.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { verbose } from './ui.js';
 import * as ui from './ui.js';
 import { readCloudToken } from './credentials.js';
+import { readMachineAccessToken } from './machine-credentials.js';
 
 // --- Godot MCP connection constants (mirror addons/godot_mcp GodotMcpConfig). ---
 
@@ -105,13 +106,10 @@ function isCloudMode(): boolean {
  * Token priority:
  *   1. --token flag (explicit override)
  *   2. GODOT_MCP_TOKEN env
- *   3. persisted cloud token from `.godot-mcp/credentials.json` (Cloud mode only,
- *      written by `godot-cli login`)
- *
- * Unlike the Unity CLI, there is NO deterministic project-path→port hash:
- * the Godot plugin is a server-less client whose live config lives in `user://`
- * (outside the project tree). The one project-local surface the CLI DOES own is
- * the `login`-written credentials file, consulted last so `--token`/env still win.
+ *   3. persisted cloud token (Cloud mode only) — the project-local
+ *      `.godot-mcp/credentials.json` (a `--project` login) first, then the shared machine
+ *      store `~/.ai-game-dev/credentials.json` (a default `godot-cli login`), so a
+ *      sign-once-per-machine credential is picked up here too.
  */
 export function resolveConnection(
   projectPath: string,
@@ -145,10 +143,10 @@ export function resolveConnection(
   } else if (token) {
     verbose(`Using ${ENV_TOKEN}`);
   } else if (isCloudMode()) {
-    const persisted = readCloudToken(projectPath);
+    const persisted = readCloudToken(projectPath) ?? readMachineAccessToken();
     if (persisted) {
       token = persisted;
-      verbose('Using persisted cloud token from .godot-mcp/credentials.json');
+      verbose('Using persisted cloud token (project store, then machine store)');
     }
   }
 
@@ -178,7 +176,7 @@ export function resolveOpenAuthToken(
   }
   const selectedMode = options.mode ?? normalizeEnv(process.env[ENV_CONNECTION_MODE]);
   if (selectedMode !== undefined && selectedMode.toLowerCase() === 'cloud') {
-    return readCloudToken(projectPath);
+    return readCloudToken(projectPath) ?? readMachineAccessToken();
   }
   return undefined;
 }

--- a/cli/src/utils/machine-credentials.ts
+++ b/cli/src/utils/machine-credentials.ts
@@ -1,0 +1,218 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+
+/**
+ * The shared **machine credential store** at `~/.ai-game-dev/` — a single per-machine home for the
+ * ai-game.dev account credential (`credentials.json`). Engines, CLIs, and the local server all read
+ * this store, so **sign-in happens once per machine** (design `06-engine-plugins.md` / D12).
+ *
+ * This is the TypeScript peer of the shared C# `MachineCredentialStore`
+ * (`MCP-Plugin-dotnet/McpPlugin/src/AgentConfig/MachineCredentialStore.cs`). The on-disk contract is
+ * matched byte-for-byte so a credential written by `godot-cli login` is read by the engine plugin
+ * (which auto-adopts it on editor boot) and vice-versa:
+ *
+ * - **POSIX** — `credentials.json` is written plaintext with `0600` permissions inside a `0700`
+ *   directory.
+ * - **Windows** — the file content is **DPAPI-encrypted** with the current user's key
+ *   (`CryptProtectData`, `CurrentUser` scope, no entropy) so the on-disk bytes are never plaintext.
+ *   Node has no built-in DPAPI, so we interop via PowerShell's `System.Security.Cryptography.
+ *   ProtectedData`, which is a managed wrapper over the very same `CryptProtectData`/
+ *   `CryptUnprotectData` calls the C# store uses — the blobs are cross-readable.
+ *
+ * Credentials are NEVER written to a project file / VCS. The optional `--project` per-project override
+ * (project-local `.godot-mcp/credentials.json`, gitignored) is handled by `credentials.ts`, not here.
+ */
+
+/** Directory name under the user home that holds the store (matches C# `MachineCredentialStore.DirectoryName`). */
+export const MACHINE_STORE_DIR_NAME = '.ai-game-dev';
+
+/** File name of the secret credential document. */
+export const MACHINE_CREDENTIALS_FILE_NAME = 'credentials.json';
+
+/**
+ * Optional env override for the store directory (advanced use / tests). When set, this exact
+ * directory is used verbatim; otherwise the store lives at `~/.ai-game-dev`. The DEFAULT matches the
+ * C# store so cross-tool interop holds — the override never changes the production path.
+ */
+export const MACHINE_STORE_DIR_ENV = 'AI_GAME_DEV_CREDENTIALS_DIR';
+
+// Schema version of the persisted document (matches C# `MachineCredentials.Version`).
+const SCHEMA_VERSION = 1;
+
+/**
+ * The secret credential material persisted per machine (mirrors the C# `MachineCredentials` document,
+ * camelCase field names). Unknown fields are ignored on read so the schema can grow forwards.
+ */
+export interface MachineCredentials {
+  /** Schema version of the persisted document (currently 1). */
+  version?: number;
+  /** The current short-lived JWT access token (the cloud bearer token). */
+  accessToken?: string;
+  /** The rotating refresh token used to mint a new access token before `expiresAt`. */
+  refreshToken?: string;
+  /** Absolute expiry of `accessToken` (ISO 8601); used to schedule proactive refresh. */
+  expiresAt?: string;
+  /** The server target the credential was issued for (hosted `https://ai-game.dev` or a local URL). */
+  serverTarget?: string;
+  /** The account id (`sub`) the credential resolves to. Audit/diagnostic only. */
+  subject?: string;
+}
+
+/** Absolute path of the store directory (honoring the env override). */
+export function getMachineStoreDir(baseDirOverride?: string): string {
+  if (baseDirOverride) return baseDirOverride;
+  const envDir = process.env[MACHINE_STORE_DIR_ENV];
+  if (envDir && envDir.trim().length > 0) return envDir;
+  return path.join(os.homedir(), MACHINE_STORE_DIR_NAME);
+}
+
+/** Absolute path of the secret credential file. */
+export function getMachineCredentialsPath(baseDirOverride?: string): string {
+  return path.join(getMachineStoreDir(baseDirOverride), MACHINE_CREDENTIALS_FILE_NAME);
+}
+
+/** True when a credential file exists in the store. */
+export function machineCredentialsExist(baseDirOverride?: string): boolean {
+  return fs.existsSync(getMachineCredentialsPath(baseDirOverride));
+}
+
+/**
+ * Read and (on Windows) decrypt the stored credentials, or `null` when none are present / empty.
+ * Throws on a decryption failure or malformed JSON (a corrupt or foreign-user credential); callers on
+ * a hot path should use {@link readMachineAccessToken}, which swallows those.
+ */
+export function readMachineCredentials(baseDirOverride?: string): MachineCredentials | null {
+  const credentialsPath = getMachineCredentialsPath(baseDirOverride);
+  if (!fs.existsSync(credentialsPath)) {
+    return null;
+  }
+  const raw = fs.readFileSync(credentialsPath);
+  if (raw.length === 0) {
+    return null;
+  }
+  const plaintext = isWindows() ? unprotectDpapi(raw) : raw;
+  const json = plaintext.toString('utf8');
+  if (json.trim().length === 0) {
+    return null;
+  }
+  const parsed = JSON.parse(json) as MachineCredentials;
+  return parsed;
+}
+
+/**
+ * Encrypt (Windows) / restrict (POSIX) and write `credentials` to the store, creating the store
+ * directory with owner-only permissions if needed.
+ */
+export function writeMachineCredentials(credentials: MachineCredentials, baseDirOverride?: string): void {
+  const dir = getMachineStoreDir(baseDirOverride);
+  const credentialsPath = path.join(dir, MACHINE_CREDENTIALS_FILE_NAME);
+
+  ensureStoreDirectory(dir);
+
+  const json = serialize(credentials);
+  const plaintext = Buffer.from(json, 'utf8');
+  const bytes = isWindows() ? protectDpapi(plaintext) : plaintext;
+
+  fs.writeFileSync(credentialsPath, bytes, { mode: 0o600 });
+  setPosixPermissions(credentialsPath, 0o600);
+}
+
+/**
+ * Convenience reader for the persisted access token. Swallows a missing / malformed / undecryptable
+ * file (returns undefined) so a broken store can never crash a command; `login` re-authenticates and
+ * overwrites it.
+ */
+export function readMachineAccessToken(baseDirOverride?: string): string | undefined {
+  let credentials: MachineCredentials | null;
+  try {
+    credentials = readMachineCredentials(baseDirOverride);
+  } catch {
+    return undefined;
+  }
+  const token = credentials?.accessToken;
+  return typeof token === 'string' && token.trim().length > 0 ? token : undefined;
+}
+
+/** Delete the stored credentials (sign-out). No-op when none exist. */
+export function deleteMachineCredentials(baseDirOverride?: string): void {
+  const credentialsPath = getMachineCredentialsPath(baseDirOverride);
+  if (fs.existsSync(credentialsPath)) {
+    fs.rmSync(credentialsPath, { force: true });
+  }
+}
+
+// ── Serialization ────────────────────────────────────────────────────────────────────────────────
+
+function serialize(credentials: MachineCredentials): string {
+  // Mirror the C# store's camelCase + WhenWritingNull: always emit `version`, omit null/undefined
+  // optional fields. Indentation is cosmetic (the reader is whitespace-insensitive).
+  const doc: Record<string, unknown> = { version: credentials.version ?? SCHEMA_VERSION };
+  if (credentials.accessToken != null) doc.accessToken = credentials.accessToken;
+  if (credentials.refreshToken != null) doc.refreshToken = credentials.refreshToken;
+  if (credentials.expiresAt != null) doc.expiresAt = credentials.expiresAt;
+  if (credentials.serverTarget != null) doc.serverTarget = credentials.serverTarget;
+  if (credentials.subject != null) doc.subject = credentials.subject;
+  return JSON.stringify(doc, null, 2) + '\n';
+}
+
+// ── Filesystem permissions ───────────────────────────────────────────────────────────────────────
+
+function ensureStoreDirectory(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  setPosixPermissions(dir, 0o700);
+}
+
+function setPosixPermissions(target: string, mode: number): void {
+  if (isWindows()) return; // chmod is a no-op on Windows; DPAPI provides at-rest protection there.
+  try {
+    fs.chmodSync(target, mode);
+  } catch {
+    // Best-effort only — never fail persistence over a chmod (e.g. exotic filesystems).
+  }
+}
+
+// ── Windows DPAPI via PowerShell (System.Security.Cryptography.ProtectedData) ───────────────────────
+// ProtectedData.Protect/Unprotect wrap CryptProtectData/CryptUnprotectData with the SAME CurrentUser
+// scope + null entropy the C# MachineCredentialStore uses, so the on-disk blobs are cross-readable.
+
+function isWindows(): boolean {
+  return process.platform === 'win32';
+}
+
+const DPAPI_PROTECT_SCRIPT =
+  "Add-Type -AssemblyName System.Security; " +
+  "$in = [Console]::In.ReadToEnd().Trim(); " +
+  "$bytes = [Convert]::FromBase64String($in); " +
+  "$prot = [System.Security.Cryptography.ProtectedData]::Protect($bytes, $null, 'CurrentUser'); " +
+  "[Console]::Out.Write([Convert]::ToBase64String($prot))";
+
+const DPAPI_UNPROTECT_SCRIPT =
+  "Add-Type -AssemblyName System.Security; " +
+  "$in = [Console]::In.ReadToEnd().Trim(); " +
+  "$bytes = [Convert]::FromBase64String($in); " +
+  "$plain = [System.Security.Cryptography.ProtectedData]::Unprotect($bytes, $null, 'CurrentUser'); " +
+  "[Console]::Out.Write([Convert]::ToBase64String($plain))";
+
+function protectDpapi(plaintext: Buffer): Buffer {
+  return runDpapi(DPAPI_PROTECT_SCRIPT, plaintext, 'encrypt');
+}
+
+function unprotectDpapi(cipher: Buffer): Buffer {
+  return runDpapi(DPAPI_UNPROTECT_SCRIPT, cipher, 'decrypt');
+}
+
+function runDpapi(script: string, input: Buffer, op: 'encrypt' | 'decrypt'): Buffer {
+  try {
+    const out = execFileSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', script], {
+      input: input.toString('base64'),
+      encoding: 'utf8',
+      windowsHide: true,
+    });
+    return Buffer.from(out.trim(), 'base64');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to ${op} the machine credential store via DPAPI: ${message}`);
+  }
+}

--- a/cli/src/utils/project-identity.ts
+++ b/cli/src/utils/project-identity.ts
@@ -1,0 +1,135 @@
+import { createHash } from 'crypto';
+
+/**
+ * The single canonical derivation of a project's **routing pin** and its
+ * **deterministic local port** from the project root path — the TypeScript port of the
+ * shared 7.0 library `com.IvanMurzak.McpPlugin.AgentConfig.ProjectIdentity`
+ * (`MCP-Plugin-dotnet/McpPlugin/src/AgentConfig/ProjectIdentity.cs`), which the Godot addon
+ * consumes via `GodotProjectIdentity`. Every runtime (Unity/Godot/Unreal plugins, the .NET
+ * sidecar, and the engine CLIs) derives identical values with no shared state and no probing,
+ * so an agent session launched in a project folder routes strictly to that project's engine
+ * instance (design `06-engine-plugins.md` § D14/D15).
+ *
+ * Algorithm (kept verbatim from the shipped Unity `GeneratePortFromDirectory` / the C# reference):
+ *   1. Trim trailing directory separators (`/` and `\`) so `/a/b` and `/a/b/` are the same project.
+ *      Separators are NOT converted — `C:\a` and `C:/a` hash differently (do NOT `path.normalize`).
+ *   2. Lowercase with an invariant fold (`ToLowerInvariant`-equivalent — see {@link toLowerInvariant}).
+ *   3. UTF-8 encode, then SHA-256 hash.
+ *   4. pin  = the first 4 bytes of the hash as 8 lowercase hex chars.
+ *   5. port = 20000 + (littleEndianUInt32(first 4 bytes) % 10000).  Range 20000-29999.
+ *
+ * Cross-language parity (C# vs TS) is pinned by the committed golden-vector file
+ * (`ProjectIdentity.GoldenVectors.json`) and reproduced byte-for-byte by
+ * `tests/project-identity.test.ts`.
+ */
+
+/** Inclusive lower bound of the deterministic local-port range. */
+export const MIN_PORT = 20000;
+
+/** Inclusive upper bound of the deterministic local-port range. */
+export const MAX_PORT = 29999;
+
+/** Number of ports in the deterministic range (10000). */
+export const PORT_RANGE = MAX_PORT - MIN_PORT + 1;
+
+/** Number of hex characters in the routing pin (first 4 bytes of the hash). */
+export const PIN_LENGTH = 8;
+
+const SEPARATOR_FORWARD = '/';
+const SEPARATOR_BACK = String.fromCharCode(92); // backslash
+
+/** The resolved identity for a project root. */
+export interface ProjectIdentity {
+  /** The routing pin: first 8 lowercase hex chars of the SHA-256 of the normalized project root. */
+  pin: string;
+  /** The resolved local port — the hash-derived port unless an explicit override was supplied. */
+  port: number;
+  /** True when {@link port} came from an explicit user override rather than the hash. */
+  portIsOverridden: boolean;
+}
+
+/**
+ * Invariant lowercasing that matches C# `string.ToLowerInvariant()`.
+ *
+ * JS `String.prototype.toLowerCase()` and C# `ToLowerInvariant()` disagree on some Unicode
+ * characters. The one that matters for real project paths — and the one the golden-vector file
+ * explicitly pins (`unicodeDivergence`) — is **U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE**:
+ * C# `ToLowerInvariant` leaves it unchanged, whereas a naive JS `toLowerCase()` folds it to
+ * `i` + U+0307 (COMBINING DOT ABOVE), producing a DIFFERENT hash. Preserve U+0130 so the TS
+ * derivation reproduces the canonical C# value byte-for-byte; every other character lowercases
+ * identically under both implementations.
+ */
+export function toLowerInvariant(value: string): string {
+  let result = '';
+  for (const ch of value) {
+    result += ch === 'İ' ? ch : ch.toLowerCase();
+  }
+  return result;
+}
+
+/**
+ * The exact string that is UTF-8/SHA-256 hashed: the project root with trailing directory
+ * separators trimmed, then invariant-lowercased. Exposed so callers/tests can reproduce the
+ * pre-hash string.
+ */
+export function normalize(projectRoot: string): string {
+  return toLowerInvariant(trimTrailingSeparators(projectRoot));
+}
+
+/** The routing pin only (first 8 lowercase hex chars of the hash). Never affected by overrides. */
+export function derivePin(projectRoot: string): string {
+  return hashOf(projectRoot).subarray(0, PIN_LENGTH / 2).toString('hex');
+}
+
+/**
+ * The pure hash-derived port (ignores any override). Byte-for-byte equivalent of the shipped
+ * Unity `GeneratePortFromDirectory` when given the same directory string.
+ */
+export function derivePort(projectRoot: string): number {
+  return portFromHash(hashOf(projectRoot));
+}
+
+/**
+ * The FULL project-path hash: the complete 64-char lowercase hex SHA-256 of the normalized
+ * project root — the `projectPathHash` an engine plugin sends in its hub instance-metadata
+ * handshake. The routing pin is a case-insensitive prefix of this value by construction.
+ */
+export function deriveProjectPathHash(projectRoot: string): string {
+  return hashOf(projectRoot).toString('hex');
+}
+
+/**
+ * Derive the identity for `projectRoot`. When `portOverride` is non-null (the user's explicit
+ * override from the project marker) it always wins for {@link ProjectIdentity.port}; the
+ * {@link ProjectIdentity.pin} is always hash-derived.
+ */
+export function deriveProjectIdentity(projectRoot: string, portOverride?: number | null): ProjectIdentity {
+  const hash = hashOf(projectRoot);
+  const pin = hash.subarray(0, PIN_LENGTH / 2).toString('hex');
+  if (portOverride !== undefined && portOverride !== null) {
+    return { pin, port: portOverride, portIsOverridden: true };
+  }
+  return { pin, port: portFromHash(hash), portIsOverridden: false };
+}
+
+function hashOf(projectRoot: string): Buffer {
+  if (projectRoot === null || projectRoot === undefined) {
+    throw new TypeError('projectRoot must be a string');
+  }
+  return createHash('sha256').update(Buffer.from(normalize(projectRoot), 'utf8')).digest();
+}
+
+function portFromHash(hash: Buffer): number {
+  // First 4 bytes as an explicit little-endian uint32 — matches the C# byte-shift
+  // (`hash[0] | hash[1]<<8 | hash[2]<<16 | hash[3]<<24`) and is CPU-endianness independent.
+  const value = hash.readUInt32LE(0);
+  return MIN_PORT + (value % PORT_RANGE);
+}
+
+function trimTrailingSeparators(path: string): string {
+  let end = path.length;
+  while (end > 1 && (path[end - 1] === SEPARATOR_FORWARD || path[end - 1] === SEPARATOR_BACK)) {
+    end--;
+  }
+  return end === path.length ? path : path.slice(0, end);
+}

--- a/cli/tests/cloud-login.test.ts
+++ b/cli/tests/cloud-login.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { runCloudLogin } from '../src/utils/cloud-login.js';
 import { readCredentials, getCredentialsPath } from '../src/utils/credentials.js';
+import { readMachineCredentials, getMachineCredentialsPath } from '../src/utils/machine-credentials.js';
 import type { DeviceAuthDeps } from '../src/utils/auth.js';
 
 function jsonResponse(status: number, body: unknown): Response {
@@ -34,7 +35,7 @@ function authDeps(polls: Response[]): DeviceAuthDeps {
   };
 }
 
-describe('runCloudLogin', () => {
+describe('runCloudLogin — project sink (--project override)', () => {
   let tmpDir: string;
 
   beforeEach(() => {
@@ -45,12 +46,13 @@ describe('runCloudLogin', () => {
     vi.restoreAllMocks();
   });
 
-  it('persists the token and returns it on success', async () => {
+  it('persists the token to the project store and returns it on success', async () => {
     const openBrowserImpl = vi.fn();
-    const token = await runCloudLogin(tmpDir, {
+    const token = await runCloudLogin({
       baseUrl: 'https://example.test',
       openBrowserImpl,
       authDeps: authDeps([jsonResponse(200, { access_token: 'cloud-tok', token_type: 'Bearer' })]),
+      sink: { kind: 'project', projectPath: tmpDir },
     });
 
     expect(token).toBe('cloud-tok');
@@ -59,13 +61,75 @@ describe('runCloudLogin', () => {
   });
 
   it('returns null and writes nothing when authorization is denied', async () => {
-    const token = await runCloudLogin(tmpDir, {
+    const token = await runCloudLogin({
       baseUrl: 'https://example.test',
       openBrowserImpl: vi.fn(),
       authDeps: authDeps([jsonResponse(400, { error: 'access_denied' })]),
+      sink: { kind: 'project', projectPath: tmpDir },
     });
 
     expect(token).toBeNull();
     expect(fs.existsSync(getCredentialsPath(tmpDir))).toBe(false);
+  });
+});
+
+describe('runCloudLogin — machine sink (default)', () => {
+  let storeDir: string;
+
+  beforeEach(() => {
+    storeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-login-machine-'));
+  });
+  afterEach(() => {
+    fs.rmSync(storeDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('persists the token to the shared machine store (not a project file) and returns it', async () => {
+    const token = await runCloudLogin({
+      baseUrl: 'https://example.test',
+      openBrowserImpl: vi.fn(),
+      authDeps: authDeps([jsonResponse(200, { access_token: 'machine-tok', token_type: 'Bearer' })]),
+      sink: { kind: 'machine', storeBaseDir: storeDir },
+    });
+
+    expect(token).toBe('machine-tok');
+    const creds = readMachineCredentials(storeDir);
+    expect(creds?.accessToken).toBe('machine-tok');
+    expect(creds?.serverTarget).toBe('https://example.test');
+    expect(creds?.version).toBe(1);
+    // No project-local credentials file is created anywhere near the store dir.
+    expect(fs.existsSync(path.join(storeDir, '.godot-mcp', 'credentials.json'))).toBe(false);
+  });
+
+  it('defaults to the machine store when no sink is supplied', async () => {
+    // Redirect the default store to a temp dir via the env override so the real ~/.ai-game-dev
+    // is never touched by the test.
+    const prev = process.env.AI_GAME_DEV_CREDENTIALS_DIR;
+    process.env.AI_GAME_DEV_CREDENTIALS_DIR = storeDir;
+    try {
+      const token = await runCloudLogin({
+        baseUrl: 'https://example.test',
+        openBrowserImpl: vi.fn(),
+        authDeps: authDeps([jsonResponse(200, { access_token: 'default-tok', token_type: 'Bearer' })]),
+      });
+      expect(token).toBe('default-tok');
+      expect(fs.existsSync(getMachineCredentialsPath(storeDir))).toBe(true);
+      expect(readMachineCredentials(storeDir)?.accessToken).toBe('default-tok');
+    } finally {
+      if (prev === undefined) delete process.env.AI_GAME_DEV_CREDENTIALS_DIR;
+      else process.env.AI_GAME_DEV_CREDENTIALS_DIR = prev;
+    }
+  });
+
+  it('returns null and writes nothing to the machine store when denied', async () => {
+    const token = await runCloudLogin({
+      baseUrl: 'https://example.test',
+      openBrowserImpl: vi.fn(),
+      authDeps: authDeps([jsonResponse(400, { error: 'access_denied' })]),
+      sink: { kind: 'machine', storeBaseDir: storeDir },
+    });
+
+    expect(token).toBeNull();
+    expect(fs.existsSync(getMachineCredentialsPath(storeDir))).toBe(false);
   });
 });

--- a/cli/tests/connection.test.ts
+++ b/cli/tests/connection.test.ts
@@ -14,6 +14,7 @@ import {
   ENV_CONNECTION_MODE,
 } from '../src/utils/connection.js';
 import { writeCredentials } from '../src/utils/credentials.js';
+import { writeMachineCredentials, MACHINE_STORE_DIR_ENV } from '../src/utils/machine-credentials.js';
 
 describe('resolveConnection', () => {
   const saved: Record<string, string | undefined> = {};
@@ -155,5 +156,56 @@ describe('resolveOpenAuthToken', () => {
 
   it('returns undefined in Custom mode', () => {
     expect(resolveOpenAuthToken(tmpDir, { mode: 'Custom' })).toBeUndefined();
+  });
+});
+
+describe('token readers — shared machine-store fallback', () => {
+  const saved: Record<string, string | undefined> = {};
+  const ENV_KEYS = [ENV_HOST, ENV_CLOUD_URL, ENV_TOKEN, ENV_CONNECTION_MODE, MACHINE_STORE_DIR_ENV];
+  let projectDir: string;
+  let storeDir: string;
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-conn-proj-'));
+    storeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-conn-store-'));
+    // Redirect the machine store to a temp dir so the real ~/.ai-game-dev is never read.
+    process.env[MACHINE_STORE_DIR_ENV] = storeDir;
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.rmSync(storeDir, { recursive: true, force: true });
+  });
+
+  it('resolveConnection falls back to the machine store when there is no project token (Cloud mode)', () => {
+    writeMachineCredentials({ accessToken: 'machine-tok', serverTarget: DEFAULT_CLOUD_BASE_URL }, storeDir);
+    process.env[ENV_CONNECTION_MODE] = 'Cloud';
+    expect(resolveConnection(projectDir, {}).token).toBe('machine-tok');
+  });
+
+  it('resolveConnection prefers the project-local token over the machine store', () => {
+    writeCredentials(projectDir, { cloudToken: 'project-tok', cloudBaseUrl: DEFAULT_CLOUD_BASE_URL });
+    writeMachineCredentials({ accessToken: 'machine-tok', serverTarget: DEFAULT_CLOUD_BASE_URL }, storeDir);
+    process.env[ENV_CONNECTION_MODE] = 'Cloud';
+    expect(resolveConnection(projectDir, {}).token).toBe('project-tok');
+  });
+
+  it('resolveOpenAuthToken falls back to the machine store in Cloud mode', () => {
+    writeMachineCredentials({ accessToken: 'machine-tok' }, storeDir);
+    expect(resolveOpenAuthToken(projectDir, { mode: 'Cloud' })).toBe('machine-tok');
+  });
+
+  it('does not use the machine store outside Cloud mode', () => {
+    writeMachineCredentials({ accessToken: 'machine-tok' }, storeDir);
+    expect(resolveConnection(projectDir, {}).token).toBeUndefined();
+    expect(resolveOpenAuthToken(projectDir, { mode: 'Custom' })).toBeUndefined();
   });
 });

--- a/cli/tests/machine-credentials.test.ts
+++ b/cli/tests/machine-credentials.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  MACHINE_STORE_DIR_NAME,
+  MACHINE_STORE_DIR_ENV,
+  getMachineStoreDir,
+  getMachineCredentialsPath,
+  machineCredentialsExist,
+  readMachineCredentials,
+  writeMachineCredentials,
+  readMachineAccessToken,
+  deleteMachineCredentials,
+} from '../src/utils/machine-credentials.js';
+
+const isWindows = process.platform === 'win32';
+
+describe('machine credential store — location', () => {
+  it('defaults to ~/.ai-game-dev/credentials.json', () => {
+    const prev = process.env[MACHINE_STORE_DIR_ENV];
+    delete process.env[MACHINE_STORE_DIR_ENV];
+    try {
+      expect(getMachineStoreDir()).toBe(path.join(os.homedir(), MACHINE_STORE_DIR_NAME));
+      expect(getMachineCredentialsPath()).toBe(
+        path.join(os.homedir(), MACHINE_STORE_DIR_NAME, 'credentials.json'),
+      );
+    } finally {
+      if (prev === undefined) delete process.env[MACHINE_STORE_DIR_ENV];
+      else process.env[MACHINE_STORE_DIR_ENV] = prev;
+    }
+  });
+
+  it('honors the AI_GAME_DEV_CREDENTIALS_DIR env override', () => {
+    const prev = process.env[MACHINE_STORE_DIR_ENV];
+    process.env[MACHINE_STORE_DIR_ENV] = path.join('some', 'override', 'dir');
+    try {
+      expect(getMachineStoreDir()).toBe(path.join('some', 'override', 'dir'));
+    } finally {
+      if (prev === undefined) delete process.env[MACHINE_STORE_DIR_ENV];
+      else process.env[MACHINE_STORE_DIR_ENV] = prev;
+    }
+  });
+
+  it('an explicit baseDir argument overrides both env and default', () => {
+    const prev = process.env[MACHINE_STORE_DIR_ENV];
+    process.env[MACHINE_STORE_DIR_ENV] = path.join('env', 'dir');
+    try {
+      expect(getMachineStoreDir('/explicit/base')).toBe('/explicit/base');
+      expect(getMachineCredentialsPath('/explicit/base')).toBe(path.join('/explicit/base', 'credentials.json'));
+    } finally {
+      if (prev === undefined) delete process.env[MACHINE_STORE_DIR_ENV];
+      else process.env[MACHINE_STORE_DIR_ENV] = prev;
+    }
+  });
+});
+
+describe('machine credential store — read/write', () => {
+  let storeDir: string;
+
+  beforeEach(() => {
+    storeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-machine-'));
+  });
+  afterEach(() => {
+    fs.rmSync(storeDir, { recursive: true, force: true });
+  });
+
+  it('returns null when no credential file exists', () => {
+    expect(readMachineCredentials(storeDir)).toBeNull();
+    expect(machineCredentialsExist(storeDir)).toBe(false);
+    expect(readMachineAccessToken(storeDir)).toBeUndefined();
+  });
+
+  it('round-trips written credentials (DPAPI on Windows / plaintext on POSIX)', () => {
+    writeMachineCredentials(
+      { accessToken: 'acc-123', serverTarget: 'https://ai-game.dev', subject: 'user-1' },
+      storeDir,
+    );
+    expect(machineCredentialsExist(storeDir)).toBe(true);
+    const creds = readMachineCredentials(storeDir);
+    expect(creds).toEqual({
+      version: 1,
+      accessToken: 'acc-123',
+      serverTarget: 'https://ai-game.dev',
+      subject: 'user-1',
+    });
+    expect(readMachineAccessToken(storeDir)).toBe('acc-123');
+  });
+
+  it('always stamps version=1 and omits absent optional fields', () => {
+    writeMachineCredentials({ accessToken: 'only-token' }, storeDir);
+    const creds = readMachineCredentials(storeDir);
+    expect(creds).toEqual({ version: 1, accessToken: 'only-token' });
+    expect(creds).not.toHaveProperty('refreshToken');
+    expect(creds).not.toHaveProperty('expiresAt');
+    expect(creds).not.toHaveProperty('serverTarget');
+  });
+
+  it('overwrites an existing credential', () => {
+    writeMachineCredentials({ accessToken: 'first', serverTarget: 'https://a.test' }, storeDir);
+    writeMachineCredentials({ accessToken: 'second', serverTarget: 'https://b.test' }, storeDir);
+    const creds = readMachineCredentials(storeDir);
+    expect(creds?.accessToken).toBe('second');
+    expect(creds?.serverTarget).toBe('https://b.test');
+  });
+
+  it('readMachineAccessToken ignores an empty/whitespace token', () => {
+    writeMachineCredentials({ accessToken: '   ' }, storeDir);
+    expect(readMachineAccessToken(storeDir)).toBeUndefined();
+  });
+
+  it('deletes the credential (sign-out); delete is a no-op when absent', () => {
+    writeMachineCredentials({ accessToken: 'acc' }, storeDir);
+    expect(machineCredentialsExist(storeDir)).toBe(true);
+    deleteMachineCredentials(storeDir);
+    expect(machineCredentialsExist(storeDir)).toBe(false);
+    // No throw on a second delete.
+    expect(() => deleteMachineCredentials(storeDir)).not.toThrow();
+  });
+});
+
+describe('machine credential store — at-rest protection', () => {
+  let storeDir: string;
+
+  beforeEach(() => {
+    storeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-machine-atrest-'));
+  });
+  afterEach(() => {
+    fs.rmSync(storeDir, { recursive: true, force: true });
+  });
+
+  it.skipIf(isWindows)('POSIX: writes plaintext JSON with 0600 file perms inside a 0700 dir', () => {
+    writeMachineCredentials({ accessToken: 'plain-secret', serverTarget: 'https://ai-game.dev' }, storeDir);
+    const credPath = getMachineCredentialsPath(storeDir);
+
+    const onDisk = fs.readFileSync(credPath, 'utf8');
+    expect(onDisk).toContain('plain-secret');
+    expect(JSON.parse(onDisk)).toEqual({
+      version: 1,
+      accessToken: 'plain-secret',
+      serverTarget: 'https://ai-game.dev',
+    });
+
+    expect(fs.statSync(credPath).mode & 0o777).toBe(0o600);
+    expect(fs.statSync(storeDir).mode & 0o777).toBe(0o700);
+  });
+
+  it.runIf(isWindows)('Windows: on-disk bytes are DPAPI-encrypted (never plaintext), still decryptable', () => {
+    writeMachineCredentials({ accessToken: 'dpapi-secret', serverTarget: 'https://ai-game.dev' }, storeDir);
+    const credPath = getMachineCredentialsPath(storeDir);
+
+    const raw = fs.readFileSync(credPath);
+    // The plaintext token must NOT appear anywhere in the encrypted blob.
+    expect(raw.toString('utf8')).not.toContain('dpapi-secret');
+    expect(raw.toString('latin1')).not.toContain('dpapi-secret');
+    // And the bytes are not parseable as the JSON document.
+    expect(() => JSON.parse(raw.toString('utf8'))).toThrow();
+
+    // But decryption via the store recovers the exact document.
+    expect(readMachineCredentials(storeDir)).toEqual({
+      version: 1,
+      accessToken: 'dpapi-secret',
+      serverTarget: 'https://ai-game.dev',
+    });
+  });
+});

--- a/cli/tests/project-identity.test.ts
+++ b/cli/tests/project-identity.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MIN_PORT,
+  MAX_PORT,
+  PORT_RANGE,
+  PIN_LENGTH,
+  normalize,
+  toLowerInvariant,
+  derivePin,
+  derivePort,
+  deriveProjectPathHash,
+  deriveProjectIdentity,
+} from '../src/utils/project-identity.js';
+
+/**
+ * Golden vectors copied VERBATIM (inline, no runtime file dependency) from the committed
+ * `MCP-Plugin-dotnet/McpPlugin/src/AgentConfig/ProjectIdentity.GoldenVectors.json`. The C# reference
+ * implementation is the origin; this TS port MUST reproduce every pin/port byte-for-byte, including
+ * the trailing-separator, no-separator-conversion, and U+0130 ToLowerInvariant behaviors.
+ */
+const GOLDEN_VECTORS: ReadonlyArray<{ path: string; pin: string; port: number; note: string }> = [
+  { path: '/home/user/my-game', pin: '34ea75f2', port: 23940, note: 'POSIX typical project path.' },
+  { path: '/home/user/my-game/', pin: '34ea75f2', port: 23940, note: 'Trailing slash trimmed.' },
+  { path: '/home/USER/My-Game', pin: '34ea75f2', port: 23940, note: 'Case-folded.' },
+  { path: 'C:\\Users\\user\\my-game', pin: '8ef72cf7', port: 29310, note: 'Windows backslash form.' },
+  { path: 'C:\\Users\\user\\my-game\\', pin: '8ef72cf7', port: 29310, note: 'Trailing backslash trimmed.' },
+  { path: 'C:/Users/user/my-game', pin: '5a87324e', port: 24298, note: 'Forward-slash form DIFFERS (no separator normalization).' },
+  { path: '/home/İstanbul/game', pin: '672d80a7', port: 25303, note: 'U+0130 — C# ToLowerInvariant leaves it unchanged.' },
+  { path: '/srv/games/space sim', pin: '08c6cbb6', port: 27816, note: 'Path containing a space.' },
+];
+
+// From the golden file's `unicodeDivergence`: a NAIVE JS toLowerCase() port would produce THIS
+// (incorrect) value for the U+0130 path. Pinned here so the special-casing can never silently regress.
+const U0130_PATH = '/home/İstanbul/game';
+const U0130_NAIVE_JS_PIN = '77300275';
+const U0130_NAIVE_JS_PORT = 27751;
+
+describe('ProjectIdentity — golden-vector parity (byte-for-byte with the C# reference)', () => {
+  for (const vector of GOLDEN_VECTORS) {
+    it(`pin+port match for ${JSON.stringify(vector.path)} (${vector.note})`, () => {
+      expect(derivePin(vector.path)).toBe(vector.pin);
+      expect(derivePort(vector.path)).toBe(vector.port);
+      const identity = deriveProjectIdentity(vector.path);
+      expect(identity.pin).toBe(vector.pin);
+      expect(identity.port).toBe(vector.port);
+      expect(identity.portIsOverridden).toBe(false);
+    });
+  }
+
+  it('trailing separators do not change the identity (a project and its slashed form match)', () => {
+    expect(derivePin('/home/user/my-game/')).toBe(derivePin('/home/user/my-game'));
+    expect(derivePort('/home/user/my-game/')).toBe(derivePort('/home/user/my-game'));
+  });
+
+  it('separators are NOT normalized: the backslash and forward-slash Windows forms differ', () => {
+    expect(derivePin('C:\\Users\\user\\my-game')).not.toBe(derivePin('C:/Users/user/my-game'));
+    expect(derivePort('C:\\Users\\user\\my-game')).not.toBe(derivePort('C:/Users/user/my-game'));
+  });
+
+  it('reproduces the canonical U+0130 value and NOT the naive JS toLowerCase() value', () => {
+    // Canonical (ToLowerInvariant leaves U+0130 unchanged):
+    expect(derivePin(U0130_PATH)).toBe('672d80a7');
+    expect(derivePort(U0130_PATH)).toBe(25303);
+    // Must differ from the documented naive-toLowerCase divergence:
+    expect(derivePin(U0130_PATH)).not.toBe(U0130_NAIVE_JS_PIN);
+    expect(derivePort(U0130_PATH)).not.toBe(U0130_NAIVE_JS_PORT);
+  });
+});
+
+describe('ProjectIdentity — normalization', () => {
+  it('trims trailing separators (both / and \\) but keeps at least one char', () => {
+    expect(normalize('/a/b/')).toBe('/a/b');
+    expect(normalize('/a/b\\')).toBe('/a/b');
+    expect(normalize('/a/b///')).toBe('/a/b');
+    expect(normalize('/')).toBe('/');
+  });
+
+  it('lowercases invariantly (ASCII folds; U+0130 is preserved)', () => {
+    expect(normalize('/Home/USER/My-Game')).toBe('/home/user/my-game');
+    // toLowerInvariant keeps U+0130 (unlike a naive toLowerCase which folds it to 'i' + U+0307).
+    expect(toLowerInvariant('İ')).toBe('İ');
+    expect('İ'.toLowerCase()).not.toBe('İ'); // sanity: the naive fold DOES change it
+  });
+
+  it('does not convert separators during normalization', () => {
+    expect(normalize('C:\\A')).toBe('c:\\a');
+    expect(normalize('C:/A')).toBe('c:/a');
+    expect(normalize('C:\\A')).not.toBe(normalize('C:/A'));
+  });
+});
+
+describe('ProjectIdentity — derivation surface', () => {
+  it('an explicit port override wins for port but never for pin', () => {
+    const base = deriveProjectIdentity('/home/user/my-game');
+    const overridden = deriveProjectIdentity('/home/user/my-game', 51234);
+    expect(overridden.port).toBe(51234);
+    expect(overridden.portIsOverridden).toBe(true);
+    expect(overridden.pin).toBe(base.pin); // pin is always hash-derived
+  });
+
+  it('null/undefined override yields the hash-derived port', () => {
+    expect(deriveProjectIdentity('/home/user/my-game', null).port).toBe(23940);
+    expect(deriveProjectIdentity('/home/user/my-game', undefined).port).toBe(23940);
+    expect(deriveProjectIdentity('/home/user/my-game', null).portIsOverridden).toBe(false);
+  });
+
+  it('the pin is the lowercase-hex prefix of the full 64-char project path hash', () => {
+    const full = deriveProjectPathHash('/home/user/my-game');
+    expect(full).toHaveLength(64);
+    expect(full).toMatch(/^[0-9a-f]{64}$/);
+    expect(full.startsWith(derivePin('/home/user/my-game'))).toBe(true);
+    expect(derivePin('/home/user/my-game')).toHaveLength(PIN_LENGTH);
+  });
+
+  it('derived ports always fall inside the 20000-29999 range', () => {
+    for (const p of ['/a', '/b', '/c/d/e', 'C:\\x\\y', '/srv/games/space sim', '/home/İstanbul/game']) {
+      const port = derivePort(p);
+      expect(port).toBeGreaterThanOrEqual(MIN_PORT);
+      expect(port).toBeLessThanOrEqual(MAX_PORT);
+    }
+    expect(PORT_RANGE).toBe(10000);
+    expect(MAX_PORT - MIN_PORT + 1).toBe(PORT_RANGE);
+  });
+});


### PR DESCRIPTION
## Summary

- **`login` repoint (D12):** `godot-cli login` now persists the credential to the shared per-machine store `~/.ai-game-dev/credentials.json` (0600 on POSIX / **DPAPI-encrypted on Windows**, `MachineCredentials` camelCase schema — byte-compatible with the C# `MachineCredentialStore`) instead of the project-local `.godot-mcp/credentials.json`, so the editor plugin auto-adopts it and sign-in happens once per machine. `--project <path>` keeps the legacy gitignored project-local credential. The token never lands in a committable/project file on the default path.
- **ProjectIdentity TS port (D15):** new `project-identity.ts` reproduces the shared 7.0 derivation (routing pin + deterministic 20000-29999 port) byte-for-byte — trim trailing separators, no separator conversion, `ToLowerInvariant` incl. the U+0130 divergence — verified against the committed golden vectors (copied inline, no runtime dependency).
- The CLI's own token readers (`resolveConnection` / `resolveOpenAuthToken`) consult the machine store after the project store, so a machine-store login is picked up by `open` / `run-tool` in Cloud mode.

DPAPI on Windows is implemented via PowerShell's `System.Security.Cryptography.ProtectedData` (CurrentUser scope, null entropy) — the managed wrapper over the same `CryptProtectData`/`CryptUnprotectData` the C# store uses, so the blobs are cross-readable. Node has no built-in DPAPI.

**Out of scope (CLI PR 2):** `install-plugin --with-server` / `--enroll` / `--enroll-stdin`, `configure --agent`, extending `test_cli_e2e_install.yml`, live e2e. No CLI version bump / no npm publish (godot-cli rides the addon release). No McpPlugin/ReflectorNet pin or addon version bump.

## Test plan

- [x] `cli/` unit tests pass (`npm run build && npm test`): **433 passed, 1 platform-skipped** (37 files). New coverage:
  - login writes to the machine store (not `.godot-mcp/credentials.json`); `--project` override still writes the project store; denied-auth writes nothing.
  - machine store round-trips; POSIX writes plaintext + `0600`/`0700`; **Windows on-disk bytes are DPAPI-encrypted (never plaintext) and still decrypt**.
  - ProjectIdentity golden-vector parity (all 8 vectors, pin + port, incl. the U+0130 divergence guard) + normalization / override / range tests.
  - token readers fall back to the machine store in Cloud mode, preferring the project-local token.
- [x] Existing `test_cli_e2e_install.yml` flow untouched.

Closes #272