### PR TITLE
fix(connection): honour a user-typed loopback port in the local-server bind port

### DIFF
--- a/Godot-MCP.Tests/GodotProjectIdentityTests.cs
+++ b/Godot-MCP.Tests/GodotProjectIdentityTests.cs
@@ -256,14 +256,22 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.InRange(identity.Port, ProjectIdentity.MinPort, ProjectIdentity.MaxPort);
         }
 
-        // === Local server BIND port — mcp-authorize g3 (server bind == written config == derived) ======
+        // === Local server BIND port — mcp-authorize g3 (server bind == written config) =================
         //
-        // Completes the Phase-4 8080 → derived-port migration for the LOCAL self-hosted server: the port
-        // the server BINDS (GodotProjectIdentity.ResolveLocalServerBindPort, called by the connection panel's
-        // Start Server action) must equal the port the shared b6 config writer writes into the AI-client
-        // config (AgentConfiguratorSettings.PinnedHttpUrl / ResolvedPort). These pin the three-way equality
-        // on the default local path, the D15 override precedence, and the b6-loopback-rule parity — all pure
-        // over the shared McpPlugin 7.0 primitives, so they run in the plain xUnit host on the Linux CI runner.
+        // The port the server BINDS (GodotProjectIdentity.ResolveLocalServerBindPort, called by the
+        // connection panel's Start Server action) must equal the port the shared config writer writes into
+        // the AI-client config (AgentConfiguratorSettings.PinnedHttpUrl / PinnedPort), so an agent always
+        // dials the port the server is actually listening on.
+        //
+        // These assert the BINDER'S OWN CONTRACT — given a host + marker + project root, which port comes
+        // out — under the three-level precedence the 2026-07-19 owner ruling fixed on BOTH sides:
+        //   1. marker portOverride  →  2. an explicit port typed into the host  →  3. deterministic derived.
+        // Asserting the contract rather than diffing against whatever the currently-pinned McpPlugin build
+        // writes is deliberate: coupling these to the writer's build is what let the binder and the writer
+        // silently diverge in the first place. The one genuine cross-check against the live writer is
+        // parked below until the pin reaches the release that carries the new precedence.
+        //
+        // All pure over the shared McpPlugin primitives, so they run in the plain xUnit host on Linux CI.
 
         [Theory]
         [InlineData("C:/Games/MyGame", 29062)]
@@ -271,28 +279,52 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         [InlineData("/home/user/Demo Project", 20832)]
         public void ResolveLocalServerBindPort_DefaultLoopbackHost_IsTheDerivedPort_NotFixed8080(string projectRoot, int expectedPort)
         {
-            // The default local path (the baseline loopback host, no marker) binds the ProjectIdentity-derived
-            // port — the whole point of g3: no fixed 8080 anywhere on the golden path.
-            var port = GodotProjectIdentity.ResolveLocalServerBindPort(
-                resolvedCustomHost: GodotMcpConfig.DefaultCustomHost, projectRoot, marker: null);
+            // The GOLDEN BOOT PATH: GodotMcpConnection.SeedDefaultLocalServerHost replaces the fixed
+            // DefaultCustomHost baseline with the project's derived local URL before anything binds, so the
+            // host the binder actually sees is http://localhost:{derived}. Levels 2 and 3 agree there — and
+            // no fixed 8080 can reach either side, which is the whole point of g3.
+            var seededHost = GodotProjectIdentity.ResolveDefaultLocalServerHost(projectRoot, marker: null);
+
+            var port = GodotProjectIdentity.ResolveLocalServerBindPort(seededHost, projectRoot, marker: null);
 
             Assert.Equal(expectedPort, port);
             Assert.NotEqual(8080, port);
             Assert.InRange(port, ProjectIdentity.MinPort, ProjectIdentity.MaxPort);
         }
 
-        [Fact]
-        public void ResolveLocalServerBindPort_MatchesTheB6WrittenConfigPort_OnTheDefaultPath()
+        [Theory]
+        [InlineData("http://localhost")]
+        [InlineData("http://127.0.0.1")]
+        [InlineData("http://localhost/mcp")]
+        public void ResolveLocalServerBindPort_PortlessLoopbackHost_FallsBackToDerived_NotTheSchemeDefault(string host)
         {
-            // THE g3 guarantee: server bind port == written config port == the ProjectIdentity-derived port.
             const string root = "C:/Games/MyGame";
-            var settings = LocalSettings(root, "http://localhost:8080/mcp");
 
-            var bindPort = GodotProjectIdentity.ResolveLocalServerBindPort(GodotMcpConfig.DefaultCustomHost, root, marker: null);
+            // Level 3. A portless host carries no user intent, so it must NOT be read as the scheme's
+            // default port: Uri.Port would synthesize 80 here, which would bind 80 while the writer wrote
+            // the derived port. The raw-authority parse (GodotMcpConfig.TryGetExplicitPort) is what keeps
+            // this case on level 3 instead of level 2.
+            Assert.Equal(
+                ProjectIdentity.DerivePort(root),
+                GodotProjectIdentity.ResolveLocalServerBindPort(host, root, marker: null));
+        }
+
+        [Fact]
+        public void ResolveLocalServerBindPort_MatchesTheWrittenConfigPort_OnTheDefaultPath()
+        {
+            // THE g3 guarantee on the golden path: server bind port == written config port == derived.
+            // The seeded host carries the derived port explicitly, so this holds under BOTH the old writer
+            // (which rewrote a loopback port to ResolvedPort) and the new one (which honours the typed port
+            // — here the same number). That is why this cross-check stays live across the pin bump.
+            const string root = "C:/Games/MyGame";
+            var seededHost = GodotProjectIdentity.ResolveDefaultLocalServerHost(root, marker: null);
+            var settings = LocalSettings(root, seededHost + "/mcp");
+
+            var bindPort = GodotProjectIdentity.ResolveLocalServerBindPort(seededHost, root, marker: null);
             var writtenPort = new Uri(settings.PinnedHttpUrl).Port;
 
             Assert.Equal(ProjectIdentity.DerivePort(root), bindPort); // == derived
-            Assert.Equal(settings.ResolvedPort, bindPort);            // == the port b6 resolves
+            Assert.Equal(settings.ResolvedPort, bindPort);            // == the port the writer resolves
             Assert.Equal(writtenPort, bindPort);                      // == the port in the written URL
             Assert.Equal(29062, bindPort);                            // golden vector
             Assert.NotEqual(8080, bindPort);
@@ -305,8 +337,8 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             new ProjectMarker { PortOverride = 24242 }.Write(dir.Path);
             var marker = ProjectMarker.Read(dir.Path);
 
-            // The user's explicit marker portOverride (D15) wins for BOTH the server bind AND the written
-            // config, so they still agree.
+            // Level 1. The user's explicit marker portOverride wins for BOTH the server bind AND the
+            // written config, so they still agree.
             var bindPort = GodotProjectIdentity.ResolveLocalServerBindPort(GodotMcpConfig.DefaultCustomHost, dir.Path, marker);
             var settings = LocalSettings(dir.Path, "http://localhost:8080/mcp"); // reads the same marker at dir.Path
 
@@ -316,18 +348,60 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         }
 
         [Fact]
