### PR TITLE
feat(cli): install-plugin --with-server/--enroll + configure --agent proxy (mcp-authorize e2)

### DIFF
--- a/.github/workflows/test_cli_e2e_install.yml
+++ b/.github/workflows/test_cli_e2e_install.yml
@@ -177,6 +177,64 @@ jobs:
 
           echo "Godot ${{ inputs.godotVersion }}: from-scratch terminal install loaded cleanly."
 
+      # Agent-first onboarding surface (design 06 / 09 workflows 1A + 1B):
+      # install-plugin --with-server, install-plugin --enroll, and configure --agent.
+      # The network legs are STUBBED (the real gamedev-mcp-server download + SHA256
+      # verify and the real cloud AS redeem are unit-tested in cli/tests with mocked
+      # fetch); here we drive the actual terminal commands end-to-end so a regression
+      # in the managed-server-dir path, the redeem → machine-store + marker + pin
+      # flow, or the configure proxy BREAKS this gate on the real Godot matrix.
+      - name: Exercise agent-first flows (--with-server / --enroll / configure --agent, stubbed network)
+        shell: bash
+        run: |
+          set -euo pipefail
+          CLI="${GITHUB_WORKSPACE}/cli/bin/godot-cli.js"
+
+          # A stub managed server binary. The real gamedev-mcp-server download +
+          # SHA256SUMS verify is unit-tested with a mocked fetch; --server-source
+          # exercises the managed-dir extraction + the configure proxy offline. The
+          # stub echoes its argv so the proxy call is observable.
+          STUB_SERVER_DIR="${WORK}/stub-server"
+          mkdir -p "${STUB_SERVER_DIR}"
+          printf '#!/usr/bin/env bash\necho "STUB-SERVER invoked: $*"\n' > "${STUB_SERVER_DIR}/gamedev-mcp-server"
+          chmod +x "${STUB_SERVER_DIR}/gamedev-mcp-server"
+
+          # A stub AS enrollment-redeem endpoint (the real redeem needs a live agent
+          # JWT); this stubs the HTTP contract so the CLI's redeem → machine-store +
+          # marker + pin flow runs end-to-end. Credentials are redirected to a temp
+          # dir via AI_GAME_DEV_CREDENTIALS_DIR so we never touch the runner home.
+          export AI_GAME_DEV_CREDENTIALS_DIR="${WORK}/store"
+          node -e 'const http=require("http");const s=http.createServer((req,res)=>{if(req.method==="POST"&&req.url==="/api/auth/enroll/redeem"){res.setHeader("content-type","application/json");res.end(JSON.stringify({access_token:"stub.jwt",token_type:"Bearer",expires_in:3600,refresh_token:"stub.refresh",scope:"mcp:plugin",server_url:"https://ai-game.dev"}));}else{res.statusCode=404;res.end("{}");}});s.listen(8791,"127.0.0.1",()=>console.log("stub AS on 8791"));' &
+          STUB_AS_PID=$!
+          trap 'kill "${STUB_AS_PID}" 2>/dev/null || true' EXIT
+          for i in $(seq 1 40); do
+            curl -s -o /dev/null "http://127.0.0.1:8791/" && break || sleep 0.25
+          done
+
+          # install-plugin combining the addon (--source), the managed server
+          # (--server-source, offline) AND enrollment (--enroll against the stub AS).
+          node "${CLI}" install-plugin \
+            --source "${GITHUB_WORKSPACE}/addons/godot_mcp" \
+            --with-server --server-source "${STUB_SERVER_DIR}" \
+            --enroll "STUB-ENROLL-CODE" --base-url "http://127.0.0.1:8791" \
+            "${WORK}/project"
+
+          # --with-server: the managed server binary landed in the CLI-managed dir.
+          test -x "${WORK}/project/.ai-game-dev/server/gamedev-mcp-server"
+          # --enroll: the plugin credential was planted in the (redirected) machine store.
+          test -f "${WORK}/store/credentials.json"
+          # --enroll: the project marker records the server target + the D14 pin.
+          test -f "${WORK}/project/.ai-game-dev/project.json"
+          grep -q '"serverTarget"' "${WORK}/project/.ai-game-dev/project.json"
+          grep -q '"pin"' "${WORK}/project/.ai-game-dev/project.json"
+
+          # configure --agent proxies to the managed server binary (the stub echoes its argv).
+          CFG_OUT="$(node "${CLI}" configure --agent claude-code "${WORK}/project" 2>&1)"
+          echo "${CFG_OUT}"
+          echo "${CFG_OUT}" | grep -q "STUB-SERVER invoked: configure --agent claude-code"
+
+          echo "Godot ${{ inputs.godotVersion }}: agent-first flows (--with-server / --enroll / configure --agent) verified."
+
       - name: Upload logs on failure
         if: failure()
         uses: actions/upload-artifact@v4

--- a/cli/src/commands/configure.ts
+++ b/cli/src/commands/configure.ts
@@ -10,6 +10,7 @@ import {
   type McpFeature,
   type GodotMcpFeaturesConfig,
 } from '../utils/config.js';
+import { configureAgentViaServer } from '../lib/configure-agent.js';
 
 function parseCommaSeparated(value: string): string[] {
   return value.split(',').map((s) => s.trim()).filter(Boolean);
@@ -44,9 +45,13 @@ function snapshotFeatures(config: GodotMcpFeaturesConfig, key: 'tools' | 'prompt
 }
 
 export const configureCommand = new Command('configure')
-  .description('List / enable / disable MCP tools, prompts, and resources in the project-local .godot-mcp/features.json')
+  .description(
+    'Configure an AI agent for the project (--agent <id> proxies to the managed gamedev-mcp-server binary, writing that client\'s MCP config with the derived pin + port), OR list / enable / disable MCP tools, prompts, and resources in the project-local .godot-mcp/features.json',
+  )
   .argument('[path]', 'Path to the Godot project')
   .option('--path <path>', 'Path to the Godot project')
+  .option('--agent <id>', 'Configure an AI agent by proxying to the managed gamedev-mcp-server binary (requires install-plugin --with-server)')
+  .option('--url <url>', 'Explicit MCP server URL override forwarded to the server binary (--agent only)')
   .option('--enable-tools <names>', 'Enable specific tools (comma-separated)', parseCommaSeparated)
   .option('--disable-tools <names>', 'Disable specific tools (comma-separated)', parseCommaSeparated)
   .option('--enable-all-tools', 'Enable all tools')
@@ -65,6 +70,8 @@ export const configureCommand = new Command('configure')
       positionalPath: string | undefined,
       options: {
         path?: string;
+        agent?: string;
+        url?: string;
         enableTools?: string[];
         disableTools?: string[];
         enableAllTools?: boolean;
@@ -90,6 +97,27 @@ export const configureCommand = new Command('configure')
       if (!fs.existsSync(projectPath)) {
         ui.error(`Project path does not exist: ${projectPath}`);
         process.exit(1);
+      }
+
+      // --agent: proxy to the managed gamedev-mcp-server binary's configurator surface.
+      if (options.agent !== undefined) {
+        ui.heading(`Configuring agent "${options.agent}"`);
+        const spinner = ui.startSpinner('Proxying to the managed server binary...');
+        const result = await configureAgentViaServer({
+          godotProjectPath: projectPath,
+          agentId: options.agent,
+          url: options.url,
+        });
+        if (result.kind === 'failure') {
+          spinner.error('Failed to configure agent');
+          ui.error(result.error.message);
+          process.exit(1);
+        }
+        spinner.success(`Configured "${result.agentId}" via ${result.serverBinaryPath}`);
+        if (result.output.trim().length > 0) {
+          console.log(result.output.trimEnd());
+        }
+        return;
       }
 
       verbose(`Loading config for project: ${projectPath}`);

--- a/cli/src/commands/install-plugin.ts
+++ b/cli/src/commands/install-plugin.ts
@@ -1,14 +1,24 @@
 import { Command } from 'commander';
 import { createRequire } from 'module';
+import * as fs from 'fs';
 import * as path from 'path';
 import * as ui from '../utils/ui.js';
 import { verbose } from '../utils/ui.js';
+import { DEFAULT_CLOUD_BASE_URL } from '../utils/connection.js';
 import { installPlugin } from '../lib/install-plugin.js';
+import { installServer } from '../lib/install-server.js';
+import { enrollPlugin } from '../lib/enroll.js';
 
 interface InstallPluginCliOptions {
   path?: string;
   source?: string;
   version?: string;
+  withServer?: boolean;
+  serverSource?: string;
+  serverVersion?: string;
+  enroll?: string;
+  enrollStdin?: boolean;
+  baseUrl?: string;
 }
 
 /** The CLI's own version — the default addon release version to download. */
@@ -22,9 +32,26 @@ function cliVersion(): string {
   }
 }
 
+/** Read a single enrollment code from stdin (so it never lands in argv / shell history). */
+function readEnrollCodeFromStdin(): string {
+  let content: string;
+  try {
+    content = fs.readFileSync(0, 'utf-8');
+  } catch {
+    ui.error('Failed to read the enrollment code from stdin.');
+    process.exit(1);
+  }
+  const code = content.trim();
+  if (code.length === 0) {
+    ui.error('No enrollment code received on stdin.');
+    process.exit(1);
+  }
+  return code;
+}
+
 export const installPluginCommand = new Command('install-plugin')
   .description(
-    'Install the godot_mcp addon into a Godot C# project: materialize res://addons/godot_mcp/ (download the matching GitHub release, or --source a local copy), add the required NuGet PackageReferences and the extension-catalog <EmbeddedResource> to the project .csproj, and enable the plugin in project.godot.',
+    'Install the godot_mcp addon into a Godot C# project: materialize res://addons/godot_mcp/ (download the matching GitHub release, or --source a local copy), add the required NuGet PackageReferences and the extension-catalog <EmbeddedResource> to the project .csproj, and enable the plugin in project.godot. Optionally download the RID-matched gamedev-mcp-server binary (--with-server) and/or redeem an agent enrollment code (--enroll / --enroll-stdin).',
   )
   .argument('[path]', 'Path to the Godot project')
   .option('--path <path>', 'Path to the Godot project')
@@ -36,10 +63,36 @@ export const installPluginCommand = new Command('install-plugin')
     '--version <x.y.z>',
     'Addon release version to download (defaults to this CLI version). Ignored with --source.',
   )
+  .option(
+    '--with-server',
+    'Also download the RID-matched gamedev-mcp-server binary into the CLI-managed dir (verified against the release SHA256SUMS)',
+  )
+  .option(
+    '--server-source <path>',
+    'Install the server binary from a local directory or .zip (offline / dev / CI) instead of downloading it. Implies --with-server.',
+  )
+  .option(
+    '--server-version <x.y.z>',
+    "Server version to download (defaults to the addon's pinned ServerVersion). Ignored with --server-source.",
+  )
+  .option('--enroll <code>', 'Redeem an agent enrollment code (plants a plugin credential, no browser hop)')
+  .option('--enroll-stdin', 'Read the enrollment code from stdin instead of argv (keeps it out of shell history)')
+  .option('--base-url <url>', 'Cloud base URL to redeem the enrollment code against (default: https://ai-game.dev)')
   .action(async (positionalPath: string | undefined, options: InstallPluginCliOptions) => {
     const resolvedPath = positionalPath ?? options.path ?? process.cwd();
     const projectPath = path.resolve(resolvedPath);
 
+    // Resolve the enrollment code (argv vs stdin) up-front so misuse fails fast.
+    if (options.enroll !== undefined && options.enrollStdin) {
+      ui.error('Use either --enroll <code> or --enroll-stdin, not both.');
+      process.exit(1);
+    }
+    const enrollCode = options.enrollStdin ? readEnrollCodeFromStdin() : options.enroll;
+    const wantServer = options.withServer === true || options.serverSource !== undefined;
+
+    let failed = false;
+
+    // 1. Addon install (the existing real installer — always runs).
     ui.heading('Installing godot_mcp addon');
     verbose(`Project path: ${projectPath}`);
     if (options.source) verbose(`--source: ${options.source}`);
@@ -76,13 +129,9 @@ export const installPluginCommand = new Command('install-plugin')
 
     // csproj outcome.
     if (result.csproj.csprojPath) {
-      const summary = result.csproj.packages
-        .map((p) => `${p.id}@${p.version} (${p.action})`)
-        .join(', ');
+      const summary = result.csproj.packages.map((p) => `${p.id}@${p.version} (${p.action})`).join(', ');
       ui.label('NuGet packages', summary || '(none)');
-      const embedSummary = result.csproj.embeds
-        .map((e) => `${e.logicalName} (${e.action})`)
-        .join(', ');
+      const embedSummary = result.csproj.embeds.map((e) => `${e.logicalName} (${e.action})`).join(', ');
       ui.label('Embedded resources', embedSummary || '(none)');
     }
 
@@ -93,4 +142,65 @@ export const installPluginCommand = new Command('install-plugin')
       console.log('');
       ui.warn(warning);
     }
+
+    // 2. Server binary (--with-server / --server-source).
+    if (wantServer) {
+      console.log('');
+      ui.heading('Downloading gamedev-mcp-server');
+      const serverSpinner = ui.startSpinner('Installing server binary...');
+      const serverResult = await installServer({
+        godotProjectPath: projectPath,
+        source: options.serverSource,
+        version: options.serverVersion,
+      });
+      if (serverResult.kind === 'failure') {
+        serverSpinner.error('Failed to install server binary');
+        ui.error(serverResult.error.message);
+        failed = true;
+      } else {
+        serverSpinner.success(
+          serverResult.source === 'download'
+            ? `gamedev-mcp-server ${serverResult.version} (${serverResult.rid}) verified + installed`
+            : `gamedev-mcp-server installed from local source (${serverResult.rid})`,
+        );
+        ui.label('Server binary', serverResult.executablePath);
+        for (const warning of serverResult.warnings) {
+          console.log('');
+          ui.warn(warning);
+        }
+      }
+    }
+
+    // 3. Enrollment (--enroll / --enroll-stdin).
+    if (enrollCode !== undefined) {
+      console.log('');
+      ui.heading('Redeeming enrollment code');
+      const enrollSpinner = ui.startSpinner('Redeeming...');
+      const enrollResult = await enrollPlugin({
+        godotProjectPath: projectPath,
+        code: enrollCode,
+        baseUrl: options.baseUrl ?? DEFAULT_CLOUD_BASE_URL,
+      });
+      if (enrollResult.kind === 'failure') {
+        enrollSpinner.error('Enrollment failed');
+        ui.error(enrollResult.error.message);
+        failed = true;
+      } else {
+        enrollSpinner.success('Enrolled — plugin credential planted in the machine store');
+        ui.label('Server target', enrollResult.serverTarget);
+        ui.label('Project pin', enrollResult.pin);
+        if (enrollResult.port !== undefined) ui.label('Local port', String(enrollResult.port));
+        ui.label('Credential', enrollResult.credentialsPath);
+        ui.label('Project marker', enrollResult.markerPath);
+        if (enrollResult.pinnedConfigs.length > 0) {
+          ui.label('Pinned configs', enrollResult.pinnedConfigs.join(', '));
+        }
+        for (const warning of enrollResult.warnings) {
+          console.log('');
+          ui.warn(warning);
+        }
+      }
+    }
+
+    if (failed) process.exit(1);
   });

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -21,6 +21,9 @@ export { setupMcp, listAgentIds } from './lib/setup-mcp.js';
 export { setupSkills } from './lib/setup-skills.js';
 export { installPlugin, removePlugin } from './lib/install-plugin.js';
 export { installExtension } from './lib/install-extension.js';
