### PR TITLE
feat(connection): log instance-metadata hash-input string (dual-hash / OQ1)

### DIFF
--- a/Godot-MCP.Tests/GodotProjectIdentityTests.cs
+++ b/Godot-MCP.Tests/GodotProjectIdentityTests.cs
@@ -129,7 +129,8 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             // Every hash the handshake actually sends is surfaced: the released pin sends only
             // project_path_hash; once the dual-hash LIB lands, project_path_hash_legacy appears too — with
             // NO code change, because the line reads the query dict, not a named property.
-            var hashKeys = meta.ToQuery().Where(kvp => kvp.Key.Contains("hash")).ToList();
+            var hashKeys = meta.ToQuery()
+                .Where(kvp => kvp.Key.IndexOf("hash", StringComparison.OrdinalIgnoreCase) >= 0).ToList();
             Assert.NotEmpty(hashKeys);
             foreach (var kvp in hashKeys)
                 Assert.Contains($"{kvp.Key}={kvp.Value}", line);

--- a/Godot-MCP.Tests/GodotProjectIdentityTests.cs
+++ b/Godot-MCP.Tests/GodotProjectIdentityTests.cs
@@ -95,6 +95,57 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Equal(GodotProjectIdentity.SessionInstanceId, GodotProjectIdentity.SessionInstanceId);
         }
 
+        // === Hash-input diagnostic (auth-fixes h1 — OQ1 · k2) =========================================
+        //
+        // The connection logs the EXACT project-root string it hashes so the k2 matrix can CONFIRM the
+        // path form each engine feeds into ProjectIdentity (open question OQ1) rather than assume it. On
+        // Godot the source is GlobalizePath("res://") which already yields forward slashes, so pin v2 is a
+        // no-op and the dual-hash is transition insurance — the line proves that empirically.
+
+        [Fact]
+        public void DescribeHashInput_SurfacesTheExactHashInputPathString_AndTheDerivedPinAndHash()
+        {
+            const string root = "/home/user/MyGame";
+            var meta = GodotProjectIdentity.BuildInstanceMetadata(root, "MyGame", "id", "host");
+
+            var line = GodotProjectIdentity.DescribeHashInput(root, meta);
+
+            // The exact hash-input string is logged verbatim + quoted (OQ1: confirm the path form per engine).
+            Assert.Contains($"projectRoot='{root}'", line);
+            // The stable hash the routing pin is drawn from, and the 8-hex pin itself.
+            Assert.Contains(meta.ProjectPathHash, line);
+            Assert.Contains($"pin={meta.ProjectPathHash.Substring(0, 8)}", line);
+            Assert.Contains("engine=godot", line);
+        }
+
+        [Fact]
+        public void DescribeHashInput_EnumeratesEveryHandshakeHash_SoDualHashSurfacesWhenThePinCarriesIt()
+        {
+            const string root = "/home/user/MyGame";
+            var meta = GodotProjectIdentity.BuildInstanceMetadata(root, "MyGame", "id", "host");
+
+            var line = GodotProjectIdentity.DescribeHashInput(root, meta);
+
+            // Every hash the handshake actually sends is surfaced: the released pin sends only
+            // project_path_hash; once the dual-hash LIB lands, project_path_hash_legacy appears too — with
+            // NO code change, because the line reads the query dict, not a named property.
+            var hashKeys = meta.ToQuery().Where(kvp => kvp.Key.Contains("hash")).ToList();
+            Assert.NotEmpty(hashKeys);
+            foreach (var kvp in hashKeys)
+                Assert.Contains($"{kvp.Key}={kvp.Value}", line);
+        }
+
+        [Fact]
+        public void DescribeHashInput_NeverThrows_OnNullInputs()
+        {
+            // A diagnostic must never break the connection boot — a null metadata / root degrades to a
+            // still-informative line rather than throwing on the connect path.
+            var line = GodotProjectIdentity.DescribeHashInput(null, null);
+
+            Assert.Contains("engine=godot", line);
+            Assert.Contains("metadata unavailable", line);
+        }
+
         // === ProjectIdentity derivation — golden-vector parity =======================================
         //
         // These pin the committed cross-language vectors. The derivation is McpPlugin 7.0's canonical