-        public void ResolveLocalServerBindPort_LoopbackExplicitPort_StillDerives_MatchingTheWriter()
+        public void ResolveLocalServerBindPort_MarkerPortOverride_BeatsAnExplicitHostPort()
+        {
+            using var dir = new TempDir();
+            new ProjectMarker { PortOverride = 24242 }.Write(dir.Path);
+            var marker = ProjectMarker.Read(dir.Path);
+
+            // Level 1 BEATS level 2: portOverride is a deliberate per-project pin, so it outranks an
+            // incidental port in the host string. Same ordering as the writer's PinnedPort.
+            var bindPort = GodotProjectIdentity.ResolveLocalServerBindPort("http://localhost:9000", dir.Path, marker);
+
+            Assert.Equal(24242, bindPort);
+            Assert.NotEqual(9000, bindPort);
+        }
+
+        [Theory]
+        [InlineData("http://localhost:9000", 9000)]
+        [InlineData("http://localhost:9000/mcp", 9000)]
+        [InlineData("http://127.0.0.1:27618", 27618)]
+        public void ResolveLocalServerBindPort_LoopbackExplicitPort_HonorsTheTypedPort(string host, int expectedPort)
         {
             const string root = "C:/Games/MyGame";
 
-            // A user-typed loopback host with an explicit port: the b6 writer REWRITES a loopback URL's port
-            // to the derived port, so the server binds the derived port too (a loopback port override goes
-            // through the marker, not the URL) — server bind stays == written config, not the typed :9000.
-            var bindPort = GodotProjectIdentity.ResolveLocalServerBindPort("http://localhost:9000", root, marker: null);
-            var settings = LocalSettings(root, "http://localhost:9000/mcp");
+            // Level 2 — THE BEHAVIOUR CHANGE (owner ruling 2026-07-19). A port the user typed into a
+            // loopback host is now BOUND, not overwritten with the derived port.
+            //
+            // This method used to assert the opposite (ResolveLocalServerBindPort_LoopbackExplicitPort_
+            // StillDerives_MatchingTheWriter), deliberately mirroring the OLD writer, which rewrote a
+            // loopback URL's port to the derived one. The writer now honours the typed port
+            // (MCP-Plugin-dotnet #174 / #176), so mirroring the old rule would make the server listen on
+            // the derived port while the written config pointed at the typed one — the exact defect this
+            // precedence exists to kill. Unity's binder already resolved a typed port this way.
+            var bindPort = GodotProjectIdentity.ResolveLocalServerBindPort(host, root, marker: null);
 
-            Assert.Equal(ProjectIdentity.DerivePort(root), bindPort);
-            Assert.NotEqual(9000, bindPort);
+            Assert.Equal(expectedPort, bindPort);
+            Assert.NotEqual(ProjectIdentity.DerivePort(root), bindPort);
+        }
+
+        [Fact(Skip = "Un-skip when Godot-MCP.csproj pins com.IvanMurzak.McpPlugin >= 7.3.0 — see body.")]
+        public void ResolveLocalServerBindPort_LoopbackExplicitPort_MatchesTheWrittenConfigPort()
+        {
+            const string root = "C:/Games/MyGame";
+            const string host = "http://localhost:9000";
+
+            // The live cross-check for level 2: the binder's typed-port result must equal the port the
+            // shared writer emits for the same host. It CANNOT pass on the currently-pinned McpPlugin
+            // 7.2.0, whose PinnedHttpUrl still rewrites a loopback port to the derived one — that old
+            // writer is precisely what this task stopped mirroring. The binder-contract assertions above
+            // (ResolveLocalServerBindPort_LoopbackExplicitPort_HonorsTheTypedPort) carry the behaviour in
+            // the meantime; this one re-arms the two-sided guarantee once the pin lands in the release
+            // cascade. Do not delete it and do not weaken it — un-skip it with the pin bump.
+            var bindPort = GodotProjectIdentity.ResolveLocalServerBindPort(host, root, marker: null);
+            var settings = LocalSettings(root, host + "/mcp");
+
+            Assert.Equal(9000, bindPort);
             Assert.Equal(new Uri(settings.PinnedHttpUrl).Port, bindPort);
         }
 
@@ -358,6 +432,39 @@ namespace com.IvanMurzak.Godot.MCP.Tests
                 ProjectIdentity.DerivePort(root),
                 GodotProjectIdentity.ResolveLocalServerBindPort(host, root, marker: null));
         }
+
+        // --- level-2 input: the raw-authority explicit-port parse -------------------------------------
+        //
+        // GodotMcpConfig.TryGetExplicitPort is the Godot mirror of the writer's internal
+        // AgentConfiguratorSettings.TryGetExplicitPort. "No explicit port" MUST be distinguishable from
+        // "the scheme default", or the binder silently binds 80 where the writer wrote the derived port.
+
+        [Theory]
+        [InlineData("http://localhost:9000", 9000)]
+        [InlineData("http://localhost:9000/mcp", 9000)]
+        [InlineData("https://example.com:443/p/abc?x=1", 443)]
+        [InlineData("http://user:pass@localhost:9000", 9000)] // userinfo colon is not a port separator
+        [InlineData("http://[::1]:8080", 8080)]               // IPv6 literal — port follows the bracket
+        [InlineData("localhost:9000", 9000)]                  // scheme-less authority
+        public void TryGetExplicitPort_ReadsAPortTheUserTyped(string url, int expected)
+            => Assert.Equal(expected, GodotMcpConfig.TryGetExplicitPort(url));
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("http://localhost")]        // portless — must NOT read as the scheme default 80
+        [InlineData("http://localhost/mcp")]
+        [InlineData("http://[::1]")]
+        [InlineData("http://localhost:")]       // empty port
+        [InlineData("http://localhost:abc")]    // non-numeric
+        [InlineData("http://localhost:-1")]     // signed — rejected by NumberStyles.None
+        [InlineData("http://localhost: 90")]    // whitespace — likewise
+        [InlineData("http://localhost:0")]      // out of range (low)
+        [InlineData("http://localhost:65536")]  // out of range (high)
+        [InlineData("http://localhost:99999999999")] // overflow
+        public void TryGetExplicitPort_ReturnsNull_WhenThereIsNoUsableTypedPort(string? url)
+            => Assert.Null(GodotMcpConfig.TryGetExplicitPort(url));
 
         /// <summary>
         /// A shared local-mode <see cref="AgentConfiguratorSettings"/> for the three-way equality assertions:

--- a/Godot-MCP.Tests/GodotProjectIdentityTests.cs
+++ b/Godot-MCP.Tests/GodotProjectIdentityTests.cs
@@ -260,11 +260,11 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         //
         // The port the server BINDS (GodotProjectIdentity.ResolveLocalServerBindPort, called by the
         // connection panel's Start Server action) must equal the port the shared config writer writes into
-        // the AI-client config (AgentConfiguratorSettings.PinnedHttpUrl / PinnedPort), so an agent always
+        // the AI-client config (AgentConfiguratorSettings.PinnedHttpUrl / ResolvedPort), so an agent always
         // dials the port the server is actually listening on.
         //
         // These assert the BINDER'S OWN CONTRACT — given a host + marker + project root, which port comes
-        // out — under the three-level precedence the 2026-07-19 owner ruling fixed on BOTH sides:
+        // out — under the three-level precedence both sides now share:
         //   1. marker portOverride  →  2. an explicit port typed into the host  →  3. deterministic derived.
         // Asserting the contract rather than diffing against whatever the currently-pinned McpPlugin build
         // writes is deliberate: coupling these to the writer's build is what let the binder and the writer
