### PR TITLE
fix: close three vacuous gates and correct the stale McpPlugin pin doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ MCP server (cloud `ai-game.dev` by default, or a custom local server) over the r
 `com.IvanMurzak.McpPlugin` SignalR client. The MCP/reflection stack is **not forked** — it is consumed
 from nuget.org as `PackageReference`s and the pins are owned by the upstream release pipelines (never bump
 them here). The reused pins are frozen at `com.IvanMurzak.ReflectorNet` **5.3.2** and
-`com.IvanMurzak.McpPlugin` **7.1.1** (in `Godot-MCP.csproj`, mirrored by `Godot-MCP.Tests/` and the infra
+`com.IvanMurzak.McpPlugin` **7.3.0** (in `Godot-MCP.csproj`, mirrored by `Godot-MCP.Tests/` and the infra
 testbed) — keep all three in lockstep; never bump here. (6.10.0 carries the shared engine-agnostic
 `com.IvanMurzak.McpPlugin.AgentConfig` module the addon consumes for AI-agent configurators — registry +
 `AiAgentConfig` + `AgentConfiguratorDescription` — replacing the addon's retired local copy; it also carries
@@ -167,7 +167,7 @@ reads at editor runtime:
 ```xml
 <ItemGroup>
   <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.2" />
-  <PackageReference Include="com.IvanMurzak.McpPlugin"   Version="7.1.1" />
+  <PackageReference Include="com.IvanMurzak.McpPlugin"   Version="7.3.0" />
 </ItemGroup>
 
 <ItemGroup>

--- a/Godot-MCP.Tests/GodotProjectIdentityTests.cs
+++ b/Godot-MCP.Tests/GodotProjectIdentityTests.cs
@@ -406,19 +406,18 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.NotEqual(ProjectIdentity.DerivePort(root), bindPort);
         }
 
-        [Fact(Skip = "Un-skip when Godot-MCP.csproj pins com.IvanMurzak.McpPlugin >= 7.3.0 (issue #304) — see body.")]
+        [Fact]
         public void ResolveLocalServerBindPort_LoopbackExplicitPort_MatchesTheWrittenConfigPort()
         {
             const string root = "C:/Games/MyGame";
             const string host = "http://localhost:9000";
 
             // The live cross-check for level 2: the binder's typed-port result must equal the port the
-            // shared writer emits for the same host. It CANNOT pass on the currently-pinned McpPlugin
-            // 7.2.0, whose PinnedHttpUrl still rewrites a loopback port to the derived one — that old
-            // writer is precisely what this change stopped mirroring. The binder-contract assertions above
-            // (ResolveLocalServerBindPort_LoopbackExplicitPort_HonorsTheTypedPort) carry the behaviour in
-            // the meantime; this one re-arms the two-sided guarantee once the pin lands in the release
-            // cascade. Do not delete it and do not weaken it — un-skip it with the pin bump.
+            // shared writer emits for the same host. It could NOT pass on the then-pinned McpPlugin
+            // 7.2.0, whose PinnedHttpUrl still rewrote a loopback port to the derived one — that old
+            // writer is precisely what this change stopped mirroring — so it shipped `[Fact(Skip = ...)]`
+            // with the instruction "un-skip it with the pin bump" (issue #304). `Godot-MCP.csproj` now
+            // pins 7.3.0, so the two-sided guarantee is re-armed here. Do not weaken it.
             var bindPort = GodotProjectIdentity.ResolveLocalServerBindPort(host, root, marker: null);
             var settings = LocalSettings(root, host + "/mcp");
 

--- a/Godot-MCP.Tests/SkillBodyExportSafetyTests.cs
+++ b/Godot-MCP.Tests/SkillBodyExportSafetyTests.cs
@@ -1,0 +1,346 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using com.IvanMurzak.Godot.MCP.Tools;
+using com.IvanMurzak.McpPlugin;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Export-build safety for the C# samples embedded in <c>[AiSkillBody]</c> markdown.
+    ///
+    /// <para>
+    /// WHY THIS EXISTS: an <c>[AiSkillBody]</c> sample is a copy-me template — it is written into a
+    /// generated <c>SKILL.md</c> precisely so an AI agent reproduces it verbatim through
+    /// <c>godot-skill-create</c>. Godot compiles EVERY <c>.cs</c> under a project into ONE assembly, and
+    /// <c>EditorInterface</c> / <c>EditorPlugin</c> / <c>EditorFileSystem</c> / <c>EditorScript</c> exist
+    /// only in an editor build, so a sample that touches them without <c>#if TOOLS</c> hands the consumer
+    /// code that BREAKS THEIR EXPORT BUILD. That regression shipped once (the sample called
+    /// <c>EditorInterface</c> unguarded while its own prose, 20 lines further down, required the guard).
+    /// </para>
+    ///
+    /// <para>
+    /// The addon's own shipping sources are covered by <c>scripts/check-runtime-boundary.py</c> — but that
+    /// guard blanks string literals before it scans (otherwise the sample's own text would trip it), so a
+    /// sample living INSIDE a string is invisible to it by construction. This suite closes exactly that
+    /// hole: it reads each skill body's real runtime value by reflection, extracts the fenced C# blocks,
+    /// and applies the boundary rule to the sample code itself.
+    /// </para>
+    /// </summary>
+    public class SkillBodyExportSafetyTests
+    {
+        /// <summary>
+        /// Editor-only Godot APIs a sample must not use outside <c>#if TOOLS</c>. Kept identical to
+        /// <c>EDITOR_TOKENS</c> in <c>scripts/check-runtime-boundary.py</c> — one rule, two enforcement points.
+        /// </summary>
+        static readonly string[] EditorOnlyApis = { "EditorInterface", "EditorPlugin", "EditorFileSystem", "EditorScript" };
+
+        static readonly Regex EditorApiRe = new(@"\b(" + string.Join("|", EditorOnlyApis) + @")\b", RegexOptions.Compiled);
+
+        /// <summary>Fenced C# blocks inside a markdown body (```csharp / ```cs / ```c#).</summary>
+        static readonly Regex FenceRe = new(@"```(?:csharp|cs|c\#)\r?\n(.*?)```", RegexOptions.Singleline | RegexOptions.Compiled);
+
+        // ---------------------------------------------------------------------------------------------
+        // The checks
+        // ---------------------------------------------------------------------------------------------
+
+        [Fact]
+        public void EverySkillBodySample_GuardsEditorOnlyApisWithIfTools()
+        {
+            var bodies = SkillBodies();
+            Assert.True(bodies.Count > 0,
+                "No [AiSkillBody] methods were found by reflection — this suite would pass vacuously. " +
+                "Did the skill tools move out of the Godot-MCP.Tests compile set?");
+
+            var offenders = new List<string>();
+            var samplesSeen = 0;
+
+            foreach (var (owner, body) in bodies)
+            {
+                foreach (Match fence in FenceRe.Matches(body))
+                {
+                    samplesSeen++;
+                    foreach (var violation in FindUnguardedEditorApiUsages(fence.Groups[1].Value))
+                        offenders.Add($"{owner}: {violation}");
+                }
+            }
+
+            Assert.True(samplesSeen > 0,
+                "No fenced C# sample was found in any [AiSkillBody] — the scan matched nothing, so a " +
+                "regression could not be detected. Check the fence marker (```csharp).");
+
+            Assert.True(offenders.Count == 0,
+                "An [AiSkillBody] teaching sample uses an editor-only Godot API OUTSIDE `#if TOOLS`. " +
+                "Godot compiles every .cs into one assembly, so an agent copying the sample verbatim " +
+                "breaks the consumer's EXPORT build. Wrap the sample (and say why in its comments):\n  " +
+                string.Join("\n  ", offenders));
+        }
+
+        [Fact]
+        public void TheGodotSkillCreateSample_IsGuarded_AndSaysWhy()
+        {
+            // The specific sample the shipped regression was in — pinned by name so a rewrite that drops
+            // the guard fails here with an unambiguous message, and so the "explains why" half of the fix
+            // (a reader copying the template must understand the constraint) cannot be silently deleted.
+            var sample = Assert.Single(FenceRe.Matches(Tool_Skills.SkillsCreateSkillBody).Cast<Match>()).Groups[1].Value;
+
+            Assert.Contains("#if TOOLS", sample);
+            Assert.Contains("#endif", sample);
+            Assert.Empty(FindUnguardedEditorApiUsages(sample));
+
+            // The guard must be explained, not merely present: the sample is read by an agent that will
+            // decide whether its OWN new tool needs the guard.
+            var rationale = sample.Substring(0, sample.IndexOf("#if TOOLS", StringComparison.Ordinal));
+            Assert.Contains("export", rationale, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("TOOLS", rationale, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void EverySkillBodyInTheAddonIsReachableByThisSuite()
+        {
+            // Coverage guard. The scan above reflects over the sources Godot-MCP.Tests compiles, which is a
+            // CURATED SUBSET of the addon. A new [AiSkillBody] added to a file outside that subset would be
+            // invisible and this suite would keep reporting green — the same vacuous-gate failure mode the
+            // sample regression itself had. Count the declaration sites on disk and require a match.
+            var addonRoot = FindRepoDir("addons/godot_mcp");
+            Assert.True(addonRoot != null, "Could not locate addons/godot_mcp from the test assembly.");
+
+            var declaringFiles = Directory
+                .EnumerateFiles(addonRoot!, "*.cs", SearchOption.AllDirectories)
+                .Where(f => File.ReadAllText(f).Contains("[AiSkillBody("))
+                .OrderBy(f => f, StringComparer.Ordinal)
+                .ToList();
+
+            Assert.True(declaringFiles.Count > 0, "No [AiSkillBody(...)] declaration found in the addon sources.");
+            Assert.True(declaringFiles.Count == SkillBodies().Count,
+                $"The addon declares [AiSkillBody] in {declaringFiles.Count} file(s) but reflection found " +
+                $"{SkillBodies().Count} — some skill body is not compiled into Godot-MCP.Tests, so its sample " +
+                "is UNCHECKED. Add the file to Godot-MCP.Tests.csproj's <Compile Include> list:\n  " +
+                string.Join("\n  ", declaringFiles.Select(Path.GetFileName)));
+        }
+
+        [Fact]
+        public void TheAnalyzerIsNonVacuous_ItFlagsAnUnguardedSampleAndAcceptsTheGuardedOne()
+        {
+            // Negative control: the exact defect that shipped, as the analyzer sees it. Without this, a
+            // broken analyzer (wrong token list, wrong directive handling) would report a clean bill of
+            // health on genuinely unsafe samples.
+            const string unguarded =
+                "using Godot;\n" +
+                "public partial class Tool_Sample\n" +
+                "{\n" +
+                "    public void Run() => EditorInterface.Singleton.GetEditedSceneRoot();\n" +
+                "}\n";
+            Assert.NotEmpty(FindUnguardedEditorApiUsages(unguarded));
+
+            const string guarded =
+                "#if TOOLS\n" +
+                "using Godot;\n" +
+                "public partial class Tool_Sample\n" +
+                "{\n" +
+                "    public void Run() => EditorInterface.Singleton.GetEditedSceneRoot();\n" +
+                "}\n" +
+                "#endif\n";
+            Assert.Empty(FindUnguardedEditorApiUsages(guarded));
+
+            // The `#else` arm of an `#if TOOLS` is NOT the editor build — it must still be flagged.
+            const string elseArm =
+                "#if TOOLS\n" +
+                "// editor build\n" +
+                "#else\n" +
+                "public void Run() => EditorInterface.Singleton.GetEditedSceneRoot();\n" +
+                "#endif\n";
+            Assert.NotEmpty(FindUnguardedEditorApiUsages(elseArm));
+
+            // A mention in a comment or a string is prose, not a call — it must NOT be flagged, or the
+            // guard becomes noise and gets disabled. (The shipped sample's own rationale comment names
+            // EditorInterface, outside the guard, on purpose.)
+            const string proseOnly =
+                "// This sample drives EditorInterface, so the whole file is guarded.\n" +
+                "const string Hint = \"call EditorInterface.Singleton on the main thread\";\n";
+            Assert.Empty(FindUnguardedEditorApiUsages(proseOnly));
+        }
+
+        // ---------------------------------------------------------------------------------------------
+        // Helpers
+        // ---------------------------------------------------------------------------------------------
+
+        /// <summary>Every <c>[AiSkillBody]</c> value compiled into this test assembly, with its owner.</summary>
+        static List<(string Owner, string Body)> SkillBodies()
+        {
+            const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
+            var found = new List<(string, string)>();
+
+            foreach (var type in typeof(Tool_Skills).Assembly.GetTypes())
+            {
+                foreach (var method in type.GetMethods(flags))
+                {
+                    var attr = method.GetCustomAttribute<AiSkillBodyAttribute>();
+                    if (attr == null || string.IsNullOrWhiteSpace(attr.Body))
+                        continue;
+
+                    found.Add(($"{type.Name}.{method.Name}", attr.Body));
+                }
+            }
+
+            return found;
+        }
+
+        /// <summary>
+        /// Report every editor-only API token in <paramref name="sample"/> that is NOT inside an active
+        /// <c>#if TOOLS</c> region. Comments and string/char literals are blanked first (the same
+        /// discipline <c>scripts/check-runtime-boundary.py</c> uses) so prose naming an API is not a hit.
+        /// </summary>
+        static List<string> FindUnguardedEditorApiUsages(string sample)
+        {
+            var code = BlankNonCode(sample);
+            var violations = new List<string>();
+
+            // One frame per open `#if`; the value is "this arm is compiled only when TOOLS is defined".
+            var guards = new List<bool>();
+            var lines = code.Replace("\r\n", "\n").Split('\n');
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var trimmed = lines[i].TrimStart();
+
+                if (trimmed.StartsWith("#if", StringComparison.Ordinal))
+                {
+                    guards.Add(IsToolsCondition(trimmed));
+                    continue;
+                }
+                if (trimmed.StartsWith("#elif", StringComparison.Ordinal))
+                {
+                    if (guards.Count > 0) guards[guards.Count - 1] = IsToolsCondition(trimmed);
+                    continue;
+                }
+                if (trimmed.StartsWith("#else", StringComparison.Ordinal))
+                {
+                    // The complement of `#if TOOLS` is the NON-editor build — never guarded.
+                    if (guards.Count > 0) guards[guards.Count - 1] = false;
+                    continue;
+                }
+                if (trimmed.StartsWith("#endif", StringComparison.Ordinal))
+                {
+                    if (guards.Count > 0) guards.RemoveAt(guards.Count - 1);
+                    continue;
+                }
+
+                if (guards.Any(g => g))
+                    continue;
+
+                foreach (Match m in EditorApiRe.Matches(lines[i]))
+                    violations.Add($"line {i + 1}: unguarded `{m.Value}`");
+            }
+
+            return violations;
+        }
+
+        /// <summary>True when a <c>#if</c>/<c>#elif</c> directive compiles only where <c>TOOLS</c> is defined.</summary>
+        static bool IsToolsCondition(string directive)
+            => Regex.IsMatch(directive, @"\bTOOLS\b") && !Regex.IsMatch(directive, @"!\s*TOOLS\b");
+
+        /// <summary>
+        /// Replace comment and string/char-literal spans with spaces, preserving every newline so line
+        /// numbers and preprocessor-directive positions survive.
+        /// </summary>
+        static string BlankNonCode(string source)
+        {
+            var sb = new StringBuilder(source.Length);
+            var i = 0;
+
+            void Skip(Func<int, bool> isEnd, int endWidth)
+            {
+                while (i < source.Length && !isEnd(i))
+                {
+                    sb.Append(source[i] == '\n' ? '\n' : ' ');
+                    i++;
+                }
+                for (var k = 0; k < endWidth && i < source.Length; k++, i++)
+                    sb.Append(source[i] == '\n' ? '\n' : ' ');
+            }
+
+            while (i < source.Length)
+            {
+                var c = source[i];
+
+                if (c == '/' && i + 1 < source.Length && source[i + 1] == '/')
+                {
+                    Skip(k => source[k] == '\n', 0);
+                    continue;
+                }
+                if (c == '/' && i + 1 < source.Length && source[i + 1] == '*')
+                {
+                    sb.Append("  ");
+                    i += 2;
+                    Skip(k => k + 1 < source.Length && source[k] == '*' && source[k + 1] == '/', 2);
+                    continue;
+                }
+                if (c == '@' && i + 1 < source.Length && source[i + 1] == '"')
+                {
+                    sb.Append("  ");
+                    i += 2;
+                    // A verbatim string ends at a `"` that is not doubled.
+                    Skip(k => source[k] == '"' && (k + 1 >= source.Length || source[k + 1] != '"'), 1);
+                    continue;
+                }
+                if (c == '"' || c == '\'')
+                {
+                    var quote = c;
+                    sb.Append(' ');
+                    i++;
+                    while (i < source.Length && source[i] != quote)
+                    {
+                        if (source[i] == '\\' && i + 1 < source.Length)
+                        {
+                            sb.Append("  ");
+                            i += 2;
+                            continue;
+                        }
+                        sb.Append(source[i] == '\n' ? '\n' : ' ');
+                        i++;
+                    }
+                    if (i < source.Length) { sb.Append(' '); i++; }
+                    continue;
+                }
+
+                sb.Append(c);
+                i++;
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Walk up from the test assembly location to find a repo-relative directory, so the on-disk scan
+        /// does not depend on the runner's working directory. (Same walk as
+        /// <c>SystemToolsTests.FindRepoFile</c>.) Returns null when not found.
+        /// </summary>
+        static string? FindRepoDir(string relativePath)
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            for (var i = 0; i < 12 && dir != null; i++, dir = dir.Parent)
+            {
+                var candidate = Path.Combine(dir.FullName, relativePath.Replace('/', Path.DirectorySeparatorChar));
+                if (Directory.Exists(candidate))
+                    return candidate;
+            }
+            return null;
+        }
+    }
+}

--- a/Godot-MCP.Tests/SkillBodyExportSafetyTests.cs
+++ b/Godot-MCP.Tests/SkillBodyExportSafetyTests.cs
@@ -120,18 +120,25 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             var addonRoot = FindRepoDir("addons/godot_mcp");
             Assert.True(addonRoot != null, "Could not locate addons/godot_mcp from the test assembly.");
 
-            var declaringFiles = Directory
+            // Count DECLARATION SITES, not the files holding them: a single file may legitimately carry
+            // two `[AiSkillBody]` methods, and comparing a file count against a method count would then
+            // fail on a perfectly correct addition while still not proving reachability.
+            var declarationSites = Directory
                 .EnumerateFiles(addonRoot!, "*.cs", SearchOption.AllDirectories)
-                .Where(f => File.ReadAllText(f).Contains("[AiSkillBody("))
-                .OrderBy(f => f, StringComparer.Ordinal)
+                .Select(f => (File: f, Count: CountOccurrences(File.ReadAllText(f), "[AiSkillBody(")))
+                .Where(x => x.Count > 0)
+                .OrderBy(x => x.File, StringComparer.Ordinal)
                 .ToList();
 
-            Assert.True(declaringFiles.Count > 0, "No [AiSkillBody(...)] declaration found in the addon sources.");
-            Assert.True(declaringFiles.Count == SkillBodies().Count,
-                $"The addon declares [AiSkillBody] in {declaringFiles.Count} file(s) but reflection found " +
-                $"{SkillBodies().Count} — some skill body is not compiled into Godot-MCP.Tests, so its sample " +
+            var declaredCount = declarationSites.Sum(x => x.Count);
+            var reflectedCount = SkillBodies().Count;
+
+            Assert.True(declaredCount > 0, "No [AiSkillBody(...)] declaration found in the addon sources.");
+            Assert.True(declaredCount == reflectedCount,
+                $"The addon declares [AiSkillBody] {declaredCount} time(s) but reflection found " +
+                $"{reflectedCount} — some skill body is not compiled into Godot-MCP.Tests, so its sample " +
                 "is UNCHECKED. Add the file to Godot-MCP.Tests.csproj's <Compile Include> list:\n  " +
-                string.Join("\n  ", declaringFiles.Select(Path.GetFileName)));
+                string.Join("\n  ", declarationSites.Select(x => $"{Path.GetFileName(x.File)} (x{x.Count})")));
         }
 
         [Fact]
@@ -174,6 +181,57 @@ namespace com.IvanMurzak.Godot.MCP.Tests
                 "// This sample drives EditorInterface, so the whole file is guarded.\n" +
                 "const string Hint = \"call EditorInterface.Singleton on the main thread\";\n";
             Assert.Empty(FindUnguardedEditorApiUsages(proseOnly));
+        }
+
+        [Fact]
+        public void BlankingLiterals_HandlesEscapesWithoutLosingCodeOrLines()
+        {
+            // The blanking pass is the analyzer's foundation: get a literal's EXTENT wrong and every
+            // verdict after it is arbitrary. Two escape forms are the sharp edges.
+
+            // A verbatim string closes on a `"` that is NOT doubled; `""` is an escaped quote. Reading the
+            // second quote of a pair as the terminator spills the rest of the literal back into the scan as
+            // code (a spurious hit here) and then re-opens a string span that swallows whatever followed
+            // (a MISSED hit after it) — both directions of wrong, from one off-by-one.
+            const string verbatimWithEscapedQuotes =
+                "const string Doc = @\"say \"\"EditorInterface\"\" out loud\";\n" +
+                "public void Run() { }\n";
+            Assert.Empty(FindUnguardedEditorApiUsages(verbatimWithEscapedQuotes));
+
+            // Blanking must never destroy a newline, or the directive tracker reads the following line as
+            // part of this one and loses the `#if TOOLS` that guards it.
+            const string escapeAtLineEnd =
+                "const string S = \"trailing backslash \\\n" +
+                "#if TOOLS\n" +
+                "public void Run() => EditorInterface.Singleton.GetEditedSceneRoot();\n" +
+                "#endif\n";
+            Assert.Equal(
+                escapeAtLineEnd.Count(ch => ch == '\n'),
+                BlankNonCode(escapeAtLineEnd).Count(ch => ch == '\n'));
+        }
+
+        [Fact]
+        public void TheEditorApiTokenList_StaysInLockstepWithTheRuntimeBoundaryGuard()
+        {
+            // ONE rule, two enforcement points: `scripts/check-runtime-boundary.py` covers the addon's
+            // shipping sources, this suite covers the teaching samples living inside string literals (which
+            // that guard blanks by construction). Nothing but a comment links the two token lists, so a
+            // token added on one side would silently stop being enforced on the other — exactly the
+            // quietly-decaying gate this PR exists to eliminate. Make the drift a red test instead.
+            var guardPath = FindRepoFile("scripts/check-runtime-boundary.py");
+            Assert.True(guardPath != null, "Could not locate scripts/check-runtime-boundary.py from the test assembly.");
+
+            var declaration = Regex.Match(File.ReadAllText(guardPath!), @"EDITOR_TOKENS\s*=\s*\(([^)]*)\)");
+            Assert.True(declaration.Success, "Could not parse EDITOR_TOKENS from scripts/check-runtime-boundary.py.");
+
+            var pythonTokens = Regex.Matches(declaration.Groups[1].Value, "\"([^\"]+)\"")
+                .Cast<Match>()
+                .Select(m => m.Groups[1].Value)
+                .OrderBy(t => t, StringComparer.Ordinal)
+                .ToArray();
+
+            Assert.NotEmpty(pythonTokens);
+            Assert.Equal(EditorOnlyApis.OrderBy(t => t, StringComparer.Ordinal).ToArray(), pythonTokens);
         }
 
         // ---------------------------------------------------------------------------------------------
@@ -295,8 +353,27 @@ namespace com.IvanMurzak.Godot.MCP.Tests
                 {
                     sb.Append("  ");
                     i += 2;
-                    // A verbatim string ends at a `"` that is not doubled.
-                    Skip(k => source[k] == '"' && (k + 1 >= source.Length || source[k + 1] != '"'), 1);
+                    // A verbatim string ends at a `"` that is not doubled. `""` is an ESCAPED quote and
+                    // must be consumed as a PAIR — testing "is this quote followed by another?" alone
+                    // mis-reads the SECOND quote of a pair as the terminator, which leaks the rest of the
+                    // literal back into the scan as if it were code.
+                    while (i < source.Length)
+                    {
+                        if (source[i] == '"')
+                        {
+                            if (i + 1 < source.Length && source[i + 1] == '"')
+                            {
+                                sb.Append("  ");
+                                i += 2;
+                                continue;
+                            }
+                            sb.Append(' ');
+                            i++;
+                            break;
+                        }
+                        sb.Append(source[i] == '\n' ? '\n' : ' ');
+                        i++;
+                    }
                     continue;
                 }
                 if (c == '"' || c == '\'')
@@ -308,7 +385,12 @@ namespace com.IvanMurzak.Godot.MCP.Tests
                     {
                         if (source[i] == '\\' && i + 1 < source.Length)
                         {
-                            sb.Append("  ");
+                            // Blank the escape PAIR, but never a newline: this method's whole contract is
+                            // that line numbers and directive positions survive blanking, and swallowing a
+                            // `\` + newline would merge the next line into this one — hiding an `#if TOOLS`
+                            // or `#endif` from the region tracker.
+                            sb.Append(' ');
+                            sb.Append(source[i + 1] == '\n' ? '\n' : ' ');
                             i += 2;
                             continue;
                         }
@@ -326,21 +408,39 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             return sb.ToString();
         }
 
+        /// <summary>Number of non-overlapping occurrences of <paramref name="needle"/> in <paramref name="haystack"/>.</summary>
+        static int CountOccurrences(string haystack, string needle)
+        {
+            var count = 0;
+            for (var at = haystack.IndexOf(needle, StringComparison.Ordinal); at >= 0;
+                 at = haystack.IndexOf(needle, at + needle.Length, StringComparison.Ordinal))
+            {
+                count++;
+            }
+            return count;
+        }
+
         /// <summary>
-        /// Walk up from the test assembly location to find a repo-relative directory, so the on-disk scan
-        /// does not depend on the runner's working directory. (Same walk as
+        /// Walk up from the test assembly location to find a repo-relative path, so the on-disk scans do
+        /// not depend on the runner's working directory. (Same walk as
         /// <c>SystemToolsTests.FindRepoFile</c>.) Returns null when not found.
         /// </summary>
-        static string? FindRepoDir(string relativePath)
+        static string? FindRepoEntry(string relativePath, Func<string, bool> exists)
         {
             var dir = new DirectoryInfo(AppContext.BaseDirectory);
             for (var i = 0; i < 12 && dir != null; i++, dir = dir.Parent)
             {
                 var candidate = Path.Combine(dir.FullName, relativePath.Replace('/', Path.DirectorySeparatorChar));
-                if (Directory.Exists(candidate))
+                if (exists(candidate))
                     return candidate;
             }
             return null;
         }
+
+        /// <summary>Repo-relative directory lookup. Returns null when not found.</summary>
+        static string? FindRepoDir(string relativePath) => FindRepoEntry(relativePath, Directory.Exists);
+
+        /// <summary>Repo-relative file lookup. Returns null when not found.</summary>
+        static string? FindRepoFile(string relativePath) => FindRepoEntry(relativePath, File.Exists);
     }
 }

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Add both `PackageReference`s **and** the extension-catalog `<EmbeddedResource>` 
 ```xml
 <ItemGroup>
   <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.2" />
-  <PackageReference Include="com.IvanMurzak.McpPlugin"   Version="7.1.1" />
+  <PackageReference Include="com.IvanMurzak.McpPlugin"   Version="7.3.0" />
 </ItemGroup>
 
 <!-- Embed the extension catalog so the Extensions panel populates (else it is EMPTY). -->
@@ -326,7 +326,7 @@ Add both `PackageReference`s **and** the extension-catalog `<EmbeddedResource>` 
 | Package | Version | Role |
 | --- | --- | --- |
 | [`com.IvanMurzak.ReflectorNet`](https://www.nuget.org/packages/com.IvanMurzak.ReflectorNet) | `5.3.2` | Reflection / serialization core |
-| [`com.IvanMurzak.McpPlugin`](https://www.nuget.org/packages/com.IvanMurzak.McpPlugin) | `7.1.1` | MCP plugin client (transitively pulls `McpPlugin.Common` + `ReflectorNet`; carries the shared `AgentConfig` module) |
+| [`com.IvanMurzak.McpPlugin`](https://www.nuget.org/packages/com.IvanMurzak.McpPlugin) | `7.3.0` | MCP plugin client (transitively pulls `McpPlugin.Common` + `ReflectorNet`; carries the shared `AgentConfig` module) |
 
 The `<EmbeddedResource>` is **as required as the NuGet pins**: the addon's pure-managed extension
 registry reads the catalog at editor runtime via `GetManifestResourceStream` (no `res://` / filesystem