+export { installServer } from './lib/install-server.js';
+export { enrollPlugin } from './lib/enroll.js';
+export { configureAgentViaServer } from './lib/configure-agent.js';
 
 // Shared extension catalog (single-sourced from addons/godot_mcp/extensions.catalog.json)
 // + its lookup helpers, so the app can render the same list the dock + CLI install from.
@@ -87,4 +90,19 @@ export type {
   InstallExtensionSuccess,
   InstallExtensionFailure,
   ExtensionInstallOutcome,
+  // install-server (install-plugin --with-server)
+  InstallServerOptions,
+  InstallServerResult,
+  InstallServerSuccess,
+  InstallServerFailure,
+  // enroll-plugin (install-plugin --enroll / --enroll-stdin)
+  EnrollPluginOptions,
+  EnrollPluginResult,
+  EnrollPluginSuccess,
+  EnrollPluginFailure,
+  // configure-agent (configure --agent)
+  ConfigureAgentOptions,
+  ConfigureAgentResult,
+  ConfigureAgentSuccess,
+  ConfigureAgentFailure,
 } from './lib/types.js';

--- a/cli/src/lib/configure-agent.ts
+++ b/cli/src/lib/configure-agent.ts
@@ -1,0 +1,138 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawn } from 'child_process';
+import { getManagedServerExecutablePath } from './install-server.js';
+import { emitProgress } from './progress.js';
+import type { ConfigureAgentOptions, ConfigureAgentResult } from './types.js';
+
+/**
+ * Proxy `configure --agent <id>` to the CLI-managed `gamedev-mcp-server` binary's
+ * own `configure` subcommand (design 06 / 09 workflow 1B, step 2). The downloaded
+ * server binary — placed by `install-plugin --with-server` in the CLI's managed
+ * dir, NOT on PATH — owns the shared C# configurator registry and writes the
+ * agent's MCP-client config (with the derived `port=` + `project=` pin). The CLI
+ * merely locates the managed binary and spawns:
+ *
+ *   <managed-server> configure --agent <id> [--url <url>]     (cwd = project root)
+ *
+ * forwarding the agent id + optional URL and the binary's exit code. cwd is the
+ * project root so the server derives this project's pin + port. When no managed
+ * binary exists (the user never ran `--with-server`), a clean failure tells them
+ * to run it first — NOT a cryptic ENOENT.
+ *
+ * Library-safe: never throws past the boundary; captures the server's output and
+ * returns it (the command prints it). `spawnImpl` is injectable for tests.
+ */
+export async function configureAgentViaServer(opts: ConfigureAgentOptions): Promise<ConfigureAgentResult> {
+  const warnings: string[] = [];
+
+  try {
+    const projectPath = path.resolve(opts.godotProjectPath);
+    if (!fs.existsSync(projectPath)) {
+      throw new Error(`Project path does not exist: ${projectPath}`);
+    }
+    const agentId = (opts.agentId ?? '').trim();
+    if (agentId.length === 0) {
+      throw new Error('An agent id is required (configure --agent <id>).');
+    }
+
+    const serverBinaryPath = getManagedServerExecutablePath(projectPath);
+    if (!fs.existsSync(serverBinaryPath)) {
+      throw new Error(
+        `No managed server binary found at ${serverBinaryPath}. ` +
+          `Run \`godot-cli install-plugin --with-server\` first to download it.`,
+      );
+    }
+
+    const args = ['configure', '--agent', agentId];
+    if (opts.url && opts.url.trim().length > 0) {
+      args.push('--url', opts.url.trim());
+    }
+
+    emitProgress(opts.onProgress, {
+      phase: 'start',
+      message: `Proxying to ${serverBinaryPath} ${args.join(' ')}`,
+    });
+
+    const run = await runServerConfigure(serverBinaryPath, args, projectPath, opts.spawnImpl);
+
+    if (run.code !== 0) {
+      const detail = run.output.trim();
+      const err = new Error(
+        `The managed server \`configure --agent ${agentId}\` exited with code ${run.code ?? 'null'}.` +
+          (detail.length > 0 ? `\n${detail}` : ''),
+      );
+      return { kind: 'failure', success: false, exitCode: run.code ?? undefined, warnings, error: err };
+    }
+
+    emitProgress(opts.onProgress, { phase: 'done', message: `Configured ${agentId} via the managed server.` });
+
+    return {
+      kind: 'success',
+      success: true,
+      agentId,
+      serverBinaryPath,
+      args,
+      exitCode: 0,
+      output: run.output,
+      warnings,
+    };
+  } catch (err: unknown) {
+    return {
+      kind: 'failure',
+      success: false,
+      warnings,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}
+
+interface ServerConfigureRun {
+  code: number | null;
+  output: string;
+}
+
+/**
+ * Spawn the managed server's `configure` subcommand, capturing stdout+stderr, and
+ * resolve once it exits. A spawn `error` (e.g. the binary is not executable)
+ * resolves as a non-zero run rather than throwing past the boundary. `spawnImpl`
+ * is injectable for unit tests.
+ */
+function runServerConfigure(
+  bin: string,
+  args: string[],
+  cwd: string,
+  spawnImpl: typeof spawn = spawn,
+): Promise<ServerConfigureRun> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (run: ServerConfigureRun): void => {
+      if (settled) return;
+      settled = true;
+      resolve(run);
+    };
+
+    let child: import('child_process').ChildProcess;
+    try {
+      child = spawnImpl(bin, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      finish({ code: 127, output: `Failed to spawn "${bin}": ${msg}` });
+      return;
+    }
+
+    let output = '';
+    child.stdout?.on('data', (chunk: Buffer | string) => {
+      output += chunk.toString();
+    });
+    child.stderr?.on('data', (chunk: Buffer | string) => {
+      output += chunk.toString();
+    });
+    child.on('error', (err: Error) => {
+      finish({ code: 127, output: `${output}\nFailed to run "${bin}": ${err.message}` });
+    });
+    child.on('close', (code: number | null) => {
+      finish({ code, output });
+    });
+  });
+}

