### PR TITLE
feat(connection): local server binds the ProjectIdentity-derived port (mcp-authorize g3)

### DIFF
--- a/Godot-MCP.Tests/GodotProjectIdentityTests.cs
+++ b/Godot-MCP.Tests/GodotProjectIdentityTests.cs
@@ -204,6 +204,124 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.InRange(identity.Port, ProjectIdentity.MinPort, ProjectIdentity.MaxPort);
         }
 
+        // === Local server BIND port — mcp-authorize g3 (server bind == written config == derived) ======
+        //
+        // Completes the Phase-4 8080 → derived-port migration for the LOCAL self-hosted server: the port
+        // the server BINDS (GodotProjectIdentity.ResolveLocalServerBindPort, called by the connection panel's
+        // Start Server action) must equal the port the shared b6 config writer writes into the AI-client
+        // config (AgentConfiguratorSettings.PinnedHttpUrl / ResolvedPort). These pin the three-way equality
+        // on the default local path, the D15 override precedence, and the b6-loopback-rule parity — all pure
+        // over the shared McpPlugin 7.0 primitives, so they run in the plain xUnit host on the Linux CI runner.
+
+        [Theory]
+        [InlineData("C:/Games/MyGame", 29062)]
+        [InlineData("/home/user/MyGame", 24998)]
+        [InlineData("/home/user/Demo Project", 20832)]
+        public void ResolveLocalServerBindPort_DefaultLoopbackHost_IsTheDerivedPort_NotFixed8080(string projectRoot, int expectedPort)
+        {
+            // The default local path (the baseline loopback host, no marker) binds the ProjectIdentity-derived
+            // port — the whole point of g3: no fixed 8080 anywhere on the golden path.
+            var port = GodotProjectIdentity.ResolveLocalServerBindPort(
+                resolvedCustomHost: GodotMcpConfig.DefaultCustomHost, projectRoot, marker: null);
+
+            Assert.Equal(expectedPort, port);
+            Assert.NotEqual(8080, port);
+            Assert.InRange(port, ProjectIdentity.MinPort, ProjectIdentity.MaxPort);
+        }
+
+        [Fact]
+        public void ResolveLocalServerBindPort_MatchesTheB6WrittenConfigPort_OnTheDefaultPath()
+        {
+            // THE g3 guarantee: server bind port == written config port == the ProjectIdentity-derived port.
+            const string root = "C:/Games/MyGame";
+            var settings = LocalSettings(root, "http://localhost:8080/mcp");
+
+            var bindPort = GodotProjectIdentity.ResolveLocalServerBindPort(GodotMcpConfig.DefaultCustomHost, root, marker: null);
+            var writtenPort = new Uri(settings.PinnedHttpUrl).Port;
+
+            Assert.Equal(ProjectIdentity.DerivePort(root), bindPort); // == derived
+            Assert.Equal(settings.ResolvedPort, bindPort);            // == the port b6 resolves
+            Assert.Equal(writtenPort, bindPort);                      // == the port in the written URL
+            Assert.Equal(29062, bindPort);                            // golden vector
+            Assert.NotEqual(8080, bindPort);
+        }
+
+        [Fact]
+        public void ResolveLocalServerBindPort_MarkerPortOverride_WinsOnBothSides()
+        {
+            using var dir = new TempDir();
+            new ProjectMarker { PortOverride = 24242 }.Write(dir.Path);
+            var marker = ProjectMarker.Read(dir.Path);
+
+            // The user's explicit marker portOverride (D15) wins for BOTH the server bind AND the written
+            // config, so they still agree.
+            var bindPort = GodotProjectIdentity.ResolveLocalServerBindPort(GodotMcpConfig.DefaultCustomHost, dir.Path, marker);
+            var settings = LocalSettings(dir.Path, "http://localhost:8080/mcp"); // reads the same marker at dir.Path
+
+            Assert.Equal(24242, bindPort);
+            Assert.Equal(settings.ResolvedPort, bindPort);
+            Assert.Equal(new Uri(settings.PinnedHttpUrl).Port, bindPort);
+        }
+
+        [Fact]
+        public void ResolveLocalServerBindPort_LoopbackExplicitPort_StillDerives_MatchingTheWriter()
+        {
+            const string root = "C:/Games/MyGame";
+
+            // A user-typed loopback host with an explicit port: the b6 writer REWRITES a loopback URL's port
+            // to the derived port, so the server binds the derived port too (a loopback port override goes
+            // through the marker, not the URL) — server bind stays == written config, not the typed :9000.
+            var bindPort = GodotProjectIdentity.ResolveLocalServerBindPort("http://localhost:9000", root, marker: null);
+            var settings = LocalSettings(root, "http://localhost:9000/mcp");
+
+            Assert.Equal(ProjectIdentity.DerivePort(root), bindPort);
+            Assert.NotEqual(9000, bindPort);
+            Assert.Equal(new Uri(settings.PinnedHttpUrl).Port, bindPort);
+        }
+
+        [Fact]
+        public void ResolveLocalServerBindPort_NonLoopbackHost_HonorsExplicitPort_MatchingTheWriter()
+        {
+            const string root = "C:/Games/MyGame";
+            const string host = "http://192.168.1.50:9000";
+
+            // A non-loopback target: the b6 writer keeps its authority verbatim (:9000), so the server binds
+            // that explicit port — an explicitly-set non-default custom host still wins, on both sides.
+            var bindPort = GodotProjectIdentity.ResolveLocalServerBindPort(host, root, marker: null);
+            var settings = LocalSettings(root, host + "/mcp");
+
+            Assert.Equal(9000, bindPort);
+            Assert.Equal(new Uri(settings.PinnedHttpUrl).Port, bindPort);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("not-a-url")]
+        public void ResolveLocalServerBindPort_UnsetOrInvalidHost_FallsBackToDerived(string? host)
+        {
+            const string root = "C:/Games/MyGame";
+            Assert.Equal(
+                ProjectIdentity.DerivePort(root),
+                GodotProjectIdentity.ResolveLocalServerBindPort(host, root, marker: null));
+        }
+
+        /// <summary>
+        /// A shared local-mode <see cref="AgentConfiguratorSettings"/> for the three-way equality assertions:
+        /// its <c>ResolvedPort</c> / <c>PinnedHttpUrl</c> derive the local port from <paramref name="projectRoot"/>
+        /// (+ that root's marker) exactly as production does. The raw engine <c>port: 8080</c> is deliberately the
+        /// stale value — b6 ignores it for the loopback rewrite — so a passing test proves the derivation, not the input.
+        /// </summary>
+        static AgentConfiguratorSettings LocalSettings(string projectRoot, string host) =>
+            AgentConfiguratorSettings.CreateForHost(
+                projectRootPath: projectRoot,
+                executableFullPath: string.Empty,
+                port: 8080,
+                timeoutMs: 10000,
+                host: host,
+                connectionMode: ConnectionMode.Local);
+
         // === Project marker read/write + server-target resolution =====================================
 
         [Fact]