@@ -277,7 +277,7 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         [InlineData("C:/Games/MyGame", 29062)]
         [InlineData("/home/user/MyGame", 24998)]
         [InlineData("/home/user/Demo Project", 20832)]
-        public void ResolveLocalServerBindPort_DefaultLoopbackHost_IsTheDerivedPort_NotFixed8080(string projectRoot, int expectedPort)
+        public void ResolveLocalServerBindPort_SeededLocalHost_IsTheDerivedPort_NotFixed8080(string projectRoot, int expectedPort)
         {
             // The GOLDEN BOOT PATH: GodotMcpConnection.SeedDefaultLocalServerHost replaces the fixed
             // DefaultCustomHost baseline with the project's derived local URL before anything binds, so the
@@ -290,6 +290,27 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Equal(expectedPort, port);
             Assert.NotEqual(8080, port);
             Assert.InRange(port, ProjectIdentity.MinPort, ProjectIdentity.MaxPort);
+        }
+
+        [Fact]
+        public void ResolveLocalServerBindPort_UnSeededDefaultCustomHost_BindsItsLiteralPort()
+        {
+            const string root = "C:/Games/MyGame";
+
+            // The un-seeded DefaultCustomHost baseline ("http://localhost:8080") reaches the binder only on
+            // degraded paths — an unresolvable project root, a marker that fails to parse, or an explicit
+            // GODOT_MCP_HOST pointing there — because SeedDefaultLocalServerHost normally replaces it
+            // before anything binds (see the golden-path test above).
+            //
+            // Pinning the outcome deliberately: 8080 is a port present in the host string, so level 2
+            // binds it. That is NOT a regression to the retired fixed-8080 rule — the writer reads the same
+            // host and resolves the same 8080, which is the property that matters (bind == written). The
+            // binder must NOT special-case this string: a user who genuinely types :8080 gets it honoured
+            // by the writer, so a special case here would reintroduce the very divergence the three-level
+            // precedence removes.
+            Assert.Equal(
+                8080,
+                GodotProjectIdentity.ResolveLocalServerBindPort(GodotMcpConfig.DefaultCustomHost, root, marker: null));
         }
 
         [Theory]
@@ -316,6 +337,10 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             // The seeded host carries the derived port explicitly, so this holds under BOTH the old writer
             // (which rewrote a loopback port to ResolvedPort) and the new one (which honours the typed port
             // — here the same number). That is why this cross-check stays live across the pin bump.
+            //
+            // It also survives the writer's v1 → v2 root-normalization change, but only because Godot roots
+            // come from GlobalizePath("res://") and are already forward-slashed, so v2's '\' → '/' step is a
+            // no-op and both derivations yield the same port. A backslashed root would NOT be equivalent.
             const string root = "C:/Games/MyGame";
             var seededHost = GodotProjectIdentity.ResolveDefaultLocalServerHost(root, marker: null);
             var settings = LocalSettings(root, seededHost + "/mcp");
@@ -355,7 +380,7 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             var marker = ProjectMarker.Read(dir.Path);
 
             // Level 1 BEATS level 2: portOverride is a deliberate per-project pin, so it outranks an
-            // incidental port in the host string. Same ordering as the writer's PinnedPort.
+            // incidental port in the host string. Same ordering as the writer's own port resolution.
             var bindPort = GodotProjectIdentity.ResolveLocalServerBindPort("http://localhost:9000", dir.Path, marker);
 
             Assert.Equal(24242, bindPort);
@@ -370,22 +395,18 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         {
             const string root = "C:/Games/MyGame";
 
-            // Level 2 — THE BEHAVIOUR CHANGE (owner ruling 2026-07-19). A port the user typed into a
-            // loopback host is now BOUND, not overwritten with the derived port.
-            //
-            // This method used to assert the opposite (ResolveLocalServerBindPort_LoopbackExplicitPort_
-            // StillDerives_MatchingTheWriter), deliberately mirroring the OLD writer, which rewrote a
-            // loopback URL's port to the derived one. The writer now honours the typed port
-            // (MCP-Plugin-dotnet #174 / #176), so mirroring the old rule would make the server listen on
-            // the derived port while the written config pointed at the typed one — the exact defect this
-            // precedence exists to kill. Unity's binder already resolved a typed port this way.
+            // Level 2 — a port the user typed into a loopback host is BOUND, not overwritten with the
+            // derived port. This assertion is the inverse of the rule that stood here before: mirroring
+            // the retired writer (which rewrote a loopback URL's port) would make the server listen on the
+            // derived port while the written config pointed at the typed one. Unity's binder already
+            // resolves a typed port this way.
             var bindPort = GodotProjectIdentity.ResolveLocalServerBindPort(host, root, marker: null);
 
             Assert.Equal(expectedPort, bindPort);
             Assert.NotEqual(ProjectIdentity.DerivePort(root), bindPort);
         }
 
-        [Fact(Skip = "Un-skip when Godot-MCP.csproj pins com.IvanMurzak.McpPlugin >= 7.3.0 — see body.")]
+        [Fact(Skip = "Un-skip when Godot-MCP.csproj pins com.IvanMurzak.McpPlugin >= 7.3.0 (issue #304) — see body.")]
         public void ResolveLocalServerBindPort_LoopbackExplicitPort_MatchesTheWrittenConfigPort()
         {
             const string root = "C:/Games/MyGame";
@@ -394,7 +415,7 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             // The live cross-check for level 2: the binder's typed-port result must equal the port the
             // shared writer emits for the same host. It CANNOT pass on the currently-pinned McpPlugin
             // 7.2.0, whose PinnedHttpUrl still rewrites a loopback port to the derived one — that old
-            // writer is precisely what this task stopped mirroring. The binder-contract assertions above
+            // writer is precisely what this change stopped mirroring. The binder-contract assertions above
             // (ResolveLocalServerBindPort_LoopbackExplicitPort_HonorsTheTypedPort) carry the behaviour in
             // the meantime; this one re-arms the two-sided guarantee once the pin lands in the release
             // cascade. Do not delete it and do not weaken it — un-skip it with the pin bump.
@@ -411,13 +432,34 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             const string root = "C:/Games/MyGame";
             const string host = "http://192.168.1.50:9000";
 
-            // A non-loopback target: the b6 writer keeps its authority verbatim (:9000), so the server binds
+            // A non-loopback target: the writer keeps its authority verbatim (:9000), so the server binds
             // that explicit port — an explicitly-set non-default custom host still wins, on both sides.
             var bindPort = GodotProjectIdentity.ResolveLocalServerBindPort(host, root, marker: null);
             var settings = LocalSettings(root, host + "/mcp");
 
             Assert.Equal(9000, bindPort);
             Assert.Equal(new Uri(settings.PinnedHttpUrl).Port, bindPort);
+        }
+
+        [Fact]
+        public void ResolveLocalServerBindPort_NonLoopbackHost_BeatsMarkerPortOverride()
+        {
+            using var dir = new TempDir();
+            new ProjectMarker { PortOverride = 24242 }.Write(dir.Path);
+            var marker = ProjectMarker.Read(dir.Path);
+
+            // Host CLASS is decided before the port ladder: a marker portOverride is a LOCAL pin and does
+            // NOT override a remote authority, which the writer keeps verbatim. This is the one cell where
+            // the flat "portOverride wins outright" reading would give the wrong answer, so it is pinned
+            // here — do not "restore" level-1 primacy by hoisting the override check above the loopback
+            // branch in ResolveLocalServerBindPort.
+            const string host = "http://192.168.1.50:9000";
+            var bindPort = GodotProjectIdentity.ResolveLocalServerBindPort(host, dir.Path, marker);
+            var settings = LocalSettings(dir.Path, host + "/mcp");
+
+            Assert.Equal(9000, bindPort);
+            Assert.NotEqual(24242, bindPort);
+            Assert.Equal(new Uri(settings.PinnedHttpUrl).Port, bindPort); // the writer agrees
         }
 
         [Theory]