--- a/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
@@ -367,11 +367,19 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             // pin) is derived from the SAME normalized project root a configurator hashes, so an agent
             // session launched in this project folder routes strictly to this instance.
             var projectRootPath = ResolveProjectRootPath();
-            _config.InstanceMetadata = GodotProjectIdentity.BuildInstanceMetadata(
+            var instanceMetadata = GodotProjectIdentity.BuildInstanceMetadata(
                 projectRootPath,
                 ResolveProjectName(),
                 GodotProjectIdentity.SessionInstanceId,
                 System.Environment.MachineName);
+            _config.InstanceMetadata = instanceMetadata;
+
+            // Log the EXACT hash-input string the metadata was built from (auth-fixes h1, design 01 §7 /
+            // OQ1 · k2). Godot globalizes res:// to forward slashes, so the pin v2 separator-normalization is
+            // a no-op and the dual-hash (v2 + legacy v1 carried by c1's ConnectionInstanceMetadata) is pure
+            // transition insurance — this line is what lets the k2 matrix CONFIRM that path form per engine
+            // rather than assume it, and surfaces every hash the handshake actually sends.
+            GodotMcpLog.Info(GodotProjectIdentity.DescribeHashInput(projectRootPath, instanceMetadata));
 
             // Surface the resolved project identity (routing pin + derived local port) and the enrolled
             // server target for the operator smoke. The pin is what agent sessions route on; the derived

--- a/addons/godot_mcp/Runtime/Connection/GodotProjectIdentity.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotProjectIdentity.cs
@@ -9,6 +9,7 @@
 */
 #nullable enable
 using System;
+using System.Linq;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.McpPlugin.AgentConfig;
 
@@ -83,6 +84,50 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 projectRootPath: projectRoot ?? string.Empty,
                 instanceId: string.IsNullOrEmpty(instanceId) ? SessionInstanceId : instanceId,
                 machineName: machineName ?? string.Empty);
+
+        /// <summary>
+        /// Build the diagnostic line for the instance-metadata hash input (auth-fixes h1, design 01 §7 /
+        /// OQ1 · k2). It surfaces the <b>exact project-root string</b> fed into the hash derivation — the
+        /// empirical answer to "what path form does each engine actually hash?" (open question OQ1, verified
+        /// in the k2 matrix) — plus every hash the handshake carries. On Godot the path source is
+        /// <c>GlobalizePath("res://")</c>, which already yields forward slashes (01 §7), so the pin v2
+        /// separator-normalization is a no-op here and the dual-hash (v2 + legacy v1) is carried purely as
+        /// transition insurance — this line is how a smoke/CI run PROVES that form rather than assuming it.
+        ///
+        /// <para>
+        /// The hashes are read from <see cref="ConnectionInstanceMetadata.ToQuery"/> rather than named
+        /// properties, so the SINGLE hash of the currently-pinned package AND the additional
+        /// <c>project_path_hash_legacy</c> that a dual-hash LIB adds both surface with no compile-time
+        /// dependency on a field the pinned package may not yet expose (the pin bump lands at release · k3).
+        /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) and never throws — a null/partial input
+        /// degrades to a still-informative line so a diagnostic can never break the connection boot.
+        /// </para>
+        /// </summary>
+        /// <param name="projectRoot">The exact hash-input string (the globalized, trailing-sep-trimmed
+        /// <c>res://</c> root) the metadata was built from — logged verbatim, quoted so trailing/again-case
+        /// differences are visible.</param>
+        /// <param name="metadata">The metadata built for this connection (via <see cref="BuildInstanceMetadata"/>).</param>
+        public static string DescribeHashInput(string? projectRoot, ConnectionInstanceMetadata? metadata)
+        {
+            var root = projectRoot ?? string.Empty;
+            if (metadata == null)
+                return $"[Godot-MCP] instance-metadata hash input: engine={Engine} projectRoot='{root}' (metadata unavailable).";
+
+            var hash = metadata.ProjectPathHash ?? string.Empty;
+            var pin = hash.Length >= 8 ? hash.Substring(0, 8) : hash;
+
+            // Enumerate EVERY handshake hash key so the line stays correct across the dual-hash transition:
+            // the released pin sends only `project_path_hash`; a dual-hash LIB additionally sends
+            // `project_path_hash_legacy`. Both surface here without naming a property the pin may lack.
+            var hashes = string.Join(", ", metadata.ToQuery()
+                .Where(kvp => kvp.Key.IndexOf("hash", StringComparison.OrdinalIgnoreCase) >= 0)
+                .Select(kvp => $"{kvp.Key}={kvp.Value}"));
+            if (string.IsNullOrEmpty(hashes))
+                hashes = "<none>";
+
+            return $"[Godot-MCP] instance-metadata hash input: engine={metadata.Engine} " +
+                   $"projectRoot='{root}' pin={pin}; handshake hashes: {hashes}.";
+        }
 
         /// <summary>
         /// Resolve the project's <see cref="ProjectIdentity"/> (<c>{pin, port}</c>) from its root,

