### PR TITLE
chore: bump gamedev-mcp-server to 9.1.1

### DIFF
--- a/addons/godot_mcp/Runtime/Connection/GodotMcpServerView.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotMcpServerView.cs
@@ -66,7 +66,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// <c>v&lt;ServerVersion&gt;</c> release with all 7 RID zips exists on GameDev-MCP-Server BEFORE
         /// cutting an addon release that pins it — otherwise the download 404s, the issue-#94 class of bug).
         /// </summary>
-        public const string ServerVersion = "9.1.0";
+        public const string ServerVersion = "9.1.1";
 
         /// <summary>
         /// The server executable base name (the shared <c>GameDev-MCP-Server</c> binary). On Windows the

--- a/cli/src/utils/server-source.ts
+++ b/cli/src/utils/server-source.ts
@@ -20,7 +20,7 @@ import { createHash } from 'crypto';
  * download entirely (offline / CI). Bumping the addon's server pin requires
  * bumping this in the same PR or the parity test goes red.
  */
-export const DEFAULT_SERVER_VERSION = '9.1.0';
+export const DEFAULT_SERVER_VERSION = '9.1.1';
 
 /** GitHub-release host the server zip + manifest are downloaded from. NOTHING else is trusted. */
 export const TRUSTED_DOWNLOAD_HOST = 'github.com';


### PR DESCRIPTION
Automated downstream bump of the pinned GameDev-MCP-Server version `9.1.0` -> `9.1.1` (adopts the just-released `v9.1.1` server: NuGet + Docker tag + all 7 RID zips are already live).