@@ -470,7 +512,8 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         /// A shared local-mode <see cref="AgentConfiguratorSettings"/> for the three-way equality assertions:
         /// its <c>ResolvedPort</c> / <c>PinnedHttpUrl</c> derive the local port from <paramref name="projectRoot"/>
         /// (+ that root's marker) exactly as production does. The raw engine <c>port: 8080</c> is deliberately the
-        /// stale value — b6 ignores it for the loopback rewrite — so a passing test proves the derivation, not the input.
+        /// stale value — the writer resolves the port from the root/marker and the host, never from this field — so a
+        /// passing test proves the derivation, not the input.
         /// </summary>
         static AgentConfiguratorSettings LocalSettings(string projectRoot, string host) =>
             AgentConfiguratorSettings.CreateForHost(

--- a/addons/godot_mcp/Editor/UI/Agents/AgentConfiguratorSettingsFactory.cs
+++ b/addons/godot_mcp/Editor/UI/Agents/AgentConfiguratorSettingsFactory.cs
@@ -86,11 +86,13 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents
         /// (<c>-p &lt;port&gt;:&lt;port&gt;</c>, <c>-e PORT=&lt;port&gt;</c>, container name) — the SAME
         /// port the local server binds (<see cref="GodotMcpConnection.ResolveLocalServerPort"/>) and the
         /// written config URL carries (<see cref="AgentConfig.AgentConfiguratorSettings.PinnedHttpUrl"/>),
-        /// under the shared three-level precedence (marker <c>portOverride</c> → a port the user typed
-        /// into the host → the deterministic derived port), so the "Manual Configuration Steps" Docker
+        /// under the port precedence owned by <see cref="GodotProjectIdentity.ResolveLocalServerBindPort"/>
+        /// (see that method for the canonical ladder), so the "Manual Configuration Steps" Docker
         /// command can never show the stale fixed 8080 — nor a derived port while the server binds the
-        /// port the user typed (mcp-authorize g3, extended by the 2026-07-19 owner ruling; design 06 ·
-        /// D15). Resolved from the live custom host + project marker via the pure,
+        /// port the user typed (mcp-authorize g3; design 06 · D15). See
+        /// <see cref="GodotProjectIdentity.ResolveLocalServerBindPort"/> for the transitional window in
+        /// which a user-typed loopback port is honoured here before the pinned writer honours it.
+        /// Resolved from the live custom host + project marker via the pure,
         /// unit-tested <see cref="GodotProjectIdentity.ResolveLocalServerBindPort"/>; a malformed marker
         /// degrades to "no override" so config rendering never faults.
         /// </summary>

--- a/addons/godot_mcp/Editor/UI/Agents/AgentConfiguratorSettingsFactory.cs
+++ b/addons/godot_mcp/Editor/UI/Agents/AgentConfiguratorSettingsFactory.cs
@@ -84,11 +84,13 @@ namespace com.IvanMurzak.Godot.MCP.UI.Agents
         /// <summary>
         /// The local server port for the shared Custom configurator's Docker hints
         /// (<c>-p &lt;port&gt;:&lt;port&gt;</c>, <c>-e PORT=&lt;port&gt;</c>, container name) — the SAME
-        /// ProjectIdentity-derived port the local server binds (<see cref="GodotMcpConnection.ResolveLocalServerPort"/>)
-        /// and the written config URL carries (<see cref="AgentConfig.AgentConfiguratorSettings.PinnedHttpUrl"/>),
-        /// so the "Manual Configuration Steps" Docker command can never show the stale fixed 8080 while the
-        /// server binds a different port (mcp-authorize g3 — completing the Phase-4 8080 → derived-port
-        /// migration, design 06 · D15). Resolved from the live custom host + project marker via the pure,
+        /// port the local server binds (<see cref="GodotMcpConnection.ResolveLocalServerPort"/>) and the
+        /// written config URL carries (<see cref="AgentConfig.AgentConfiguratorSettings.PinnedHttpUrl"/>),
+        /// under the shared three-level precedence (marker <c>portOverride</c> → a port the user typed
+        /// into the host → the deterministic derived port), so the "Manual Configuration Steps" Docker
+        /// command can never show the stale fixed 8080 — nor a derived port while the server binds the
+        /// port the user typed (mcp-authorize g3, extended by the 2026-07-19 owner ruling; design 06 ·
+        /// D15). Resolved from the live custom host + project marker via the pure,
         /// unit-tested <see cref="GodotProjectIdentity.ResolveLocalServerBindPort"/>; a malformed marker
         /// degrades to "no override" so config rendering never faults.
         /// </summary>

--- a/addons/godot_mcp/Runtime/Connection/GodotMcpConfig.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotMcpConfig.cs
@@ -532,6 +532,11 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         ///
         /// <para>An out-of-range port yields <c>null</c> too, mirroring the writer, so an unusable value
         /// falls back to the derived port on BOTH sides rather than diverging.</para>
+        ///
+        /// <para><b>Keep this a line-for-line mirror of the library's copy.</b> There is no compiler-
+        /// enforced link between the two, so structural fidelity is the only thing that makes drift
+        /// visible on inspection. Do not "tidy" a step away — including the empty-port guard that the
+        /// <c>NumberStyles.None</c> parse would also reject — without making the same change upstream.</para>
         /// </summary>
         internal static int? TryGetExplicitPort(string? url)
         {
@@ -568,7 +573,8 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             return port > 0 && port <= HubConsts.MaxPort ? port : (int?)null;
         }
 
-        /// <summary>Characters that terminate a URL authority. Static so the parse allocates nothing.</summary>
+        /// <summary>Characters that terminate a URL authority. Static so the parse does not allocate a
+        /// fresh separator array on every call.</summary>
         static readonly char[] AuthorityTerminators = { '/', '?', '#' };
     }
 }

--- a/addons/godot_mcp/Runtime/Connection/GodotMcpConfig.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotMcpConfig.cs
@@ -12,6 +12,7 @@ using System;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin;
+using HubConsts = com.IvanMurzak.McpPlugin.Common.Consts.Hub;
 using McpServerConsts = com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
 
 namespace com.IvanMurzak.Godot.MCP.Connection
@@ -513,5 +514,61 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
             return false;
         }