--- a/addons/godot_mcp/Runtime/Connection/GodotProjectIdentity.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotProjectIdentity.cs
@@ -114,7 +114,9 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 return $"[Godot-MCP] instance-metadata hash input: engine={Engine} projectRoot='{root}' (metadata unavailable).";
 
             var hash = metadata.ProjectPathHash ?? string.Empty;
-            var pin = hash.Length >= 8 ? hash.Substring(0, 8) : hash;
+            // The pin is the first ProjectIdentity.PinLength hex of the path hash — reuse the library's
+            // canonical constant so this diagnostic can never drift from the real routing-pin width.
+            var pin = hash.Length >= ProjectIdentity.PinLength ? hash.Substring(0, ProjectIdentity.PinLength) : hash;
 
             // Enumerate EVERY handshake hash key so the line stays correct across the dual-hash transition:
             // the released pin sends only `project_path_hash`; a dual-hash LIB additionally sends


### PR DESCRIPTION
## Summary

- Adds `GodotProjectIdentity.DescribeHashInput(projectRoot, metadata)` — pure-managed and unit-tested —
  that builds a diagnostic line with the **exact project-root string** fed into the
  `ConnectionInstanceMetadata` hash (quoted), the derived 8-hex routing pin, and **every** hash the
  handshake sends, read from `ToQuery()`.
- Logs it from `GodotMcpConnection.Start()` right after building the instance metadata.
- Reading the hashes from the query dict (not a named property) means the dual-hash **legacy** hash
  (`project_path_hash_legacy`, added by c1's LIB pin-v2 primitive) surfaces automatically once the pinned
  package carries it — **no code change** at the addon; the final NuGet pin bump lands at release.

Part of the `auth-fixes` design (task `h1-godot-plugin-dualhash`, depends on c1). Godot's path source is
`GlobalizePath("res://")`, which already yields forward slashes, so the pin-v2 separator normalization is a
no-op on Godot and the dual-hash is transition insurance — this line lets the k2 matrix **confirm** that
path form (open question OQ1) rather than assume it.

## Test plan

- [x] Suite 1 — `dotnet build Godot-MCP.sln` (Debug, .NET 8): 0 errors / 0 warnings.
- [x] Suite 2 — `dotnet test Godot-MCP.Tests`: 1082/1082 passed (incl. 3 new `DescribeHashInput` tests).
- [x] Dual-hash evidence: c1's LIB `ConnectionInstanceMetadataTests` prove `Create`/`ToQuery` derive+send
      both v2 + legacy hashes; the addon's `BuildInstanceMetadata` forwards to `Create` unchanged, so the
      Godot handshake carries dual-hash once linked to the dual-hash LIB (verified transitively; the new
      `EnumeratesEveryHandshakeHash` test pins that the log auto-surfaces the legacy hash when present).
- [ ] Live-editor headless smoke: the software testbed pins `McpPlugin` 7.0.0 while the addon pins 7.1.1,
      so the testbed cannot compile the addon locally (`CS0234 ServerLaunch`) — the 3-step smoke is
      infeasible until the separate testbed-lockstep bump lands. Live-editor boot is covered by CI's
      five-version Godot mono matrices (addon-load / dock-reload / e2e-install / runtime-harness).

Closes #295