--- a/cli/src/utils/skills.ts
+++ b/cli/src/utils/skills.ts
@@ -455,12 +455,50 @@ export function addonToolDirs(repoRoot: string): string[] {
 }
 
 /**
+ * Every addon `.cs` file under {@link addonToolDirs}, **recursively**.
+ *
+ * The scan used to be a flat `readdirSync` over the two `Tools/` folders, which made
+ * any tool family placed in a SUBFOLDER (the Unity-MCP `API/SystemTool/` layout, and
+ * the natural thing to reach for as the family list grows) invisible to both parity
+ * checks below. That did not fail the gate — it made it pass VACUOUSLY at the stale
+ * counts, which is strictly worse than no gate at all. Discovery is therefore
+ * recursive, and nesting is a free organisational choice again.
+ *
+ * Implemented as an explicit walk rather than `readdirSync(dir, { recursive: true })`
+ * so the behaviour is identical on every Node version this package supports
+ * (`^20.19.0 || >=22.12.0`) — the `withFileTypes` + `recursive` combination reports
+ * the parent directory through differently-named properties across those releases.
+ * Returns absolute paths sorted for deterministic ordering.
+ */
+export function addonToolFiles(repoRoot: string): string[] {
+  const files: string[] = [];
+
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile() && entry.name.endsWith('.cs')) files.push(full);
+    }
+  };
+
+  for (const dir of addonToolDirs(repoRoot)) {
+    if (!fs.existsSync(dir)) continue;
+    walk(dir);
+  }
+
+  return files.sort();
+}
+
+/**
  * Addon side of the parity check: discover every tool family declared in the addon
  * by scanning for `[AiToolType] ... partial class Tool_<Family>` in the `.cs` sources
  * under the addon `Tools/` directories. Returns the sorted set of `<Family>` suffixes
  * (e.g. `Node`, `FileSystem`, `RuntimeErrors`).
  *
  * Robustness notes:
+ * - The source scan is RECURSIVE (see {@link addonToolFiles}), so a family in a
+ *   subfolder of `{Runtime,Editor}/Tools/` is discovered rather than silently
+ *   skipped — a skipped family made the parity assertions pass vacuously.
  * - Tool families are partial classes split across files (`Tool_RuntimeErrors.cs`,
  *   `Tool_RuntimeErrors.Get.cs`, `Tool_RuntimeErrors.Clear.cs`). Only the base file
  *   carries the `[AiToolType]` attribute, so keying on `[AiToolType]` (not on file
@@ -490,18 +528,14 @@ export function discoverAddonToolFamilies(repoRoot: string): string[] {
     /\[AiToolType[^\]]*\](?:(?!\b(?:class|struct|interface|enum|record)\b)[\s\S])*?\bpartial\s+class\s+Tool_([A-Za-z][A-Za-z0-9]*(?:_[A-Za-z][A-Za-z0-9]*)*)\b/g;
   const found = new Set<string>();
 
-  for (const dir of addonToolDirs(repoRoot)) {
-    if (!fs.existsSync(dir)) continue;
-    for (const entry of fs.readdirSync(dir)) {
-      if (!entry.endsWith('.cs')) continue;
-      const src = readAddonCode(path.join(dir, entry), /* blankStrings */ true);
-      let m: RegExpExecArray | null;
-      familyRe.lastIndex = 0;
-      while ((m = familyRe.exec(src)) !== null) {
-        // Attribute a compound sub-tool class (`Tool_Editor_Selection`) to its
-        // parent family by taking the FIRST `_`-delimited segment (`Editor`).
-        found.add(m[1].split('_')[0]);
-      }
+  for (const file of addonToolFiles(repoRoot)) {
+    const src = readAddonCode(file, /* blankStrings */ true);
+    let m: RegExpExecArray | null;
+    familyRe.lastIndex = 0;
+    while ((m = familyRe.exec(src)) !== null) {
+      // Attribute a compound sub-tool class (`Tool_Editor_Selection`) to its
+      // parent family by taking the FIRST `_`-delimited segment (`Editor`).
+      found.add(m[1].split('_')[0]);
     }
   }
 