+
+        /// <summary>
+        /// The port the user EXPLICITLY typed into <paramref name="url"/>, or <c>null</c> when the URL
+        /// carries no explicit port. This is the Godot mirror of the shared writer's
+        /// <c>AgentConfiguratorSettings.TryGetExplicitPort</c> — the level-2 input of the writer's
+        /// marker → typed → derived port precedence. The library's copy is <c>internal</c>, so it cannot
+        /// be consumed here; this reimplements the same documented rule (URL parsing, not the hashing /
+        /// port math, which stays inherited from <see cref="GodotProjectIdentity.Derive"/>).
+        ///
+        /// <para><b>Why the raw string and not <c>Uri.Port</c>:</b> <see cref="Uri"/> synthesises the
+        /// scheme's default port, so <c>http://localhost/mcp</c> and <c>http://localhost:80/mcp</c> both
+        /// report <c>80</c> and become indistinguishable. Only the first has no user intent behind it and
+        /// must fall through to the derived port; the second is a port the user deliberately typed. Reading
+        /// the raw authority is what preserves that distinction — using <c>Uri.Port</c> here would make the
+        /// binder bind <c>80</c> for a portless loopback host while the writer wrote the derived port.</para>
+        ///
+        /// <para>An out-of-range port yields <c>null</c> too, mirroring the writer, so an unusable value
+        /// falls back to the derived port on BOTH sides rather than diverging.</para>
+        /// </summary>
+        internal static int? TryGetExplicitPort(string? url)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+                return null;
+
+            // Isolate the authority: after "scheme://" (if present), up to the first '/', '?' or '#'.
+            var schemeEnd = url!.IndexOf("://", StringComparison.Ordinal);
+            var start = schemeEnd >= 0 ? schemeEnd + 3 : 0;
+            var end = url.IndexOfAny(AuthorityTerminators, start);
+            var authority = end >= 0 ? url.Substring(start, end - start) : url.Substring(start);
+
+            // Drop any userinfo ("user:pass@host:port") — its colon is not a port separator.
+            var at = authority.LastIndexOf('@');
+            if (at >= 0)
+                authority = authority.Substring(at + 1);
+
+            // For an IPv6 literal the port follows the closing bracket ("[::1]:8080"); the colons inside
+            // the brackets are part of the address. LastIndexOf returns -1 for a normal host, so the
+            // search then starts at 0 and finds a plain "host:port" colon.
+            var colon = authority.IndexOf(':', authority.LastIndexOf(']') + 1);
+            if (colon < 0 || colon == authority.Length - 1)
+                return null;
+
+            // NumberStyles.None is the whole validator: it rejects sign, whitespace, separators and any
+            // non-ASCII-digit character, so a hand-rolled digit scan on top would be redundant.
+            if (!int.TryParse(
+                    authority.Substring(colon + 1),
+                    System.Globalization.NumberStyles.None,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out var port))
+                return null;
+
+            return port > 0 && port <= HubConsts.MaxPort ? port : (int?)null;
+        }
+
+        /// <summary>Characters that terminate a URL authority. Static so the parse allocates nothing.</summary>
+        static readonly char[] AuthorityTerminators = { '/', '?', '#' };
     }
 }

--- a/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
@@ -1244,14 +1244,12 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// Resolve the port the local self-hosted server must BIND — the mcp-authorize g3 single source
         /// of truth the connection panel's Start Server action (see
         /// <see cref="UI.ConnectionPanel.OnServerStartStopPressed"/>) uses so the bind port ALWAYS matches
-        /// the port the shared b6 config writer writes into the AI-client config (server bind == written
-        /// config == the ProjectIdentity-derived port; design 06 · D15). Wires this connection's project
+        /// the port the shared config writer writes into the AI-client config (server bind == written
+        /// config; design 06 · D15). Wires this connection's project
         /// root + marker + the active Custom host into the pure, unit-tested
-        /// <see cref="GodotProjectIdentity.ResolveLocalServerBindPort"/>, which applies the writer's
-        /// three-level precedence (marker <c>portOverride</c> → a port the user typed into the host →
-        /// the deterministic derived port). There is no fixed 8080 fallback: a portless / unset host
-        /// resolves to the derived port, and any host carrying an explicit port binds exactly that port —
-        /// loopback included, so a user-typed local port is honoured rather than silently overwritten.
+        /// <see cref="GodotProjectIdentity.ResolveLocalServerBindPort"/>, which owns the port precedence —
+        /// see that method for the canonical ladder rather than a copy of it here. There is no fixed 8080
+        /// fallback. This method's own job is only the WIRING: project root + marker + active Custom host.
         /// A marker read failure degrades to "no override" (never throws — starting the server must
         /// not fault on a malformed marker), the same defensive discipline as
         /// <see cref="SeedDefaultLocalServerHost"/>.

--- a/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
@@ -1247,9 +1247,12 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// the port the shared b6 config writer writes into the AI-client config (server bind == written
         /// config == the ProjectIdentity-derived port; design 06 · D15). Wires this connection's project
         /// root + marker + the active Custom host into the pure, unit-tested
-        /// <see cref="GodotProjectIdentity.ResolveLocalServerBindPort"/>. There is no fixed 8080 fallback:
-        /// a loopback/default host resolves to the derived port; a non-loopback host to its own explicit
-        /// port. A marker read failure degrades to "no override" (never throws — starting the server must
+        /// <see cref="GodotProjectIdentity.ResolveLocalServerBindPort"/>, which applies the writer's
+        /// three-level precedence (marker <c>portOverride</c> → a port the user typed into the host →
+        /// the deterministic derived port). There is no fixed 8080 fallback: a portless / unset host
+        /// resolves to the derived port, and any host carrying an explicit port binds exactly that port —
+        /// loopback included, so a user-typed local port is honoured rather than silently overwritten.
+        /// A marker read failure degrades to "no override" (never throws — starting the server must
         /// not fault on a malformed marker), the same defensive discipline as
         /// <see cref="SeedDefaultLocalServerHost"/>.
         /// </summary>

--- a/addons/godot_mcp/Runtime/Connection/GodotMcpServerView.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotMcpServerView.cs
@@ -552,9 +552,16 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
         /// <summary>
         /// Resolve the port the locally-hosted server should listen on, parsed from the configured Custom
