### PR TITLE
ci(release): match Unity-MCP's Discord announcement formatting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -613,6 +613,21 @@ jobs:
             exit 0
           fi
 
+          # --- Unity-MCP formatting parity: synthesize the release-notes PREAMBLE ---
+          # Unity-MCP hand-builds a `release.md` whose first lines are a
+          # project+version heading, a "**Released:** *<date>*" line and a `---`
+          # separator (see its `prepare-release-notes` job), and feeds that ONE file to
+          # both the GitHub Release body and Discord — which is why its Discord post
+          # opens with a large heading. This repo's release body is GitHub-generated
+          # (`generate_release_notes: true`), so it has no heading by construction.
+          # Prepending the same preamble here, BEFORE the shared cleanup below, makes
+          # the rendered Discord message identical in shape to Unity's.
+          # `date +'%B %e, %Y'` is copied verbatim from Unity-MCP (%e is space-padded)
+          # so the date renders character-for-character the same as Unity's.
+          today=$(date +'%B %e, %Y')
+          release_notes="$(printf '# AI Game Developer (Godot MCP) %s\n**Released:** *%s*\n\n---\n\n%s\n' \
+            "$tag" "$today" "$release_notes")"
+
           # Convert usernames to GitHub profile links
           # Convert "by @username" to "by [@username](https://github.com/username)"
           release_notes_with_links=$(echo "$release_notes" | sed -E 's/by @([A-Za-z0-9_-]+)/by [@\1](https:\/\/github.com\/\1)/g')
@@ -636,7 +651,16 @@ jobs:
           if [ ${#full_message} -gt 2000 ]; then
             # Remove lines from the end until it fits, keeping the link
             link_text=$'\n\n'"📦 **[View Full Release](${release_url})**"
-            max_length=$((2000 - ${#link_text}))
+            # The truncated message is reassembled as `<notes>` + `\n...` + `<link>`,
+            # so the ellipsis line costs 4 more characters on top of the link. Budget
+            # for BOTH so the assembled message is provably <= 2000 (Unity-MCP omits
+            # the ellipsis from its budget and can emit 2004 chars, which Discord
+            # rejects with a 400 — see the report on this change). The heading
+            # synthesized above is part of `release_notes_cleaned` and is therefore
+            # kept by the loop below (it is the first lines); it simply consumes
+            # budget that would otherwise hold more note lines.
+            ellipsis_text=$'\n'"..."
+            max_length=$((2000 - ${#link_text} - ${#ellipsis_text}))
 
             # Split into lines and rebuild until we exceed the limit
             truncated_notes=""


### PR DESCRIPTION
## Problem

The Discord release announcement had **no title** — no project name, no version — unlike Unity-MCP's, which opens with a proper large heading.

**Why:** Unity-MCP hand-builds a `release.md` in its `prepare-release-notes` job that OPENS with a project+version heading, a `**Released:** *<date>*` line and a `---` separator, and feeds that ONE file to both the GitHub Release body and Discord. This repo's release body is GitHub-generated (`generate_release_notes: true`) and read back with `gh release view --json body`, which has no heading by construction. Everything else in `publish_discord` was already a faithful port of Unity's.

## Change

Synthesize the same preamble inside `publish_discord`, **before** the shared cleanup pipeline, so the rendered message is identical in shape to Unity's. The `---` and its surrounding blank lines are stripped/collapsed by the existing `sed` chain exactly as they are for Unity, so the two render the same structure.

The GitHub Release body is deliberately **left alone**: the release page already renders the release name (`v0.20.0`) as its title and shows the publish date natively, so the heading there is redundant chrome — the gap is Discord-only, because Discord renders the content as a flat message with no title chrome. Keeping the change inside `publish_discord` also keeps it out of the release-critical `release-addon` job.

### Rendered message

Before:
```
## What's Changed
* chore: bump gamedev-mcp-server to 9.2.1 by [@IvanMurzak](https://github.com/IvanMurzak) in .../pull/314
...
📦 **[View Full Release](https://github.com/IvanMurzak/Godot-MCP/releases/tag/v0.20.0)**
```

After:
```
# AI Game Developer (Godot MCP) v0.20.0
**Released:** *July 27, 2026*
## What's Changed
* chore: bump gamedev-mcp-server to 9.2.1 by [@IvanMurzak](https://github.com/IvanMurzak) in .../pull/314
...
📦 **[View Full Release](https://github.com/IvanMurzak/Godot-MCP/releases/tag/v0.20.0)**
```

## Truncation fix

The message is reassembled as `<notes>` + `\n...` + `<link>`, but only the link was subtracted from the 2000-char budget. A boundary-aligned body therefore realized **2003 chars** — over Discord's limit, so the webhook would 400 and the announcement would silently not post. Subtracting the ellipsis line too caps the worst case at **1999**. The heading is part of the truncated notes (it is the first lines), so it always survives truncation and simply consumes budget that would otherwise hold more note lines.

Unity-MCP has the same latent overflow; fixing it there is a follow-up outside this PR's scope.

## Verification

- Replayed the **real** step script (extracted from this workflow via `yaml.safe_load`, run under `bash -e` with `curl`/`jq` shadowed) against a realistic auto-generated body containing apostrophes, `by @user` lines and a `---` separator. Output matches Unity's structure line for line; `by @user` → profile links and `---` stripping still work.
- Truncation swept over short line widths to land the accumulator exactly on `max_length`: **before 2003 chars (overflow), after 1999**, link preserved as the final line in every case.
- `bash -n` on all 14 bash `run:` blocks in this workflow; `yaml.safe_load` parses (27 jobs).

## Non-fatal guarantees preserved

`publish_discord` stays isolated (nothing `needs:` it), the `continue-on-error` notes read with its 3× retry and tag-name fallback is untouched, the missing-webhook `exit 0` guard is untouched, and the `flags: 4` payload is unchanged. Nothing here can fail the release or block the npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)