@@ -539,16 +573,12 @@ export function discoverAddonToolIds(repoRoot: string): string[] {
   const toolIdRe = /public\s+const\s+string\s+\w+ToolId\s*=\s*"([a-z][a-z0-9-]*)"/g;
   const found = new Set<string>();
 
-  for (const dir of addonToolDirs(repoRoot)) {
-    if (!fs.existsSync(dir)) continue;
-    for (const entry of fs.readdirSync(dir)) {
-      if (!entry.endsWith('.cs')) continue;
-      const src = readAddonCode(path.join(dir, entry), /* blankStrings */ false);
-      let m: RegExpExecArray | null;
-      toolIdRe.lastIndex = 0;
-      while ((m = toolIdRe.exec(src)) !== null) {
-        found.add(m[1]);
-      }
+  for (const file of addonToolFiles(repoRoot)) {
+    const src = readAddonCode(file, /* blankStrings */ false);
+    let m: RegExpExecArray | null;
+    toolIdRe.lastIndex = 0;
+    while ((m = toolIdRe.exec(src)) !== null) {
+      found.add(m[1]);
     }
   }
 

--- a/cli/tests/helpers/cli.ts
+++ b/cli/tests/helpers/cli.ts
@@ -4,17 +4,26 @@
 import * as path from 'path';
 import { spawn } from 'child_process';
 import { fileURLToPath } from 'url';
+import { CLI_SPAWN_TIMEOUT_MS } from './timeouts.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const CLI_PATH = path.resolve(__dirname, '..', '..', 'bin', 'godot-cli.js');
 
-/** Run the CLI as a child process with timeout and error handling. */
+/**
+ * Run the CLI as a child process with timeout and error handling.
+ *
+ * The internal budget is {@link CLI_SPAWN_TIMEOUT_MS}, deliberately kept BELOW the
+ * suite's per-test timeout so a stalled child is reported by this guard (with its
+ * captured output) instead of by an opaque `Test timed out` from the runner. It used
+ * to be 30 s against a 5 s test timeout, which made it unreachable — see
+ * `tests/helpers/timeouts.ts`.
+ */
 export function runCliAsync(args: string[], cwd?: string): Promise<{ stdout: string; exitCode: number }> {
   return new Promise((resolve) => {
     const child = spawn('node', [CLI_PATH, ...args], { stdio: 'pipe', cwd });
     let stdout = '';
     let settled = false;
-    const timeoutMs = 30000;
+    const timeoutMs = CLI_SPAWN_TIMEOUT_MS;
 
     const timeout = setTimeout(() => {
       if (settled) return;

--- a/cli/tests/helpers/timeouts.ts
+++ b/cli/tests/helpers/timeouts.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+/**
+ * Timeout budgets for the `cli/` vitest suite — the single source of truth shared by
+ * `vitest.config.ts` and by every helper that waits on something.
+ *
+ * ## Why this file exists
+ *
+ * 17 of the suite's ~48 test files spawn a REAL `node` child process (the CLI itself,
+ * or a sleeper used to probe process signalling), and vitest runs those files in
+ * parallel. Under that load a spawn+exit round trip routinely takes several seconds
+ * on a busy machine.
+ *
+ * The suite used to run on vitest's DEFAULT 5 s per-test timeout while its own internal
+ * waits were budgeted far higher — `runCliAsync` gave a child 30 s, and
+ * `godot-shutdown.test.ts` awaits `waitForExit(pid, 5000..8000)`. An inner budget that
+ * meets or exceeds the outer test timeout can never actually fire: vitest kills the
+ * test first, so the failure surfaces as a bare `Test timed out in 5000ms` with no
+ * diagnostic, and it surfaces INTERMITTENTLY because it depends on machine load. That
+ * is what made the suite flaky (observed locally: 4 of 5 consecutive full runs red,
+ * 1-5 failures each, all `Test timed out in 5000ms`, every one of them green in
+ * isolation).
+ *
+ * ## The invariant
+ *
+ * `CLI_SPAWN_TIMEOUT_MS < TEST_TIMEOUT_MS` — every internal wait budget must be
+ * strictly smaller than the test timeout that contains it, so the inner guard fires
+ * first and reports WHAT stalled instead of the runner reporting THAT something did.
+ * `tests/test-timeout-budget.test.ts` enforces it, so a future edit that raises a
+ * helper budget past the test timeout fails CI instead of re-introducing the flake.
+ */
+
+/**
+ * Per-test timeout for the whole suite (`vitest.config.ts` → `test.testTimeout`).
+ * Sized to dominate {@link CLI_SPAWN_TIMEOUT_MS} with headroom; the full suite still
+ * completes in ~13 s wall-clock because the budget is only consumed on a real stall.
+ */
+export const TEST_TIMEOUT_MS = 30_000;
+
+/** Per-hook timeout (`vitest.config.ts` → `test.hookTimeout`); hooks here are fs setup/teardown. */
+export const HOOK_TIMEOUT_MS = 30_000;
+
+/**
+ * How long `tests/helpers/cli.ts` lets a spawned `godot-cli` child run before it kills
+ * it and resolves with a `[runCliAsync] Process timed out.` marker in the captured
+ * output. MUST stay strictly below {@link TEST_TIMEOUT_MS}.
+ */
+export const CLI_SPAWN_TIMEOUT_MS = 20_000;

--- a/cli/tests/skills-addon-parity.test.ts
+++ b/cli/tests/skills-addon-parity.test.ts
@@ -355,18 +355,22 @@ describe('docs single-source: counts + McpPlugin version derive from addon sourc
   const PIN_DOCS = ['README.md', 'CLAUDE.md', 'docs/ARCHITECTURE.md', 'docs/RELEASING.md'];
   const PINNED_PACKAGES = ['com.IvanMurzak.ReflectorNet', 'com.IvanMurzak.McpPlugin'];
 
+  /** Escape a literal package id so it cannot act as a regex pattern (`.` above all). */
+  function reEscape(literal: string): string {
+    return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
   /** The version `Godot-MCP.csproj` pins for `packageId` — the single source of truth. */
   function csprojPin(packageId: string): string {
     const csproj = readRepoFile('Godot-MCP.csproj');
-    const shortName = packageId.replace('com.IvanMurzak.', '');
-    const m = csproj.match(new RegExp(`${shortName}"\\s+Version="([^"]+)"`));
+    const m = csproj.match(new RegExp(`${reEscape(packageId)}"\\s+Version="([^"]+)"`));
     expect(m, `Godot-MCP.csproj must declare a ${packageId} PackageReference`).not.toBeNull();
     return m![1];
   }
 
   /** Every version literal stated on a line that names `packageId`, with line numbers. */
   function statedVersions(text: string, packageId: string): { line: number; version: string }[] {
-    const idRe = new RegExp(`${packageId.replace(/\./g, '\\.')}(?!\\.)`);
+    const idRe = new RegExp(`${reEscape(packageId)}(?!\\.)`);
     const semverRe = /\b\d+\.\d+\.\d+(?:[-.][A-Za-z0-9.]+)?\b/g;
     const hits: { line: number; version: string }[] = [];
 

--- a/cli/tests/skills-addon-parity.test.ts
+++ b/cli/tests/skills-addon-parity.test.ts
@@ -75,12 +75,14 @@ describe('skills.ts ⇄ addon tool-family parity (CI cross-check)', () => {
     });
 
     // Write a synthetic addon tree under a temp repo root so we can probe discovery on
-    // hand-crafted edge cases without depending on the real addon source.
-    function writeSyntheticAddon(fileName: string, contents: string): string {
+    // hand-crafted edge cases without depending on the real addon source. `relPath` is
+    // resolved UNDER `Runtime/Tools/` and may contain sub-directories.
+    function writeSyntheticAddon(relPath: string, contents: string): string {
       tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'godot-mcp-parity-'));
       const runtimeDir = addonToolDirs(tmpRoot)[0]; // .../Runtime/Tools
-      fs.mkdirSync(runtimeDir, { recursive: true });
-      fs.writeFileSync(path.join(runtimeDir, fileName), contents, 'utf-8');
+      const target = path.join(runtimeDir, relPath);
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, contents, 'utf-8');
       return tmpRoot;
     }
 
@@ -127,6 +129,44 @@ describe('skills.ts ⇄ addon tool-family parity (CI cross-check)', () => {
       // The id scan KEEPS string literals (it matches the quoted id), so it relies on comment
       // stripping alone — the commented-out id must not be discovered, the real one must.
       expect(discoverAddonToolIds(root)).toEqual(['real-tool']);
+    });
+
+    it('discovers a tool family nested in a SUBFOLDER of Tools/ (the vacuous-parity trap)', () => {
+      // Discovery used to be a NON-recursive `readdirSync`, so a family placed in a
+      // subfolder of `{Runtime,Editor}/Tools/` — the layout Unity-MCP uses
+      // (`API/SystemTool/`) and the obvious thing to reach for as the addon grows —
+      // was INVISIBLE. The parity assertions then passed at STALE counts instead of
+      // failing: the gate silently stopped protecting the catalog the moment anyone
+      // nested a file. This fixture fails against the non-recursive scan.
+      const root = writeSyntheticAddon(
+        path.join('SystemTool', 'Nested', 'Tool_Nested.cs'),
+        '[AiToolType]\n    public partial class Tool_Nested\n    {\n' +
+          '        public const string NestedRunToolId = "nested-run";\n' +
+          '    }\n',
+      );
+      expect(discoverAddonToolFamilies(root)).toEqual(['Nested']);
+      expect(discoverAddonToolIds(root)).toEqual(['nested-run']);
+    });
+
+    it('discovers families/ids from BOTH a top-level file and a nested one (no shadowing)', () => {
+      // Recursion must ADD the nested family, not replace the flat scan.
+      const root = writeSyntheticAddon(
+        'Tool_Flat.cs',
+        '[AiToolType]\n    public partial class Tool_Flat\n    {\n' +
+          '        public const string FlatGoToolId = "flat-go";\n' +
+          '    }\n',
+      );
+      const nestedDir = path.join(addonToolDirs(root)[0], 'Sub', 'Deeper');
+      fs.mkdirSync(nestedDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(nestedDir, 'Tool_Deep.Run.cs'),
+        '[AiToolType]\n    public partial class Tool_Deep\n    {\n' +
+          '        public const string DeepRunToolId = "deep-run";\n' +
+          '    }\n',
+        'utf-8',
+      );
+      expect(discoverAddonToolFamilies(root)).toEqual(['Deep', 'Flat']);
+      expect(discoverAddonToolIds(root)).toEqual(['deep-run', 'flat-go']);
     });
 
     it('does not misattribute a stray [AiToolType] on a non-Tool_ type to a later Tool_ class', () => {
@@ -299,4 +339,67 @@ describe('docs single-source: counts + McpPlugin version derive from addon sourc
       ).toBe(true);
     }
   });
+
+  // The adjacency assert above covers ONLY the two Asset Library surfaces. The pin is
+  // restated in four more consumer-facing docs, and none of them was gated — which is
+  // exactly how `README.md` and `CLAUDE.md` shipped a stale `7.1.1` while the csproj
+  // had moved to `7.3.0`. This block closes that hole for BOTH reused packages.
+  //
+  // Rule: on any LINE that names a reused package by its FULL id, every semantic
+  // version on that line must equal the csproj pin. Line-scoping is what makes the
+  // check precise — it never reaches across to an unrelated number, and it ignores
+  // the many prose/`using`/URL mentions that carry no version at all. The full-id
+  // requirement (plus a `(?!\.)` guard) skips sub-packages (`McpPlugin.Common`,
+  // `ReflectorNet.Utils`) and bare-name prose such as the historical
+  // `'ReflectorNet, Version=5.3.1.0'` exception text in CLAUDE.md.
+  const PIN_DOCS = ['README.md', 'CLAUDE.md', 'docs/ARCHITECTURE.md', 'docs/RELEASING.md'];
+  const PINNED_PACKAGES = ['com.IvanMurzak.ReflectorNet', 'com.IvanMurzak.McpPlugin'];
+
+  /** The version `Godot-MCP.csproj` pins for `packageId` — the single source of truth. */
+  function csprojPin(packageId: string): string {
+    const csproj = readRepoFile('Godot-MCP.csproj');
+    const shortName = packageId.replace('com.IvanMurzak.', '');
+    const m = csproj.match(new RegExp(`${shortName}"\\s+Version="([^"]+)"`));
+    expect(m, `Godot-MCP.csproj must declare a ${packageId} PackageReference`).not.toBeNull();
+    return m![1];
+  }
+
+  /** Every version literal stated on a line that names `packageId`, with line numbers. */
+  function statedVersions(text: string, packageId: string): { line: number; version: string }[] {
+    const idRe = new RegExp(`${packageId.replace(/\./g, '\\.')}(?!\\.)`);
+    const semverRe = /\b\d+\.\d+\.\d+(?:[-.][A-Za-z0-9.]+)?\b/g;
+    const hits: { line: number; version: string }[] = [];
+
+    text.split(/\r?\n/).forEach((line, i) => {
+      if (!idRe.test(line)) return;
+      for (const m of line.matchAll(semverRe)) hits.push({ line: i + 1, version: m[0] });
+    });
+    return hits;
+  }
+
+  it('the pin-parity scan is non-vacuous (it finds a stated version in every gated doc)', () => {
+    // Without this, a doc that stops mentioning the packages — or a regex that stops
+    // matching — would make every assertion below pass by finding nothing.
+    for (const rel of PIN_DOCS) {
+      const text = readRepoFile(rel);
+      const all = PINNED_PACKAGES.flatMap((pkg) => statedVersions(text, pkg));
+      expect(all.length, `${rel} should state at least one reused-package version`).toBeGreaterThan(0);
+    }
+  });
+
+  for (const packageId of PINNED_PACKAGES) {
+    for (const rel of PIN_DOCS) {
+      it(`${rel} states the csproj-pinned ${packageId} version`, () => {
+        const expected = csprojPin(packageId);
+        const stated = statedVersions(readRepoFile(rel), packageId);
+        const stale = stated.filter((s) => s.version !== expected);
+        expect(
+          stale,
+          `${rel} states ${packageId} version(s) that disagree with Godot-MCP.csproj's pin ` +
+            `(${expected}): ${stale.map((s) => `line ${s.line}: ${s.version}`).join(', ')}. ` +
+            `The csproj is the single source of truth — update the doc, never the pin.`,
+        ).toEqual([]);
+      });
+    }
+  }
 });

--- a/cli/tests/test-timeout-budget.test.ts
+++ b/cli/tests/test-timeout-budget.test.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+// Guards the suite's timeout budget invariant. The `cli/` suite was intermittently red
+// under parallel load with bare `Test timed out in 5000ms` failures that every affected
+// test passed in isolation: 17 test files spawn REAL `node` child processes, while
+// vitest's DEFAULT 5 s per-test timeout sat BELOW the suite's own internal wait budgets
+// (`runCliAsync` allowed a child 30 s). An inner budget that meets or exceeds the outer
+// test timeout can never fire — the runner kills the test first and reports nothing
+// useful, intermittently, as a function of machine load.
+//
+// These asserts keep the ordering intact, so a future edit that raises a helper budget
+// (or lowers the test timeout) fails CI here instead of re-introducing the flake.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { TEST_TIMEOUT_MS, HOOK_TIMEOUT_MS, CLI_SPAWN_TIMEOUT_MS } from './helpers/timeouts.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI_ROOT = path.resolve(__dirname, '..');
+
+describe('vitest timeout budgets', () => {
+  it('every internal wait budget is strictly below the per-test timeout', () => {
+    expect(
+      CLI_SPAWN_TIMEOUT_MS,
+      'runCliAsync must be able to kill a stalled child and report it BEFORE vitest ' +
+        'kills the test — otherwise the failure is an opaque "Test timed out".',
+    ).toBeLessThan(TEST_TIMEOUT_MS);
+  });
+
+  it('the per-test timeout leaves real headroom over a spawn round trip', () => {
+    // A CLI smoke test costs ~1.5-3.5 s of spawn time on an idle machine; the observed
+    // flaky failures overshot 5 s. Anything below ~15 s is back in flake territory.
+    expect(TEST_TIMEOUT_MS).toBeGreaterThanOrEqual(15_000);
+    expect(HOOK_TIMEOUT_MS).toBeGreaterThanOrEqual(10_000);
+  });
+
+  it('vitest.config.ts actually wires the shared budgets (they are not dead constants)', () => {
+    // Source-text check rather than importing the config: importing it would pull vite
+    // into the worker for no gain. Same technique the addon-parity suite uses to pin a
+    // value against its real declaration site.
+    const config = fs.readFileSync(path.join(CLI_ROOT, 'vitest.config.ts'), 'utf-8');
+    expect(config).toMatch(/testTimeout:\s*TEST_TIMEOUT_MS/);
+    expect(config).toMatch(/hookTimeout:\s*HOOK_TIMEOUT_MS/);
+    expect(config).toMatch(/from\s+'\.\/tests\/helpers\/timeouts\.js'/);
+  });
+
+  it('the CLI spawn helper consumes the shared budget rather than a local literal', () => {
+    const helper = fs.readFileSync(path.join(CLI_ROOT, 'tests', 'helpers', 'cli.ts'), 'utf-8');
+    expect(helper).toMatch(/const\s+timeoutMs\s*=\s*CLI_SPAWN_TIMEOUT_MS/);
+  });
+});

--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import { defineConfig } from 'vitest/config';
+import { TEST_TIMEOUT_MS, HOOK_TIMEOUT_MS } from './tests/helpers/timeouts.js';
+
+// The suite spawns real `node` child processes in 17 of its test files and runs those
+// files in PARALLEL, so vitest's default 5 s per-test timeout sat BELOW the suite's own
+// internal wait budgets and fired first under load — an intermittent `Test timed out in
+// 5000ms` that always passed in isolation. See `tests/helpers/timeouts.ts` for the full
+// rationale and the budget invariant (`tests/test-timeout-budget.test.ts` enforces it).
+//
+// Nothing else is configured here: `npm test` (`vitest run`) and CI's
+// `npm test -- --coverage` keep vitest's defaults for discovery, pooling and coverage.
+export default defineConfig({
+  test: {
+    testTimeout: TEST_TIMEOUT_MS,
+    hookTimeout: HOOK_TIMEOUT_MS,
+  },
+});


### PR DESCRIPTION
## Summary

Four follow-ups from #316. Three of them are the same failure mode: **a gate that is green while protecting nothing.**

- **Recursive tool discovery.** `discoverAddonToolFamilies` / `discoverAddonToolIds` scanned with a flat `fs.readdirSync`, so a family in a SUBFOLDER of `addons/godot_mcp/{Runtime,Editor}/Tools/` was invisible and the addon⇄CLI parity assertions passed at the STALE counts. New `addonToolFiles()` walks both trees depth-first. Two nested fixtures were written FIRST and confirmed red against the flat scan (`expected [] to deeply equal [ 'Nested' ]`), green after.
- **Export-safety check for `[AiSkillBody]` teaching samples.** New `Godot-MCP.Tests/SkillBodyExportSafetyTests` reads every skill body's real runtime value by reflection, extracts the fenced C# blocks, blanks comments/strings, and fails on any `EditorInterface` / `EditorPlugin` / `EditorFileSystem` / `EditorScript` outside an active `#if TOOLS` (same token list as `scripts/check-runtime-boundary.py`).
- **`cli/` vitest timeout budget.** The suite was intermittently red under parallel load with bare `Test timed out in 5000ms`.
- **Stale pin doc + a gate for it.** `README.md` and `CLAUDE.md` stated McpPlugin `7.1.1` while `Godot-MCP.csproj` pins `7.3.0`.

## ⚠ Where ground truth disagreed with the task brief

The brief flagged item 1 as a **live defect on `main`**. **It is not** — verify before reading further:

- `addons/godot_mcp/Runtime/Tools/Tool_Skills.Create.SkillBody.cs` on `main` (`90f4f19`) already wraps the whole sample in `#if TOOLS ... #endif` and already carries a four-line comment explaining that Godot compiles every `.cs` into one assembly so an unguarded copy fails an export build. It was fixed inside #316 itself, in the late-review commit `e6dcf20`, before the squash — the PR body records it.
- **This PR therefore changes no addon source at all.** `git diff` for that file is empty; the DoD item "sample is `#if TOOLS`-guarded and explains why" was already satisfied.
- What was genuinely missing is the *"consider an automated check"* half, and it was missing for a structural reason worth recording: `scripts/check-runtime-boundary.py` **blanks string literals before scanning** (it must — otherwise the sample's own text trips it), so a teaching sample living inside a string is invisible to the addon's boundary guard **by construction**. That is why the defect could ship past a green boundary job. The new xUnit suite covers exactly that blind spot.
- Proof it is not vacuous: deleting the `#if TOOLS` line from the shipped sample makes it fail with `Tool_Skills.Create: line 34: unguarded EditorInterface` (verified locally, then reverted).

Two further findings the brief did not name:

- **The stale `7.1.1` was in `README.md` too**, not only `CLAUDE.md` — twice (the consumer-install snippet and the dependency table). The reason both survived is that the existing pin assertion only covered `.github/assetlib/edit.hbs` and `docs/assetlib/SUBMISSION.md`. The gate is now extended to `README.md`, `CLAUDE.md`, `docs/ARCHITECTURE.md` and `docs/RELEASING.md`: on any line naming a reused package by its full id, every version literal on that line must equal the csproj pin. Proven non-vacuous by planting `7.1.1` back into `README.md` (`line 317: 7.1.1 ... disagree with Godot-MCP.csproj's pin (7.3.0)`), then reverting.
- **`ResolveLocalServerBindPort_LoopbackExplicitPort_MatchesTheWrittenConfigPort` was still `[Fact(Skip = ...)]`** with the instruction *"un-skip it with the pin bump"* and the condition *"McpPlugin >= 7.3.0 (#304)"*. The csproj already satisfies it. Un-skipped; it passes.

## The vitest flake — root cause, not a load excuse

Reproduced before touching anything: **4 of 5 consecutive full runs red**, 1-5 failures each, all `Test timed out in 5000ms`, every one green in isolation.

The cause is a budget inversion, not slow hardware. 17 of the 49 test files spawn a real `node` child process and vitest runs them in parallel, but the suite ran on vitest's **default 5 s** per-test timeout while its own internal waits were budgeted far higher — `tests/helpers/cli.ts` gave a spawned CLI **30 s**, and `godot-shutdown.test.ts` awaits `waitForExit(pid, 5000..8000)`. An inner budget that meets or exceeds the outer timeout can never fire: the runner kills the test first, so the failure is opaque *and* intermittent as a function of machine load.

Fix: `cli/vitest.config.ts` sets `testTimeout` / `hookTimeout` from a single source (`tests/helpers/timeouts.ts`), the CLI helper's budget drops below it so a stalled child reports itself with its captured output, and `tests/test-timeout-budget.test.ts` enforces the ordering so a future edit that re-inverts it fails CI.

Result: **6/6 clean sequential full runs, then 3 concurrent full runs (3x parallel load) all green** — 49 files, 535 passed / 1 skipped.

## Deliberately NOT changed

- **`engines/godot/test-project/` (the software-repo testbed) still pins McpPlugin `7.2.0` while this addon pins `7.3.0`.** Pre-existing drift, not introduced here — this PR bumps no pin. It is out of the task's stated `engines/godot/Godot-MCP` scope, it is invisible to every Godot-MCP CI leg, and it is why the local headless-editor smoke is currently infeasible. Flagged for a separate testbed-lockstep task.
- The software repo's root `CLAUDE.md` describes those testbed pins as ReflectorNet `5.3.1` / McpPlugin `6.11.0`; the testbed csproj actually says `5.3.2` / `7.2.0`. Also out of scope, also reported.
- No CHANGELOG entry: `cli/src/utils/skills.ts` is not re-exported from `cli/src/lib.ts`, so nothing here changes the published CLI surface or any command's behavior.

## Test plan

- [x] Suite 1 — `dotnet build Godot-MCP.sln -c Debug`: **0 errors, 0 warnings**.
- [x] Suite 2 — `dotnet test Godot-MCP.Tests`: **1162 passed / 0 failed** (1157 before: +4 export-safety, +1 un-skipped).
- [x] Suite 2b — `cli/` `npm run build` + `vitest run`: **535 passed / 1 skipped / 0 failed** across 49 files; 6 sequential runs and 3 concurrent runs all green.
- [x] `scripts/check-runtime-boundary.py`: **0 violations** (88 Runtime/ files).
- [x] Every new gate proven non-vacuous by planting the defect it claims to catch, observing the failure, and reverting (nested family; unguarded sample; stale pin).
- [ ] Live-editor behavioral verification: **not applicable** — no addon source changed, and the testbed pin lag above makes the local smoke infeasible regardless. Build-verified; the five-version Godot mono CI matrices cover addon load.

Closes #317

## Refine pass (commit `ff206cf`)

A local review pass over this diff found four defects **inside the new gates themselves** — a gate
that mis-parses fails the same way as a gate that is green while protecting nothing:

- **`BlankNonCode` mis-terminated verbatim strings.** `""` is an escaped quote, not the closing
  delimiter; ending the literal on the *second* quote of a pair spilled the rest of it back into the
  scan as code (spurious hit) and then re-opened a string span that swallowed whatever followed
  (missed hit). Both directions of wrong.
- **`BlankNonCode` could destroy a newline** when blanking a `\`-escape pair, breaking the method's
  stated contract that line numbers and directive positions survive — a lost newline can hide an
  `#if TOOLS` / `#endif` from the region tracker.
- **The coverage guard compared a FILE count to a METHOD count**, so two `[AiSkillBody]` methods in
  one file would have failed a perfectly correct addition. It now counts declaration sites.
- **`csprojPin` built a RegExp from an unescaped derived name** while its sibling `statedVersions`
  escaped; both now share one `reEscape` helper and match the full package id.

Also added `TheEditorApiTokenList_StaysInLockstepWithTheRuntimeBoundaryGuard`: the C# token list and
`scripts/check-runtime-boundary.py`'s `EDITOR_TOKENS` were linked by a comment only, so a token added
on one side would silently stop being enforced on the other.

Each new assertion was proven non-vacuous by planting the defect it claims to catch and observing the
failure, then reverting out-of-tree (checksum-verified).

Gates on `ff206cf`: build **0 errors / 0 warnings**; xUnit **1164 passed / 0 failed** (1162 before);
cli **49 files, 535 passed / 1 skipped / 0 failed**; `check-runtime-boundary.py` **0 violations**.