--- a/cli/src/lib/enroll.ts
+++ b/cli/src/lib/enroll.ts
@@ -1,0 +1,122 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { DEFAULT_CLOUD_BASE_URL } from '../utils/connection.js';
+import { redeemEnrollment } from '../utils/enroll.js';
+import {
+  writeMachineCredentials,
+  readMachineCredentials,
+  getMachineCredentialsPath,
+} from '../utils/machine-credentials.js';
+import { derivePin, derivePort } from '../utils/project-identity.js';
+import {
+  writeProjectMarker,
+  getProjectMarkerPath,
+  isLocalhostUrl,
+  upsertPinIntoAgentConfigs,
+} from '../utils/project-marker.js';
+import { emitProgress } from './progress.js';
+import type { EnrollPluginOptions, EnrollPluginResult } from './types.js';
+
+/**
+ * Redeem a D13 enrollment code and complete the agent-first onboarding for a
+ * project (design 06 / 09 workflow 1A, step 3), with NO browser hop:
+ *
+ *  1. POST the code to the cloud AS `enroll/redeem` endpoint → an `mcp:plugin`
+ *     JWT + refresh token + the server-target URL the code was minted for.
+ *  2. Persist the plugin credential to the SHARED machine store
+ *     (`~/.ai-game-dev/credentials.json`, 0600 / DPAPI) so the editor plugin
+ *     auto-adopts it (D12) — zero editor clicks.
+ *  3. Write the project marker (`.ai-game-dev/project.json`) with the server
+ *     target, the D14 pin, and — for a localhost target — the deterministic
+ *     local port.
+ *  4. Upsert the D14 pin into any existing project-local agent config entry so a
+ *     server the user added manually before enrolling becomes pinned.
+ *
+ * Library-safe: never throws past the boundary; returns a `{ kind }` union. On a
+ * redeem failure NOTHING is written (the machine store + marker + configs are
+ * left as found).
+ */
+export async function enrollPlugin(opts: EnrollPluginOptions): Promise<EnrollPluginResult> {
+  const warnings: string[] = [];
+
+  try {
+    const projectPath = path.resolve(opts.godotProjectPath);
+    if (!fs.existsSync(projectPath)) {
+      throw new Error(`Project path does not exist: ${projectPath}`);
+    }
+
+    const baseUrl = (opts.baseUrl ?? DEFAULT_CLOUD_BASE_URL).replace(/\/$/, '');
+
+    emitProgress(opts.onProgress, { phase: 'enroll-redeeming', message: 'Redeeming enrollment code' });
+    const redeem = await redeemEnrollment({ code: opts.code, baseUrl, fetchImpl: opts.fetchImpl });
+    if (!redeem.success) {
+      // A redeem failure is terminal but non-throwing — nothing was written.
+      throw new Error(redeem.message);
+    }
+
+    const { access_token, refresh_token, expires_in, server_url } = redeem.credential;
+    const serverTarget = server_url;
+
+    // 2. Machine store: plant the plugin credential, preserving any existing
+    // identity fields (e.g. `subject`), replacing token material + server target.
+    let existing = {};
+    try {
+      existing = readMachineCredentials(opts.storeBaseDir) ?? {};
+    } catch {
+      existing = {};
+    }
+    const expiresAt =
+      typeof expires_in === 'number' && expires_in > 0
+        ? new Date(Date.now() + expires_in * 1000).toISOString()
+        : undefined;
+    writeMachineCredentials(
+      {
+        ...existing,
+        version: 1,
+        accessToken: access_token,
+        refreshToken: refresh_token,
+        ...(expiresAt ? { expiresAt } : {}),
+        serverTarget,
+      },
+      opts.storeBaseDir,
+    );
+    const credentialsPath = getMachineCredentialsPath(opts.storeBaseDir);
+
+    emitProgress(opts.onProgress, { phase: 'enroll-redeemed', message: 'Credential planted', serverTarget });
+
+    // 3. Project marker: server target + pin (+ derived port for a localhost target).
+    const pin = derivePin(projectPath);
+    const localhost = isLocalhostUrl(serverTarget);
+    const port = localhost ? derivePort(projectPath) : undefined;
+    writeProjectMarker(projectPath, {
+      serverTarget,
+      pin,
+      ...(port !== undefined ? { port } : {}),
+    });
+    const markerPath = getProjectMarkerPath(projectPath);
+
+    // 4. Upsert the pin into any existing project-local agent config entry.
+    const pinnedConfigs = upsertPinIntoAgentConfigs(projectPath, pin);
+
+    emitProgress(opts.onProgress, { phase: 'done', message: 'Enrollment complete.' });
+
+    return {
+      kind: 'success',
+      success: true,
+      serverTarget,
+      pin,
+      port,
+      credentialsPath,
+      markerPath,
+      pinnedConfigs,
+      warnings,
+    };
+  } catch (err: unknown) {
+    return {
+      kind: 'failure',
+      success: false,
+      warnings,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}

--- a/cli/src/lib/install-server.ts
+++ b/cli/src/lib/install-server.ts
@@ -1,0 +1,289 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  DEFAULT_SERVER_VERSION,
+  detectHostRid,
+  serverDownloadUrl,
+  serverAssetName,
+  serverExecutableFileName,
+  sha256SumsUrl,
+  assertTrustedServerUrl,
+  verifyZipChecksum,
+  checksumFailureReason,
+  sha256Hex,
+} from '../utils/server-source.js';
+import { parseZip, type ZipEntry } from '../utils/unzip.js';
+import { emitProgress } from './progress.js';
+import type { InstallServerOptions, InstallServerResult, ProgressCallback } from './types.js';
+
+/** Relative path of the CLI-managed server dir inside a project (design 06: "the CLI's managed directory"). */
+export const MANAGED_SERVER_REL_DIR = path.join('.ai-game-dev', 'server');
+
+/** Absolute path of the CLI-managed server directory for a project. */
+export function getManagedServerDir(projectPath: string): string {
+  return path.join(projectPath, MANAGED_SERVER_REL_DIR);
+}
+
+/** Absolute path of the managed server executable for a project (the file the `configure` proxy spawns). */
+export function getManagedServerExecutablePath(
+  projectPath: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  return path.join(getManagedServerDir(projectPath), serverExecutableFileName(platform));
+}
+
+/**
+ * Install the shared `gamedev-mcp-server` binary into the CLI-managed directory
+ * `<project>/.ai-game-dev/server/` — the `install-plugin --with-server` flow (D12).
+ *
+ *  1. Download path (default): resolve the host RID, download the RID-matched
+ *     `gamedev-mcp-server-<rid>.zip` from github.com only (fail-closed host
+ *     trust), download the release `SHA256SUMS`, and VERIFY the zip's SHA256
+ *     against the manifest BEFORE extraction (fail-closed — any non-`verified`
+ *     verdict aborts and leaves the project untouched). Then extract + swap.
+ *  2. Local path (`--server-source`): copy a trusted local server dir / `.zip`
+ *     into the managed dir with no network + no checksum (the local artifact is
+ *     trusted). Offline / dev / CI.
+ *
+ * Library-safe: no stdout noise, no `process.exit`, no throws past the boundary;
+ * returns a `{ kind }` union. Materializes into a temp sibling and swaps only on
+ * full success, so a partial download/extract is rolled back.
+ */
+export async function installServer(opts: InstallServerOptions): Promise<InstallServerResult> {
+  const warnings: string[] = [];
+  const platform = process.platform;
+
+  try {
+    const projectPath = path.resolve(opts.godotProjectPath);
+    if (!fs.existsSync(projectPath)) {
+      throw new Error(`Project path does not exist: ${projectPath}`);
+    }
+    const serverDir = getManagedServerDir(projectPath);
+
+    if (opts.source !== undefined && opts.source !== '') {
+      return installFromLocal(projectPath, serverDir, opts.source, platform, warnings, opts.onProgress);
+    }
+
+    return await installFromDownload(projectPath, serverDir, platform, warnings, opts);
+  } catch (err: unknown) {
+    return {
+      kind: 'failure',
+      success: false,
+      warnings,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}
+
+async function installFromDownload(
+  projectPath: string,
+  serverDir: string,
+  platform: NodeJS.Platform,
+  warnings: string[],
+  opts: InstallServerOptions,
+): Promise<InstallServerResult> {
+  const rid = (opts.rid ?? detectHostRid()).trim();
+  if (rid.includes('unknown')) {
+    throw new Error(
+      `Cannot detect a supported host RID (got "${rid}"). Use --server-source <path> to install a server binary manually.`,
+    );
+  }
+  const version = (opts.version ?? DEFAULT_SERVER_VERSION).trim();
+  if (version === '') {
+    throw new Error('No server version to download. Pass --server-version <x.y.z> or --server-source <path>.');
+  }
+
+  const url = serverDownloadUrl(version, rid);
+  assertTrustedServerUrl(url);
+  const assetName = serverAssetName(rid);
+
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+
+  emitProgress(opts.onProgress, {
+    phase: 'server-downloading',
+    message: `Downloading ${assetName} (${version}) from ${url}`,
+    url,
+  });
+  const zipResponse = await fetchImpl(url);
+  if (!zipResponse.ok) {
+    throw new Error(
+      `Failed to download server ${version} for ${rid}: HTTP ${zipResponse.status} ${zipResponse.statusText} from ${url}. ` +
+        `Verify the release v${version} exists with a ${assetName} asset, or use --server-source <path>.`,
+    );
+  }
+  const archive = Buffer.from(await zipResponse.arrayBuffer());
+
+  // Fail-closed integrity: download SHA256SUMS + verify BEFORE extraction.
+  const sumsUrl = sha256SumsUrl(version);
+  assertTrustedServerUrl(sumsUrl);
+  emitProgress(opts.onProgress, { phase: 'server-verifying', message: `Verifying against ${sumsUrl}` });
+  const sumsResponse = await fetchImpl(sumsUrl);
+  if (!sumsResponse.ok) {
+    throw new Error(
+      `Refusing to install an unverified server: could not download ${sumsUrl} (HTTP ${sumsResponse.status}). ` +
+        `The release must publish a SHA256SUMS manifest.`,
+    );
+  }
+  const sumsText = await sumsResponse.text();
+  const actualDigest = sha256Hex(archive);
+  const verdict = verifyZipChecksum(sumsText, assetName, actualDigest);
+  if (verdict !== 'verified') {
+    throw new Error(
+      `Refusing to install server ${version} for ${rid}: ${checksumFailureReason(verdict, assetName)} (fail-closed).`,
+    );
+  }
+
+  emitProgress(opts.onProgress, { phase: 'server-extracting', message: 'Extracting verified server zip' });
+  const entries = parseZip(archive);
+  stageThenSwap(projectPath, serverDir, (staging) => extractServerEntries(entries, staging));
+
+  const executablePath = resolveExecutable(serverDir, platform);
+  if (executablePath === null) {
+    throw new Error(
+      `Server zip extracted but no ${serverExecutableFileName(platform)} was found under ${serverDir} — the archive is not a valid server release.`,
+    );
+  }
+  makeExecutable(executablePath, platform);
+
+  emitProgress(opts.onProgress, {
+    phase: 'server-materialized',
+    message: `Downloaded + verified server to ${serverDir}`,
+    serverDir,
+    source: 'download',
+  });
+
+  return {
+    kind: 'success',
+    success: true,
+    source: 'download',
+    rid,
+    version,
+    serverDir,
+    executablePath,
+    downloadUrl: url,
+    warnings,
+  };
+}
+
+function installFromLocal(
+  projectPath: string,
+  serverDir: string,
+  source: string,
+  platform: NodeJS.Platform,
+  warnings: string[],
+  onProgress?: ProgressCallback,
+): InstallServerResult {
+  const resolved = path.resolve(source);
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`--server-source ${resolved} does not exist.`);
+  }
+
+  emitProgress(onProgress, { phase: 'server-extracting', message: `Installing server from ${resolved}` });
+
+  const stat = fs.statSync(resolved);
+  if (stat.isFile() && resolved.toLowerCase().endsWith('.zip')) {
+    const entries = parseZip(fs.readFileSync(resolved));
+    stageThenSwap(projectPath, serverDir, (staging) => extractServerEntries(entries, staging));
+  } else if (stat.isDirectory()) {
+    stageThenSwap(projectPath, serverDir, (staging) => {
+      fs.cpSync(resolved, staging, { recursive: true });
+    });
+  } else {
+    throw new Error(`--server-source ${resolved} must be a directory or a .zip archive.`);
+  }
+
+  const executablePath = resolveExecutable(serverDir, platform);
+  if (executablePath === null) {
+    throw new Error(
+      `--server-source ${resolved} did not yield a ${serverExecutableFileName(platform)} under ${serverDir}.`,
+    );
+  }
+  makeExecutable(executablePath, platform);
+
+  emitProgress(onProgress, {
+    phase: 'server-materialized',
+    message: `Copied server from ${resolved}`,
+    serverDir,
+    source: 'local',
+  });
+
+  return {
+    kind: 'success',
+    success: true,
+    source: 'local',
+    rid: detectHostRid(),
+    version: '',
+    serverDir,
+    executablePath,
+    warnings,
+  };
+}
+
+/**
+ * Write every zip entry into `staging` (no `addons/` prefix stripping — the
+ * server zip expands to the binary + deps at the archive root). Path-safety:
+ * reject zip-slip `../` traversal escaping the staging dir.
+ */
+function extractServerEntries(entries: ZipEntry[], staging: string): void {
+  for (const entry of entries) {
+    if (entry.path === '') continue;
+    const target = path.resolve(staging, entry.path);
+    if (target !== staging && !target.startsWith(staging + path.sep)) {
+      throw new Error(`Refusing to extract entry escaping the server dir: ${entry.path}`);
+    }
+    if (entry.isDirectory) {
+      fs.mkdirSync(target, { recursive: true });
+      continue;
+    }
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, entry.bytes);
+  }
+}
+
+/** Locate the server executable at the managed-dir root, else one level down. Null when absent. */
+function resolveExecutable(serverDir: string, platform: NodeJS.Platform): string | null {
+  const exeName = serverExecutableFileName(platform);
+  const atRoot = path.join(serverDir, exeName);
+  if (fs.existsSync(atRoot)) return atRoot;
+  // Self-contained builds sometimes nest under a single top dir; search one level.
+  let children: string[];
+  try {
+    children = fs.readdirSync(serverDir);
+  } catch {
+    return null;
+  }
+  for (const child of children) {
+    const candidate = path.join(serverDir, child, exeName);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/** Mark the executable runnable on POSIX (no-op on Windows). Best-effort. */
+function makeExecutable(executablePath: string, platform: NodeJS.Platform): void {
+  if (platform === 'win32') return;
+  try {
+    fs.chmodSync(executablePath, 0o755);
+  } catch {
+    // Best-effort; never fail the install over a chmod.
+  }
+}
+
+/**
+ * Fill a fresh staging sibling, then atomically swap it into `serverDir`. A mid-
+ * fill failure discards staging and leaves any existing managed server untouched.
+ */
+function stageThenSwap(projectPath: string, serverDir: string, fill: (staging: string) => void): void {
+  const serverReal = path.resolve(serverDir);
+  const staging = path.resolve(projectPath, `.gamedev-server-staging-${process.pid}-${Date.now()}`);
+  fs.rmSync(staging, { recursive: true, force: true });
+  fs.mkdirSync(staging, { recursive: true });
+  try {
+    fill(staging);
+    fs.rmSync(serverReal, { recursive: true, force: true });
+    fs.mkdirSync(path.dirname(serverReal), { recursive: true });
+    fs.renameSync(staging, serverReal);
+  } finally {
+    fs.rmSync(staging, { recursive: true, force: true });
+  }
+}

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -23,6 +23,14 @@ export type ProgressEvent =
   | { phase: 'addon-extracting'; message: string }
   | { phase: 'addon-materialized'; message: string; addonDir: string; source: 'download' | 'local' }
   | { phase: 'csproj-patched'; message: string; csprojPath: string }
+  // installServer (--with-server) phases
+  | { phase: 'server-downloading'; message: string; url: string }
+  | { phase: 'server-verifying'; message: string }
+  | { phase: 'server-extracting'; message: string }
+  | { phase: 'server-materialized'; message: string; serverDir: string; source: 'download' | 'local' }
+  // enrollPlugin (--enroll) phases
+  | { phase: 'enroll-redeeming'; message: string }
+  | { phase: 'enroll-redeemed'; message: string; serverTarget: string }
   // createProject phases
   | { phase: 'project-scaffolded'; message: string; projectPath: string }
   // buildProject phases (also emitted by openProject when it builds first)
@@ -532,3 +540,143 @@ export interface InstallExtensionFailure {
 }
 
 export type InstallExtensionResult = InstallExtensionSuccess | InstallExtensionFailure;
+
+// ---------------------------------------------------------------------------
+// install-server (install-plugin --with-server)
+// ---------------------------------------------------------------------------
+
+export interface InstallServerOptions {
+  /** Absolute or relative path to the Godot project root (holds the managed server dir). */
+  godotProjectPath: string;
+  /**
+   * Local path to install the server from instead of downloading it (offline /
+   * dev / CI — the `--server-source` flag). May be a directory containing the
+   * server binary, or a `.zip` archive of one. When set, no network call is made
+   * and no checksum is verified (the local artifact is trusted).
+   */
+  source?: string;
+  /**
+   * Shared-server version to download (`v<version>` release on GameDev-MCP-Server).
+   * Defaults to the addon's pinned `ServerVersion`. Ignored when `source` is set.
+   */
+  version?: string;
+  /** Host RID override (`<os>-<arch>`). Defaults to the detected host RID. */
+  rid?: string;
+  /** Injectable fetch for tests (mock the GitHub download). Used only on the download path. */
+  fetchImpl?: typeof fetch;
+  onProgress?: ProgressCallback;
+}
+
+export interface InstallServerSuccess {
+  kind: 'success';
+  success: true;
+  /** Where the server binary came from. */
+  source: 'download' | 'local';
+  /** The host RID the binary was resolved for. */
+  rid: string;
+  /** The downloaded server version (empty on the local path). */
+  version: string;
+  /** Absolute path to the CLI-managed server directory the binary was extracted into. */
+  serverDir: string;
+  /** Absolute path to the resolved server executable. */
+  executablePath: string;
+  /** The download URL used (download path only). */
+  downloadUrl?: string;
+  warnings: string[];
+}
+
+export interface InstallServerFailure {
+  kind: 'failure';
+  success: false;
+  warnings: string[];
+  error: Error;
+}
+
+export type InstallServerResult = InstallServerSuccess | InstallServerFailure;
+
+// ---------------------------------------------------------------------------
+// enroll-plugin (install-plugin --enroll / --enroll-stdin)
+// ---------------------------------------------------------------------------
+
+export interface EnrollPluginOptions {
+  /** Absolute or relative path to the Godot project root (holds the project marker). */
+  godotProjectPath: string;
+  /** The D13 enrollment code to redeem. */
+  code: string;
+  /** Cloud AS base URL to redeem against (default https://ai-game.dev). */
+  baseUrl?: string;
+  /** Override the machine credential store directory (tests only). */
+  storeBaseDir?: string;
+  /** Injectable fetch for the redeem round-trip (tests). */
+  fetchImpl?: typeof fetch;
+  onProgress?: ProgressCallback;
+}
+
+export interface EnrollPluginSuccess {
+  kind: 'success';
+  success: true;
+  /** The server target the enrollment code was minted for (recorded in the marker). */
+  serverTarget: string;
+  /** The D14 routing pin recorded in the marker. */
+  pin: string;
+  /** The deterministic local port recorded for a localhost target (undefined for a hosted target). */
+  port?: number;
+  /** Absolute path to the machine credential store the plugin credential was written to. */
+  credentialsPath: string;
+  /** Absolute path to the project marker written. */
+  markerPath: string;
+  /** Absolute paths of any existing project-local agent configs whose URL was pin-upserted. */
+  pinnedConfigs: string[];
+  warnings: string[];
+}
+
+export interface EnrollPluginFailure {
+  kind: 'failure';
+  success: false;
+  warnings: string[];
+  error: Error;
+}
+
+export type EnrollPluginResult = EnrollPluginSuccess | EnrollPluginFailure;
+
+// ---------------------------------------------------------------------------
+// configure-agent (configure --agent — proxies to the managed server binary)
+// ---------------------------------------------------------------------------
+
+export interface ConfigureAgentOptions {
+  /** Absolute or relative path to the Godot project root (locates the managed server binary + is the config target). */
+  godotProjectPath: string;
+  /** The agent id to configure (forwarded verbatim to the server binary's `configure --agent`). */
+  agentId: string;
+  /** Explicit MCP server URL override (forwarded as `--url`). */
+  url?: string;
+  /** Injectable `child_process.spawn` for tests (mock the server binary). */
+  spawnImpl?: typeof import('child_process').spawn;
+  onProgress?: ProgressCallback;
+}
+
+export interface ConfigureAgentSuccess {
+  kind: 'success';
+  success: true;
+  agentId: string;
+  /** Absolute path to the managed server binary that was proxied to. */
+  serverBinaryPath: string;
+  /** The argv passed to the server binary (after the executable), for diagnostics. */
+  args: string[];
+  /** The server binary's exit code (0 on success). */
+  exitCode: number;
+  /** The server binary's captured stdout+stderr (surfaced to the user by the command). */
+  output: string;
+  warnings: string[];
+}
+
+export interface ConfigureAgentFailure {
+  kind: 'failure';
+  success: false;
+  /** The server binary's exit code when it ran and failed; undefined when it could not be launched. */
+  exitCode?: number;
+  warnings: string[];
+  error: Error;
+}
+
+export type ConfigureAgentResult = ConfigureAgentSuccess | ConfigureAgentFailure;

--- a/cli/src/utils/enroll.ts
+++ b/cli/src/utils/enroll.ts
@@ -1,0 +1,108 @@
+import { verbose } from './ui.js';
+
+/**
+ * Redeem a D13 **enrollment code** against the cloud AS `POST /api/auth/enroll/redeem`
+ * endpoint (design 05 §Enrollment endpoints) — the agent-first path that plants a
+ * plugin credential with NO browser hop. The code is **burned on the first redeem
+ * attempt** (server-side), and every failure returns the SAME uniform error (no
+ * oracle), so a spent/invalid/expired code is indistinguishable — the CLI surfaces
+ * one clean message.
+ *
+ * Injectable `fetch` so the round-trip is fully unit-testable with no live network.
+ * Never throws past its boundary — returns a discriminated union.
+ */
+
+/** The redeem-endpoint success body (mirrors AGS `EnrollRedeemResponse`). */
+export interface EnrollRedeemSuccessBody {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  refresh_token: string;
+  scope: string;
+  /** The server target the code was minted for (the plugin boots against this hub). */
+  server_url: string;
+}
+
+export type EnrollRedeemResult =
+  | { success: true; credential: EnrollRedeemSuccessBody }
+  | { success: false; message: string };
+
+export interface RedeemEnrollmentOptions {
+  /** The enrollment code to redeem. */
+  code: string;
+  /** Cloud AS base URL (default https://ai-game.dev). */
+  baseUrl: string;
+  /** Injectable fetch for tests (defaults to global fetch). */
+  fetchImpl?: typeof fetch;
+  /** Request timeout in ms (default 30000). */
+  timeoutMs?: number;
+}
+
+export async function redeemEnrollment(options: RedeemEnrollmentOptions): Promise<EnrollRedeemResult> {
+  const code = (options.code ?? '').trim();
+  if (code.length === 0) {
+    return { success: false, message: 'No enrollment code supplied.' };
+  }
+
+  const baseUrl = (options.baseUrl ?? '').replace(/\/$/, '');
+  const redeemUrl = `${baseUrl}/api/auth/enroll/redeem`;
+  const doFetch = options.fetchImpl ?? fetch;
+  const timeoutMs = options.timeoutMs ?? 30_000;
+
+  verbose(`POST ${redeemUrl}`);
+
+  let response: Response;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    response = await doFetch(redeemUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enroll_code: code }),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes('ECONNREFUSED') || message.includes('fetch failed')) {
+      return { success: false, message: `Cannot reach the enrollment server at ${baseUrl}.` };
+    }
+    if (message.toLowerCase().includes('abort')) {
+      return { success: false, message: `Enrollment request to ${baseUrl} timed out.` };
+    }
+    return { success: false, message: `Enrollment request failed: ${message}` };
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!response.ok) {
+    // Uniform-error contract: the server returns the same {error, error_description}
+    // for any invalid/expired/used/mismatched code. Surface one clean message.
+    let description: string | undefined;
+    try {
+      const body = (await response.json()) as { error?: string; error_description?: string };
+      description = body.error_description ?? body.error;
+    } catch {
+      description = undefined;
+    }
+    verbose(`Redeem failed: HTTP ${response.status} — ${description ?? ''}`);
+    return {
+      success: false,
+      message:
+        description ??
+        `Enrollment code could not be redeemed (HTTP ${response.status}). The code may be invalid, expired, or already used.`,
+    };
+  }
+
+  let body: EnrollRedeemSuccessBody;
+  try {
+    body = (await response.json()) as EnrollRedeemSuccessBody;
+  } catch {
+    return { success: false, message: 'The enrollment server returned an unreadable response.' };
+  }
+
+  if (typeof body.access_token !== 'string' || body.access_token.length === 0 || typeof body.server_url !== 'string') {
+    return { success: false, message: 'The enrollment server returned an incomplete credential.' };
+  }
+
+  return { success: true, credential: body };
+}