--- a/addons/godot_mcp/Editor/UI/Agents/AgentConfiguratorSettingsFactory.cs
+++ b/addons/godot_mcp/Editor/UI/Agents/AgentConfiguratorSettingsFactory.cs
@@ -38,9 +38,11 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents
         /// connection state, auto-detecting the host OS. The <c>host</c> is the resolved MCP-client URL
         /// (Cloud <c>/mcp</c> or Custom <c>&lt;host&gt;/mcp</c>) so every shared configurator points the AI
         /// client at the SAME endpoint the plugin connects to — exactly what the retired Godot-local
-        /// configurators emitted. Godot is a pure HTTP client (no local-server lifecycle), so the port /
-        /// executable / Docker fields are populated from the addon's authoritative server identity for the
-        /// shared Custom configurator's Docker hints; the HTTP-config write path never reads them.
+        /// configurators emitted. The <c>port</c> is the ProjectIdentity-derived local-server port
+        /// (<see cref="ResolveLocalServerPort"/> — the same one the local server binds and the loopback
+        /// config URL carries, mcp-authorize g3), so the shared Custom configurator's Docker hints agree
+        /// with the written URL and the running server instead of showing the stale fixed 8080; the
+        /// executable field is unused (the HTTP-config write path reads neither).
         ///
         /// <para>
         /// The <paramref name="credentialMode"/> (mcp-authorize e1 · PR 5) governs how the token surfaces:
