### PR TITLE
fix: setup-mcp emits URL-only MCP config for OAuth-capable clients

### DIFF
--- a/cli/src/lib/setup-mcp.ts
+++ b/cli/src/lib/setup-mcp.ts
@@ -158,8 +158,13 @@ export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
 
     // Flow C safety: a static PAT written into a project-scoped config file is a
     // VCS leak risk — warn so the user prefers an env var / user-scoped config (or
-    // relies on native OAuth by omitting the token).
-    if (authRequired && isInsideProject(projectPath, configPath)) {
+    // relies on native OAuth by omitting the token). Gate on whether a static
+    // header was ACTUALLY emitted into `props`, not merely on `authRequired`:
+    // agents whose `getHttpProps` ignore the token (e.g. Codex / Antigravity)
+    // write no `headers`, so an explicit `--token` there must NOT raise a "leaked
+    // credential" warning about a header that was never written to the file.
+    const wroteAuthHeader = Boolean((props as { headers?: unknown }).headers);
+    if (wroteAuthHeader && isInsideProject(projectPath, configPath)) {
       warnings.push(
         `Wrote a static Authorization (PAT) header into the project-scoped config ${configPath}. ` +
           `Committing this file would leak the credential — prefer setting ${ENV_TOKEN} in your ` +

--- a/cli/src/lib/setup-mcp.ts
+++ b/cli/src/lib/setup-mcp.ts
@@ -47,6 +47,45 @@ function resolveMcpClientUrl(optUrl: string | undefined): string {
 }
 
 /**
+ * Decide whether `setup-mcp` writes a static `Authorization: Bearer` header for a
+ * given agent + credential (design decision D11 / auth Flow A & C, mirroring the
+ * shared b6 configurators' `SupportsOAuth` policy).
+ *
+ * OAuth-capable interactive clients (Claude Code, Cursor, Codex, Copilot, …)
+ * perform native RFC 9728 discovery + OAuth against the hosted endpoint (Flow A).
+ * A static Bearer header BOTH fails there (the hosted AS rejects the token with
+ * 401) AND suppresses the client's own OAuth handshake ("OAuth fallback is
+ * disabled when headers.Authorization is set"), so it must be omitted — the
+ * config stays URL-only `{type,url}`.
+ *
+ * A header is written ONLY for the Flow C fallback:
+ *   - `supportsOAuth === false` — a client that cannot OAuth and needs a static
+ *     token against a required-auth (typically self-hosted) endpoint; OR
+ *   - an EXPLICIT PAT opt-in — the caller passed the token explicitly (`--token`
+ *     / the library `token` arg), a deliberate Flow C request.
+ *
+ * A token that is only present ambiently (the `GODOT_MCP_TOKEN` env a prior
+ * `login` set) is NOT an opt-in: for an OAuth-capable client it is ignored so the
+ * native handshake runs. This is the flagship g1 fix — `login` + `setup-mcp
+ * claude-code .` must no longer emit a header.
+ */
+export function shouldWriteAuthHeader(input: {
+  hasToken: boolean;
+  explicitToken: boolean;
+  supportsOAuth: boolean;
+}): boolean {
+  if (!input.hasToken) return false;
+  if (input.supportsOAuth === false) return true;
+  return input.explicitToken;
+}
+
+/** True when `configPath` resolves inside `projectPath` (a project-scoped, likely VCS-tracked file). */
+function isInsideProject(projectPath: string, configPath: string): boolean {
+  const rel = path.relative(projectPath, configPath);
+  return rel.length > 0 && !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
+/**
  * Write MCP configuration for the given AI agent so it can talk to a Godot-MCP
  * server. Library-safe: no stdout noise, no process.exit, no throws past the
  * public boundary.
@@ -99,11 +138,34 @@ export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
     });
 
     const serverUrl = resolveMcpClientUrl(opts.url);
+    // A token supplied EXPLICITLY by the caller (`--token` / the library `token`
+    // arg) is a deliberate Flow C PAT opt-in; a token that is only present in the
+    // ambient `GODOT_MCP_TOKEN` env (e.g. one a prior `login` set) is NOT.
+    const explicitToken = typeof opts.token === 'string' && opts.token.length > 0;
     const token = opts.token ?? normalizeEnv(process.env[ENV_TOKEN]) ?? '';
-    const authRequired = token.length > 0;
+    // OAuth-aware header gate (design D11 / auth Flow A & C): OAuth-capable clients
+    // get a credential-free, URL-only config so their native RFC 9728 OAuth runs;
+    // a static Authorization header is written only for a non-OAuth client or an
+    // explicit PAT opt-in. See `shouldWriteAuthHeader`.
+    const authRequired = shouldWriteAuthHeader({
+      hasToken: token.length > 0,
+      explicitToken,
+      supportsOAuth: agent.supportsOAuth,
+    });
 
     const configPath = agent.getConfigPath(projectPath);
     const props = agent.getHttpProps(serverUrl, token, authRequired);
+
+    // Flow C safety: a static PAT written into a project-scoped config file is a
+    // VCS leak risk — warn so the user prefers an env var / user-scoped config (or
+    // relies on native OAuth by omitting the token).
+    if (authRequired && isInsideProject(projectPath, configPath)) {
+      warnings.push(
+        `Wrote a static Authorization (PAT) header into the project-scoped config ${configPath}. ` +
+          `Committing this file would leak the credential — prefer setting ${ENV_TOKEN} in your ` +
+          `environment or a user-scoped config, or omit the token to use the client's native OAuth.`,
+      );
+    }
 
     if (agent.configFormat === 'toml') {
       writeTomlAgentConfig(configPath, agent.bodyPath, MCP_SERVER_NAME, props, agent.httpRemoveKeys);

--- a/cli/src/utils/agents.ts
+++ b/cli/src/utils/agents.ts
@@ -39,6 +39,18 @@ export interface AgentDefinition {
   /** Config-file serialization format. `toml` is the Codex branch. */
   configFormat: 'json' | 'toml';
   bodyPath: string;
+  /**
+   * Whether this MCP client performs native RFC 9728 OAuth against the hosted
+   * endpoint (auth Flow A). Default policy is `true`, mirroring the shared b6
+   * configurators / decision D11: OAuth-capable clients get a credential-free,
+   * URL-only `{type,url}` config so their own OAuth handshake runs, and
+   * `setup-mcp` OMITS the static `Authorization` header for them — a static
+   * header both fails against the hosted AS (401) and suppresses the client's
+   * OAuth fallback ("OAuth fallback is disabled when headers.Authorization is
+   * set"). Set `false` only for a client that cannot OAuth and needs a static
+   * token against a required-auth (typically self-hosted) endpoint (Flow C).
+   */
+  supportsOAuth: boolean;
   /** Resolve the absolute config-file path for a given project root. */
   getConfigPath(projectPath: string): string;
   /** Build the HTTP server entry written under `bodyPath[MCP_SERVER_NAME]`. */
@@ -67,6 +79,16 @@ function isMac(): boolean {
   return process.platform === 'darwin';
 }
 
+/**
+ * Build the optional `headers` object for an HTTP server entry. Emits a Bearer
+ * `Authorization` header ONLY when `authRequired` is set AND a non-empty token is
+ * present. `authRequired` is the OAuth-aware decision made per agent in
+ * `lib/setup-mcp.ts` (see `shouldWriteAuthHeader`): OAuth-capable clients
+ * (`supportsOAuth: true`, the default) are handed `authRequired = false`, so this
+ * stays `undefined` and the client runs its own RFC 9728 OAuth (Flow A). A header
+ * is produced only for the Flow C fallback (a non-OAuth client, or an explicit
+ * PAT opt-in). Returns `undefined` otherwise.
+ */
 function authHeaders(token: string, authRequired: boolean): Record<string, string> | undefined {
   if (authRequired && token) {
     return { Authorization: `Bearer ${token}` };
@@ -91,6 +113,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
   {
     id: 'claude-code',
     name: 'Claude Code',
+    supportsOAuth: true,
     skillsPath: '.claude/skills',
     configPathDisplay: '.mcp.json',
     configFormat: 'json',
@@ -108,6 +131,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
   {
     id: 'claude-desktop',
     name: 'Claude Desktop',
+    supportsOAuth: true,
     skillsPath: null,
     configPathDisplay: '~/Claude/claude_desktop_config.json',
     configFormat: 'json',
@@ -133,6 +157,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
   {
     id: 'cursor',
     name: 'Cursor',
+    supportsOAuth: true,
     skillsPath: '.cursor/skills',
     configPathDisplay: '.cursor/mcp.json',
     configFormat: 'json',
@@ -150,6 +175,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
   {
     id: 'vscode-copilot',
     name: 'Visual Studio Code (Copilot)',
+    supportsOAuth: true,
     skillsPath: '.github/skills',
     configPathDisplay: '.vscode/mcp.json',
     configFormat: 'json',
@@ -167,6 +193,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
   {
     id: 'vs-copilot',
     name: 'Visual Studio (Copilot)',
+    supportsOAuth: true,
     skillsPath: '.github/skills',
     configPathDisplay: '.vs/mcp.json',
     configFormat: 'json',
@@ -184,6 +211,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
   {
     id: 'rider-junie',
     name: 'Rider (Junie)',
+    supportsOAuth: true,
     skillsPath: '.junie/skills',
     configPathDisplay: '.junie/mcp/mcp.json',
     configFormat: 'json',
@@ -202,6 +230,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
   {
     id: 'github-copilot-cli',
     name: 'GitHub Copilot CLI',
+    supportsOAuth: true,
     skillsPath: '.github/skills',
     configPathDisplay: '~/.copilot/mcp-config.json',
     configFormat: 'json',
@@ -220,6 +249,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
   {
     id: 'gemini',
     name: 'Gemini',
+    supportsOAuth: true,
     skillsPath: '.gemini/skills',
     configPathDisplay: '.gemini/settings.json',
     configFormat: 'json',
@@ -237,6 +267,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
   {
     id: 'antigravity',
     name: 'Antigravity',
+    supportsOAuth: true,
     skillsPath: '.agent/skills',
     configPathDisplay: '~/.gemini/config/mcp_config.json',
     configFormat: 'json',
@@ -254,6 +285,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
   {
     id: 'cline',
     name: 'Cline',
+    supportsOAuth: true,
     skillsPath: '.cline/skills',
     configPathDisplay: '~/Code/globalStorage/.../cline_mcp_settings.json',
     configFormat: 'json',
@@ -287,6 +319,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
   {
     id: 'open-code',
     name: 'Open Code',
+    supportsOAuth: true,
     skillsPath: '.opencode/skills',
     configPathDisplay: 'opencode.json',
     configFormat: 'json',
@@ -305,6 +338,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
   {
     id: 'codex',
     name: 'Codex',
+    supportsOAuth: true,
     skillsPath: '.agents/skills',
     configPathDisplay: '.codex/config.toml',
     configFormat: 'toml',
@@ -323,6 +357,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
   {
     id: 'kilo-code',
     name: 'Kilo Code',
+    supportsOAuth: true,
     skillsPath: '.kilocode/skills',
     configPathDisplay: '.kilocode/mcp.json',
     configFormat: 'json',
@@ -341,6 +376,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
   {
     id: 'custom',
     name: 'Custom (generic MCP client)',
+    supportsOAuth: true,
     skillsPath: null,
     configPathDisplay: 'mcp.json',
     configFormat: 'json',

--- a/cli/tests/setup-mcp.test.ts
+++ b/cli/tests/setup-mcp.test.ts
@@ -294,6 +294,11 @@ describe('setupMcp', () => {
     const toml = fs.readFileSync(result.configPath, 'utf-8');
     expect(toml).not.toContain('Authorization');
     expect(toml).not.toContain('headers');
+    // Codex's getHttpProps ignores the token (URL-only TOML), so no static header
+    // lands in the file — and therefore NO VCS-leak warning must be raised. The
+    // warning is gated on the header actually written to the config, not on the
+    // presence of an (explicit) token.
+    expect(result.warnings.some((w) => /PAT/i.test(w) && /leak/i.test(w))).toBe(false);
   });
 });
 

--- a/cli/tests/setup-mcp.test.ts
+++ b/cli/tests/setup-mcp.test.ts
@@ -11,7 +11,7 @@ vi.mock('os', async (importOriginal) => {
   const actual = await importOriginal<typeof import('os')>();
   return { ...actual, homedir: () => homeHolder.dir || actual.homedir() };
 });
-import { setupMcp, listAgentIds } from '../src/lib/setup-mcp.js';
+import { setupMcp, listAgentIds, shouldWriteAuthHeader } from '../src/lib/setup-mcp.js';
 import {
   agentRegistry,
   getAgentById,
@@ -228,7 +228,46 @@ describe('setupMcp', () => {
     expect(toml).toContain('startup_timeout_sec = 30');
   });
 
-  it('adds an Authorization header when a token is provided (claude-code)', async () => {
+  // --- D11 / Flow A: OAuth-capable clients get a credential-free, URL-only config ---
+
+  it('omits the Authorization header for OAuth-capable clients even when GODOT_MCP_TOKEN is set (flagship g1 fix)', async () => {
+    // A prior `login` leaves GODOT_MCP_TOKEN in the environment. setup-mcp must NOT
+    // inject it as a static header for OAuth-capable clients (claude-code, cursor,
+    // copilot, …): the hosted AS rejects the token (401) AND the client then skips
+    // its own OAuth handshake ("OAuth fallback is disabled when headers.Authorization
+    // is set"). The config must stay URL-only so native RFC 9728 OAuth runs (Flow A).
+    process.env[ENV_TOKEN] = 'agd_pat_ambient';
+    const cases: Array<[string, string[], string]> = [
+      ['claude-code', ['.mcp.json'], 'mcpServers'],
+      ['cursor', ['.cursor', 'mcp.json'], 'mcpServers'],
+      ['vscode-copilot', ['.vscode', 'mcp.json'], 'servers'],
+    ];
+    for (const [id, rel, body] of cases) {
+      const result = await setupMcp({ agentId: id, godotProjectPath: tmpDir });
+      expect(result.kind).toBe('success');
+      if (result.kind !== 'success') continue;
+      const json = JSON.parse(fs.readFileSync(path.join(tmpDir, ...rel), 'utf-8'));
+      const entry = json[body][SERVER_NAME];
+      expect(entry).toMatchObject({ type: 'http', url: 'https://ai-game.dev/mcp' });
+      expect(entry.headers).toBeUndefined();
+      // No credential landed in the file → no VCS-leak warning.
+      expect(result.warnings).toEqual([]);
+    }
+  });
+
+  it('codex writes URL-only TOML (no Authorization) even with an ambient GODOT_MCP_TOKEN', async () => {
+    process.env[ENV_TOKEN] = 'agd_pat_ambient';
+    const result = await setupMcp({ agentId: 'codex', godotProjectPath: tmpDir });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+    const toml = fs.readFileSync(result.configPath, 'utf-8');
+    expect(toml).not.toContain('Authorization');
+    expect(toml).not.toContain('headers');
+  });
+
+  it('adds an Authorization header on an explicit --token opt-in (Flow C) and warns about the project-file PAT (claude-code)', async () => {
+    // Passing --token / the library `token` arg is a deliberate PAT opt-in, unlike
+    // the ambient env token above — the legacy header shape is still written.
     const result = await setupMcp({
       agentId: 'claude-code',
       godotProjectPath: tmpDir,
@@ -236,8 +275,11 @@ describe('setupMcp', () => {
       token: 'secret',
     });
     expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
     const json = JSON.parse(fs.readFileSync(path.join(tmpDir, '.mcp.json'), 'utf-8'));
     expect(json.mcpServers[SERVER_NAME].headers).toEqual({ Authorization: 'Bearer secret' });
+    // Flow C: writing a PAT into a project-scoped config warns about the VCS-leak risk.
+    expect(result.warnings.some((w) => /PAT/i.test(w) && /leak/i.test(w))).toBe(true);
   });
 
   it('does NOT add Authorization headers to codex (token-less TOML)', async () => {
@@ -318,6 +360,38 @@ describe('agent config-path resolution', () => {
     expect(getAgentById('codex')!.configFormat).toBe('toml');
     const tomlAgents = agentRegistry.filter((a) => a.configFormat === 'toml').map((a) => a.id);
     expect(tomlAgents).toEqual(['codex']);
+  });
+
+  it('every agent declares supportsOAuth (boolean); all shipped clients are OAuth-capable (D11/b6 default true)', () => {
+    for (const agent of agentRegistry) {
+      expect(typeof agent.supportsOAuth).toBe('boolean');
+      // Every client shipped today performs native RFC 9728 OAuth; a future
+      // non-OAuth client would set this false to opt back into a static header.
+      expect(agent.supportsOAuth).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OAuth-aware header gate (design D11 / auth Flow A & C)
+// ---------------------------------------------------------------------------
+
+describe('shouldWriteAuthHeader', () => {
+  it('never writes a header without a token', () => {
+    expect(shouldWriteAuthHeader({ hasToken: false, explicitToken: false, supportsOAuth: true })).toBe(false);
+    expect(shouldWriteAuthHeader({ hasToken: false, explicitToken: true, supportsOAuth: false })).toBe(false);
+  });
+
+  it('OAuth-capable client: omits the header for an ambient token, writes it only on explicit opt-in', () => {
+    // ambient token (env), not explicit → URL-only (Flow A, the flagship fix)
+    expect(shouldWriteAuthHeader({ hasToken: true, explicitToken: false, supportsOAuth: true })).toBe(false);
+    // explicit --token opt-in → header (Flow C)
+    expect(shouldWriteAuthHeader({ hasToken: true, explicitToken: true, supportsOAuth: true })).toBe(true);
+  });
+
+  it('non-OAuth client (supportsOAuth:false): writes the header whenever a token is present', () => {
+    expect(shouldWriteAuthHeader({ hasToken: true, explicitToken: false, supportsOAuth: false })).toBe(true);
+    expect(shouldWriteAuthHeader({ hasToken: true, explicitToken: true, supportsOAuth: false })).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- `setup-mcp` now writes a **credential-free, URL-only** `{type,url}` config (no `Authorization` header) for OAuth-capable interactive clients (Claude Code, Cursor, Codex, Copilot), so the client performs native RFC 9728 OAuth against the hosted endpoint (auth Flow A). Previously a static `Authorization: Bearer <token>` was injected whenever a token was present — the hosted OAuth server rejects it (401) and the client then skips its own OAuth handshake, so users could never connect.
- A static Bearer header is written ONLY for the Flow C fallback: a non-OAuth client (`supportsOAuth:false`) or an **explicit PAT opt-in** (`--token` / the library `token` arg). An ambient `GODOT_MCP_TOKEN` env (e.g. one a prior `login` set) is no longer treated as an opt-in. A PAT written into a project-scoped config now warns about the VCS-leak risk.
- Mirrors decision **D11** / the shared **b6** C# configurators. Scope: `cli/src` only (`utils/agents.ts` `supportsOAuth` capability + `lib/setup-mcp.ts` OAuth-aware `shouldWriteAuthHeader` gate); no addon/editor or other-command changes.

## Test plan
- [x] Target-specific local tests passed (see profile test.md): `npm run build` + `npm test` (vitest) — 500 passed | 1 skipped.
- [x] Behaviorally verified with the built CLI: `setup-mcp claude-code <dir>` with an ambient `GODOT_MCP_TOKEN` → URL-only `{type,url}`, no header; `--token <PAT>` → Bearer header + VCS-leak warning.

Closes #279