-        /// host URL (e.g. <c>http://localhost:5300</c> → <c>5300</c>). When the URL has no explicit port,
-        /// or is not parseable, falls back to <paramref name="defaultPort"/> (pass
-        /// <c>Consts.Hub.DefaultPort</c>). Deterministic string/URI parse — no platform divergence.
+        /// host URL (e.g. <c>http://localhost:5300</c> → <c>5300</c>). When the URL is absent or not
+        /// parseable, falls back to <paramref name="defaultPort"/> (pass <c>Consts.Hub.DefaultPort</c>).
+        /// Deterministic string/URI parse — no platform divergence.
+        ///
+        /// <para>This uses <c>Uri.Port</c> DELIBERATELY, so a portless URL yields the scheme's default
+        /// (80/443) rather than the fallback — the right answer for a remote authority the config writer
+        /// keeps verbatim, since the written URL resolves to that same default. To ask the different
+        /// question "did the user actually TYPE a port?", use <see cref="GodotMcpConfig.TryGetExplicitPort"/>,
+        /// which reads the raw authority and never synthesises a default. The two are not duplicates; see
+        /// <see cref="GodotProjectIdentity.ResolveLocalServerBindPort"/>, which calls both.</para>
         /// </summary>
         public static int ResolveServerPort(string? customHostUrl, int defaultPort)
         {

--- a/addons/godot_mcp/Runtime/Connection/GodotProjectIdentity.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotProjectIdentity.cs
@@ -166,37 +166,50 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// <summary>
         /// Resolve the port the LOCAL self-hosted server must BIND so it MATCHES the port the shared
         /// config writer (<see cref="AgentConfiguratorSettings.PinnedHttpUrl"/> /
-        /// <see cref="AgentConfiguratorSettings.PinnedPort"/>) writes into the AI-client config — the
+        /// <see cref="AgentConfiguratorSettings.ResolvedPort"/>) writes into the AI-client config — the
         /// mcp-authorize g3 guarantee that <b>server bind port == written config port</b>, so an agent
         /// always dials the port the server is actually listening on.
         ///
         /// <para>
-        /// The port follows the shared writer's THREE-LEVEL precedence (owner ruling 2026-07-19,
-        /// auth-fixes T1 · defect A — MCP-Plugin-dotnet PRs #174 / #176), applied identically here:
+        /// Host CLASS is decided first, then the port. A <b>NON-loopback</b> host is a remote target the
+        /// writer keeps verbatim, so it binds that host's own port unconditionally — a marker
+        /// <c>portOverride</c> does NOT override a remote authority, on either side.
+        /// </para>
+        ///
+        /// <para>
+        /// For a <b>loopback / unset</b> host the port follows the shared writer's THREE-LEVEL precedence
+        /// (MCP-Plugin-dotnet #174 / #176), applied identically here:
         /// <list type="number">
-        ///   <item>the project marker's <c>portOverride</c> — a deliberate per-project pin, wins outright;</item>
+        ///   <item>the project marker's <c>portOverride</c> — a deliberate per-project pin, and it
+        ///   SUPPRESSES level 2 entirely;</item>
         ///   <item>an explicit port the user typed into the Custom host — read off the RAW authority via
         ///   <see cref="GodotMcpConfig.TryGetExplicitPort"/>, so a portless host is NOT mistaken for the
         ///   scheme default (80/443);</item>
         ///   <item>the deterministic hash-derived <see cref="ProjectIdentity"/> port — the fallback when
-        ///   the host carries no explicit port. There is NO fixed 8080 on this path.</item>
+        ///   the host carries no explicit port.</item>
         /// </list>
-        /// Levels 1 and 3 are inherited from <see cref="Derive"/> (the golden-vector-pinned math); only
-        /// level 2 is resolved here, and only from the host string.
+        /// Levels 1 and 3 are inherited from <see cref="Derive"/> (the golden-vector-pinned math), which
+        /// folds an override into <see cref="ProjectIdentity.Port"/>; only level 2 is resolved here, and
+        /// only from the host string.
         /// </para>
         ///
-        /// <para><b>Why the loopback rule changed.</b> This method used to ignore a loopback host's own
-        /// explicit port and always bind the derived one, deliberately mirroring the OLD writer, which
-        /// rewrote a loopback URL's port to the derived port. That writer has since changed: it now
-        /// honours the typed port (level 2 above) because the user "can enter any port, and the Configure
-        /// button must use exactly that port". Keeping the old mirroring would therefore make the binder
-        /// and the writer DISAGREE the moment this addon picks up McpPlugin ≥ 7.3.0 — the server would
-        /// listen on the derived port while the written config pointed at the typed one, which is the
-        /// exact defect this precedence exists to kill. Unity's binder (<c>UnityMcpPluginEditor.Port</c>)
-        /// already resolves a typed port this way; Godot was the outlier. Note the resulting shape is
-        /// UNCHANGED on the golden boot path: <see cref="GodotMcpConnection.SeedDefaultLocalServerHost"/>
-        /// seeds the Custom host as <c>http://localhost:{derived}</c>, so level 2 and level 3 agree and no
-        /// fixed 8080 can reach either side.</para>
+        /// <para><b>Why a loopback host's own port is honoured.</b> A port the user typed is user intent:
+        /// "the Configure button must use exactly that port". The shared writer resolves it the same way,
+        /// so both sides land on the same number. This method previously ignored it and always bound the
+        /// derived port, mirroring an older writer that rewrote a loopback URL's port — mirroring that
+        /// retired rule is what would make the two sides disagree. Unity's binder
+        /// (<c>UnityMcpPluginEditor.Port</c>) already resolves a typed port this way.</para>
+        ///
+        /// <para><b>⚠ Transitional window — read before debugging a port mismatch.</b> The precedence
+        /// above is the writer's behaviour from McpPlugin <b>7.3.0</b> onward. While this addon is pinned
+        /// BELOW that (see <c>Godot-MCP.csproj</c>), the pinned writer still rewrites a loopback URL's
+        /// port to the derived one, so a user-typed loopback port makes the binder and the written config
+        /// disagree until the pin lands. The golden boot path is unaffected —
+        /// <c>GodotMcpConnection.SeedDefaultLocalServerHost</c> seeds the Custom host as
+        /// <c>http://localhost:{derived}</c>, so levels 2 and 3 agree there and no fixed 8080 reaches
+        /// either side. The parked cross-check
+        /// <c>ResolveLocalServerBindPort_LoopbackExplicitPort_MatchesTheWrittenConfigPort</c> re-arms the
+        /// two-sided guarantee at the pin bump.</para>
         ///
         /// <para>A NON-loopback host (a real remote / self-hosted target the writer keeps verbatim) still
         /// binds that host's own port — that branch was already correct and is untouched.</para>
@@ -212,30 +225,38 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         public static int ResolveLocalServerBindPort(string? resolvedCustomHost, string projectRoot, ProjectMarker? marker)
         {
             var identity = Derive(projectRoot, marker);
-            var derivedPort = identity.Port;
+
+            // NOT necessarily the hash-derived port: Derive folds a marker portOverride into Port, so this
+            // is the override when one is set. That is exactly what makes it the right level-3 fallback AND
+            // the right level-1 answer — hence the deliberately neutral name.
+            var identityPort = identity.Port;
 
             var host = GodotMcpConfig.NormalizeUrl(resolvedCustomHost);
-            var hostIsUsable = !string.IsNullOrEmpty(host) && GodotMcpConfig.IsValidHttpUrl(host!);
 
-            if (hostIsUsable && !GodotMcpConfig.IsLoopbackUrl(host))
+            // An unset / unparseable host carries no intent at all: level 3. This guard is load-bearing
+            // for level 2 below — TryGetExplicitPort parses a bare authority ("localhost:9000") that
+            // IsValidHttpUrl rejects, so without it a non-URL string could still yield a port.
+            if (string.IsNullOrEmpty(host) || !GodotMcpConfig.IsValidHttpUrl(host!))
+                return identityPort;
+
+            if (!GodotMcpConfig.IsLoopbackUrl(host))
             {
-                // Non-loopback target: the writer keeps its authority verbatim, so bind that host's own
-                // explicit port. A portless non-loopback host resolves to the URI scheme's default port
-                // (e.g. 80 for http) — the same value the written authority reports for it, so both sides
-                // still agree; the derivedPort fallback applies only to an unparseable authority.
-                return GodotMcpServerView.ResolveServerPort(host!, derivedPort);
+                // Non-loopback target: the writer keeps its authority verbatim — regardless of the marker,
+                // which is why this branch precedes the level-1 check below. Bind that host's own port. A
+                // portless non-loopback host resolves to the URI scheme's default (e.g. 80 for http), the
+                // same value the written authority reports, so both sides still agree. The identityPort
+                // fallback is reached only by an authority whose port is explicitly 0.
+                return GodotMcpServerView.ResolveServerPort(host!, identityPort);
             }
 
-            // Level 1 — a marker portOverride is a deliberate per-project pin and beats an incidental
-            // port in the host string (identical ordering to the writer's PinnedPort).
-            if (identity.PortIsOverridden)
-                return derivedPort;
+            // Loopback. Level 1 — a marker portOverride is a deliberate per-project pin, so it SUPPRESSES
+            // the level-2 lookup rather than merely outranking its result (identical ordering to the
+            // writer's own port resolution). Level 2 — the port the user typed, read from the RAW
+            // authority (not Uri.Port) so a portless host is not mistaken for the synthesized scheme
+            // default. Level 3 — neither applies: identityPort, which here IS the derived port.
+            var typedPort = identity.PortIsOverridden ? null : GodotMcpConfig.TryGetExplicitPort(host);
 
-            // Level 2 — the port the user typed into the loopback host, when there is one. Read from the
-            // RAW authority (not Uri.Port) so a portless host falls through to level 3 instead of binding
-            // the synthesized scheme default.
-            // Level 3 — loopback with no typed port / unset / unparseable: the derived port.
-            return hostIsUsable ? GodotMcpConfig.TryGetExplicitPort(host) ?? derivedPort : derivedPort;
+            return typedPort ?? identityPort;
         }
 
         /// <summary>

--- a/addons/godot_mcp/Runtime/Connection/GodotProjectIdentity.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotProjectIdentity.cs
@@ -165,49 +165,77 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
         /// <summary>
         /// Resolve the port the LOCAL self-hosted server must BIND so it MATCHES the port the shared
-        /// b6 config writer (<see cref="AgentConfiguratorSettings.PinnedHttpUrl"/> /
-        /// <see cref="AgentConfiguratorSettings.ResolvedPort"/>) writes into the AI-client config — the
-        /// mcp-authorize g3 guarantee that <b>server bind port == written config port == the
-        /// ProjectIdentity-derived port</b> on the default local path (completing the Phase-4 8080 →
-        /// derived-port migration, design 06 · D15). Mirrors the b6 loopback rule byte-for-byte:
-        /// <list type="bullet">
-        ///   <item>a LOOPBACK local host (the default / self-hosted case) binds the
-        ///   <see cref="ProjectIdentity"/>-derived port — a marker <c>portOverride</c> wins, else the
-        ///   deterministic hash-derived port; there is NO fixed 8080 on this path.</item>
-        ///   <item>a NON-loopback host (a real remote / self-hosted target the writer keeps verbatim)
-        ///   binds that host's own explicit port — the same authority the written config carries.</item>
+        /// config writer (<see cref="AgentConfiguratorSettings.PinnedHttpUrl"/> /
+        /// <see cref="AgentConfiguratorSettings.PinnedPort"/>) writes into the AI-client config — the
+        /// mcp-authorize g3 guarantee that <b>server bind port == written config port</b>, so an agent
+        /// always dials the port the server is actually listening on.
+        ///
+        /// <para>
+        /// The port follows the shared writer's THREE-LEVEL precedence (owner ruling 2026-07-19,
+        /// auth-fixes T1 · defect A — MCP-Plugin-dotnet PRs #174 / #176), applied identically here:
+        /// <list type="number">
+        ///   <item>the project marker's <c>portOverride</c> — a deliberate per-project pin, wins outright;</item>
+        ///   <item>an explicit port the user typed into the Custom host — read off the RAW authority via
+        ///   <see cref="GodotMcpConfig.TryGetExplicitPort"/>, so a portless host is NOT mistaken for the
+        ///   scheme default (80/443);</item>
+        ///   <item>the deterministic hash-derived <see cref="ProjectIdentity"/> port — the fallback when
+        ///   the host carries no explicit port. There is NO fixed 8080 on this path.</item>
         /// </list>
-        /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>): the port math is inherited from
-        /// the golden-vector-pinned <see cref="Derive"/>, so the bind port can never drift from the
-        /// written config's port. The loopback / URL-validity predicates are the same ones
-        /// <see cref="GodotMcpConfig"/> and the b6 writer use, so a marker, an env/UI custom host, and a
-        /// terminal-written config all classify identically.
+        /// Levels 1 and 3 are inherited from <see cref="Derive"/> (the golden-vector-pinned math); only
+        /// level 2 is resolved here, and only from the host string.
+        /// </para>
+        ///
+        /// <para><b>Why the loopback rule changed.</b> This method used to ignore a loopback host's own
+        /// explicit port and always bind the derived one, deliberately mirroring the OLD writer, which
+        /// rewrote a loopback URL's port to the derived port. That writer has since changed: it now
+        /// honours the typed port (level 2 above) because the user "can enter any port, and the Configure
+        /// button must use exactly that port". Keeping the old mirroring would therefore make the binder
+        /// and the writer DISAGREE the moment this addon picks up McpPlugin ≥ 7.3.0 — the server would
+        /// listen on the derived port while the written config pointed at the typed one, which is the
+        /// exact defect this precedence exists to kill. Unity's binder (<c>UnityMcpPluginEditor.Port</c>)
+        /// already resolves a typed port this way; Godot was the outlier. Note the resulting shape is
+        /// UNCHANGED on the golden boot path: <see cref="GodotMcpConnection.SeedDefaultLocalServerHost"/>
+        /// seeds the Custom host as <c>http://localhost:{derived}</c>, so level 2 and level 3 agree and no
+        /// fixed 8080 can reach either side.</para>
+        ///
+        /// <para>A NON-loopback host (a real remote / self-hosted target the writer keeps verbatim) still
+        /// binds that host's own port — that branch was already correct and is untouched.</para>
+        ///
+        /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>). The loopback / URL-validity
+        /// predicates are the same ones <see cref="GodotMcpConfig"/> and the writer use, so a marker, an
+        /// env/UI custom host, and a terminal-written config all classify identically.
         /// </summary>
         /// <param name="resolvedCustomHost">The active Custom-mode host (already env/persist-resolved via
         /// <see cref="GodotMcpConfig.ResolveCustomHost"/>).</param>
         /// <param name="projectRoot">The normalized project root — the same string the config writer hashes.</param>