@@ -62,7 +64,7 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents
             return AgentConfig.AgentConfiguratorSettings.CreateForHost(
                 projectRootPath: ProjectRootPath,
                 executableFullPath: string.Empty,
-                port: DefaultPort,
+                port: ResolveLocalServerPort(config),
                 timeoutMs: DefaultTimeoutMs,
                 host: GodotMcpConfig.ResolveMcpClientUrl(config),
                 token: token,
@@ -80,11 +82,30 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents
         const int DefaultTimeoutMs = 10000;
 
         /// <summary>
-        /// The port for the shared Custom configurator's Docker hints. Godot connects over HTTP to a host
-        /// URL and has no editor-facing port field, so a single sensible default is used (the shared
-        /// server's default port). The HTTP-config write path the dock actually uses is port-agnostic.
+        /// The local server port for the shared Custom configurator's Docker hints
+        /// (<c>-p &lt;port&gt;:&lt;port&gt;</c>, <c>-e PORT=&lt;port&gt;</c>, container name) — the SAME
+        /// ProjectIdentity-derived port the local server binds (<see cref="GodotMcpConnection.ResolveLocalServerPort"/>)
+        /// and the written config URL carries (<see cref="AgentConfig.AgentConfiguratorSettings.PinnedHttpUrl"/>),
+        /// so the "Manual Configuration Steps" Docker command can never show the stale fixed 8080 while the
+        /// server binds a different port (mcp-authorize g3 — completing the Phase-4 8080 → derived-port
+        /// migration, design 06 · D15). Resolved from the live custom host + project marker via the pure,
+        /// unit-tested <see cref="GodotProjectIdentity.ResolveLocalServerBindPort"/>; a malformed marker
+        /// degrades to "no override" so config rendering never faults.
         /// </summary>
-        const int DefaultPort = 8080;
+        static int ResolveLocalServerPort(GodotMcpConfig config)
+        {
+            AgentConfig.ProjectMarker? marker = null;
+            try
+            {
+                marker = AgentConfig.ProjectMarker.Read(ProjectRootPath);
+            }
+            catch
+            {
+                // A malformed marker degrades to no override — never break config rendering.
+            }
+
+            return GodotProjectIdentity.ResolveLocalServerBindPort(config.ResolveCustomHost(), ProjectRootPath, marker);
+        }
 
         /// <summary>The absolute Godot project root (<c>res://</c> globalized, trailing slash stripped).</summary>
         static string ProjectRootPath => ProjectSettings.GlobalizePath("res://").TrimEnd('/');

--- a/addons/godot_mcp/Editor/UI/ConnectionPanel.cs
+++ b/addons/godot_mcp/Editor/UI/ConnectionPanel.cs
@@ -721,12 +721,14 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
         /// <summary>
         /// Handle a click on the local-server Start/Stop button. When stopped, downloads the version-matched
-        /// binary if needed then launches it with <c>client-transport=streamableHttp</c> on the port parsed
-        /// from the configured Custom host URL, passing the bearer token only when auth is required (the
-        /// token is never logged). When running, terminates it. The download/launch is fire-and-forget; the
-        /// status circle + button converge via the manager's <see cref="GodotMcpServerManager.StatusChanged"/>
-        /// stream. The button is disabled by <see cref="ApplyServerStatus"/> during transient states, so a
-        /// double-click cannot race a start/stop.
+        /// binary if needed then launches it with <c>client-transport=streamableHttp</c> on the
+        /// ProjectIdentity-derived local port (mcp-authorize g3 — <see cref="GodotMcpConnection.ResolveLocalServerPort"/>,
+        /// which MATCHES the port the shared config writer writes into the AI-client config, so the server
+        /// bind port == the written config port; no fixed 8080 on the default path), passing the bearer token
+        /// only when auth is required (the token is never logged). When running, terminates it. The
+        /// download/launch is fire-and-forget; the status circle + button converge via the manager's
+        /// <see cref="GodotMcpServerManager.StatusChanged"/> stream. The button is disabled by
+        /// <see cref="ApplyServerStatus"/> during transient states, so a double-click cannot race a start/stop.
         /// </summary>
         public void OnServerStartStopPressed()
         {
@@ -736,9 +738,7 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 return;
             }
 
-            var port = GodotMcpServerView.ResolveServerPort(
-                _connection.Config.ResolveCustomHost(),
-                com.IvanMurzak.McpPlugin.Common.Consts.Hub.DefaultPort);
+            var port = _connection.ResolveLocalServerPort();
             var timeoutMs = com.IvanMurzak.McpPlugin.Common.Consts.Hub.DefaultTimeoutMs;
             var authRequired = _connection.Config.ActiveAuthOption == GodotMcpAuthOption.Required;
             var token = _connection.Config.ResolveCustomToken();

--- a/addons/godot_mcp/Runtime/Connection/GodotMcpConfig.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotMcpConfig.cs
@@ -96,7 +96,17 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// <summary>The MCP hub path appended to the cloud base URL.</summary>
         public const string CloudHubPath = "/mcp";
 
-        /// <summary>Default custom-mode host when nothing is configured (local dev server convention).</summary>
+        /// <summary>
+        /// The connect-side "nothing configured yet" BASELINE SENTINEL for the Custom-mode host. It is NOT
+        /// the port anything actually binds or writes on the golden path: at connect time
+        /// <c>GodotMcpConnection.ResolveConfig → SeedDefaultLocalServerHost</c> replaces this baseline with
+        /// the project's ProjectIdentity-derived local host (<c>http://localhost:&lt;derived-port&gt;</c>),
+        /// and the local self-hosted server binds the derived port directly via
+        /// <c>GodotMcpConnection.ResolveLocalServerPort</c> (mcp-authorize e1 · PR 4 + g3 — the Phase-4
+        /// 8080 → derived-port migration, design 06 · D15). The literal 8080 survives only as the sentinel
+        /// the seed detects (so a pre-migration persisted <c>http://localhost:8080</c> is re-derived) and as
+        /// the Server-URL field's placeholder format hint.
+        /// </summary>
         public const string DefaultCustomHost = "http://localhost:8080";
 
         // --- Serialized backing fields. ---

--- a/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
@@ -1233,6 +1233,36 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         }
 
         /// <summary>
