### PR TITLE
chore(ci): upgrade Node20-deprecated actions to Node24-capable versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -30,10 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET 8
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "8.0.x"
 
@@ -50,7 +50,7 @@ jobs:
       # produced by coverlet so progress is measurable; the gate never turns red on low coverage.
       - name: Upload .NET coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dotnet-coverage
           path: TestResults/**/coverage.cobertura.xml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,10 +51,10 @@ jobs:
         working-directory: ./cli
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
       server_version: ${{ steps.server_version.outputs.server_version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -183,10 +183,10 @@ jobs:
     if: needs.check-version-tag.outputs.should_release == 'true'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET 8
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "8.0.x"
 
@@ -422,10 +422,10 @@ jobs:
       published: ${{ steps.mark.outputs.published }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET 8
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "8.0.x"
 
@@ -465,7 +465,7 @@ jobs:
       # plugin.cfg. The server binaries are NOT attached — the addon downloads
       # the shared GameDev-MCP-Server release pinned by ServerVersion.
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: ${{ needs.check-version-tag.outputs.tag }}
           tag_name: ${{ needs.check-version-tag.outputs.tag }}
@@ -500,7 +500,7 @@ jobs:
       - name: Checkout repository
         # The action reads the handlebars template (.github/assetlib/edit.hbs)
         # from the workspace, so the repo must be checked out.
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Submit Asset Library version edit
         # deep-entertainment/godot-asset-lib-action @ v0.6.0

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -18,10 +18,10 @@ jobs:
       run:
         working-directory: ./cli
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -39,7 +39,7 @@ jobs:
       # artifact name avoids upload-artifact@v4 duplicate-name collisions across the matrix.
       - name: Upload CLI coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cli-coverage-node-${{ matrix.node-version }}
           path: cli/coverage/**

--- a/.github/workflows/test_cli_e2e_install.yml
+++ b/.github/workflows/test_cli_e2e_install.yml
@@ -55,15 +55,15 @@ jobs:
       PROJECT_NAME: E2EConsumer
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET 8
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "8.0.x"
 
       - name: Setup Node 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
@@ -237,7 +237,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-install-${{ inputs.godotVersion }}-logs
           path: |

--- a/.github/workflows/test_godot_dock_reload.yml
+++ b/.github/workflows/test_godot_dock_reload.yml
@@ -45,15 +45,15 @@ jobs:
       DEV_CONTROL_PORT: "9920"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET 8
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "8.0.x"
 
       - name: Setup Python 3
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -134,7 +134,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dock-reload-${{ inputs.godotVersion }}-logs
           path: |

--- a/.github/workflows/test_godot_plugin.yml
+++ b/.github/workflows/test_godot_plugin.yml
@@ -31,10 +31,10 @@ jobs:
       TEST_PROJECT: Godot-Tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET 8
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "8.0.x"
 
@@ -134,7 +134,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: godot-${{ inputs.godotVersion }}-logs
           path: |

--- a/.github/workflows/test_godot_runtime_harness.yml
+++ b/.github/workflows/test_godot_runtime_harness.yml
@@ -61,10 +61,10 @@ jobs:
       SERVER_BIN_NAME: gamedev-mcp-server
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET 8
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "8.0.x"
 
@@ -288,7 +288,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: runtime-harness-${{ inputs.godotVersion }}-logs
           path: |

--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -46,10 +46,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET 8
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "8.0.x"
 
@@ -66,7 +66,7 @@ jobs:
       # produced by coverlet so progress is measurable; the gate never turns red on low coverage.
       - name: Upload .NET coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dotnet-coverage
           path: TestResults/**/coverage.cobertura.xml
@@ -176,7 +176,7 @@ jobs:
       serverVersion: ${{ steps.read.outputs.serverVersion }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Read ServerVersion from the addon constant
         id: read


### PR DESCRIPTION
All of these actions are pinned at their last Node20-based major and are
already being force-run on Node 24 by the runner. This is a runtime
compatibility fix, not cosmetics.

- actions/checkout            v4 -> v6  (14 occurrences)
- actions/setup-dotnet        v4 -> v5  (8 occurrences)
- actions/setup-node          v4 -> v6  (3 occurrences)
- actions/setup-python        v5 -> v6  (2 occurrences)
- actions/upload-artifact     v4 -> v6  (7 occurrences)
- softprops/action-gh-release v2 -> v3  (1 occurrence)

Targets deliberately stop short of "latest":
- checkout v7 blocks fork-PR checkout on pull_request_target/workflow_run
- setup-node v7 drops the implicit NODE_AUTH_TOKEN export (npm publish auth)
- setup-dotnet v6 drops an unenumerated set of older SDKs
- setup-python v7 removes the pip-install input
- upload-artifact v7 is ESM-only

Left untouched: mukunku/tag-exists-action@v1.7.0 and
chickensoft-games/setup-godot@v2 (already Node24 / not in scope), and the
SHA-pinned deep-entertainment/godot-asset-lib-action.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012WxMrEo6Nk4RCQZjA4LkFC