-        /// <param name="marker">The project marker (its <c>portOverride</c> wins for the derived port), or null.</param>
+        /// <param name="marker">The project marker (its <c>portOverride</c> wins outright), or null.</param>
         public static int ResolveLocalServerBindPort(string? resolvedCustomHost, string projectRoot, ProjectMarker? marker)
         {
-            var derivedPort = Derive(projectRoot, marker).Port;
+            var identity = Derive(projectRoot, marker);
+            var derivedPort = identity.Port;
 
             var host = GodotMcpConfig.NormalizeUrl(resolvedCustomHost);
-            if (!string.IsNullOrEmpty(host) &&
-                GodotMcpConfig.IsValidHttpUrl(host!) &&
-                !GodotMcpConfig.IsLoopbackUrl(host))
+            var hostIsUsable = !string.IsNullOrEmpty(host) && GodotMcpConfig.IsValidHttpUrl(host!);
+
+            if (hostIsUsable && !GodotMcpConfig.IsLoopbackUrl(host))
             {
-                // Non-loopback target: the b6 writer keeps its authority verbatim, so bind that host's
-                // own explicit port. A portless non-loopback host resolves to the URI scheme's default
-                // port (e.g. 80 for http) — the same value the writer's ResolvedPort reports for it, so
-                // both sides still agree; the derivedPort fallback applies only to an unparseable authority.
+                // Non-loopback target: the writer keeps its authority verbatim, so bind that host's own
+                // explicit port. A portless non-loopback host resolves to the URI scheme's default port
+                // (e.g. 80 for http) — the same value the written authority reports for it, so both sides
+                // still agree; the derivedPort fallback applies only to an unparseable authority.
                 return GodotMcpServerView.ResolveServerPort(host!, derivedPort);
             }
 
-            // Loopback / default / unset / unparseable: the ProjectIdentity-derived port — exactly what
-            // the b6 writer rewrites the loopback URL's port to. A loopback host's OWN explicit port is
-            // intentionally NOT honored here, mirroring the writer (a loopback port override goes through
-            // the marker portOverride, which flows into the derivation above).
-            return derivedPort;
+            // Level 1 — a marker portOverride is a deliberate per-project pin and beats an incidental
+            // port in the host string (identical ordering to the writer's PinnedPort).
+            if (identity.PortIsOverridden)
+                return derivedPort;
+
+            // Level 2 — the port the user typed into the loopback host, when there is one. Read from the
+            // RAW authority (not Uri.Port) so a portless host falls through to level 3 instead of binding
+            // the synthesized scheme default.
+            // Level 3 — loopback with no typed port / unset / unparseable: the derived port.
+            return hostIsUsable ? GodotMcpConfig.TryGetExplicitPort(host) ?? derivedPort : derivedPort;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- `GodotProjectIdentity.ResolveLocalServerBindPort` now follows the **three-level port precedence**
  the shared config writer adopted in MCP-Plugin-dotnet [#174](https://github.com/IvanMurzak/MCP-Plugin-dotnet/pull/174)
  / [#176](https://github.com/IvanMurzak/MCP-Plugin-dotnet/pull/176):
  **1. project-marker `portOverride` → 2. an explicit port typed into the Custom host → 3. the
  deterministic hash-derived `ProjectIdentity` port.**
- Host **class** is decided before that ladder: a **non-loopback** host is a remote authority the
  writer keeps verbatim, so it binds that host's own port and a marker `portOverride` does *not*
  override it. (Pinned by `..._NonLoopbackHost_BeatsMarkerPortOverride`.)
- New `GodotMcpConfig.TryGetExplicitPort` supplies level 2 by parsing the **raw authority** — the
  Godot mirror of the writer's `internal AgentConfiguratorSettings.TryGetExplicitPort`.

## Why mirroring the old writer is no longer correct

The binder used to ignore a loopback host's own explicit port and always bind the derived port —
deliberately, per its own comment, because the **old** writer rewrote a loopback URL's port to the
derived one. That writer has changed: it now honours the typed port, because the user *"can enter any
port … and the Configure button must use exactly that port"*.

So the mirroring inverted its own purpose: keeping it would make the server listen on the derived port
while the written config pointed at the typed one — precisely the "Configure writes a port the server
isn't listening on" defect this precedence exists to kill.

**Unity already behaves this way** — `UnityMcpPluginEditor.Port` returns `uri.Port` whenever `Host`
parses with an in-range port. Godot and Unreal were the outliers; this closes the Godot half.

## ⚠ Transitional window — this lands BEFORE the writer it matches

This repo still pins `com.IvanMurzak.McpPlugin` **7.2.0** (the OLD writer). The pin is **not** bumped
here — the release cascade owns that, per the task's hard constraint. Stating the consequence plainly
rather than only as a skipped test:

**While the pin is below 7.3.0, a user-typed loopback port is a live divergence** — the binder now
honours it while the pinned writer still rewrites it to the derived port. Concretely, if a user types
`http://localhost:9000`: the server binds `9000`, `PinnedHttpUrl` writes the derived port, and the
agent dials a port nothing is listening on. The same mismatch reaches the oauth `public-url` argument
and the Custom configurator's Docker hints, which are built from the two different resolutions.
Before this change both sides agreed on the derived port for that input.

Scope of the exposure:

- **The golden boot path is unaffected.** `SeedDefaultLocalServerHost` seeds the Custom host as
  `http://localhost:{derived}` before anything binds, so levels 2 and 3 agree and no fixed `8080`
  reaches either side (the g3 guarantee is preserved, not weakened).
- **Only a deliberately typed loopback port is affected** — a setting a user changes by hand.
- **It closes on the pin bump**, which is what makes the two sides agree by construction.

`ResolveLocalServerBindPort_LoopbackExplicitPort_MatchesTheWrittenConfigPort` is the one assertion
that compares the binder against the **live writer** for that input. It cannot pass on 7.2.0 and was
**not** forced and **not** weakened — it is committed as `[Fact(Skip = …)]` whose reason names the
exact un-skip condition, so the cascade has a greppable in-repo tripwire:

> Un-skip when `Godot-MCP.csproj` pins `com.IvanMurzak.McpPlugin` >= 7.3.0 (issue #304).

Everything else asserts the **binder's own contract** (given a host + marker + root, which port comes
out) and is green today. That restructuring is deliberate: coupling these tests to whatever the
currently-pinned writer emits is exactly what let the two sides diverge unnoticed in the first place.

## Notes on the implementation

- **Level 2 reads the RAW authority, not `Uri.Port`.** `Uri` synthesizes the scheme default, so
  `http://localhost` and `http://localhost:80` are indistinguishable through it. Only the first has no
  user intent and must fall through to level 3 — using `Uri.Port` would bind `80` where the writer
  wrote the derived port.
- **`GodotMcpServerView.ResolveServerPort` and `TryGetExplicitPort` are not duplicates.** The former
  uses `Uri.Port` deliberately (the scheme default is right for a verbatim remote authority); the
  latter must never synthesize one. Both are called, on the branches where each is correct.
- **The `http://localhost:8080` default-host sentinel is deliberately NOT special-cased.** Special-
  casing it would reintroduce the divergence for any user who genuinely types `:8080`. The
  "never a fixed 8080" property is preserved at the config layer by `SeedDefaultLocalServerHost`, not
  by the binder — pinned by `..._UnSeededDefaultCustomHost_BindsItsLiteralPort`.
- **The non-loopback branch is untouched** — it already bound the host's own explicit port.

## Test plan

- [x] Suite 1 — `dotnet build Godot-MCP.sln -c Debug`: **0 errors, 0 warnings**.
- [x] Suite 2 — `dotnet test Godot-MCP.Tests`: **1110 tests, 1109 passed, 1 skipped (the LIB-7.3.0
      cross-check above), 0 failed.**
- [x] `scripts/check-runtime-boundary.py`: OK, 81 Runtime/ files scanned, 0 violations.
- [ ] Suite 2b (`cli/` npm) — N/A, `cli/` untouched.
- [ ] Suite 3 (live editor) — not run. This change is pure-managed port resolution with **no
      editor-observable delta on the default boot path** (the seeded host makes levels 2 and 3 agree),
      and it adds no tool. CI's five-version headless Godot matrices (addon-load / dock-reload /
      e2e-install / runtime-harness) cover boot.

Coverage spans all three levels plus the host-class branch: marker `portOverride` + an explicit host
port both present (the override wins), non-loopback + `portOverride` (the host wins), portless
loopback → derived (not `80`), the un-seeded `8080` baseline, and the raw-authority parse edge cases
(userinfo colon, IPv6 literal, empty/non-numeric/signed/out-of-range/overflow ports).

## Follow-up (not this PR)

- `Unreal-MCP/bridge/tests/LocalServerPortConsistencyTests.cs` asserts the same old invariant on the
  Unreal side and needs the matching update in its own repo during the cascade.
- **`cli/src/lib/enroll.ts` still encodes the retired rule** (loopback ⇒ always the derived port, with
  no marker-`portOverride` arm), so the CLI-written marker `port` can disagree with what the plugin
  binds for a typed local port. Surfaced by review here; it ships on the CLI's own release leg and
  should flip together with the 7.3.0 pin.

Closes #304
