### PR TITLE
chore: bump gamedev-mcp-server to 9.0.0

### DIFF
--- a/addons/godot_mcp/Runtime/Connection/GodotMcpServerView.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotMcpServerView.cs
@@ -66,7 +66,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// <c>v&lt;ServerVersion&gt;</c> release with all 7 RID zips exists on GameDev-MCP-Server BEFORE
         /// cutting an addon release that pins it — otherwise the download 404s, the issue-#94 class of bug).
         /// </summary>
-        public const string ServerVersion = "8.0.3";
+        public const string ServerVersion = "9.0.0";
 
         /// <summary>
         /// The server executable base name (the shared <c>GameDev-MCP-Server</c> binary). On Windows the


### PR DESCRIPTION
Automated downstream bump of the pinned GameDev-MCP-Server version `8.0.3` -> `9.0.0` (adopts the just-released `v9.0.0` server: NuGet + Docker tag + all 7 RID zips are already live).