--- a/cli/src/utils/project-marker.ts
+++ b/cli/src/utils/project-marker.ts
@@ -1,0 +1,202 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { derivePin, PIN_LENGTH } from './project-identity.js';
+import { agentRegistry, MCP_SERVER_NAME } from './agents.js';
+
+/**
+ * The tool-neutral, committable **project marker** `<project>/.ai-game-dev/project.json`
+ * (design 06 / D15). It is NON-secret — credentials NEVER go here — and records:
+ *
+ * - `serverTarget` — the hub URL the enrolled plugin should connect to (hosted
+ *   `https://ai-game.dev` or a local `http://localhost:<port>`), returned by the
+ *   enrollment-redeem endpoint.
+ * - `pin` — the D14 routing pin (first 8 hex of the ProjectIdentity SHA256), so
+ *   the plugin, the CLIs, and `configure` all agree which project the session
+ *   routes to.
+ * - `port` — the deterministic local port (SHA256→20000–29999) recorded for a
+ *   localhost target so a terminal-written config and the plugin never diverge.
+ * - `portOverride` — an explicit user port override (D15) that always wins.
+ *
+ * ProjectIdentity resolution and every config writer consult it, so an override
+ * or target can never silently diverge between the plugin and a terminal-written
+ * config.
+ */
+export const PROJECT_MARKER_RELATIVE_PATH = path.join('.ai-game-dev', 'project.json');
+
+export interface ProjectMarker {
+  /** The enrolled server target URL (hosted or local). */
+  serverTarget?: string;
+  /** The D14 routing pin (first 8 hex of the ProjectIdentity hash). */
+  pin?: string;
+  /** The deterministic local port (recorded for localhost targets). */
+  port?: number;
+  /** An explicit user port override (always wins over the derived port). */
+  portOverride?: number;
+  /** Forward-compatible: unknown keys are preserved on rewrite. */
+  [key: string]: unknown;
+}
+
+/** Absolute path of the marker file for a project. */
+export function getProjectMarkerPath(projectPath: string): string {
+  return path.join(projectPath, PROJECT_MARKER_RELATIVE_PATH);
+}
+
+/** Read the marker, or null when absent / empty / malformed. Never throws. */
+export function readProjectMarker(projectPath: string): ProjectMarker | null {
+  const markerPath = getProjectMarkerPath(projectPath);
+  if (!fs.existsSync(markerPath)) return null;
+  try {
+    const raw = fs.readFileSync(markerPath, 'utf-8');
+    if (raw.trim().length === 0) return null;
+    const parsed = JSON.parse(raw) as ProjectMarker;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write the marker, MERGING over any existing document so a re-enroll never drops
+ * a previously-set `portOverride` or forward-compatible key. Creates the
+ * `.ai-game-dev/` directory if needed. The supplied `patch` fields overwrite the
+ * existing values; every other existing field is preserved.
+ */
+export function writeProjectMarker(projectPath: string, patch: ProjectMarker): ProjectMarker {
+  const markerPath = getProjectMarkerPath(projectPath);
+  const dir = path.dirname(markerPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  const existing = readProjectMarker(projectPath) ?? {};
+  const merged: ProjectMarker = { ...existing, ...patch };
+  fs.writeFileSync(markerPath, JSON.stringify(merged, null, 2) + '\n');
+  return merged;
+}
+
+/** True when `url`'s host is a loopback address (localhost / 127.0.0.1 / ::1). Never throws. */
+export function isLocalhostUrl(url: string): boolean {
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '[::1]';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Append (or replace) the `/p/<pin>` routing segment on an MCP-server URL —
+ * the D14 project pin the plugin routes on. A URL already ending in `/p/<hex>`
+ * has its pin REPLACED (idempotent re-enroll); otherwise `/p/<pin>` is appended
+ * to the existing path. Query/hash are preserved. Returns the input unchanged on
+ * a malformed URL. Pure.
+ */
+export function applyPinToUrl(url: string, pin: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  const segments = parsed.pathname.split('/').filter((s) => s.length > 0);
+  const hexLen = PIN_LENGTH; // 8
+  const isPinHex = (s: string): boolean => new RegExp(`^[0-9a-f]{${hexLen}}$`, 'i').test(s);
+  if (segments.length >= 2 && segments[segments.length - 2] === 'p' && isPinHex(segments[segments.length - 1])) {
+    segments[segments.length - 1] = pin;
+  } else {
+    segments.push('p', pin);
+  }
+  parsed.pathname = '/' + segments.join('/');
+  return parsed.toString();
+}
+
+/** True when `configPath` resolves INSIDE `projectPath` (a project-local, not user-global, config). */
+function isProjectLocalConfig(configPath: string, projectPath: string): boolean {
+  const root = path.resolve(projectPath) + path.sep;
+  return path.resolve(configPath).startsWith(root);
+}
+
+/**
+ * Upsert the D14 pin into the URL of the `ai-game-developer` entry of every
+ * EXISTING project-local agent config (design 06 — "upserts the D14 pin into any
+ * existing project-local agent config entry"), so a hosted/local server the user
+ * added manually before enrolling becomes pinned. Best-effort: user-global
+ * configs (Claude Desktop, Cline, …) are skipped; a config with no
+ * `ai-game-developer` entry or no URL is left untouched; a malformed/unreadable
+ * file is skipped without throwing. Returns the absolute paths that were
+ * rewritten. JSON configs rewrite the `url`/`serverUrl` value; the Codex TOML
+ * config rewrites its `url = "…"` line.
+ */
+export function upsertPinIntoAgentConfigs(projectPath: string, pin: string): string[] {
+  const updated: string[] = [];
+  for (const agent of agentRegistry) {
+    let configPath: string;
+    try {
+      configPath = agent.getConfigPath(projectPath);
+    } catch {
+      continue;
+    }
+    if (!isProjectLocalConfig(configPath, projectPath)) continue;
+    if (!fs.existsSync(configPath)) continue;
+
+    try {
+      if (agent.configFormat === 'toml') {
+        if (upsertPinInTomlConfig(configPath, pin)) updated.push(configPath);
+      } else {
+        if (upsertPinInJsonConfig(configPath, agent.bodyPath, pin)) updated.push(configPath);
+      }
+    } catch {
+      // Best-effort: a single unreadable/malformed config never fails enrollment.
+    }
+  }
+  return updated;
+}
+
+/** Rewrite the `url`/`serverUrl` of `bodyPath.ai-game-developer` in a JSON config. Returns true when changed. */
+function upsertPinInJsonConfig(configPath: string, bodyPath: string, pin: string): boolean {
+  const root = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+  if (!root || typeof root !== 'object' || Array.isArray(root)) return false;
+  const body = root[bodyPath] as Record<string, unknown> | undefined;
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return false;
+  const entry = body[MCP_SERVER_NAME] as Record<string, unknown> | undefined;
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return false;
+
+  // The registry uses `url` for most agents and `serverUrl` for Antigravity.
+  const urlKey = typeof entry['url'] === 'string' ? 'url' : typeof entry['serverUrl'] === 'string' ? 'serverUrl' : null;
+  if (!urlKey) return false;
+
+  const current = entry[urlKey] as string;
+  const pinned = applyPinToUrl(current, pin);
+  if (pinned === current) return false;
+
+  entry[urlKey] = pinned;
+  fs.writeFileSync(configPath, JSON.stringify(root, null, 2) + '\n');
+  return true;
+}
+
+/** Rewrite the `url = "…"` line under `[mcp_servers.ai-game-developer]` in a Codex TOML config. Returns true when changed. */
+function upsertPinInTomlConfig(configPath: string, pin: string): boolean {
+  const lines = fs.readFileSync(configPath, 'utf-8').split('\n');
+  const header = `[mcp_servers.${MCP_SERVER_NAME}]`;
+  const sectionIdx = lines.findIndex((l) => l.trim() === header);
+  if (sectionIdx < 0) return false;
+
+  for (let i = sectionIdx + 1; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (trimmed.startsWith('[')) break; // next section
+    const m = trimmed.match(/^url\s*=\s*"([^"]*)"\s*$/);
+    if (m) {
+      const pinned = applyPinToUrl(m[1], pin);
+      if (pinned === m[1]) return false;
+      lines[i] = `url = "${pinned}"`;
+      fs.writeFileSync(configPath, lines.join('\n'));
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Convenience: derive the pin for a project root (re-exported for callers that only need the pin). */
+export function projectPin(projectPath: string): string {
+  return derivePin(projectPath);
+}

--- a/cli/src/utils/project-marker.ts
+++ b/cli/src/utils/project-marker.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { derivePin, PIN_LENGTH } from './project-identity.js';
+import { PIN_LENGTH } from './project-identity.js';
 import { agentRegistry, MCP_SERVER_NAME } from './agents.js';
 
 /**
@@ -194,9 +194,4 @@ function upsertPinInTomlConfig(configPath: string, pin: string): boolean {
     }
   }
   return false;
-}
-
-/** Convenience: derive the pin for a project root (re-exported for callers that only need the pin). */
-export function projectPin(projectPath: string): string {
-  return derivePin(projectPath);
 }

--- a/cli/src/utils/server-source.ts
+++ b/cli/src/utils/server-source.ts
@@ -1,0 +1,251 @@
+// Pure helpers for resolving WHERE the shared `gamedev-mcp-server` binary comes
+// from when `install-plugin --with-server` materializes it: RID detection, the
+// trusted GitHub-release download URL, the `SHA256SUMS` integrity manifest, and
+// the fail-closed verify verdict. These MIRROR the addon's own server logic in
+// `addons/godot_mcp/Runtime/Connection/GodotMcpServerView.cs` (github.com only,
+// `releases/download/v<version>/gamedev-mcp-server-<rid>.zip`, verify-before-
+// extract against `SHA256SUMS`). No side effects; unit-testable with no network.
+//
+// The DEFAULT server version is single-sourced from the addon's pinned
+// `ServerVersion` constant (a parity test — `cli/tests/server-source-parity.test.ts`
+// — reads `GodotMcpServerView.cs` and FAILS the build if this drifts), so the CLI
+// and the addon can never download two different server versions.
+
+import { createHash } from 'crypto';
+
+/**
+ * The DEFAULT shared-server version `--with-server` downloads. Single-sourced
+ * from the addon's `GodotMcpServerView.ServerVersion` constant (parity-tested).
+ * `--server-version <v>` overrides it; `--server-source <path>` skips the
+ * download entirely (offline / CI). Bumping the addon's server pin requires
+ * bumping this in the same PR or the parity test goes red.
+ */
+export const DEFAULT_SERVER_VERSION = '9.0.0';
+
+/** GitHub-release host the server zip + manifest are downloaded from. NOTHING else is trusted. */
+export const TRUSTED_DOWNLOAD_HOST = 'github.com';
+
+/** The `owner/repo` the shared server releases live under. */
+export const SERVER_RELEASE_REPO = 'IvanMurzak/GameDev-MCP-Server';
+
+/** The server-binary base name (matches the addon's `GodotMcpServerView.ExecutableName`). */
+export const SERVER_EXECUTABLE_NAME = 'gamedev-mcp-server';
+
+/** The release-asset / RID prefix (matches the addon's `AssetPrefix`). */
+export const SERVER_ASSET_PREFIX = SERVER_EXECUTABLE_NAME;
+
+/** The integrity-manifest asset attached to every GameDev-MCP-Server release. */
+export const SHA256SUMS_ASSET_NAME = 'SHA256SUMS';
+
+/** Map a Node `process.platform` token to the .NET RID os segment (`win`/`osx`/`linux`). */
+export function osToken(platform: NodeJS.Platform = process.platform): string {
+  switch (platform) {
+    case 'win32':
+      return 'win';
+    case 'darwin':
+      return 'osx';
+    case 'linux':
+      return 'linux';
+    default:
+      return 'unknown';
+  }
+}
+
+/** Map a Node `process.arch` token to the .NET RID arch segment (`x86`/`x64`/`arm`/`arm64`). */
+export function archToken(arch: string = process.arch): string {
+  switch (arch) {
+    case 'x64':
+      return 'x64';
+    case 'arm64':
+      return 'arm64';
+    case 'ia32':
+      return 'x86';
+    case 'arm':
+      return 'arm';
+    default:
+      return 'unknown';
+  }
+}
+
+/**
+ * The RID-style platform name `<os>-<arch>` (e.g. `win-x64`) for the given (or
+ * current) host. Matches the addon's `GodotMcpServerView.PlatformName` and the
+ * GameDev-MCP-Server release asset RIDs (linux-arm64/linux-x64/osx-arm64/osx-x64/
+ * win-arm64/win-x64/win-x86). Pure.
+ */
+export function detectHostRid(platform: NodeJS.Platform = process.platform, arch: string = process.arch): string {
+  return `${osToken(platform)}-${archToken(arch)}`;
+}
+
+/** The on-disk executable file name for an os: `gamedev-mcp-server.exe` on Windows, else `gamedev-mcp-server`. */
+export function serverExecutableFileName(platform: NodeJS.Platform = process.platform): string {
+  return platform === 'win32' ? `${SERVER_EXECUTABLE_NAME}.exe` : SERVER_EXECUTABLE_NAME;
+}
+
+/** The GitHub release-zip asset name for a RID: `gamedev-mcp-server-<rid>.zip`. Pure. */
+export function serverAssetName(rid: string): string {
+  return `${SERVER_ASSET_PREFIX}-${rid}.zip`;
+}
+
+/** Drop a single leading `v`/`V` from a version string. Pure. */
+export function stripLeadingV(version: string): string {
+  const v = (version ?? '').trim();
+  return /^v/i.test(v) ? v.slice(1) : v;
+}
+
+/** The git release TAG for a server version: the version with a leading `v` (`9.0.0` → `v9.0.0`). Pure. */
+export function serverReleaseTag(version: string): string {
+  const v = (version ?? '').trim();
+  return v.startsWith('v') ? v : `v${v}`;
+}
+
+/**
+ * The download URL for a server version's per-RID zip:
+ * `https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/v<version>/gamedev-mcp-server-<rid>.zip`.
+ * Mirrors `GodotMcpServerView.DownloadUrl`. The host is always `github.com` by
+ * construction; `assertTrustedServerUrl` re-checks a URL before any network call. Pure.
+ */
+export function serverDownloadUrl(version: string, rid: string): string {
+  return `https://${TRUSTED_DOWNLOAD_HOST}/${SERVER_RELEASE_REPO}/releases/download/${serverReleaseTag(version)}/${serverAssetName(rid)}`;
+}
+
+/**
+ * The `SHA256SUMS` manifest URL — the sibling of the per-RID zip under the SAME
+ * `v<version>` release tag. Mirrors `GodotMcpServerView.Sha256SumsUrl`. Pure.
+ */
+export function sha256SumsUrl(version: string): string {
+  return `https://${TRUSTED_DOWNLOAD_HOST}/${SERVER_RELEASE_REPO}/releases/download/${serverReleaseTag(version)}/${SHA256SUMS_ASSET_NAME}`;
+}
+
+/**
+ * Fail-closed host trust check: throw unless `url` is an HTTPS URL whose host is
+ * EXACTLY `github.com` (no subdomains, no `github.com.evil.test`, no http). The
+ * security boundary the task requires for the server download. Returns the parsed
+ * URL on success. Pure (throws on the unhappy path; callers turn it into a
+ * structured failure so nothing escapes the public boundary).
+ */
+export function assertTrustedServerUrl(url: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Refusing to download server: malformed URL "${url}".`);
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`Refusing to download server: only https is allowed, got "${parsed.protocol}" (${url}).`);
+  }
+  if (parsed.hostname.toLowerCase() !== TRUSTED_DOWNLOAD_HOST) {
+    throw new Error(
+      `Refusing to download server from untrusted host "${parsed.hostname}". Only ${TRUSTED_DOWNLOAD_HOST} is trusted.`,
+    );
+  }
+  return parsed;
+}
+
+// --- SHA256SUMS integrity manifest (download-verify-before-extract, fail-closed) ---
+// Ported from GodotMcpServerView.{ParseSha256Sums,LookupDigest,DigestMatches,VerifyZipChecksum}
+// so the CLI and the addon apply byte-identical integrity rules.
+
+/** True when `value` is exactly 64 ASCII hex characters (a SHA256 hex digest). */
+function isHex64(value: string): boolean {
+  if (value.length !== 64) return false;
+  return /^[0-9a-fA-F]{64}$/.test(value);
+}
+
+/**
+ * Parse a coreutils `sha256sum` manifest into a `{filename → lowercase-hex-digest}`
+ * map. One line per file: a 64-char hex digest, whitespace, then the file name.
+ * Tolerances (matching the C# reference): CRLF + bare-LF; blank lines skipped;
+ * leading/trailing whitespace trimmed; the binary-mode `*` marker before the
+ * filename stripped; a line whose first token is not 64-hex, or which has no
+ * filename, is skipped (never a spurious entry — fail-closed at lookup). On a
+ * duplicate filename the LAST entry wins. Never throws. Pure.
+ */
+export function parseSha256Sums(sha256SumsText: string | null | undefined): Map<string, string> {
+  const map = new Map<string, string>();
+  if (!sha256SumsText) return map;
+
+  for (const rawLine of sha256SumsText.replace(/\r\n/g, '\n').split('\n')) {
+    const line = rawLine.trim();
+    if (line.length === 0) continue;
+
+    // Split into the digest token and the remainder (the filename) on the FIRST
+    // run of whitespace, so single-space/tab variants still parse.
+    let sepIndex = -1;
+    for (let i = 0; i < line.length; i++) {
+      if (line[i] === ' ' || line[i] === '\t') {
+        sepIndex = i;
+        break;
+      }
+    }
+    if (sepIndex <= 0 || sepIndex >= line.length - 1) continue;
+
+    const digestToken = line.slice(0, sepIndex);
+    if (!isHex64(digestToken)) continue;
+
+    let fileName = line.slice(sepIndex + 1).replace(/^[ \t]+/, '');
+    if (fileName.startsWith('*')) fileName = fileName.slice(1);
+    fileName = fileName.trim();
+    if (fileName.length === 0) continue;
+
+    map.set(fileName, digestToken.toLowerCase());
+  }
+
+  return map;
+}
+
+/** Look up the expected digest for an asset zip name in a parsed manifest, or null when absent. Pure. */
+export function lookupDigest(parsed: Map<string, string>, assetZipName: string): string | null {
+  if (!parsed || !assetZipName) return null;
+  return parsed.get(assetZipName) ?? null;
+}
+
+/** Case-insensitive hex-digest equality (both trimmed). A null/empty side is NEVER a match (fail-closed). Pure. */
+export function digestMatches(expectedHexDigest: string | null | undefined, actualHexDigest: string | null | undefined): boolean {
+  if (!expectedHexDigest || !expectedHexDigest.trim() || !actualHexDigest || !actualHexDigest.trim()) return false;
+  return expectedHexDigest.trim().toLowerCase() === actualHexDigest.trim().toLowerCase();
+}
+
+/** The verdict of verifying a downloaded zip against a release `SHA256SUMS` manifest. */
+export type ChecksumVerdict = 'verified' | 'manifest-unparsable' | 'missing-entry' | 'digest-mismatch';
+
+/**
+ * The single fail-closed integrity decision the installer calls BEFORE extract:
+ * parse the release `SHA256SUMS`, find the entry for `assetZipName`, and compare
+ * it (case-insensitive hex) against the locally-computed SHA256 of the downloaded
+ * zip. Returns `'verified'` ONLY when the manifest parsed, contained the asset,
+ * and the digest matched; every other outcome is a distinct fail-closed verdict
+ * the caller MUST treat as "do NOT extract". Never throws. Pure.
+ */
+export function verifyZipChecksum(
+  sha256SumsText: string | null | undefined,
+  assetZipName: string,
+  actualZipHexDigest: string | null | undefined,
+): ChecksumVerdict {
+  const parsed = parseSha256Sums(sha256SumsText);
+  if (parsed.size === 0) return 'manifest-unparsable';
+
+  const expected = lookupDigest(parsed, assetZipName);
+  if (expected === null) return 'missing-entry';
+
+  return digestMatches(expected, actualZipHexDigest) ? 'verified' : 'digest-mismatch';
+}
+
+/** A short, actionable reason for a non-`verified` verdict, for the installer's fail-closed error. Pure. */
+export function checksumFailureReason(verdict: ChecksumVerdict, assetZipName: string): string {
+  switch (verdict) {
+    case 'manifest-unparsable':
+      return `the downloaded ${SHA256SUMS_ASSET_NAME} manifest was empty or unparsable`;
+    case 'missing-entry':
+      return `the ${SHA256SUMS_ASSET_NAME} manifest has no entry for '${assetZipName}'`;
+    case 'digest-mismatch':
+      return `the downloaded '${assetZipName}' SHA256 did not match the ${SHA256SUMS_ASSET_NAME} manifest entry`;
+    default:
+      return 'the checksum was verified';
+  }
+}
+
+/** The lowercase hex SHA256 of a byte buffer (the downloaded zip). Pure. */
+export function sha256Hex(bytes: Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}

--- a/cli/src/utils/server-source.ts
+++ b/cli/src/utils/server-source.ts
@@ -87,12 +87,6 @@ export function serverAssetName(rid: string): string {
   return `${SERVER_ASSET_PREFIX}-${rid}.zip`;
 }
 
-/** Drop a single leading `v`/`V` from a version string. Pure. */
-export function stripLeadingV(version: string): string {
-  const v = (version ?? '').trim();
-  return /^v/i.test(v) ? v.slice(1) : v;
-}
-
 /** The git release TAG for a server version: the version with a leading `v` (`9.0.0` → `v9.0.0`). Pure. */
 export function serverReleaseTag(version: string): string {
   const v = (version ?? '').trim();

--- a/cli/tests/configure-agent.test.ts
+++ b/cli/tests/configure-agent.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { EventEmitter } from 'events';
+import type { spawn as SpawnType } from 'child_process';
+import { configureAgentViaServer } from '../src/lib/configure-agent.js';
+import { getManagedServerDir, getManagedServerExecutablePath } from '../src/lib/install-server.js';
+
+interface SpawnCall {
+  bin: string;
+  args: string[];
+  cwd?: string;
+}
+
+/** A fake `spawn` that records the call and emits `stdout` + `close(code)` on next tick. */
+function fakeSpawn(exitCode: number, stdout: string, calls: SpawnCall[]): typeof SpawnType {
+  return ((bin: string, args: string[], opts: { cwd?: string }) => {
+    calls.push({ bin, args, cwd: opts?.cwd });
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+    };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    setImmediate(() => {
+      if (stdout) child.stdout.emit('data', Buffer.from(stdout));
+      child.emit('close', exitCode);
+    });
+    return child as unknown as ReturnType<typeof SpawnType>;
+  }) as unknown as typeof SpawnType;
+}
+
+/** Create the managed server binary so the existsSync gate passes. */
+function planetManagedBinary(project: string): string {
+  const dir = getManagedServerDir(project);
+  fs.mkdirSync(dir, { recursive: true });
+  const exe = getManagedServerExecutablePath(project);
+  fs.writeFileSync(exe, '#!/bin/sh\necho stub\n');
+  return exe;
+}
+
+describe('configureAgentViaServer', () => {
+  let project: string;
+  beforeEach(() => {
+    project = fs.mkdtempSync(path.join(os.tmpdir(), 'gmcp-cfg-'));
+  });
+  afterEach(() => fs.rmSync(project, { recursive: true, force: true }));
+
+  it('proxies `configure --agent <id>` to the managed binary with cwd=project and forwards exit 0', async () => {
+    const exe = planetManagedBinary(project);
+    const calls: SpawnCall[] = [];
+    const result = await configureAgentViaServer({
+      godotProjectPath: project,
+      agentId: 'claude-code',
+      spawnImpl: fakeSpawn(0, 'wrote .mcp.json\n', calls),
+    });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+    expect(result.serverBinaryPath).toBe(exe);
+    expect(result.args).toEqual(['configure', '--agent', 'claude-code']);
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('wrote .mcp.json');
+    expect(calls).toHaveLength(1);
+    expect(calls[0].bin).toBe(exe);
+    expect(calls[0].args).toEqual(['configure', '--agent', 'claude-code']);
+    expect(path.resolve(calls[0].cwd ?? '')).toBe(path.resolve(project));
+  });
+
+  it('forwards --url when supplied', async () => {
+    planetManagedBinary(project);
+    const calls: SpawnCall[] = [];
+    await configureAgentViaServer({
+      godotProjectPath: project,
+      agentId: 'cursor',
+      url: 'http://localhost:20001/mcp',
+      spawnImpl: fakeSpawn(0, '', calls),
+    });
+    expect(calls[0].args).toEqual(['configure', '--agent', 'cursor', '--url', 'http://localhost:20001/mcp']);
+  });
+
+  it('fails cleanly (not ENOENT) when no managed server binary is present', async () => {
+    let spawned = false;
+    const spy = (() => {
+      spawned = true;
+      throw new Error('should not spawn');
+    }) as unknown as typeof SpawnType;
+    const result = await configureAgentViaServer({ godotProjectPath: project, agentId: 'claude-code', spawnImpl: spy });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') expect(result.error.message).toMatch(/install-plugin --with-server/);
+    expect(spawned).toBe(false);
+  });
+
+  it('surfaces the server binary’s non-zero exit code', async () => {
+    planetManagedBinary(project);
+    const calls: SpawnCall[] = [];
+    const result = await configureAgentViaServer({
+      godotProjectPath: project,
+      agentId: 'unknown-agent',
+      spawnImpl: fakeSpawn(2, 'error: unknown agent\n', calls),
+    });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') {
+      expect(result.exitCode).toBe(2);
+      expect(result.error.message).toMatch(/exited with code 2/);
+    }
+  });
+
+  it('rejects an empty agent id', async () => {
+    planetManagedBinary(project);
+    const result = await configureAgentViaServer({ godotProjectPath: project, agentId: '   ' });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') expect(result.error.message).toMatch(/agent id/i);
+  });
+});

--- a/cli/tests/enroll-plugin.test.ts
+++ b/cli/tests/enroll-plugin.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { enrollPlugin } from '../src/lib/enroll.js';
+import { readMachineCredentials } from '../src/utils/machine-credentials.js';
+import { readProjectMarker } from '../src/utils/project-marker.js';
+import { derivePin, derivePort } from '../src/utils/project-identity.js';
+
+function mockRedeem(serverUrl: string): typeof fetch {
+  return (async () =>
+    ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        access_token: 'plugin.jwt',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        refresh_token: 'refresh.jwt',
+        scope: 'mcp:plugin',
+        server_url: serverUrl,
+      }),
+    }) as unknown as Response) as unknown as typeof fetch;
+}
+
+function mockRedeemError(): typeof fetch {
+  return (async () =>
+    ({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      json: async () => ({ error: 'invalid_grant', error_description: 'Invalid or expired enrollment code.' }),
+    }) as unknown as Response) as unknown as typeof fetch;
+}
+
+describe('enrollPlugin', () => {
+  let project: string;
+  let store: string;
+  beforeEach(() => {
+    project = fs.mkdtempSync(path.join(os.tmpdir(), 'gmcp-enroll-proj-'));
+    store = fs.mkdtempSync(path.join(os.tmpdir(), 'gmcp-enroll-store-'));
+  });
+  afterEach(() => {
+    fs.rmSync(project, { recursive: true, force: true });
+    fs.rmSync(store, { recursive: true, force: true });
+  });
+
+  it('redeems, plants the credential in the machine store, and writes the marker (hosted target — no port)', async () => {
+    const result = await enrollPlugin({
+      godotProjectPath: project,
+      code: 'CODE-1',
+      storeBaseDir: store,
+      fetchImpl: mockRedeem('https://ai-game.dev'),
+    });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+
+    expect(result.serverTarget).toBe('https://ai-game.dev');
+    expect(result.pin).toBe(derivePin(project));
+    expect(result.port).toBeUndefined(); // hosted → no derived local port
+
+    const creds = readMachineCredentials(store);
+    expect(creds?.accessToken).toBe('plugin.jwt');
+    expect(creds?.refreshToken).toBe('refresh.jwt');
+    expect(creds?.serverTarget).toBe('https://ai-game.dev');
+    expect(creds?.expiresAt).toBeTruthy();
+
+    const marker = readProjectMarker(project);
+    expect(marker?.serverTarget).toBe('https://ai-game.dev');
+    expect(marker?.pin).toBe(derivePin(project));
+    expect(marker?.port).toBeUndefined();
+  });
+
+  it('records the deterministic local port for a localhost target', async () => {
+    const result = await enrollPlugin({
+      godotProjectPath: project,
+      code: 'CODE-1',
+      storeBaseDir: store,
+      fetchImpl: mockRedeem('http://localhost:20001'),
+    });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+    expect(result.port).toBe(derivePort(project));
+    const marker = readProjectMarker(project);
+    expect(marker?.port).toBe(derivePort(project));
+  });
+
+  it('upserts the D14 pin into an existing project-local .mcp.json', async () => {
+    const mcpJson = path.join(project, '.mcp.json');
+    fs.writeFileSync(
+      mcpJson,
+      JSON.stringify({ mcpServers: { 'ai-game-developer': { type: 'http', url: 'https://ai-game.dev/mcp' } } }, null, 2),
+    );
+    const result = await enrollPlugin({
+      godotProjectPath: project,
+      code: 'CODE-1',
+      storeBaseDir: store,
+      fetchImpl: mockRedeem('https://ai-game.dev'),
+    });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+    expect(result.pinnedConfigs).toContain(mcpJson);
+    const root = JSON.parse(fs.readFileSync(mcpJson, 'utf-8'));
+    expect(root.mcpServers['ai-game-developer'].url).toBe(`https://ai-game.dev/mcp/p/${derivePin(project)}`);
+  });
+
+  it('writes NOTHING on a redeem failure (no marker, no credential)', async () => {
+    const result = await enrollPlugin({
+      godotProjectPath: project,
+      code: 'BAD',
+      storeBaseDir: store,
+      fetchImpl: mockRedeemError(),
+    });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') expect(result.error.message).toMatch(/Invalid or expired/);
+    expect(readMachineCredentials(store)).toBeNull();
+    expect(readProjectMarker(project)).toBeNull();
+  });
+});

--- a/cli/tests/enroll.test.ts
+++ b/cli/tests/enroll.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { redeemEnrollment } from '../src/utils/enroll.js';
+
+const OK_BODY = {
+  access_token: 'plugin.jwt.token',
+  token_type: 'Bearer',
+  expires_in: 3600,
+  refresh_token: 'refresh.token',
+  scope: 'mcp:plugin',
+  server_url: 'https://ai-game.dev',
+};
+
+function mockFetchJson(status: number, body: unknown): typeof fetch {
+  return (async (url: string, init?: RequestInit) => {
+    // Assert the CLI targets the redeem endpoint with the right body.
+    expect(url).toBe('https://ai-game.dev/api/auth/enroll/redeem');
+    expect(JSON.parse(String(init?.body))).toEqual({ enroll_code: 'CODE-1234' });
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: 'x',
+      json: async () => body,
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+}
+
+describe('redeemEnrollment', () => {
+  it('returns the credential + server_url on a 200', async () => {
+    const result = await redeemEnrollment({ code: 'CODE-1234', baseUrl: 'https://ai-game.dev', fetchImpl: mockFetchJson(200, OK_BODY) });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.credential.access_token).toBe('plugin.jwt.token');
+      expect(result.credential.refresh_token).toBe('refresh.token');
+      expect(result.credential.server_url).toBe('https://ai-game.dev');
+    }
+  });
+
+  it('surfaces the uniform error message on an invalid/expired/used code', async () => {
+    const result = await redeemEnrollment({
+      code: 'CODE-1234',
+      baseUrl: 'https://ai-game.dev',
+      fetchImpl: mockFetchJson(400, { error: 'invalid_grant', error_description: 'Invalid or expired enrollment code.' }),
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.message).toBe('Invalid or expired enrollment code.');
+  });
+
+  it('empty code fails before any network call', async () => {
+    let called = false;
+    const spy = (async () => {
+      called = true;
+      throw new Error('should not be called');
+    }) as unknown as typeof fetch;
+    const result = await redeemEnrollment({ code: '   ', baseUrl: 'https://ai-game.dev', fetchImpl: spy });
+    expect(result.success).toBe(false);
+    expect(called).toBe(false);
+  });
+
+  it('maps a connection error to a reachability message', async () => {
+    const spy = (async () => {
+      throw new Error('fetch failed');
+    }) as unknown as typeof fetch;
+    const result = await redeemEnrollment({ code: 'CODE-1234', baseUrl: 'http://localhost:9', fetchImpl: spy });
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.message).toMatch(/Cannot reach the enrollment server/);
+  });
+
+  it('rejects a 200 with an incomplete body (no access_token / server_url)', async () => {
+    const result = await redeemEnrollment({
+      code: 'CODE-1234',
+      baseUrl: 'https://ai-game.dev',
+      fetchImpl: mockFetchJson(200, { token_type: 'Bearer' }),
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.message).toMatch(/incomplete credential/);
+  });
+});

--- a/cli/tests/install-plugin-server-cli.test.ts
+++ b/cli/tests/install-plugin-server-cli.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { runCliAsync } from './helpers/cli.js';
+import { getManagedServerExecutablePath } from '../src/lib/install-server.js';
+import { serverExecutableFileName } from '../src/utils/server-source.js';
+
+const MINIMAL_PROJECT = '; Engine configuration file.\nconfig_version=5\n\n[application]\n\nconfig/name="Test"\n';
+const CSPROJ = '<Project Sdk="Godot.NET.Sdk/4.3.0">\n  <PropertyGroup>\n    <TargetFramework>net8.0</TargetFramework>\n  </PropertyGroup>\n</Project>\n';
+
+describe('install-plugin / configure — new CLI surface (offline)', () => {
+  let project: string;
+  let addonSrc: string;
+  let serverSrc: string;
+  beforeEach(() => {
+    project = fs.mkdtempSync(path.join(os.tmpdir(), 'gmcp-cli-proj-'));
+    fs.writeFileSync(path.join(project, 'project.godot'), MINIMAL_PROJECT);
+    fs.writeFileSync(path.join(project, 'MyGame.csproj'), CSPROJ);
+
+    // A local addon source (for --source, offline install).
+    addonSrc = fs.mkdtempSync(path.join(os.tmpdir(), 'gmcp-cli-addon-'));
+    const addon = path.join(addonSrc, 'addons', 'godot_mcp');
+    fs.mkdirSync(path.join(addon, 'Editor'), { recursive: true });
+    fs.writeFileSync(path.join(addon, 'plugin.cfg'), '[plugin]\nname="godot_mcp"\n');
+    fs.writeFileSync(path.join(addon, 'Editor', 'GodotMcpPlugin.cs'), '// boot\n');
+
+    // A local server source (for --server-source, offline install).
+    serverSrc = fs.mkdtempSync(path.join(os.tmpdir(), 'gmcp-cli-srv-'));
+    fs.writeFileSync(path.join(serverSrc, serverExecutableFileName()), '#!/bin/sh\necho stub\n');
+  });
+  afterEach(() => {
+    for (const d of [project, addonSrc, serverSrc]) fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  it('install-plugin --source --with-server --server-source installs the addon AND the managed server binary (offline)', async () => {
+    const { stdout, exitCode } = await runCliAsync([
+      'install-plugin',
+      '--source',
+      addonSrc,
+      '--with-server',
+      '--server-source',
+      serverSrc,
+      project,
+    ]);
+    expect(exitCode, stdout).toBe(0);
+    // Addon materialized.
+    expect(fs.existsSync(path.join(project, 'addons', 'godot_mcp', 'plugin.cfg'))).toBe(true);
+    // Managed server binary present.
+    expect(fs.existsSync(getManagedServerExecutablePath(project))).toBe(true);
+  });
+
+  it('install-plugin --enroll and --enroll-stdin together is a usage error', async () => {
+    const { stdout, exitCode } = await runCliAsync(['install-plugin', '--enroll', 'X', '--enroll-stdin', project]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toMatch(/not both/i);
+  });
+
+  it('configure --agent without a managed server binary fails with an actionable message', async () => {
+    const { stdout, exitCode } = await runCliAsync(['configure', '--agent', 'claude-code', project]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toMatch(/install-plugin --with-server/);
+  });
+});

--- a/cli/tests/install-server.test.ts
+++ b/cli/tests/install-server.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as zlib from 'zlib';
+import { installServer, getManagedServerDir, getManagedServerExecutablePath } from '../src/lib/install-server.js';
+import { serverExecutableFileName, serverAssetName, detectHostRid, sha256Hex } from '../src/utils/server-source.js';
+
+// ---- in-memory zip builder (DEFLATE) — mirrors install-plugin-installer.test.ts ----
+function crc32(buf: Buffer): number {
+  let crc = ~0;
+  for (let i = 0; i < buf.length; i++) {
+    crc ^= buf[i];
+    for (let j = 0; j < 8; j++) crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+  }
+  return ~crc >>> 0;
+}
+function buildZip(files: { path: string; content: Buffer }[]): Buffer {
+  const local: Buffer[] = [];
+  const central: Buffer[] = [];
+  let offset = 0;
+  for (const f of files) {
+    const name = Buffer.from(f.path, 'utf8');
+    const comp = zlib.deflateRawSync(f.content);
+    const crc = crc32(f.content);
+    const lfh = Buffer.alloc(30);
+    lfh.writeUInt32LE(0x04034b50, 0);
+    lfh.writeUInt16LE(20, 4);
+    lfh.writeUInt16LE(8, 8);
+    lfh.writeUInt32LE(crc, 14);
+    lfh.writeUInt32LE(comp.length, 18);
+    lfh.writeUInt32LE(f.content.length, 22);
+    lfh.writeUInt16LE(name.length, 26);
+    const rec = Buffer.concat([lfh, name, comp]);
+    local.push(rec);
+    const cdh = Buffer.alloc(46);
+    cdh.writeUInt32LE(0x02014b50, 0);
+    cdh.writeUInt16LE(8, 10);
+    cdh.writeUInt32LE(crc, 16);
+    cdh.writeUInt32LE(comp.length, 20);
+    cdh.writeUInt32LE(f.content.length, 24);
+    cdh.writeUInt16LE(name.length, 28);
+    cdh.writeUInt32LE(offset, 42);
+    central.push(Buffer.concat([cdh, name]));
+    offset += rec.length;
+  }
+  const lb = Buffer.concat(local);
+  const cb = Buffer.concat(central);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(files.length, 8);
+  eocd.writeUInt16LE(files.length, 10);
+  eocd.writeUInt32LE(cb.length, 12);
+  eocd.writeUInt32LE(lb.length, 16);
+  return Buffer.concat([lb, cb, eocd]);
+}
+
+const EXE = serverExecutableFileName(); // host-platform exe name
+const RID = detectHostRid();
+const ASSET = serverAssetName(RID);
+
+const SERVER_ZIP = buildZip([
+  { path: EXE, content: Buffer.from('#!/bin/sh\necho server\n') },
+  { path: 'gamedev-mcp-server.dll', content: Buffer.from('deps') },
+]);
+const ZIP_DIGEST = sha256Hex(SERVER_ZIP);
+
+/** A mock fetch that serves the RID zip on the `.zip` URL and a manifest on the SHA256SUMS URL. */
+function mockServerFetch(opts: { zip?: Buffer; manifest?: string | null; zipStatus?: number; sumsStatus?: number }): typeof fetch {
+  const zip = opts.zip ?? SERVER_ZIP;
+  const manifest = opts.manifest === undefined ? `${ZIP_DIGEST}  ${ASSET}\n` : opts.manifest;
+  return (async (url: string) => {
+    if (url.endsWith('SHA256SUMS')) {
+      const status = opts.sumsStatus ?? 200;
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: 'x',
+        text: async () => manifest ?? '',
+      } as unknown as Response;
+    }
+    const status = opts.zipStatus ?? 200;
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: 'x',
+      arrayBuffer: async () => zip.buffer.slice(zip.byteOffset, zip.byteOffset + zip.byteLength),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+}
+
+describe('installServer — download path (verified)', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gmcp-srv-'));
+  });
+  afterEach(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+  it('downloads, verifies the SHA256, extracts to the managed dir, and records the exe path', async () => {
+    const result = await installServer({ godotProjectPath: tmp, version: '9.0.0', fetchImpl: mockServerFetch({}) });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+    expect(result.source).toBe('download');
+    expect(result.version).toBe('9.0.0');
+    expect(result.rid).toBe(RID);
+    expect(result.downloadUrl).toContain('github.com');
+    expect(result.downloadUrl).toContain('v9.0.0');
+    expect(result.executablePath).toBe(getManagedServerExecutablePath(tmp));
+    expect(fs.existsSync(result.executablePath)).toBe(true);
+    // no staging leftovers
+    expect(fs.readdirSync(tmp).filter((n) => n.startsWith('.gamedev-server-staging'))).toHaveLength(0);
+  });
+
+  it('FAILS CLOSED on a digest mismatch (tampered zip) and leaves no managed dir', async () => {
+    const tamperedZip = buildZip([{ path: EXE, content: Buffer.from('malware') }]);
+    const result = await installServer({
+      godotProjectPath: tmp,
+      version: '9.0.0',
+      fetchImpl: mockServerFetch({ zip: tamperedZip /* manifest still lists the ORIGINAL digest */ }),
+    });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') expect(result.error.message).toMatch(/did not match|fail-closed/i);
+    expect(fs.existsSync(getManagedServerDir(tmp))).toBe(false);
+  });
+
+  it('FAILS CLOSED when the asset has no SHA256SUMS entry', async () => {
+    const result = await installServer({
+      godotProjectPath: tmp,
+      version: '9.0.0',
+      fetchImpl: mockServerFetch({ manifest: `${'c'.repeat(64)}  some-other-asset.zip\n` }),
+    });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') expect(result.error.message).toMatch(/no entry|fail-closed/i);
+    expect(fs.existsSync(getManagedServerDir(tmp))).toBe(false);
+  });
+
+  it('FAILS CLOSED when the SHA256SUMS manifest cannot be downloaded (unverified)', async () => {
+    const result = await installServer({
+      godotProjectPath: tmp,
+      version: '9.0.0',
+      fetchImpl: mockServerFetch({ sumsStatus: 404 }),
+    });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') expect(result.error.message).toMatch(/unverified|SHA256SUMS/i);
+    expect(fs.existsSync(getManagedServerDir(tmp))).toBe(false);
+  });
+
+  it('surfaces a clean 404 when the release zip is missing', async () => {
+    const result = await installServer({
+      godotProjectPath: tmp,
+      version: '404.0.0',
+      fetchImpl: mockServerFetch({ zipStatus: 404 }),
+    });
+    expect(result.kind).toBe('failure');
+    if (result.kind === 'failure') expect(result.error.message).toMatch(/HTTP 404/);
+  });
+
+  it('rejects an unsupported host RID (unknown token) before any network call', async () => {
+    let called = false;
+    const spy = (async () => {
+      called = true;
+      throw new Error('no network');
+    }) as unknown as typeof fetch;
+    const guarded = await installServer({ godotProjectPath: tmp, version: '9.0.0', rid: 'unknown-unknown', fetchImpl: spy });
+    expect(guarded.kind).toBe('failure');
+    if (guarded.kind === 'failure') expect(guarded.error.message).toMatch(/RID|--server-source/i);
+    expect(called).toBe(false);
+  });
+});
+
+describe('installServer — --server-source (offline / CI)', () => {
+  let tmp: string;
+  let src: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gmcp-srvsrc-'));
+    src = fs.mkdtempSync(path.join(os.tmpdir(), 'gmcp-srvbin-'));
+    fs.writeFileSync(path.join(src, EXE), '#!/bin/sh\necho stub\n');
+    fs.writeFileSync(path.join(src, 'gamedev-mcp-server.dll'), 'deps');
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+    fs.rmSync(src, { recursive: true, force: true });
+  });
+
+  it('copies a local server dir into the managed dir and never hits the network', async () => {
+    let called = false;
+    const spy = (async () => {
+      called = true;
+      throw new Error('network should not be used with --server-source');
+    }) as unknown as typeof fetch;
+    const result = await installServer({ godotProjectPath: tmp, source: src, fetchImpl: spy });
+    expect(result.kind).toBe('success');
+    expect(called).toBe(false);
+    if (result.kind === 'success') {
+      expect(result.source).toBe('local');
+      expect(fs.existsSync(result.executablePath)).toBe(true);
+      expect(result.executablePath).toBe(getManagedServerExecutablePath(tmp));
+    }
+  });
+
+  it('installs from a local .zip archive', async () => {
+    const zipPath = path.join(src, 'server.zip');
+    fs.writeFileSync(zipPath, SERVER_ZIP);
+    const result = await installServer({ godotProjectPath: tmp, source: zipPath });
+    expect(result.kind).toBe('success');
+    if (result.kind === 'success') expect(fs.existsSync(result.executablePath)).toBe(true);
+  });
+
+  it('fails clearly when --server-source has no server executable', async () => {
+    const bare = fs.mkdtempSync(path.join(os.tmpdir(), 'gmcp-srvbare-'));
+    try {
+      const result = await installServer({ godotProjectPath: tmp, source: bare });
+      expect(result.kind).toBe('failure');
+      if (result.kind === 'failure') expect(result.error.message).toMatch(/did not yield|gamedev-mcp-server/i);
+    } finally {
+      fs.rmSync(bare, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/tests/project-marker.test.ts
+++ b/cli/tests/project-marker.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  readProjectMarker,
+  writeProjectMarker,
+  getProjectMarkerPath,
+  isLocalhostUrl,
+  applyPinToUrl,
+  upsertPinIntoAgentConfigs,
+} from '../src/utils/project-marker.js';
+import { derivePin } from '../src/utils/project-identity.js';
+
+describe('project-marker — read/write merge', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gmcp-marker-'));
+  });
+  afterEach(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+  it('returns null when the marker is absent', () => {
+    expect(readProjectMarker(tmp)).toBeNull();
+  });
+
+  it('writes the marker under .ai-game-dev/project.json', () => {
+    writeProjectMarker(tmp, { serverTarget: 'https://ai-game.dev', pin: 'deadbeef' });
+    expect(fs.existsSync(getProjectMarkerPath(tmp))).toBe(true);
+    const marker = readProjectMarker(tmp);
+    expect(marker?.serverTarget).toBe('https://ai-game.dev');
+    expect(marker?.pin).toBe('deadbeef');
+  });
+
+  it('merges over an existing marker, preserving a prior portOverride + unknown keys', () => {
+    writeProjectMarker(tmp, { portOverride: 27123, custom: 'keep-me' } as never);
+    writeProjectMarker(tmp, { serverTarget: 'http://localhost:20001', pin: 'cafef00d', port: 20001 });
+    const marker = readProjectMarker(tmp);
+    expect(marker?.portOverride).toBe(27123);
+    expect((marker as Record<string, unknown>).custom).toBe('keep-me');
+    expect(marker?.serverTarget).toBe('http://localhost:20001');
+    expect(marker?.port).toBe(20001);
+  });
+
+  it('a malformed marker reads as null (never throws)', () => {
+    fs.mkdirSync(path.dirname(getProjectMarkerPath(tmp)), { recursive: true });
+    fs.writeFileSync(getProjectMarkerPath(tmp), '{ not json');
+    expect(readProjectMarker(tmp)).toBeNull();
+  });
+});
+
+describe('project-marker — isLocalhostUrl', () => {
+  it('recognizes loopback hosts', () => {
+    expect(isLocalhostUrl('http://localhost:8080')).toBe(true);
+    expect(isLocalhostUrl('http://127.0.0.1:20001/mcp')).toBe(true);
+    expect(isLocalhostUrl('http://[::1]:5300')).toBe(true);
+  });
+  it('rejects hosted + malformed', () => {
+    expect(isLocalhostUrl('https://ai-game.dev/mcp')).toBe(false);
+    expect(isLocalhostUrl('not a url')).toBe(false);
+  });
+});
+
+describe('project-marker — applyPinToUrl (D14 routing pin)', () => {
+  it('appends /p/<pin> to a bare /mcp path', () => {
+    expect(applyPinToUrl('https://ai-game.dev/mcp', 'deadbeef')).toBe('https://ai-game.dev/mcp/p/deadbeef');
+  });
+  it('replaces an existing /p/<pin> segment (idempotent re-enroll)', () => {
+    expect(applyPinToUrl('https://ai-game.dev/mcp/p/00000000', 'deadbeef')).toBe(
+      'https://ai-game.dev/mcp/p/deadbeef',
+    );
+  });
+  it('works on a localhost URL with a port', () => {
+    expect(applyPinToUrl('http://localhost:20001/mcp', 'cafef00d')).toBe('http://localhost:20001/mcp/p/cafef00d');
+  });
+  it('returns a malformed URL unchanged', () => {
+    expect(applyPinToUrl('not a url', 'deadbeef')).toBe('not a url');
+  });
+});
+
+describe('project-marker — upsertPinIntoAgentConfigs', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gmcp-pinup-'));
+  });
+  afterEach(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+  it("pins the ai-game-developer entry in an existing project-local .mcp.json (Claude Code)", () => {
+    const pin = derivePin(tmp);
+    const mcpJson = path.join(tmp, '.mcp.json');
+    fs.writeFileSync(
+      mcpJson,
+      JSON.stringify({ mcpServers: { 'ai-game-developer': { type: 'http', url: 'https://ai-game.dev/mcp' } } }, null, 2),
+    );
+    const updated = upsertPinIntoAgentConfigs(tmp, pin);
+    expect(updated).toContain(mcpJson);
+    const root = JSON.parse(fs.readFileSync(mcpJson, 'utf-8'));
+    expect(root.mcpServers['ai-game-developer'].url).toBe(`https://ai-game.dev/mcp/p/${pin}`);
+  });
+
+  it('leaves a config with no ai-game-developer entry untouched', () => {
+    const pin = derivePin(tmp);
+    const mcpJson = path.join(tmp, '.mcp.json');
+    const original = JSON.stringify({ mcpServers: { other: { url: 'https://x.test' } } }, null, 2);
+    fs.writeFileSync(mcpJson, original);
+    const updated = upsertPinIntoAgentConfigs(tmp, pin);
+    expect(updated).not.toContain(mcpJson);
+    expect(fs.readFileSync(mcpJson, 'utf-8')).toBe(original);
+  });
+
+  it('pins the Antigravity-style serverUrl key too (when project-local)', () => {
+    // Antigravity's config is user-global by default and thus skipped; assert the
+    // serverUrl key is handled by pinning a project-local Custom-style config that
+    // carries serverUrl.
+    const pin = derivePin(tmp);
+    const custom = path.join(tmp, 'mcp.json'); // the `custom` agent's project-local path
+    fs.writeFileSync(
+      custom,
+      JSON.stringify({ mcpServers: { 'ai-game-developer': { serverUrl: 'http://localhost:20001/mcp' } } }, null, 2),
+    );
+    const updated = upsertPinIntoAgentConfigs(tmp, pin);
+    expect(updated).toContain(custom);
+    const root = JSON.parse(fs.readFileSync(custom, 'utf-8'));
+    expect(root.mcpServers['ai-game-developer'].serverUrl).toBe(`http://localhost:20001/mcp/p/${pin}`);
+  });
+
+  it('skips user-global configs (never rewrites files outside the project)', () => {
+    // No project-local config present → nothing updated, and no throw.
+    expect(upsertPinIntoAgentConfigs(tmp, derivePin(tmp))).toEqual([]);
+  });
+});

--- a/cli/tests/server-source-parity.test.ts
+++ b/cli/tests/server-source-parity.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { DEFAULT_SERVER_VERSION } from '../src/utils/server-source.js';
+
+// The CLI's DEFAULT_SERVER_VERSION must single-source the addon's own pinned
+// `GodotMcpServerView.ServerVersion` constant. If the addon bumps the consumed
+// server, this test fails until the CLI constant is updated — so `--with-server`
+// can NEVER download a server version the addon was not built to pin. This is the
+// drift tripwire that lets the CLI runtime stay a pure constant (no build-time
+// C#-source read), mirroring addon-deps-parity.test.ts.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SERVER_VIEW_CS = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'addons',
+  'godot_mcp',
+  'Runtime',
+  'Connection',
+  'GodotMcpServerView.cs',
+);
+
+/** Extract `public const string ServerVersion = "x.y.z";` from the addon source. */
+function parseAddonServerVersion(text: string): string | null {
+  const m = text.match(/public\s+const\s+string\s+ServerVersion\s*=\s*"([^"]+)"\s*;/);
+  return m ? m[1] : null;
+}
+
+describe('server-source parity with GodotMcpServerView.cs', () => {
+  it('the addon ServerView source is reachable (relative layout sanity)', () => {
+    expect(fs.existsSync(SERVER_VIEW_CS)).toBe(true);
+  });
+
+  it('DEFAULT_SERVER_VERSION matches the addon ServerVersion constant exactly', () => {
+    const text = fs.readFileSync(SERVER_VIEW_CS, 'utf-8');
+    const addonVersion = parseAddonServerVersion(text);
+    expect(addonVersion, 'GodotMcpServerView.cs is missing a `public const string ServerVersion = "…"`').not.toBeNull();
+    expect(
+      DEFAULT_SERVER_VERSION,
+      `CLI DEFAULT_SERVER_VERSION (${DEFAULT_SERVER_VERSION}) drifted from the addon ServerVersion (${addonVersion}). ` +
+        'Update DEFAULT_SERVER_VERSION in cli/src/utils/server-source.ts to match the addon pin.',
+    ).toBe(addonVersion);
+  });
+});

--- a/cli/tests/server-source.test.ts
+++ b/cli/tests/server-source.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import {
+  detectHostRid,
+  osToken,
+  archToken,
+  serverAssetName,
+  serverExecutableFileName,
+  serverReleaseTag,
+  serverDownloadUrl,
+  sha256SumsUrl,
+  assertTrustedServerUrl,
+  parseSha256Sums,
+  lookupDigest,
+  digestMatches,
+  verifyZipChecksum,
+  checksumFailureReason,
+  sha256Hex,
+  TRUSTED_DOWNLOAD_HOST,
+} from '../src/utils/server-source.js';
+
+describe('server-source — RID detection', () => {
+  it('maps os tokens like the addon (win/osx/linux)', () => {
+    expect(osToken('win32')).toBe('win');
+    expect(osToken('darwin')).toBe('osx');
+    expect(osToken('linux')).toBe('linux');
+    expect(osToken('aix' as NodeJS.Platform)).toBe('unknown');
+  });
+
+  it('maps arch tokens (x64/arm64/x86/arm)', () => {
+    expect(archToken('x64')).toBe('x64');
+    expect(archToken('arm64')).toBe('arm64');
+    expect(archToken('ia32')).toBe('x86');
+    expect(archToken('arm')).toBe('arm');
+    expect(archToken('mips')).toBe('unknown');
+  });
+
+  it('composes <os>-<arch> matching the released RIDs', () => {
+    expect(detectHostRid('win32', 'x64')).toBe('win-x64');
+    expect(detectHostRid('linux', 'arm64')).toBe('linux-arm64');
+    expect(detectHostRid('darwin', 'arm64')).toBe('osx-arm64');
+    expect(detectHostRid('win32', 'ia32')).toBe('win-x86');
+  });
+
+  it('names the executable per-OS', () => {
+    expect(serverExecutableFileName('win32')).toBe('gamedev-mcp-server.exe');
+    expect(serverExecutableFileName('linux')).toBe('gamedev-mcp-server');
+    expect(serverExecutableFileName('darwin')).toBe('gamedev-mcp-server');
+  });
+});
+
+describe('server-source — URLs (github.com only, v-tag)', () => {
+  it('builds the RID-matched download URL', () => {
+    expect(serverDownloadUrl('9.0.0', 'win-x64')).toBe(
+      'https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/v9.0.0/gamedev-mcp-server-win-x64.zip',
+    );
+  });
+
+  it('builds the SHA256SUMS sibling URL under the same tag', () => {
+    expect(sha256SumsUrl('9.0.0')).toBe(
+      'https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/v9.0.0/SHA256SUMS',
+    );
+  });
+
+  it('v-prefixes the tag but never double-prefixes', () => {
+    expect(serverReleaseTag('9.0.0')).toBe('v9.0.0');
+    expect(serverReleaseTag('v9.0.0')).toBe('v9.0.0');
+  });
+
+  it('asset name is gamedev-mcp-server-<rid>.zip', () => {
+    expect(serverAssetName('linux-x64')).toBe('gamedev-mcp-server-linux-x64.zip');
+  });
+
+  it('accepts a trusted github.com https URL', () => {
+    expect(assertTrustedServerUrl(serverDownloadUrl('9.0.0', 'osx-x64')).hostname).toBe(TRUSTED_DOWNLOAD_HOST);
+  });
+
+  it('rejects non-github hosts, http, and lookalike domains (fail-closed)', () => {
+    expect(() => assertTrustedServerUrl('http://github.com/x')).toThrow(/https/);
+    expect(() => assertTrustedServerUrl('https://evil.test/x')).toThrow(/untrusted host/);
+    expect(() => assertTrustedServerUrl('https://github.com.evil.test/x')).toThrow(/untrusted host/);
+    expect(() => assertTrustedServerUrl('not a url')).toThrow(/malformed/);
+  });
+});
+
+describe('server-source — SHA256SUMS parsing (ported from the addon)', () => {
+  const digestA = 'a'.repeat(64);
+  const digestB = 'b'.repeat(64);
+
+  it('parses the coreutils two-space format', () => {
+    const text = `${digestA}  gamedev-mcp-server-win-x64.zip\n${digestB}  gamedev-mcp-server-linux-x64.zip\n`;
+    const map = parseSha256Sums(text);
+    expect(map.get('gamedev-mcp-server-win-x64.zip')).toBe(digestA);
+    expect(map.get('gamedev-mcp-server-linux-x64.zip')).toBe(digestB);
+  });
+
+  it('tolerates CRLF, the binary-mode * marker, and lowercases the digest', () => {
+    const text = `${digestA.toUpperCase()} *gamedev-mcp-server-win-x64.zip\r\n\r\n`;
+    const map = parseSha256Sums(text);
+    expect(map.get('gamedev-mcp-server-win-x64.zip')).toBe(digestA);
+  });
+
+  it('skips lines whose first token is not a 64-hex digest (fail-closed, no spurious entry)', () => {
+    const map = parseSha256Sums(`not-a-digest  file.zip\n${digestA}  ok.zip\n`);
+    expect(map.has('file.zip')).toBe(false);
+    expect(map.get('ok.zip')).toBe(digestA);
+  });
+
+  it('an empty/garbage manifest yields an empty map', () => {
+    expect(parseSha256Sums('').size).toBe(0);
+    expect(parseSha256Sums(null).size).toBe(0);
+    expect(parseSha256Sums('   \n  ').size).toBe(0);
+  });
+
+  it('lookupDigest + digestMatches are fail-closed on null/empty', () => {
+    const map = parseSha256Sums(`${digestA}  a.zip`);
+    expect(lookupDigest(map, 'a.zip')).toBe(digestA);
+    expect(lookupDigest(map, 'missing.zip')).toBeNull();
+    expect(digestMatches(digestA, digestA.toUpperCase())).toBe(true);
+    expect(digestMatches(digestA, digestB)).toBe(false);
+    expect(digestMatches(null, digestA)).toBe(false);
+    expect(digestMatches(digestA, '')).toBe(false);
+  });
+});
+
+describe('server-source — verifyZipChecksum verdicts (fail-closed)', () => {
+  const asset = 'gamedev-mcp-server-win-x64.zip';
+  const zip = Buffer.from('the-real-server-zip-bytes');
+  const digest = sha256Hex(zip);
+  const manifest = `${digest}  ${asset}\n`;
+
+  it('verified when the manifest parses, has the asset, and the digest matches', () => {
+    expect(verifyZipChecksum(manifest, asset, digest)).toBe('verified');
+  });
+
+  it('manifest-unparsable when the manifest is empty/garbage', () => {
+    expect(verifyZipChecksum('', asset, digest)).toBe('manifest-unparsable');
+    expect(checksumFailureReason('manifest-unparsable', asset)).toMatch(/unparsable/);
+  });
+
+  it('missing-entry when the manifest has no line for this asset', () => {
+    expect(verifyZipChecksum(`${'c'.repeat(64)}  other.zip`, asset, digest)).toBe('missing-entry');
+    expect(checksumFailureReason('missing-entry', asset)).toContain(asset);
+  });
+
+  it('digest-mismatch when the recomputed SHA differs (tamper detection)', () => {
+    const tampered = sha256Hex(Buffer.from('tampered-bytes'));
+    expect(verifyZipChecksum(manifest, asset, tampered)).toBe('digest-mismatch');
+    expect(checksumFailureReason('digest-mismatch', asset)).toContain(asset);
+  });
+});


### PR DESCRIPTION
## Summary

Complete the Godot terminal onboarding surface — the FINAL godot-cli PR of the mcp-authorize `e2` task (design `06-engine-plugins.md` / `09-user-workflows.md`). Builds on CLI-PR1 (#273). Adds to `godot-cli`:

- **`install-plugin --with-server`** — download the RID-matched `gamedev-mcp-server-<rid>.zip` into the CLI-managed dir, verify against the release `SHA256SUMS` **before** extraction (fail-closed), record the path. `--server-source` offline/CI override; `--server-version` escape hatch. Default server version is single-sourced from the addon's `ServerVersion` const (parity-tested against `GodotMcpServerView.cs`) so CLI/addon never drift.
- **`install-plugin --enroll <code>` / `--enroll-stdin`** — redeem the D13 enrollment code against the cloud AS `POST /api/auth/enroll/redeem`, plant the plugin credential in the shared machine store, write the project marker (`.ai-game-dev/project.json`) with the server target + D14 pin (+ derived port for a localhost target), and upsert the pin into any existing project-local agent config. `--enroll-stdin` keeps the code out of argv.
- **`configure --agent <id>`** — proxy to the managed server binary's `configure` subcommand (actionable error when it is absent).
- **`test_cli_e2e_install.yml`** — extended to drive the new flows end-to-end (network legs stubbed: the real server download + SHA256 verify and the real AS redeem are unit-tested with mocked fetch) on the headless-Godot matrix, gating both PR and release.

CLI version is **not** bumped and there is **no** `npm publish` — the godot-cli rides the addon release.

## Test plan

- [x] `cli/` unit + integration tests: `npm run build && npm test` — 494 passed / 1 skipped / 45 files (baseline 433/37). New coverage: RID detect, download-URL + SHA256SUMS parse/verify (fail-closed verdicts), server-source parity, install-server download+verify+extract + `--server-source`, enroll redeem (uniform error / network / incomplete body), enroll→store+marker+pin, project-marker + pin-URL upsert, configure-agent proxy (argv/cwd/exit-code + missing-binary error), and CLI-level `install-plugin`/`configure` wiring.
- [x] Real end-to-end smoke on Windows: `install-plugin --source --with-server --server-source --enroll` against a local stub AS → addon + managed server binary + machine-store credential (DPAPI) + project marker written; `configure --agent` builds the correct proxy call.
- [x] Extended e2e leg drives `--with-server` / `--enroll` / `configure --agent` on headless Godot (4.3–4.7).

Closes #275