+        /// Resolve the port the local self-hosted server must BIND — the mcp-authorize g3 single source
+        /// of truth the connection panel's Start Server action (see
+        /// <see cref="UI.ConnectionPanel.OnServerStartStopPressed"/>) uses so the bind port ALWAYS matches
+        /// the port the shared b6 config writer writes into the AI-client config (server bind == written
+        /// config == the ProjectIdentity-derived port; design 06 · D15). Wires this connection's project
+        /// root + marker + the active Custom host into the pure, unit-tested
+        /// <see cref="GodotProjectIdentity.ResolveLocalServerBindPort"/>. There is no fixed 8080 fallback:
+        /// a loopback/default host resolves to the derived port; a non-loopback host to its own explicit
+        /// port. A marker read failure degrades to "no override" (never throws — starting the server must
+        /// not fault on a malformed marker), the same defensive discipline as
+        /// <see cref="SeedDefaultLocalServerHost"/>.
+        /// </summary>
+        public int ResolveLocalServerPort()
+        {
+            var projectRoot = ResolveProjectRootPath();
+
+            ProjectMarker? marker = null;
+            try
+            {
+                marker = ProjectMarker.Read(projectRoot);
+            }
+            catch (Exception ex)
+            {
+                GodotMcpLog.Warning($"[Godot-MCP] could not read project marker for local server port: {ex.Message}");
+            }
+
+            return GodotProjectIdentity.ResolveLocalServerBindPort(_config.ResolveCustomHost(), projectRoot, marker);
+        }
+
+        /// <summary>
         /// The absolute, native project-root path (<c>res://</c> globalized, trailing separator trimmed) —
         /// the string hashed into the instance metadata's <c>ProjectPathHash</c> and the routing pin, and
         /// the project marker's directory. The only Godot dependency of the identity path; returns empty on

--- a/addons/godot_mcp/Runtime/Connection/GodotProjectIdentity.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotProjectIdentity.cs
@@ -150,8 +150,9 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 !GodotMcpConfig.IsLoopbackUrl(host))
             {
                 // Non-loopback target: the b6 writer keeps its authority verbatim, so bind that host's
-                // own explicit port. A non-loopback host without an explicit port is degenerate for a
-                // locally-hosted server, so fall back to the derived port — both sides still agree.
+                // own explicit port. A portless non-loopback host resolves to the URI scheme's default
+                // port (e.g. 80 for http) — the same value the writer's ResolvedPort reports for it, so
+                // both sides still agree; the derivedPort fallback applies only to an unparseable authority.
                 return GodotMcpServerView.ResolveServerPort(host!, derivedPort);
             }
 

--- a/addons/godot_mcp/Runtime/Connection/GodotProjectIdentity.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotProjectIdentity.cs
@@ -117,6 +117,52 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             => $"{LocalLoopbackHost}:{Derive(projectRoot, marker).Port}";
 
         /// <summary>
