### PR TITLE
fix(connection): cloud run-tool /mcp hub + v2 derived-port/marker local fallback

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -140,16 +140,22 @@ Building first guarantees the assembly is present when the addon is instantiated
 
 ### Server URL resolution (`run-tool` / `status` / `wait-for-ready`)
 
-Unlike Unity, the Godot plugin is a **server-less client** whose persisted config lives in `user://`
-(outside the project tree), so there is no deterministic project-path → port hash. The server base URL is
-resolved as:
+The server base URL a tool call POSTs to (`<base>/api/tools/<name>`) is resolved as:
 
 1. `--url <url>` (explicit override).
 2. `GODOT_MCP_HOST` env (Custom-mode host).
-3. `GODOT_MCP_CLOUD_URL` env / Cloud mode → cloud base (`https://ai-game.dev`).
-4. Default custom host (`http://localhost:8080`).
+3. `GODOT_MCP_CLOUD_URL` env → the cloud **`/mcp` hub** URL (`/mcp` is appended if absent).
+4. `GODOT_MCP_CONNECTION_MODE=Cloud` → the default cloud hub `https://ai-game.dev/mcp`.
+5. The **enrolled project marker** (`.ai-game-dev/project.json` `serverTarget`, written by
+   `install-plugin --enroll`): a hosted target routes to its `/mcp` hub, a `localhost` target is used
+   verbatim. This makes an **enrolled cloud project reachable with zero env config** — the persisted
+   cloud credential (project store, then `~/.ai-game-dev/credentials.json`) is used automatically.
+6. Local fallback: `http://localhost:<derived-port>`, the deterministic v2 project-path port the
+   editor addon binds locally (a marker `portOverride` wins over the hash-derived port).
 
-Pass `--url http://localhost:<port>` to target a local/self-hosted server.
+The cloud paths carry the `/mcp` hub segment so the request reaches the hub rather than the cloud
+backend (which serves no `/api/tools/*`). Pass `--url http://localhost:<port>` to target a
+local/self-hosted server explicitly.
 
 ![divider](https://github.com/IvanMurzak/Unity-MCP/blob/main/docs/img/promo/hazzard-divider.svg?raw=true)
 

--- a/cli/src/lib/setup-mcp.ts
+++ b/cli/src/lib/setup-mcp.ts
@@ -2,7 +2,6 @@ import * as path from 'path';
 import { pinUrl } from '@baizor/gamedev-cli-core';
 import {
   CLOUD_MCP_URL,
-  DEFAULT_CUSTOM_HOST,
   ENV_HOST,
   ENV_TOKEN,
   MCP_HUB_PATH,
@@ -222,5 +221,5 @@ export function listAgentIds(): string[] {
   return getAgentIds();
 }
 
-// Re-export the constants so the CLI command can surface the default URL in help.
-export { CLOUD_MCP_URL, DEFAULT_CUSTOM_HOST };
+// Re-export the constant so the CLI command can surface the default URL in help.
+export { CLOUD_MCP_URL };

--- a/cli/src/utils/connection.ts
+++ b/cli/src/utils/connection.ts
@@ -4,6 +4,8 @@ import { verbose } from './ui.js';
 import * as ui from './ui.js';
 import { readCloudToken } from './credentials.js';
 import { readMachineAccessToken } from './machine-credentials.js';
+import { deriveProjectIdentityV2 } from './project-identity.js';
+import { readProjectMarker, isLocalhostUrl } from './project-marker.js';
 
 // --- Godot MCP connection constants (mirror addons/godot_mcp GodotMcpConfig). ---
 
@@ -15,9 +17,6 @@ export const MCP_HUB_PATH = '/mcp';
 
 /** Resolved cloud MCP-client URL (base + /mcp). */
 export const CLOUD_MCP_URL = `${DEFAULT_CLOUD_BASE_URL}${MCP_HUB_PATH}`;
-
-/** Default custom-mode host (GodotMcpConfig.DefaultCustomHost). */
-export const DEFAULT_CUSTOM_HOST = 'http://localhost:8080';
 
 // --- Environment-variable names the addon reads (GodotMcpConfig EnvX consts). ---
 
@@ -94,55 +93,123 @@ function isCloudMode(): boolean {
 }
 
 /**
+ * Normalize a cloud/hub base URL so it ends in exactly one `/mcp` hub segment
+ * (mirrors `setup-mcp`'s `resolveMcpClientUrl`). The mcp-server's REST
+ * direct-tool API is reachable ONLY under the `/mcp`-prefixed route — nginx maps
+ * `^/mcp(/|$)` to the mcp-server (stripping `/mcp`) while `/api` alone goes to the
+ * cloud backend — so a cloud base that LOSES `/mcp` sends `<base>/api/tools/<name>`
+ * to the backend, which 404s (defect A). Trailing slash trimmed; an already-`/mcp`
+ * base is left as-is (case-insensitive, idempotent).
+ */
+function ensureMcpHubPath(baseUrl: string): string {
+  const trimmed = baseUrl.replace(/\/$/, '');
+  if (trimmed.toLowerCase().endsWith(MCP_HUB_PATH)) return trimmed;
+  return trimmed + MCP_HUB_PATH;
+}
+
+/** A resolved connection target: the base URL + whether it is the cloud hub. */
+interface ResolvedTarget {
+  /** The base URL to which `<base>/api/tools/<name>` is appended. */
+  url: string;
+  /** True when the target is the cloud hub — a persisted cloud token then applies. */
+  isCloud: boolean;
+}
+
+/**
+ * Resolve the base URL a direct-tool-call POSTs to, plus whether that target is
+ * the cloud hub. Priority (first match wins):
+ *   1. `--url` flag — explicit override, verbatim (trailing slash trimmed).
+ *   2. `GODOT_MCP_HOST` env — an explicit Custom-mode host, verbatim.
+ *   3. `GODOT_MCP_CLOUD_URL` env — a cloud base, normalized to its `/mcp` hub URL (fix A).
+ *   4. `GODOT_MCP_CONNECTION_MODE=Cloud` — the default hosted `/mcp` hub (fix A).
+ *   5. Enrolled project marker (`.ai-game-dev/project.json` `serverTarget`) — the
+ *      ZERO-env-config path (fix B): a hosted target routes to its `/mcp` hub (cloud,
+ *      so an enrolled project reaches the cloud with no env var set); a localhost
+ *      target is used verbatim (the derived port enrollment recorded).
+ *   6. Local fallback — `http://localhost:<v2-derived-port>`, the deterministic port
+ *      the addon binds locally (fix B; replaces the dead `http://localhost:8080`). An
+ *      explicit marker `portOverride` still wins over the hash-derived port.
+ */
+function resolveTargetUrl(projectPath: string, options: ConnectionOptions): ResolvedTarget {
+  if (options.url) {
+    const url = options.url.replace(/\/$/, '');
+    verbose(`Using explicit --url: ${url}`);
+    return { url, isCloud: false };
+  }
+
+  const envHost = normalizeEnv(process.env[ENV_HOST]);
+  if (envHost) {
+    const url = envHost.replace(/\/$/, '');
+    verbose(`Using ${ENV_HOST}: ${url}`);
+    return { url, isCloud: false };
+  }
+
+  const envCloud = normalizeEnv(process.env[ENV_CLOUD_URL]);
+  if (envCloud) {
+    const url = ensureMcpHubPath(envCloud);
+    verbose(`Using ${ENV_CLOUD_URL} hub URL: ${url}`);
+    return { url, isCloud: true };
+  }
+
+  if (isCloudMode()) {
+    verbose(`Using default cloud hub URL: ${CLOUD_MCP_URL}`);
+    return { url: CLOUD_MCP_URL, isCloud: true };
+  }
+
+  // The enrolled marker (and any port override) is read once here — it backs both
+  // the zero-config marker target (5) and the derived-port fallback (6).
+  const marker = readProjectMarker(projectPath);
+  const rawTarget = marker?.serverTarget;
+  const serverTarget =
+    typeof rawTarget === 'string' && rawTarget.trim().length > 0 ? rawTarget.trim() : undefined;
+  if (serverTarget) {
+    if (isLocalhostUrl(serverTarget)) {
+      const url = serverTarget.replace(/\/$/, '');
+      verbose(`Using enrolled marker localhost target: ${url}`);
+      return { url, isCloud: false };
+    }
+    const url = ensureMcpHubPath(serverTarget);
+    verbose(`Using enrolled marker cloud hub URL: ${url}`);
+    return { url, isCloud: true };
+  }
+
+  const portOverride = typeof marker?.portOverride === 'number' ? marker.portOverride : null;
+  const { port } = deriveProjectIdentityV2(projectPath, portOverride);
+  const url = `http://localhost:${port}`;
+  verbose(`Using derived local port fallback: ${url}`);
+  return { url, isCloud: false };
+}
+
+/**
  * Resolve the MCP server base URL + auth token for direct-tool-call requests
  * (the `<base>/api/tools/<name>` HTTP API exposed by a Godot-MCP server).
  *
- * URL priority:
- *   1. --url flag (explicit override)
- *   2. GODOT_MCP_HOST env (Custom-mode host)
- *   3. GODOT_MCP_CLOUD_URL env / Cloud mode → cloud base (https://ai-game.dev)
- *   4. default custom host (http://localhost:8080)
+ * URL priority — see {@link resolveTargetUrl}. A cloud target carries the `/mcp`
+ * hub segment so `<base>/api/tools/<name>` reaches the hub (not the 404'ing
+ * backend); a local target is the addon's v2 derived port (or the enrolled
+ * marker's recorded localhost target).
  *
  * Token priority:
  *   1. --token flag (explicit override)
  *   2. GODOT_MCP_TOKEN env
- *   3. persisted cloud token (Cloud mode only) — the project-local
- *      `.godot-mcp/credentials.json` (a `--project` login) first, then the shared machine
- *      store `~/.ai-game-dev/credentials.json` (a default `godot-cli login`), so a
- *      sign-once-per-machine credential is picked up here too.
+ *   3. persisted cloud token (cloud targets only — env Cloud mode OR an enrolled
+ *      hosted marker) — the project-local `.godot-mcp/credentials.json` (a `--project`
+ *      login) first, then the shared machine store `~/.ai-game-dev/credentials.json`
+ *      (a default `godot-cli login`), so a sign-once-per-machine credential is picked
+ *      up here too. An enrolled cloud project therefore authenticates with zero env config.
  */
 export function resolveConnection(
   projectPath: string,
   options: ConnectionOptions,
 ): { url: string; token: string | undefined } {
-  let url: string;
-  if (options.url) {
-    url = options.url.replace(/\/$/, '');
-    verbose(`Using explicit --url: ${url}`);
-  } else {
-    const envHost = normalizeEnv(process.env[ENV_HOST]);
-    const envCloud = normalizeEnv(process.env[ENV_CLOUD_URL]);
-    if (envHost) {
-      url = envHost.replace(/\/$/, '');
-      verbose(`Using ${ENV_HOST}: ${url}`);
-    } else if (envCloud) {
-      url = envCloud.replace(new RegExp(`${MCP_HUB_PATH}$`), '').replace(/\/$/, '');
-      verbose(`Using ${ENV_CLOUD_URL} base: ${url}`);
-    } else if (isCloudMode()) {
-      url = DEFAULT_CLOUD_BASE_URL;
-      verbose(`Using default cloud base URL: ${url}`);
-    } else {
-      url = DEFAULT_CUSTOM_HOST;
-      verbose(`Using default custom host: ${url}`);
-    }
-  }
+  const { url, isCloud } = resolveTargetUrl(projectPath, options);
 
   let token = options.token ?? normalizeEnv(process.env[ENV_TOKEN]);
   if (options.token) {
     verbose('Using explicit --token');
   } else if (token) {
     verbose(`Using ${ENV_TOKEN}`);
-  } else if (isCloudMode()) {
+  } else if (isCloud) {
     const persisted = readCloudToken(projectPath) ?? readMachineAccessToken();
     if (persisted) {
       token = persisted;

--- a/cli/tests/connection.test.ts
+++ b/cli/tests/connection.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -7,7 +7,6 @@ import {
   resolveOpenAuthToken,
   CLOUD_MCP_URL,
   DEFAULT_CLOUD_BASE_URL,
-  DEFAULT_CUSTOM_HOST,
   ENV_HOST,
   ENV_CLOUD_URL,
   ENV_TOKEN,
@@ -15,6 +14,9 @@ import {
 } from '../src/utils/connection.js';
 import { writeCredentials } from '../src/utils/credentials.js';
 import { writeMachineCredentials, MACHINE_STORE_DIR_ENV } from '../src/utils/machine-credentials.js';
+import { derivePortV2 } from '../src/utils/project-identity.js';
+import { writeProjectMarker } from '../src/utils/project-marker.js';
+import { runTool } from '../src/lib/run-tool.js';
 
 describe('resolveConnection', () => {
   const saved: Record<string, string | undefined> = {};
@@ -46,21 +48,26 @@ describe('resolveConnection', () => {
     expect(url).toBe('http://localhost:5544');
   });
 
-  it('strips a trailing /mcp from GODOT_MCP_CLOUD_URL to get the base', () => {
+  it('normalizes GODOT_MCP_CLOUD_URL to its /mcp hub URL (keeps an existing /mcp, appends when absent)', () => {
+    // Fix A: the cloud target MUST retain /mcp so <base>/api/tools/<name> reaches
+    // the hub, not the 404'ing backend. (Old behavior stripped /mcp — the defect.)
     process.env[ENV_CLOUD_URL] = 'https://example.test/mcp';
-    const { url } = resolveConnection('/proj', {});
-    expect(url).toBe('https://example.test');
+    expect(resolveConnection('/proj', {}).url).toBe('https://example.test/mcp');
+    process.env[ENV_CLOUD_URL] = 'https://example.test';
+    expect(resolveConnection('/proj', {}).url).toBe('https://example.test/mcp');
   });
 
-  it('falls back to the cloud base when mode is Cloud', () => {
+  it('falls back to the cloud /mcp hub URL when mode is Cloud (fix A)', () => {
     process.env[ENV_CONNECTION_MODE] = 'Cloud';
     const { url } = resolveConnection('/proj', {});
-    expect(url).toBe(DEFAULT_CLOUD_BASE_URL);
+    expect(url).toBe(CLOUD_MCP_URL);
+    expect(url).toBe(`${DEFAULT_CLOUD_BASE_URL}/mcp`);
   });
 
-  it('falls back to the default custom host otherwise', () => {
+  it('falls back to the v2 derived local port otherwise — no :8080 (fix B)', () => {
     const { url } = resolveConnection('/proj', {});
-    expect(url).toBe(DEFAULT_CUSTOM_HOST);
+    expect(url).toBe(`http://localhost:${derivePortV2('/proj')}`);
+    expect(url).not.toContain('8080');
   });
 
   it('resolves the token from --token, then GODOT_MCP_TOKEN', () => {
@@ -72,6 +79,110 @@ describe('resolveConnection', () => {
 
   it('exposes the cloud MCP-client URL constant as <base>/mcp', () => {
     expect(CLOUD_MCP_URL).toBe(`${DEFAULT_CLOUD_BASE_URL}/mcp`);
+  });
+});
+
+describe('resolveConnection — fix A: cloud run-tool targets the /mcp hub', () => {
+  const saved: Record<string, string | undefined> = {};
+  const ENV_KEYS = [ENV_HOST, ENV_CLOUD_URL, ENV_TOKEN, ENV_CONNECTION_MODE];
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('composes https://ai-game.dev/mcp/api/tools/<name> in Cloud mode', () => {
+    process.env[ENV_CONNECTION_MODE] = 'Cloud';
+    const { url } = resolveConnection('/proj', {});
+    expect(`${url}/api/tools/ping`).toBe('https://ai-game.dev/mcp/api/tools/ping');
+  });
+
+  it('runTool actually POSTs to https://ai-game.dev/mcp/api/tools/<name> (end-to-end)', async () => {
+    process.env[ENV_CONNECTION_MODE] = 'Cloud';
+    const { url, token } = resolveConnection('/proj', {});
+    const fetchImpl = vi.fn(
+      async () => new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+    await runTool({
+      toolName: 'ping',
+      url,
+      ...(token ? { token } : {}),
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const [endpoint] = fetchImpl.mock.calls[0] as [string];
+    expect(endpoint).toBe('https://ai-game.dev/mcp/api/tools/ping');
+  });
+});
+
+describe('resolveConnection — fix B: enrolled marker + v2 derived-port fallback', () => {
+  const saved: Record<string, string | undefined> = {};
+  const ENV_KEYS = [ENV_HOST, ENV_CLOUD_URL, ENV_TOKEN, ENV_CONNECTION_MODE, MACHINE_STORE_DIR_ENV];
+  let projectDir: string;
+  let storeDir: string;
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-marker-proj-'));
+    storeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-marker-store-'));
+    process.env[MACHINE_STORE_DIR_ENV] = storeDir;
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.rmSync(storeDir, { recursive: true, force: true });
+  });
+
+  it('uses the v2 derived local port when there is no marker and no env (no :8080)', () => {
+    const { url } = resolveConnection(projectDir, {});
+    expect(url).toBe(`http://localhost:${derivePortV2(projectDir)}`);
+    expect(url).not.toContain('8080');
+  });
+
+  it('respects an enrolled localhost marker target verbatim', () => {
+    writeProjectMarker(projectDir, { serverTarget: 'http://localhost:23456', pin: 'abcdef01', port: 23456 });
+    const { url, token } = resolveConnection(projectDir, {});
+    expect(url).toBe('http://localhost:23456');
+    // A localhost target is not the cloud hub → no persisted-token injection.
+    expect(token).toBeUndefined();
+  });
+
+  it('honors an explicit marker portOverride in the derived-port fallback', () => {
+    writeProjectMarker(projectDir, { portOverride: 25555 });
+    const { url } = resolveConnection(projectDir, {});
+    expect(url).toBe('http://localhost:25555');
+  });
+
+  it('reaches the cloud /mcp hub with a persisted token and ZERO env in an enrolled cloud project (DoD)', () => {
+    // Enrolled hosted project: the marker records the hosted serverTarget and the
+    // credential lives in the shared machine store — no env var is set anywhere.
+    writeProjectMarker(projectDir, { serverTarget: DEFAULT_CLOUD_BASE_URL, pin: 'abcdef01' });
+    writeMachineCredentials({ accessToken: 'enrolled-tok', serverTarget: DEFAULT_CLOUD_BASE_URL }, storeDir);
+    const { url, token } = resolveConnection(projectDir, {});
+    expect(url).toBe(CLOUD_MCP_URL); // https://ai-game.dev/mcp
+    expect(token).toBe('enrolled-tok'); // zero-env cloud auth via the enrolled credential
+    expect(`${url}/api/tools/ping`).toBe('https://ai-game.dev/mcp/api/tools/ping');
+  });
+
+  it('lets explicit env (GODOT_MCP_HOST) override the enrolled marker', () => {
+    writeProjectMarker(projectDir, { serverTarget: DEFAULT_CLOUD_BASE_URL, pin: 'abcdef01' });
+    process.env[ENV_HOST] = 'http://localhost:9999';
+    expect(resolveConnection(projectDir, {}).url).toBe('http://localhost:9999');
   });
 });
 


### PR DESCRIPTION
## Summary
Fixes the two confirmed `godot-cli` connection defects (zero-config-engine-connect D11, defects A+B) in `cli/src/utils/connection.ts`:

- **(A)** Cloud run-tool no longer strips `/mcp`. `GODOT_MCP_CLOUD_URL` and Cloud mode now resolve to the `<base>/mcp` hub URL, so `<base>/api/tools/<name>` reaches the hub (`https://ai-game.dev/mcp/api/tools/<name>`) instead of the 404'ing cloud backend.
- **(B)** The dead `http://localhost:8080` fallback is replaced with the cli-core **v2** `deriveProjectIdentityV2` port. An enrolled project marker's `serverTarget` is respected (hosted → `/mcp` hub cloud; `localhost` → verbatim), as is a marker `portOverride`. An enrolled cloud project is now reachable (URL + persisted credential) with **zero env config**.

`probe.ts` (`/api/tools/ping`) is unchanged. CLI README server-URL-resolution docs updated.

## Test plan
- [x] Target-specific local tests passed (`cli/` npm suite: `npm run build` + `vitest run` → 47 files, 513 passed | 1 skipped).
- [x] Cloud run-tool endpoint asserted `https://ai-game.dev/mcp/api/tools/<name>` (composition + end-to-end `runTool` with a mock fetch).
- [x] Local fallback = v2 derived port; enrolled localhost marker respected; `portOverride` honored; `:8080` fallback gone.
- [x] Zero-env-config enrolled-cloud project resolves the `/mcp` hub + persisted token.

Closes #311