+        /// Resolve the port the LOCAL self-hosted server must BIND so it MATCHES the port the shared
+        /// b6 config writer (<see cref="AgentConfiguratorSettings.PinnedHttpUrl"/> /
+        /// <see cref="AgentConfiguratorSettings.ResolvedPort"/>) writes into the AI-client config — the
+        /// mcp-authorize g3 guarantee that <b>server bind port == written config port == the
+        /// ProjectIdentity-derived port</b> on the default local path (completing the Phase-4 8080 →
+        /// derived-port migration, design 06 · D15). Mirrors the b6 loopback rule byte-for-byte:
+        /// <list type="bullet">
+        ///   <item>a LOOPBACK local host (the default / self-hosted case) binds the
+        ///   <see cref="ProjectIdentity"/>-derived port — a marker <c>portOverride</c> wins, else the
+        ///   deterministic hash-derived port; there is NO fixed 8080 on this path.</item>
+        ///   <item>a NON-loopback host (a real remote / self-hosted target the writer keeps verbatim)
+        ///   binds that host's own explicit port — the same authority the written config carries.</item>
+        /// </list>
+        /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>): the port math is inherited from
+        /// the golden-vector-pinned <see cref="Derive"/>, so the bind port can never drift from the
+        /// written config's port. The loopback / URL-validity predicates are the same ones
+        /// <see cref="GodotMcpConfig"/> and the b6 writer use, so a marker, an env/UI custom host, and a
+        /// terminal-written config all classify identically.
+        /// </summary>
+        /// <param name="resolvedCustomHost">The active Custom-mode host (already env/persist-resolved via
+        /// <see cref="GodotMcpConfig.ResolveCustomHost"/>).</param>
+        /// <param name="projectRoot">The normalized project root — the same string the config writer hashes.</param>
+        /// <param name="marker">The project marker (its <c>portOverride</c> wins for the derived port), or null.</param>
+        public static int ResolveLocalServerBindPort(string? resolvedCustomHost, string projectRoot, ProjectMarker? marker)
+        {
+            var derivedPort = Derive(projectRoot, marker).Port;
+
+            var host = GodotMcpConfig.NormalizeUrl(resolvedCustomHost);
+            if (!string.IsNullOrEmpty(host) &&
+                GodotMcpConfig.IsValidHttpUrl(host!) &&
+                !GodotMcpConfig.IsLoopbackUrl(host))
+            {
+                // Non-loopback target: the b6 writer keeps its authority verbatim, so bind that host's
+                // own explicit port. A non-loopback host without an explicit port is degenerate for a
+                // locally-hosted server, so fall back to the derived port — both sides still agree.
+                return GodotMcpServerView.ResolveServerPort(host!, derivedPort);
+            }
+
+            // Loopback / default / unset / unparseable: the ProjectIdentity-derived port — exactly what
+            // the b6 writer rewrites the loopback URL's port to. A loopback host's OWN explicit port is
+            // intentionally NOT honored here, mirroring the writer (a loopback port override goes through
+            // the marker portOverride, which flows into the derivation above).
+            return derivedPort;
+        }
+
+        /// <summary>
         /// Resolve the enrolled server target from the project marker into a connection decision, or
         /// <c>null</c> when the marker is absent / carries no valid <c>serverTarget</c> (the common case —
         /// then the caller keeps its existing Cloud/Custom resolution untouched). A loopback target maps


### PR DESCRIPTION
## Summary
- Complete the Phase-4 `8080` → per-project **ProjectIdentity-derived** port migration for the **local / self-hosted** server: the server BIND port and the Custom-configurator's Docker-hint port now derive from the SAME `ProjectIdentity` the shared b6 config writer uses, so **server bind port == written config port == the derived port** on the default local path (mirrors Unity's single-source-of-truth).
- The D15 override (marker `portOverride` / an explicitly-set non-default custom host) still wins on both sides; cloud behavior is unchanged (URL-only, no token).
- Retires the remaining fixed-`8080` literals on the local path (`AgentConfiguratorSettingsFactory.DefaultPort`, the `Consts.Hub.DefaultPort` server-start fallback); `GodotMcpConfig.DefaultCustomHost` is documented as a replaced baseline sentinel that is never bound on the golden path.

## Test plan
- [x] Target-specific local tests passed (see profile test.md): `dotnet build Godot-MCP.sln` (0 errors); `Godot-MCP.Tests` xUnit suite **1051 passed / 0 failed** (incl. 11 new g3 tests asserting the three-way equality + D15 override); `scripts/check-runtime-boundary.py` 0 violations.
- Live-editor Start-Server verification is an operator step (testbed NuGet pins lag the addon's McpPlugin 7.0.0 pin, so the local headless smoke is infeasible per test.md); the change is fully covered by unit tests asserting parity against the real shared `AgentConfiguratorSettings` (`PinnedHttpUrl`/`ResolvedPort`).

Closes #281