### PR TITLE
feat(auth): unified-machine-auth f1 — F1 login via machine store, F6 machine-wide sign-out, O8 legacy cloudToken migration

### DIFF
--- a/Godot-MCP.Tests/ConnectionPanelViewTests.cs
+++ b/Godot-MCP.Tests/ConnectionPanelViewTests.cs
@@ -318,6 +318,47 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Equal(string.Empty, ConnectionPanelView.ConnectionUrlLabel("   "));
         }
 
+        // --- Cloud signed-in predicate + sign-out / sign-in-outcome copy (unified-machine-auth f1) ---
+
+        [Theory]
+        [InlineData(true, null, true)]        // machine-store account signed in (F1 golden path)
+        [InlineData(true, "legacy-tok", true)] // both
+        [InlineData(false, "legacy-tok", true)] // O8 read-fallback window: the legacy sink still counts
+        [InlineData(false, null, false)]
+        [InlineData(false, "", false)]
+        public void IsCloudSignedIn_MachineStoreOrLegacySink(bool accountSignedIn, string? legacyToken, bool expected)
+        {
+            Assert.Equal(expected, ConnectionPanelView.IsCloudSignedIn(accountSignedIn, legacyToken));
+        }
+
+        [Fact]
+        public void SignOutConfirmText_NamesTheMachineWideScope()
+        {
+            // F6.1: the confirmation must say it signs out ALL tools on this machine — a local-sounding
+            // confirm in front of a machine-wide delete would be a consent bug.
+            Assert.Contains("ALL", ConnectionPanelView.SignOutConfirmText);
+            Assert.Contains("machine", ConnectionPanelView.SignOutConfirmText);
+        }
+
+        [Fact]
+        public void SignInOutcomeMessage_CoversEveryStatus_AndNeverEchoesUnexpectedDetail()
+        {
+            static GodotAccountSignInResult Make(GodotAccountSignInStatus status, string? detail = null)
+                => (GodotAccountSignInResult)Activator.CreateInstance(
+                    typeof(GodotAccountSignInResult),
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+                    null, new object?[] { status, detail }, null)!;
+
+            Assert.Contains("Signed in", ConnectionPanelView.SignInOutcomeMessage(Make(GodotAccountSignInStatus.SignedIn)));
+            Assert.Contains("Partially", ConnectionPanelView.SignInOutcomeMessage(Make(GodotAccountSignInStatus.PartiallyAuthorized)));
+            // NotAuthorized: the device-flow status line already rendered the terminal state — no double message.
+            Assert.Equal(string.Empty, ConnectionPanelView.SignInOutcomeMessage(Make(GodotAccountSignInStatus.NotAuthorized)));
+            Assert.Contains("lock", ConnectionPanelView.SignInOutcomeMessage(Make(GodotAccountSignInStatus.Busy)));
+            Assert.Contains("different account", ConnectionPanelView.SignInOutcomeMessage(Make(GodotAccountSignInStatus.SubjectConflict)));
+            Assert.Contains("failed", ConnectionPanelView.SignInOutcomeMessage(Make(GodotAccountSignInStatus.Failed)));
+            Assert.Contains("exchange refused", ConnectionPanelView.SignInOutcomeMessage(Make(GodotAccountSignInStatus.Failed, "exchange refused")));
+        }
+
         [Fact]
         public void CustomHost_PersistsAndReloads()
         {

--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -144,6 +144,9 @@
     <Compile Include="..\addons\godot_mcp\Editor\Connection\GodotDeviceAuthResult.cs" Link="Source\GodotDeviceAuthResult.cs" />
     <Compile Include="..\addons\godot_mcp\Editor\Connection\GodotTokenRefresher.cs" Link="Source\GodotTokenRefresher.cs" />
     <Compile Include="..\addons\godot_mcp\Editor\Connection\GodotAccountAuth.cs" Link="Source\GodotAccountAuth.cs" />
+    <!-- unified-machine-auth f1: the pure orchestration behind the dock's Authorize button — the seam
+         whose no-new-cloudToken invariant (O8) is pinned by GodotCloudAccountControllerTests. -->
+    <Compile Include="..\addons\godot_mcp\Editor\Connection\GodotCloudAccountController.cs" Link="Source\GodotCloudAccountController.cs" />
     <!-- Editor-runtime NuGet-dependency resolver. Pure-BCL (System.Runtime.Loader), no #if TOOLS,
          no Godot native types — so it is unit-testable in this plain-xUnit host. -->
     <Compile Include="..\addons\godot_mcp\Runtime\Connection\GodotMcpAssemblyResolver.cs" Link="Source\GodotMcpAssemblyResolver.cs" />

--- a/Godot-MCP.Tests/GodotAccountAuthTests.cs
+++ b/Godot-MCP.Tests/GodotAccountAuthTests.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -22,18 +23,28 @@ using Xunit;
 namespace com.IvanMurzak.Godot.MCP.Tests
 {
     /// <summary>
-    /// Covers <see cref="GodotAccountAuth"/> — the machine-store account coordinator (mcp-authorize D12).
-    /// Verifies the three PR-2 behaviours against a temp-directory <see cref="MachineCredentialStore"/> + a
-    /// fake <see cref="HttpMessageHandler"/>: boot auto-adopt (a pre-populated store leaves the coordinator
-    /// signed in with no network I/O), sign-in persistence (the device flow's credential is written to the
-    /// store), sign-out (the store is wiped), and reactive refresh (the refresh grant rotates the stored
-    /// credential). No token is asserted into a log surface.
+    /// Covers <see cref="GodotAccountAuth"/> — the machine-store account coordinator on the shared
+    /// McpPlugin 8.1 credential stack (unified-machine-auth task f1). Verifies, against a temp-directory
+    /// <see cref="MachineCredentialStore"/> + a scripted fake authorization server
+    /// (<see cref="FakeAuthServer"/>):
+    /// <list type="bullet">
+    ///   <item>boot auto-adopt (zero-button rule), including v1/legacy-shaped store adoption;</item>
+    ///   <item>the F1 sign-in: device flow (scope <c>mcp:agent</c>) → two-lock-hold commit → RFC 8693
+    ///   derivation → agent + plugin families + v1 mirror in the store; the AgentOnly failure path;</item>
+    ///   <item>the 04 §3 refresh WIRE SHAPE the adapter must preserve — the family's STORED
+    ///   <c>clientId</c>, never the component default, and NO <c>scope</c>/<c>resource</c> (the G-SEC-1
+    ///   plant-3 discriminators) — plus the proactive expiry self-heal (08 A1);</item>
+    ///   <item>the F6 machine-wide sign-out (revoke every family with its stored id, delete the store);</item>
+    ///   <item>the O8/F11.2 legacy <c>user://</c> cloudToken migration (the G-SEC-1 plant-2 target).</item>
+    /// </list>
+    /// No token is ever asserted into a log surface.
     /// </summary>
     public class GodotAccountAuthTests
     {
         const string AsBaseUrl = "https://ai-game.dev";
-        static readonly DateTimeOffset T0 = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
-        static readonly DateTime T0Dt = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        const string ComponentClientId = "godot-mcp-plugin"; // = GodotDeviceAuthFlow.DefaultClientId
+        static readonly DateTimeOffset FarFuture = DateTimeOffset.UtcNow.AddDays(14);
+        static readonly DateTimeOffset AlreadyExpired = DateTimeOffset.UtcNow.AddMinutes(-10);
 
         // --- Boot auto-adopt (the zero-button rule) ---
 
@@ -41,7 +52,7 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         public void EmptyStore_NotSignedIn()
         {
             using var tmp = new TempDir();
-            using var account = MakeAccount(tmp, new ThrowingHandler());
+            using var account = MakeAccount(tmp, new FakeAuthServer());
 
             Assert.False(account.IsSignedIn);
         }
@@ -50,7 +61,7 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         public async Task EmptyStore_AccessTokenProvider_ReturnsNull()
         {
             using var tmp = new TempDir();
-            using var account = MakeAccount(tmp, new ThrowingHandler());
+            using var account = MakeAccount(tmp, new FakeAuthServer());
 
             var token = await account.AccessTokenProvider();
 
@@ -61,8 +72,8 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         public async Task PrePopulatedStore_AutoAdopts_WithoutNetworkIo()
         {
             using var tmp = new TempDir();
-            // ExpiresAt = null → no proactive refresh is due, so the provider must return the stored token
-            // WITHOUT touching the network (the ThrowingHandler proves it).
+            // No expiry → no proactive refresh is due, so the provider must return the stored token
+            // WITHOUT touching the network (the throwing FakeAuthServer proves it).
             Store(tmp).Write(new MachineCredentials
             {
                 AccessToken = "stored-access",
@@ -71,39 +82,101 @@ namespace com.IvanMurzak.Godot.MCP.Tests
                 ServerTarget = AsBaseUrl,
             });
 
-            using var account = MakeAccount(tmp, new ThrowingHandler());
+            using var account = MakeAccount(tmp, FakeAuthServer.Throwing());
 
             Assert.True(account.IsSignedIn);
             Assert.Equal("stored-access", await account.AccessTokenProvider());
         }
 
-        // --- Sign-in persistence (device flow → machine store) ---
-
+        /// <summary>
+        /// The DoD "v1 adoption" case: a store holding only v1-shaped (top-level) token material is read as
+        /// the LEGACY family (04 §1 v1 read-compat) and signs the account in on boot with zero UI. The
+        /// write contract this addon depends on has normalized the document to v2 (<c>families.legacy</c> +
+        /// version + compat mirror) — asserted so a regression in the consumed package's normalization is
+        /// caught here, not in an editor session.
+        /// </summary>
         [Fact]
-        public async Task SignInAsync_Success_PersistsCredential_AndAnotherCoordinatorAutoAdopts()
+        public async Task V1ShapedStore_IsAdopted_AsLegacyFamily_AndSignsIn()
         {
             using var tmp = new TempDir();
-            using var account = MakeAccount(tmp, new ThrowingHandler());
+            Store(tmp).Write(new MachineCredentials
+            {
+                AccessToken = "v1-access",
+                RefreshToken = "v1-refresh",
+                ExpiresAt = null,
+                ServerTarget = AsBaseUrl,
+            });
 
-            var flow = MakeFlow(new DeviceFlowHandler(
-                Authorize("USER-1", "dev-1"),
-                Token(access: "acc-1", refresh: "ref-1", expiresIn: 3600)));
+            var persisted = Store(tmp).Read();
+            Assert.NotNull(persisted?.Families?.Legacy);
+            Assert.Equal("v1-access", persisted!.Families!.Legacy!.AccessToken);
+            Assert.Equal("v1-access", persisted.AccessToken); // the v1 compat mirror survives
 
-            var ok = await account.SignInAsync(flow, AsBaseUrl);
+            using var account = MakeAccount(tmp, FakeAuthServer.Throwing());
 
-            Assert.True(ok);
+            Assert.True(account.IsSignedIn);
+            Assert.Equal("v1-access", await account.AccessTokenProvider());
+        }
+
+        // --- Sign-in (F1: device flow → two-lock-hold commit → RFC 8693 derivation) ---
+
+        [Fact]
+        public async Task SignInAsync_Success_CommitsAgentAndPluginFamilies_AndAnotherCoordinatorAutoAdopts()
+        {
+            using var tmp = new TempDir();
+            var server = new FakeAuthServer
+            {
+                DeviceAuthorize = Ok(DeviceAuthorizeJson("USER-1", "dev-1")),
+                DeviceToken = Ok(TokenJson("acc-agent", "ref-agent", 3600, scope: "mcp:agent")),
+                Exchange = Ok(ExchangeJson("acc-plugin", "ref-plugin", 3600, scope: "mcp:plugin", sub: "usr_1")),
+            };
+            using var account = MakeAccount(tmp, server);
+
+            var outcome = await account.SignInAsync(MakeFlow(server), AsBaseUrl);
+
+            Assert.Equal(GodotAccountSignInStatus.SignedIn, outcome.Status);
+            Assert.True(outcome.Succeeded);
             Assert.True(account.IsSignedIn);
 
             var persisted = Store(tmp).Read();
             Assert.NotNull(persisted);
-            Assert.Equal("acc-1", persisted!.AccessToken);
-            Assert.Equal("ref-1", persisted.RefreshToken);
+
+            // Agent family: the minted tokens, stamped with the clientId ACTUALLY presented (D8) + scope.
+            var agent = persisted!.Families?.Agent;
+            Assert.NotNull(agent);
+            Assert.Equal("acc-agent", agent!.AccessToken);
+            Assert.Equal("ref-agent", agent.RefreshToken);
+            Assert.Equal(ComponentClientId, agent.ClientId);
+            Assert.Equal("mcp:agent", agent.Scope);
+
+            // Plugin family: the RFC 8693 derivation, stamped with the exchanging client's own id.
+            var plugin = persisted.Families?.Plugin;
+            Assert.NotNull(plugin);
+            Assert.Equal("acc-plugin", plugin!.AccessToken);
+            Assert.Equal("ref-plugin", plugin.RefreshToken);
+            Assert.Equal(ComponentClientId, plugin.ClientId);
+            Assert.Equal("mcp:plugin", plugin.Scope);
+
+            // v1 compat mirror = the plugin family's token fields (04 §1); subject backfilled (O5);
+            // serverTarget recorded.
+            Assert.Equal("acc-plugin", persisted.AccessToken);
+            Assert.Equal("usr_1", persisted.Subject);
             Assert.Equal(AsBaseUrl, persisted.ServerTarget);
-            Assert.Equal(T0.AddSeconds(3600), persisted.ExpiresAt);
+
+            // The connection presents the PLUGIN (hub) token.
+            Assert.Equal("acc-plugin", await account.AccessTokenProvider());
+
+            // The wire: the device-authorization request carried scope=mcp:agent (F1.2), and the exchange
+            // carried the token-exchange grant with this component's client_id.
+            var authorizeBody = server.Requests.Single(r => r.Path.EndsWith("/oauth/device_authorization")).Body;
+            Assert.Contains("scope=" + WebUtility.UrlEncode("mcp:agent"), authorizeBody);
+            var exchangeBody = server.DecodedTokenRequests.Single(b => b.Contains("grant-type:token-exchange"));
+            Assert.Contains("client_id=" + ComponentClientId, exchangeBody);
+            Assert.Contains("subject_token=acc-agent", exchangeBody);
 
             // A fresh coordinator over the SAME store auto-adopts (the once-per-machine sign-in seen by a
             // second editor session / another engine).
-            using var account2 = MakeAccount(tmp, new ThrowingHandler());
+            using var account2 = MakeAccount(tmp, FakeAuthServer.Throwing());
             Assert.True(account2.IsSignedIn);
         }
 
@@ -111,86 +184,274 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         public async Task SignInAsync_Denied_DoesNotPersist()
         {
             using var tmp = new TempDir();
-            using var account = MakeAccount(tmp, new ThrowingHandler());
+            var server = new FakeAuthServer
+            {
+                DeviceAuthorize = Ok(DeviceAuthorizeJson("USER-1", "dev-1")),
+                DeviceToken = Error("access_denied"),
+            };
+            using var account = MakeAccount(tmp, server);
 
-            var flow = MakeFlow(new DeviceFlowHandler(
-                Authorize("USER-1", "dev-1"),
-                Error("access_denied")));
+            var outcome = await account.SignInAsync(MakeFlow(server), AsBaseUrl);
 
-            var ok = await account.SignInAsync(flow, AsBaseUrl);
-
-            Assert.False(ok);
+            Assert.Equal(GodotAccountSignInStatus.NotAuthorized, outcome.Status);
             Assert.False(account.IsSignedIn);
             Assert.False(Store(tmp).Exists);
+        }
+
+        /// <summary>
+        /// The F1 failure path: the exchange fails after the agent family committed under the first hold —
+        /// the agent family STAYS committed (that is why the sequence uses two separate holds), the outcome
+        /// is PartiallyAuthorized, and the account is NOT hub-signed-in (no plugin-plane credential).
+        /// </summary>
+        [Fact]
+        public async Task SignInAsync_ExchangeFails_CommitsAgentFamilyOnly()
+        {
+            using var tmp = new TempDir();
+            var server = new FakeAuthServer
+            {
+                DeviceAuthorize = Ok(DeviceAuthorizeJson("USER-1", "dev-1")),
+                DeviceToken = Ok(TokenJson("acc-agent", "ref-agent", 3600, scope: "mcp:agent")),
+                Exchange = () => JsonResponse(HttpStatusCode.BadRequest, "{ \"error\": \"invalid_request\" }"),
+            };
+            using var account = MakeAccount(tmp, server);
+
+            var outcome = await account.SignInAsync(MakeFlow(server), AsBaseUrl);
+
+            Assert.Equal(GodotAccountSignInStatus.PartiallyAuthorized, outcome.Status);
+            Assert.False(account.IsSignedIn); // no plugin-plane family ⇒ not hub-signed-in
+
+            var persisted = Store(tmp).Read();
+            Assert.NotNull(persisted?.Families?.Agent);
+            Assert.Equal("acc-agent", persisted!.Families!.Agent!.AccessToken);
+            Assert.Null(persisted.Families.Plugin);
+        }
+
+        // --- Refresh wire shape (04 §3 — the G-SEC-1 plant-3 discriminators) ---
+
+        /// <summary>
+        /// 04 §3.2: the refresh request presents the family's STORED <c>clientId</c> — never the component
+        /// default. Discriminates the adapter dropping the family context (the pre-b3 defect class).
+        /// </summary>
+        [Fact]
+        public async Task Refresh_PresentsTheFamilysStoredClientId_NeverTheComponentDefault()
+        {
+            using var tmp = new TempDir();
+            WritePluginFamily(tmp, accessToken: "acc-old", refreshToken: "ref-old",
+                expiresAt: AlreadyExpired, clientId: "stored-custom-id");
+
+            var server = new FakeAuthServer { Refresh = Ok(TokenJson("acc-new", "ref-new", 3600)) };
+            using var account = MakeAccount(tmp, server);
+
+            var refreshed = await account.RefreshAsync();
+
+            Assert.True(refreshed);
+            var refreshBody = server.DecodedTokenRequests.Single(b => b.Contains("grant_type=refresh_token"));
+            Assert.Contains("client_id=stored-custom-id", refreshBody);
+            Assert.DoesNotContain("client_id=" + ComponentClientId, refreshBody);
+        }
+
+        /// <summary>04 §3.3 / P0-3: the refresh request omits <c>scope</c> and <c>resource</c> entirely.</summary>
+        [Fact]
+        public async Task Refresh_OmitsScopeAndResourceEntirely()
+        {
+            using var tmp = new TempDir();
+            WritePluginFamily(tmp, accessToken: "acc-old", refreshToken: "ref-old",
+                expiresAt: AlreadyExpired, clientId: "stored-custom-id");
+
+            var server = new FakeAuthServer { Refresh = Ok(TokenJson("acc-new", "ref-new", 3600)) };
+            using var account = MakeAccount(tmp, server);
+
+            var refreshed = await account.RefreshAsync();
+
+            Assert.True(refreshed);
+            var refreshBody = server.DecodedTokenRequests.Single(b => b.Contains("grant_type=refresh_token"));
+            Assert.DoesNotContain("scope=", refreshBody);
+            Assert.DoesNotContain("resource=", refreshBody);
+        }
+
+        /// <summary>04 §3.7: a legacy family of unknown id refreshes with the component default.</summary>
+        [Fact]
+        public async Task Refresh_LegacyFamily_PresentsTheComponentDefault_AndStillOmitsScope()
+        {
+            using var tmp = new TempDir();
+            Store(tmp).Write(new MachineCredentials
+            {
+                AccessToken = "acc-old",
+                RefreshToken = "ref-old",
+                ExpiresAt = AlreadyExpired,
+                ServerTarget = AsBaseUrl,
+            });
+
+            var server = new FakeAuthServer { Refresh = Ok(TokenJson("acc-new", "ref-new", 3600)) };
+            using var account = MakeAccount(tmp, server);
+
+            var refreshed = await account.RefreshAsync();
+
+            Assert.True(refreshed);
+            var refreshBody = server.DecodedTokenRequests.Single(b => b.Contains("grant_type=refresh_token"));
+            Assert.Contains("client_id=" + ComponentClientId, refreshBody);
+            Assert.DoesNotContain("scope=", refreshBody);
+        }
+
+        // --- Expiry self-heal (08 A1): proactive refresh inside the access-token provider ---
+
+        [Fact]
+        public async Task AccessTokenProvider_ExpiredToken_RefreshesProactively_AndRotatesTheStore()
+        {
+            using var tmp = new TempDir();
+            WritePluginFamily(tmp, accessToken: "acc-old", refreshToken: "ref-old",
+                expiresAt: AlreadyExpired, clientId: ComponentClientId);
+
+            var server = new FakeAuthServer { Refresh = Ok(TokenJson("acc-new", "ref-new", 3600)) };
+            using var account = MakeAccount(tmp, server);
+
+            // The provider notices the expired token inside the skew window and refreshes BEFORE returning.
+            var token = await account.AccessTokenProvider();
+
+            Assert.Equal("acc-new", token);
+            var persisted = Store(tmp).Read();
+            Assert.Equal("acc-new", persisted!.Families?.Plugin?.AccessToken);
+            Assert.Equal("ref-new", persisted.Families?.Plugin?.RefreshToken);
+            Assert.Equal(AsBaseUrl, persisted.ServerTarget); // identity fields preserved across rotation
+        }
+
+        [Fact]
+        public async Task RefreshAsync_ServerRejects_FailsClosed_KeepsFailureShape()
+        {
+            using var tmp = new TempDir();
+            WritePluginFamily(tmp, accessToken: "acc-old", refreshToken: "ref-old",
+                expiresAt: AlreadyExpired, clientId: ComponentClientId);
+
+            var server = new FakeAuthServer
+            {
+                Refresh = () => JsonResponse(HttpStatusCode.BadRequest, "{ \"error\": \"invalid_grant\" }"),
+            };
+            using var account = MakeAccount(tmp, server);
+
+            var refreshed = await account.RefreshAsync();
+
+            Assert.False(refreshed);
         }
 
         // --- Sign-out ---
 
         [Fact]
-        public void SignOut_WipesStore()
+        public void SignOut_LocalOnly_WipesStore()
         {
             using var tmp = new TempDir();
             Store(tmp).Write(new MachineCredentials { AccessToken = "a", RefreshToken = "r", ServerTarget = AsBaseUrl });
 
-            using var account = MakeAccount(tmp, new ThrowingHandler());
+            using var account = MakeAccount(tmp, FakeAuthServer.Throwing());
             Assert.True(account.IsSignedIn);
 
             account.SignOut();
 
             Assert.False(account.IsSignedIn);
             Assert.False(Store(tmp).Exists);
-            using var account2 = MakeAccount(tmp, new ThrowingHandler());
+        }
+
+        /// <summary>
+        /// F6: machine-wide sign-out revokes EVERY stored family's refresh token — each with its stored
+        /// <c>clientId</c> — then deletes the store via the lock protocol; every other coordinator observes
+        /// the machine signed out.
+        /// </summary>
+        [Fact]
+        public async Task SignOutMachineWideAsync_RevokesEveryFamily_AndDeletesTheStore()
+        {
+            using var tmp = new TempDir();
+            Store(tmp).Write(new MachineCredentials
+            {
+                ServerTarget = AsBaseUrl,
+                Families = new MachineCredentialFamilies
+                {
+                    Agent = new MachineCredentialFamily
+                    {
+                        AccessToken = "acc-agent", RefreshToken = "ref-agent",
+                        ClientId = "agent-client-id", Scope = "mcp:agent",
+                    },
+                    Plugin = new MachineCredentialFamily
+                    {
+                        AccessToken = "acc-plugin", RefreshToken = "ref-plugin",
+                        ClientId = "plugin-client-id", Scope = "mcp:plugin",
+                    },
+                },
+            });
+
+            var server = new FakeAuthServer(); // /oauth/revoke answers 200 by default
+            using var account = MakeAccount(tmp, server);
+            Assert.True(account.IsSignedIn);
+
+            var result = await account.SignOutMachineWideAsync();
+
+            Assert.True(result.StoreDeleted);
+            Assert.False(result.Busy);
+            Assert.Equal(2, result.FamiliesRevoked);
+            Assert.False(Store(tmp).Exists);
+            Assert.False(account.IsSignedIn);
+
+            // Each family was revoked with ITS OWN stored clientId (F6.2).
+            var revokes = server.Requests.Where(r => r.Path.EndsWith("/oauth/revoke"))
+                .Select(r => WebUtility.UrlDecode(r.Body)).ToList();
+            Assert.Equal(2, revokes.Count);
+            Assert.Contains(revokes, b => b.Contains("token=ref-agent") && b.Contains("client_id=agent-client-id"));
+            Assert.Contains(revokes, b => b.Contains("token=ref-plugin") && b.Contains("client_id=plugin-client-id"));
+
+            using var account2 = MakeAccount(tmp, FakeAuthServer.Throwing());
             Assert.False(account2.IsSignedIn);
         }
 
-        // --- Reactive refresh rotates the stored credential ---
+        // --- O8 / F11.2 legacy user:// cloudToken migration (the G-SEC-1 plant-2 target) ---
 
         [Fact]
-        public async Task RefreshAsync_RotatesStoredCredential()
+        public async Task Migrate_SeededSink_EmptyStore_WritesLegacyFamilyUnderLock_AndSignsIn()
         {
             using var tmp = new TempDir();
-            Store(tmp).Write(new MachineCredentials
-            {
-                AccessToken = "acc-old",
-                RefreshToken = "ref-old",
-                ExpiresAt = T0.AddSeconds(-10), // already expired
-                ServerTarget = AsBaseUrl,
-            });
+            using var account = MakeAccount(tmp, FakeAuthServer.Throwing());
+            Assert.False(account.IsSignedIn);
 
-            // The refresh grant returns a fresh token pair.
-            using var account = MakeAccount(tmp, new SingleResponseHandler(
-                TokenJson(access: "acc-new", refresh: "ref-new", expiresIn: 3600)));
+            var outcome = account.TryMigrateLegacyCloudToken("sink-cloud-token", AsBaseUrl);
 
-            var refreshed = await account.RefreshAsync();
+            Assert.Equal(GodotLegacyTokenMigrationResult.Migrated, outcome);
 
-            Assert.True(refreshed);
-            Assert.True(account.IsSignedIn);
-
+            // POSITIVE artifact (not just an absence): the machine store now HOLDS the sink credential,
+            // as a v2 legacy family + v1 mirror, and the account adopted it.
             var persisted = Store(tmp).Read();
-            Assert.Equal("acc-new", persisted!.AccessToken);
-            Assert.Equal("ref-new", persisted.RefreshToken);
-            // ServerTarget is preserved across a rotation (MachineCredentialStore.Rotate keeps identity fields).
+            Assert.NotNull(persisted?.Families?.Legacy);
+            Assert.Equal("sink-cloud-token", persisted!.Families!.Legacy!.AccessToken);
+            Assert.Equal("sink-cloud-token", persisted.AccessToken); // compat mirror
             Assert.Equal(AsBaseUrl, persisted.ServerTarget);
+            Assert.True(account.IsSignedIn);
+            Assert.Equal("sink-cloud-token", await account.AccessTokenProvider());
         }
 
         [Fact]
-        public async Task RefreshAsync_ServerRejects_FailsClosed_KeepsOldCredential()
+        public void Migrate_StoreAlreadyHoldsCredential_SkipsAndLeavesStoreUntouched()
         {
             using var tmp = new TempDir();
             Store(tmp).Write(new MachineCredentials
             {
-                AccessToken = "acc-old",
-                RefreshToken = "ref-old",
-                ExpiresAt = T0.AddSeconds(-10),
+                AccessToken = "existing-access",
+                RefreshToken = "existing-refresh",
                 ServerTarget = AsBaseUrl,
             });
+            using var account = MakeAccount(tmp, FakeAuthServer.Throwing());
 
-            using var account = MakeAccount(tmp, new SingleResponseHandler(
-                () => JsonResponse(HttpStatusCode.BadRequest, "{ \"error\": \"invalid_grant\" }")));
+            var outcome = account.TryMigrateLegacyCloudToken("sink-cloud-token", AsBaseUrl);
 
-            var refreshed = await account.RefreshAsync();
+            Assert.Equal(GodotLegacyTokenMigrationResult.SkippedStoreHasCredential, outcome);
+            var persisted = Store(tmp).Read();
+            Assert.Equal("existing-access", persisted!.AccessToken); // the store always wins over the sink
+        }
 
-            Assert.False(refreshed);
+        [Fact]
+        public void Migrate_NoSinkToken_NoOp()
+        {
+            using var tmp = new TempDir();
+            using var account = MakeAccount(tmp, FakeAuthServer.Throwing());
+
+            Assert.Equal(GodotLegacyTokenMigrationResult.NoSinkToken, account.TryMigrateLegacyCloudToken(null, AsBaseUrl));
+            Assert.Equal(GodotLegacyTokenMigrationResult.NoSinkToken, account.TryMigrateLegacyCloudToken("", AsBaseUrl));
+            Assert.False(Store(tmp).Exists);
         }
 
         // --- helpers ---
@@ -201,43 +462,68 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             => new(
                 asBaseUrlProvider: () => AsBaseUrl,
                 store: new MachineCredentialStore(tmp.Path),
-                service: new GodotDeviceAuthService(new HttpClient(handler)),
-                clock: () => T0);
+                httpClient: new HttpClient(handler));
 
         static GodotDeviceAuthFlow MakeFlow(HttpMessageHandler handler)
             => new(
                 new GodotDeviceAuthService(new HttpClient(handler)),
                 delay: (_, _) => Task.CompletedTask,
-                utcNow: () => T0Dt);
+                utcNow: () => DateTime.UtcNow);
 
-        static Func<HttpResponseMessage> Authorize(string userCode, string deviceCode)
-            => () => JsonResponse(HttpStatusCode.OK, $$"""
+        /// <summary>Seed a v2 store with a PLUGIN family (the shape the F1 commit writes).</summary>
+        static void WritePluginFamily(TempDir tmp, string accessToken, string refreshToken,
+            DateTimeOffset? expiresAt, string clientId)
+            => Store(tmp).Write(new MachineCredentials
+            {
+                ServerTarget = AsBaseUrl,
+                Families = new MachineCredentialFamilies
                 {
-                  "device_code": "{{deviceCode}}",
-                  "user_code": "{{userCode}}",
-                  "verification_uri": "https://ai-game.dev/verify",
-                  "verification_uri_complete": "https://ai-game.dev/verify?code={{userCode}}",
-                  "expires_in": 600,
-                  "interval": 5
-                }
-                """);
+                    Plugin = new MachineCredentialFamily
+                    {
+                        AccessToken = accessToken,
+                        RefreshToken = refreshToken,
+                        ExpiresAt = expiresAt,
+                        ClientId = clientId,
+                        Scope = "mcp:plugin",
+                    },
+                },
+            });
 
-        static Func<HttpResponseMessage> Token(string access, string refresh, int expiresIn)
-            => () => JsonResponse(HttpStatusCode.OK, TokenJsonText(access, refresh, expiresIn));
+        static Func<HttpResponseMessage> Ok(string json) => () => JsonResponse(HttpStatusCode.OK, json);
 
         static Func<HttpResponseMessage> Error(string error)
             => () => JsonResponse(HttpStatusCode.BadRequest, $"{{ \"error\": \"{error}\" }}");
 
-        static Func<HttpResponseMessage> TokenJson(string access, string refresh, int expiresIn)
-            => () => JsonResponse(HttpStatusCode.OK, TokenJsonText(access, refresh, expiresIn));
+        static string DeviceAuthorizeJson(string userCode, string deviceCode) => $$"""
+            {
+              "device_code": "{{deviceCode}}",
+              "user_code": "{{userCode}}",
+              "verification_uri": "https://ai-game.dev/verify",
+              "verification_uri_complete": "https://ai-game.dev/verify?code={{userCode}}",
+              "expires_in": 600,
+              "interval": 5
+            }
+            """;
 
-        static string TokenJsonText(string access, string refresh, int expiresIn) => $$"""
+        static string TokenJson(string access, string refresh, int expiresIn, string scope = "mcp:plugin") => $$"""
             {
               "access_token": "{{access}}",
               "refresh_token": "{{refresh}}",
               "token_type": "Bearer",
               "expires_in": {{expiresIn}},
-              "scope": "mcp:plugin"
+              "scope": "{{scope}}"
+            }
+            """;
+
+        static string ExchangeJson(string access, string refresh, int expiresIn, string scope, string sub) => $$"""
+            {
+              "access_token": "{{access}}",
+              "refresh_token": "{{refresh}}",
+              "token_type": "Bearer",
+              "expires_in": {{expiresIn}},
+              "scope": "{{scope}}",
+              "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+              "sub": "{{sub}}"
             }
             """;
 
@@ -257,43 +543,55 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             }
         }
 
-        /// <summary>Device flow handler: first request (device_authorization) → authorize; each token POST → token.</summary>
-        sealed class DeviceFlowHandler : HttpMessageHandler
+        /// <summary>
+        /// A scripted fake ai-game.dev authorization server, routing by path + grant type:
+        /// <c>/oauth/device_authorization</c> → <see cref="DeviceAuthorize"/>; <c>/oauth/token</c> by
+        /// <c>grant_type</c> → <see cref="DeviceToken"/> / <see cref="Exchange"/> / <see cref="Refresh"/>;
+        /// <c>/oauth/revoke</c> → <see cref="Revoke"/> (200 by default — RFC 7009). Records every request's
+        /// path + raw form body for wire-shape assertions; an unscripted route throws (so a test that
+        /// expects no network proves it).
+        /// </summary>
+        sealed class FakeAuthServer : HttpMessageHandler
         {
-            readonly Func<HttpResponseMessage> _authorize;
-            readonly Queue<Func<HttpResponseMessage>> _token;
+            public Func<HttpResponseMessage>? DeviceAuthorize { get; set; }
+            public Func<HttpResponseMessage>? DeviceToken { get; set; }
+            public Func<HttpResponseMessage>? Exchange { get; set; }
+            public Func<HttpResponseMessage>? Refresh { get; set; }
+            public Func<HttpResponseMessage>? Revoke { get; set; } = () => new HttpResponseMessage(HttpStatusCode.OK);
 
-            public DeviceFlowHandler(Func<HttpResponseMessage> authorize, params Func<HttpResponseMessage>[] token)
-            {
-                _authorize = authorize;
-                _token = new Queue<Func<HttpResponseMessage>>(token);
-            }
+            public List<(string Path, string Body)> Requests { get; } = new();
 
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            /// <summary>URL-decoded bodies of every <c>/oauth/token</c> POST (for grant/field assertions).</summary>
+            public IEnumerable<string> DecodedTokenRequests =>
+                Requests.Where(r => r.Path.EndsWith("/oauth/token", StringComparison.Ordinal))
+                        .Select(r => WebUtility.UrlDecode(r.Body));
+
+            /// <summary>A server where EVERY route throws — proves a code path performs no network I/O.</summary>
+            public static FakeAuthServer Throwing() => new() { Revoke = null };
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
                 var path = request.RequestUri!.AbsolutePath;
-                var responder = path.EndsWith("/oauth/token", StringComparison.Ordinal)
-                    ? (_token.Count > 0 ? _token.Dequeue() : _token.Peek())
-                    : _authorize;
-                return Task.FromResult(responder());
+                var body = request.Content != null
+                    ? await request.Content.ReadAsStringAsync(cancellationToken)
+                    : string.Empty;
+                lock (Requests)
+                    Requests.Add((path, body));
+
+                var decoded = WebUtility.UrlDecode(body);
+                Func<HttpResponseMessage>? responder =
+                    path.EndsWith("/oauth/device_authorization", StringComparison.Ordinal) ? DeviceAuthorize
+                    : path.EndsWith("/oauth/revoke", StringComparison.Ordinal) ? Revoke
+                    : !path.EndsWith("/oauth/token", StringComparison.Ordinal) ? null
+                    : decoded.Contains("grant-type:token-exchange") ? Exchange
+                    : decoded.Contains("grant_type=refresh_token") ? Refresh
+                    : DeviceToken;
+
+                if (responder == null)
+                    throw new InvalidOperationException($"unexpected/unscripted request: {path}"); // path only — never form fields (a revoke body leads with the token)
+
+                return responder();
             }
-        }
-
-        /// <summary>Responds to every request (the refresh POST) with one scripted response.</summary>
-        sealed class SingleResponseHandler : HttpMessageHandler
-        {
-            readonly Func<HttpResponseMessage> _respond;
-            public SingleResponseHandler(Func<HttpResponseMessage> respond) => _respond = respond;
-
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-                => Task.FromResult(_respond());
-        }
-
-        /// <summary>Throws on any request — proves a code path performs no network I/O.</summary>
-        sealed class ThrowingHandler : HttpMessageHandler
-        {
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-                => throw new InvalidOperationException("unexpected network call: " + request.RequestUri);
         }
     }
 }

--- a/Godot-MCP.Tests/GodotAccountAuthTests.cs
+++ b/Godot-MCP.Tests/GodotAccountAuthTests.cs
@@ -400,7 +400,180 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.False(account2.IsSignedIn);
         }
 
+        // --- Second-phase completion (03 F1 failure path — review B1) ---
+
+        /// <summary>
+        /// 03 F1: "Token exchange fails → P retries with backoff; the agent family stays committed."
+        /// A transiently failing exchange is retried ONCE (with the documented backoff) without a second
+        /// device flow, and the retry completes the plugin-family commit.
+        /// </summary>
+        [Fact]
+        public async Task SignInAsync_ExchangeFailsOnce_RetriesWithBackoff_AndFullyCommits()
+        {
+            using var tmp = new TempDir();
+            var exchangeCalls = 0;
+            var server = new FakeAuthServer
+            {
+                DeviceAuthorize = Ok(DeviceAuthorizeJson("USER-1", "dev-1")),
+                DeviceToken = Ok(TokenJson("acc-agent", "ref-agent", 3600, scope: "mcp:agent")),
+                Exchange = () => ++exchangeCalls == 1
+                    ? JsonResponse(HttpStatusCode.BadRequest, "{ \"error\": \"temporarily_unavailable\" }")
+                    : JsonResponse(HttpStatusCode.OK, ExchangeJson("acc-plugin", "ref-plugin", 3600, "mcp:plugin", "usr_1")),
+            };
+            var delays = new List<TimeSpan>();
+            using var account = MakeAccount(tmp, server, delay: (d, _) => { delays.Add(d); return Task.CompletedTask; });
+
+            var outcome = await account.SignInAsync(MakeFlow(server), AsBaseUrl);
+
+            Assert.Equal(GodotAccountSignInStatus.SignedIn, outcome.Status);
+            Assert.True(account.IsSignedIn);
+            Assert.Equal(2, exchangeCalls); // exactly one retry — bounded
+            Assert.Equal(new[] { GodotAccountAuth.SecondPhaseRetryBackoff }, delays); // with the documented backoff
+            // ONE device flow only — the retry never re-runs RFC 8628 (no second browser round).
+            Assert.Single(server.Requests, r => r.Path.EndsWith("/oauth/device_authorization", StringComparison.Ordinal));
+
+            var persisted = Store(tmp).Read();
+            Assert.Equal("acc-agent", persisted!.Families?.Agent?.AccessToken);
+            Assert.Equal("acc-plugin", persisted.Families?.Plugin?.AccessToken);
+        }
+
+        /// <summary>
+        /// Review B1: a retryable second-hold outcome (store unreadable between the holds) is retried
+        /// with the CARRIED mint — never re-exchanged — and the retry commits the plugin family.
+        /// </summary>
+        [Fact]
+        public async Task SignInAsync_StoreUnreadableAtSecondHold_RetriesTheCarriedMint_WithoutReExchanging()
+        {
+            using var tmp = new TempDir();
+            var storePath = Store(tmp).CredentialsPath;
+            byte[]? agentDocBytes = null;
+            var server = new FakeAuthServer
+            {
+                DeviceAuthorize = Ok(DeviceAuthorizeJson("USER-1", "dev-1")),
+                DeviceToken = Ok(TokenJson("acc-agent", "ref-agent", 3600, scope: "mcp:agent")),
+                Exchange = () =>
+                {
+                    // Runs BETWEEN the holds: capture the agent-family document hold 1 wrote, then turn
+                    // the store unreadable (garbage bytes: DPAPI unprotect fails on Windows, JSON parse
+                    // fails on POSIX) so hold 2 lands on StoreUnreadable with the mint carried back.
+                    agentDocBytes = File.ReadAllBytes(storePath);
+                    File.WriteAllBytes(storePath, new byte[] { 0x00, 0x01, 0xFF });
+                    return JsonResponse(HttpStatusCode.OK, ExchangeJson("acc-plugin", "ref-plugin", 3600, "mcp:plugin", "usr_1"));
+                },
+            };
+            // The injected delay is the retry backoff hook — "repair" the store there, so the ONE
+            // bounded retry finds it readable again.
+            using var account = MakeAccount(tmp, server, delay: (_, _) =>
+            {
+                File.WriteAllBytes(storePath, agentDocBytes!);
+                return Task.CompletedTask;
+            });
+
+            var outcome = await account.SignInAsync(MakeFlow(server), AsBaseUrl);
+
+            Assert.Equal(GodotAccountSignInStatus.SignedIn, outcome.Status);
+            Assert.True(account.IsSignedIn);
+            // The carried ExchangeResult was committed — exactly ONE exchange on the wire.
+            Assert.Single(server.DecodedTokenRequests, b => b.Contains("grant-type:token-exchange"));
+
+            var persisted = Store(tmp).Read();
+            Assert.Equal("acc-agent", persisted!.Families?.Agent?.AccessToken);
+            Assert.Equal("acc-plugin", persisted.Families?.Plugin?.AccessToken);
+            Assert.Equal("usr_1", persisted.Subject); // O5 sub backfilled by the retried commit
+        }
+
+        /// <summary>
+        /// Review B1 / b3 twin rule 4: when the bounded retry ALSO fails, the coordinator stops retrying
+        /// (the user's next step is a fresh device flow) — so the minted-but-never-committed plugin
+        /// family must be best-effort revoked, not silently stranded live server-side for ≤30 d. The
+        /// unreadable store is never overwritten on this path either.
+        /// </summary>
+        [Fact]
+        public async Task SignInAsync_StoreStillUnreadableAfterRetry_RevokesTheAbandonedMint()
+        {
+            using var tmp = new TempDir();
+            var storePath = Store(tmp).CredentialsPath;
+            var garbage = new byte[] { 0x00, 0x01, 0xFF };
+            var server = new FakeAuthServer
+            {
+                DeviceAuthorize = Ok(DeviceAuthorizeJson("USER-1", "dev-1")),
+                DeviceToken = Ok(TokenJson("acc-agent", "ref-agent", 3600, scope: "mcp:agent")),
+                Exchange = () =>
+                {
+                    File.WriteAllBytes(storePath, garbage); // unreadable — and never repaired
+                    return JsonResponse(HttpStatusCode.OK, ExchangeJson("acc-plugin", "ref-plugin", 3600, "mcp:plugin", "usr_1"));
+                },
+            };
+            using var account = MakeAccount(tmp, server);
+
+            var outcome = await account.SignInAsync(MakeFlow(server), AsBaseUrl);
+
+            Assert.Equal(GodotAccountSignInStatus.PartiallyAuthorized, outcome.Status);
+            Assert.False(account.IsSignedIn);
+            // No re-exchange, no second device flow — the same mint was retried, then abandoned.
+            Assert.Single(server.DecodedTokenRequests, b => b.Contains("grant-type:token-exchange"));
+            Assert.Single(server.Requests, r => r.Path.EndsWith("/oauth/device_authorization", StringComparison.Ordinal));
+            // The abandoned mint was best-effort revoked — refresh token preferred, this component's id.
+            var revokes = server.Requests.Where(r => r.Path.EndsWith("/oauth/revoke", StringComparison.Ordinal))
+                .Select(r => WebUtility.UrlDecode(r.Body)).ToList();
+            Assert.Contains(revokes, b => b.Contains("token=ref-plugin") && b.Contains("client_id=" + ComponentClientId));
+            // 04 §1: the unreadable store was never overwritten by any of it.
+            Assert.Equal(garbage, File.ReadAllBytes(storePath));
+        }
+
         // --- O8 / F11.2 legacy user:// cloudToken migration (the G-SEC-1 plant-2 target) ---
+
+        /// <summary>
+        /// Review B2(a) / 04 §1 "never overwrite": an EXISTING-but-unreadable store (DPAPI after a
+        /// password reset, corruption) may hold a real credential — migration must skip and leave the
+        /// file byte-identical. Fails when either Unreadable guard is removed (the migration would then
+        /// treat the unreadable store as empty and write over it).
+        /// </summary>
+        [Fact]
+        public void Migrate_UnreadableStore_IsNeverOverwritten()
+        {
+            using var tmp = new TempDir();
+            Directory.CreateDirectory(tmp.Path);
+            var storePath = Store(tmp).CredentialsPath;
+            var garbage = new byte[] { 0x00, 0x10, 0xFF, 0x42 };
+            File.WriteAllBytes(storePath, garbage);
+            using var account = MakeAccount(tmp, FakeAuthServer.Throwing());
+
+            var outcome = account.TryMigrateLegacyCloudToken("sink-cloud-token", AsBaseUrl);
+
+            Assert.Equal(GodotLegacyTokenMigrationResult.SkippedStoreUnreadable, outcome);
+            Assert.Equal(garbage, File.ReadAllBytes(storePath)); // byte-identical — never overwritten
+            Assert.False(account.IsSignedIn);
+        }
+
+        /// <summary>
+        /// Review B2(b) / D9: a held machine lock makes the migration fail as Busy — it never proceeds
+        /// lock-free and writes nothing; once the lock frees, the SAME call migrates (the idempotent
+        /// retry-next-boot claim, proven rather than asserted).
+        /// </summary>
+        [Fact]
+        public void Migrate_BusyLock_SkipsWithoutWriting_ThenMigratesOnceTheLockFrees()
+        {
+            using var tmp = new TempDir();
+            using var account = MakeAccount(tmp, FakeAuthServer.Throwing(),
+                credentialLock: MakeShortBudgetLock(tmp.Path));
+
+            using (var holder = new MachineCredentialLock(tmp.Path).TryAcquire())
+            {
+                Assert.NotNull(holder); // a peer holds the machine lock for the whole attempt
+
+                var outcome = account.TryMigrateLegacyCloudToken("sink-cloud-token", AsBaseUrl);
+
+                Assert.Equal(GodotLegacyTokenMigrationResult.Busy, outcome);
+                Assert.False(Store(tmp).Exists); // nothing was written without the lock (D9)
+            }
+
+            var second = account.TryMigrateLegacyCloudToken("sink-cloud-token", AsBaseUrl);
+
+            Assert.Equal(GodotLegacyTokenMigrationResult.Migrated, second);
+            Assert.Equal("sink-cloud-token", Store(tmp).Read()!.Families?.Legacy?.AccessToken);
+            Assert.True(account.IsSignedIn);
+        }
 
         [Fact]
         public async Task Migrate_SeededSink_EmptyStore_WritesLegacyFamilyUnderLock_AndSignsIn()
@@ -458,11 +631,40 @@ namespace com.IvanMurzak.Godot.MCP.Tests
 
         static MachineCredentialStore Store(TempDir tmp) => new(tmp.Path);
 
-        static GodotAccountAuth MakeAccount(TempDir tmp, HttpMessageHandler handler)
+        static GodotAccountAuth MakeAccount(
+            TempDir tmp,
+            HttpMessageHandler handler,
+            Func<TimeSpan, CancellationToken, Task>? delay = null,
+            MachineCredentialLock? credentialLock = null)
             => new(
                 asBaseUrlProvider: () => AsBaseUrl,
                 store: new MachineCredentialStore(tmp.Path),
-                httpClient: new HttpClient(handler));
+                httpClient: new HttpClient(handler),
+                credentialLock: credentialLock,
+                // Instant by default so the bounded second-phase backoff costs no test wall-clock;
+                // tests that assert the backoff inject a recording delegate instead.
+                delay: delay ?? ((_, _) => Task.CompletedTask));
+
+        /// <summary>
+        /// A <see cref="MachineCredentialLock"/> with a SHORT acquire budget (400 ms instead of the 75 s
+        /// contract value), via the package's internal timing ctor
+        /// <c>(baseDirectory, hostId, acquireBudgetMs, staleMs, foreignStaleMs, diagnostics)</c> —
+        /// reflection because InternalsVisibleTo covers only McpPlugin.Tests. Staleness bars stay REAL
+        /// (60 s / 24 h) so the held peer lock is never taken over mid-test. If the ctor shape changes
+        /// in an upstream bump, this fails loudly here rather than silently testing nothing.
+        /// </summary>
+        static MachineCredentialLock MakeShortBudgetLock(string baseDirectory)
+        {
+            var ctor = typeof(MachineCredentialLock).GetConstructor(
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+                binder: null,
+                new[] { typeof(string), typeof(string), typeof(int), typeof(long), typeof(long), typeof(Action<string>) },
+                modifiers: null);
+            Assert.True(ctor != null,
+                "MachineCredentialLock's internal timing ctor (baseDirectory, hostId, acquireBudgetMs, staleMs, foreignStaleMs, diagnostics) "
+                + "was not found — the McpPlugin package shape changed; update this test seam.");
+            return (MachineCredentialLock)ctor!.Invoke(new object?[] { baseDirectory, null, 400, 60_000L, 86_400_000L, null });
+        }
 
         static GodotDeviceAuthFlow MakeFlow(HttpMessageHandler handler)
             => new(

--- a/Godot-MCP.Tests/GodotCloudAccountControllerTests.cs
+++ b/Godot-MCP.Tests/GodotCloudAccountControllerTests.cs
@@ -1,0 +1,212 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.Godot.MCP.Connection;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Covers <see cref="GodotCloudAccountController"/> — the pure orchestration behind the dock's Cloud
+    /// "Authorize" button (unified-machine-auth task f1), and the home of the O8 sink-write invariant:
+    ///
+    /// <para><b>A successful authorize persists the credential ONLY into the machine store.</b> The
+    /// persisted-config layer (<see cref="GodotMcpConfig.CloudToken"/> — serialized to the plaintext
+    /// <c>user://godot-mcp-config.json</c> sink) gains NO new cloudToken. This is the G-SEC-1 plant-1
+    /// test: re-enabling the historical <c>config.CloudToken = token</c> write anywhere on the authorize
+    /// path turns <see cref="SignIn_Success_WritesTheMachineStore_AndNeverTheCloudTokenSink"/> RED.
+    /// The positive half is proven in the same test by a POSITIVE artifact — the machine store actually
+    /// holding the committed families — so the no-write assert can never pass vacuously (the path
+    /// demonstrably CAN persist a credential; it persists it to the store).</para>
+    /// </summary>
+    public class GodotCloudAccountControllerTests
+    {
+        const string AsBaseUrl = "https://ai-game.dev";
+
+        [Fact]
+        public async Task SignIn_Success_WritesTheMachineStore_AndNeverTheCloudTokenSink()
+        {
+            using var tmp = new TempDir();
+            var handler = new ScriptedHandler(
+                deviceAuthorize: DeviceAuthorizeJson("USER-1", "dev-1"),
+                deviceToken: TokenJson("acc-agent", "ref-agent", scope: "mcp:agent"),
+                exchange: ExchangeJson("acc-plugin", "ref-plugin", scope: "mcp:plugin", sub: "usr_1"));
+            using var account = MakeAccount(tmp, handler);
+            var config = new GodotMcpConfig();
+            Assert.Null(config.CloudToken); // precondition: a fresh config carries no cloud token
+
+            var outcome = await GodotCloudAccountController.SignInAsync(
+                account, MakeFlow(handler), AsBaseUrl, config);
+
+            // POSITIVE artifact: the sign-in DID persist a credential — into the machine store.
+            Assert.Equal(GodotAccountSignInStatus.SignedIn, outcome.Status);
+            var persisted = new MachineCredentialStore(tmp.Path).Read();
+            Assert.Equal("acc-plugin", persisted?.Families?.Plugin?.AccessToken);
+            Assert.Equal("acc-agent", persisted?.Families?.Agent?.AccessToken);
+            Assert.True(account.IsSignedIn);
+
+            // THE PIN (O8 / G-SEC-1 plant 1): the legacy user:// sink layer gained no new cloudToken.
+            Assert.Null(config.CloudToken);
+            // And the custom-token field was not abused as a side channel either.
+            Assert.Null(config.CustomToken);
+        }
+
+        [Fact]
+        public async Task SignIn_NotAuthorized_TouchesNeitherStoreNorConfig()
+        {
+            using var tmp = new TempDir();
+            var handler = new ScriptedHandler(
+                deviceAuthorize: DeviceAuthorizeJson("USER-1", "dev-1"),
+                deviceToken: "{ \"error\": \"access_denied\" }",
+                deviceTokenStatus: HttpStatusCode.BadRequest);
+            using var account = MakeAccount(tmp, handler);
+            var config = new GodotMcpConfig();
+
+            var outcome = await GodotCloudAccountController.SignInAsync(
+                account, MakeFlow(handler), AsBaseUrl, config);
+
+            Assert.Equal(GodotAccountSignInStatus.NotAuthorized, outcome.Status);
+            Assert.False(new MachineCredentialStore(tmp.Path).Exists);
+            Assert.Null(config.CloudToken);
+        }
+
+        /// <summary>
+        /// A PRE-EXISTING legacy sink token (the O8 read-fallback window) is left exactly as it was — the
+        /// controller neither clears nor overwrites it on a successful machine-store sign-in (delete-source
+        /// semantics belong to the f4 follow-up).
+        /// </summary>
+        [Fact]
+        public async Task SignIn_Success_LeavesAPreExistingLegacySinkTokenUntouched()
+        {
+            using var tmp = new TempDir();
+            var handler = new ScriptedHandler(
+                deviceAuthorize: DeviceAuthorizeJson("USER-1", "dev-1"),
+                deviceToken: TokenJson("acc-agent", "ref-agent", scope: "mcp:agent"),
+                exchange: ExchangeJson("acc-plugin", "ref-plugin", scope: "mcp:plugin", sub: "usr_1"));
+            using var account = MakeAccount(tmp, handler);
+            var config = new GodotMcpConfig { CloudToken = "pre-existing-sink-token" };
+
+            var outcome = await GodotCloudAccountController.SignInAsync(
+                account, MakeFlow(handler), AsBaseUrl, config);
+
+            Assert.True(outcome.Succeeded);
+            Assert.Equal("pre-existing-sink-token", config.CloudToken);
+        }
+
+        // --- helpers (mirrors GodotAccountAuthTests' fixtures) ---
+
+        static GodotAccountAuth MakeAccount(TempDir tmp, HttpMessageHandler handler)
+            => new(
+                asBaseUrlProvider: () => AsBaseUrl,
+                store: new MachineCredentialStore(tmp.Path),
+                httpClient: new HttpClient(handler));
+
+        static GodotDeviceAuthFlow MakeFlow(HttpMessageHandler handler)
+            => new(
+                new GodotDeviceAuthService(new HttpClient(handler)),
+                delay: (_, _) => Task.CompletedTask,
+                utcNow: () => DateTime.UtcNow);
+
+        static string DeviceAuthorizeJson(string userCode, string deviceCode) => $$"""
+            {
+              "device_code": "{{deviceCode}}",
+              "user_code": "{{userCode}}",
+              "verification_uri": "https://ai-game.dev/verify",
+              "verification_uri_complete": "https://ai-game.dev/verify?code={{userCode}}",
+              "expires_in": 600,
+              "interval": 5
+            }
+            """;
+
+        static string TokenJson(string access, string refresh, string scope) => $$"""
+            {
+              "access_token": "{{access}}",
+              "refresh_token": "{{refresh}}",
+              "token_type": "Bearer",
+              "expires_in": 3600,
+              "scope": "{{scope}}"
+            }
+            """;
+
+        static string ExchangeJson(string access, string refresh, string scope, string sub) => $$"""
+            {
+              "access_token": "{{access}}",
+              "refresh_token": "{{refresh}}",
+              "token_type": "Bearer",
+              "expires_in": 3600,
+              "scope": "{{scope}}",
+              "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+              "sub": "{{sub}}"
+            }
+            """;
+
+        sealed class TempDir : IDisposable
+        {
+            public string Path { get; } = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(), "godot-mcp-ctrl-" + Guid.NewGuid().ToString("N"));
+
+            public void Dispose()
+            {
+                try { if (Directory.Exists(Path)) Directory.Delete(Path, recursive: true); }
+                catch { /* best-effort test cleanup */ }
+            }
+        }
+
+        /// <summary>Routes device_authorization / device-code token / token-exchange to scripted JSON.</summary>
+        sealed class ScriptedHandler : HttpMessageHandler
+        {
+            readonly string _deviceAuthorize;
+            readonly string _deviceToken;
+            readonly HttpStatusCode _deviceTokenStatus;
+            readonly string? _exchange;
+
+            public ScriptedHandler(string deviceAuthorize, string deviceToken,
+                string? exchange = null, HttpStatusCode deviceTokenStatus = HttpStatusCode.OK)
+            {
+                _deviceAuthorize = deviceAuthorize;
+                _deviceToken = deviceToken;
+                _exchange = exchange;
+                _deviceTokenStatus = deviceTokenStatus;
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var path = request.RequestUri!.AbsolutePath;
+                var body = request.Content != null
+                    ? await request.Content.ReadAsStringAsync(cancellationToken)
+                    : string.Empty;
+                var decoded = WebUtility.UrlDecode(body);
+
+                if (path.EndsWith("/oauth/device_authorization", StringComparison.Ordinal))
+                    return Json(HttpStatusCode.OK, _deviceAuthorize);
+                if (path.EndsWith("/oauth/revoke", StringComparison.Ordinal))
+                    return new HttpResponseMessage(HttpStatusCode.OK);
+                if (path.EndsWith("/oauth/token", StringComparison.Ordinal))
+                {
+                    if (decoded.Contains("grant-type:token-exchange"))
+                        return Json(HttpStatusCode.OK, _exchange ?? throw new InvalidOperationException("unscripted token exchange"));
+                    return Json(_deviceTokenStatus, _deviceToken);
+                }
+                throw new InvalidOperationException($"unexpected request: {path}"); // path only — never form fields
+
+                static HttpResponseMessage Json(HttpStatusCode code, string json)
+                    => new(code) { Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json") };
+            }
+        }
+    }
+}

--- a/Godot-MCP.Tests/GodotDeviceAuthFlowTests.cs
+++ b/Godot-MCP.Tests/GodotDeviceAuthFlowTests.cs
@@ -99,11 +99,14 @@ namespace com.IvanMurzak.Godot.MCP.Tests
 
             await flow.AuthorizeAsync(AsBaseUrl);
 
-            // Authorize request: POST /oauth/device_authorization with client_id + scope=mcp:plugin.
+            // Authorize request: POST /oauth/device_authorization with client_id + scope=mcp:agent
+            // (unified-machine-auth 03 F1.2 — the flow mints AGENT tokens; the plugin family is derived
+            // via RFC 8693 by the login commit, never requested here).
             var authorize = handler.Requests[0];
             Assert.EndsWith("/oauth/device_authorization", authorize.Path);
             Assert.Contains($"client_id={GodotDeviceAuthFlow.DefaultClientId}", authorize.Body);
-            Assert.Contains("scope=mcp%3Aplugin", authorize.Body); // "mcp:plugin" url-encoded
+            Assert.Contains("scope=mcp%3Aagent", authorize.Body); // "mcp:agent" url-encoded
+            Assert.DoesNotContain("scope=mcp%3Aplugin", authorize.Body);
 
             // Token request: POST /oauth/token with the device-code grant + same client_id + device_code.
             var token = handler.Requests[1];

--- a/Godot-MCP.Tests/GodotTokenRefresherTests.cs
+++ b/Godot-MCP.Tests/GodotTokenRefresherTests.cs
@@ -14,30 +14,32 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using com.IvanMurzak.Godot.MCP.Connection;
+using com.IvanMurzak.McpPlugin;
 using Xunit;
 
 namespace com.IvanMurzak.Godot.MCP.Tests
 {
     /// <summary>
-    /// Covers <see cref="GodotTokenRefresher"/> — the Godot <c>ITokenRefresher</c> that exchanges a refresh
-    /// token for a fresh access token at <c>POST /oauth/token</c> (<c>grant_type=refresh_token</c>). Verifies
-    /// the success mapping (access + rotated refresh + expiry), the fail-closed behaviour (error body / HTTP
-    /// fault → <c>Failure</c>, never a fabricated token), the RFC-6749 form shape, and the server-target →
-    /// AS-base resolution (a hub <c>/mcp</c> suffix is stripped). Never asserts a token into a log surface.
+    /// Covers <see cref="GodotTokenRefresher"/> — since unified-machine-auth f1 a THIN ADAPTER over the
+    /// shared <see cref="HttpTokenRefresher"/> (McpPlugin 8.1, task b3). Verifies the 04 §3 wire contract
+    /// the adapter must preserve end-to-end: <c>grant_type=refresh_token</c> at
+    /// <c>&lt;target&gt;/oauth/token</c>, the family's STORED <c>clientId</c> presented verbatim (component
+    /// default ONLY for the legacy no-context API), <c>scope</c>/<c>resource</c> omitted entirely, the
+    /// success mapping (access + rotated refresh + expiry), fail-closed error handling, and the adapter's
+    /// one local behavior — the LIVE default-AS-base resolution for target-less requests (with the shared
+    /// <c>/mcp</c>-suffix strip for stored hub URLs). Never asserts a token into a log surface.
     /// </summary>
     public class GodotTokenRefresherTests
     {
         const string AsBaseUrl = "https://ai-game.dev";
         const string NewAccess = "fresh-access-token";
         const string NewRefresh = "rotated-refresh-token";
-        static readonly DateTimeOffset T0 = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
         static GodotTokenRefresher MakeRefresher(RecordingHandler handler, Func<string>? defaultBase = null)
             => new(
-                new GodotDeviceAuthService(new HttpClient(handler)),
                 defaultBase ?? (() => AsBaseUrl),
                 clientId: GodotDeviceAuthFlow.DefaultClientId,
-                clock: () => T0);
+                httpClient: new HttpClient(handler));
 
         [Fact]
         public async Task RefreshAsync_Success_MapsAccessRefreshAndExpiry()
@@ -45,16 +47,20 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             var handler = new RecordingHandler(TokenOk(NewAccess, NewRefresh, expiresIn: 3600));
             var refresher = MakeRefresher(handler);
 
+            var before = DateTimeOffset.UtcNow;
             var result = await refresher.RefreshAsync("old-refresh", serverTarget: null);
+            var after = DateTimeOffset.UtcNow;
 
             Assert.True(result.Succeeded);
             Assert.Equal(NewAccess, result.AccessToken);
             Assert.Equal(NewRefresh, result.RefreshToken);
-            Assert.Equal(T0.AddSeconds(3600), result.ExpiresAt);
+            // The shared refresher stamps expiry off the real clock — assert the window, not an instant.
+            Assert.NotNull(result.ExpiresAt);
+            Assert.InRange(result.ExpiresAt!.Value, before.AddSeconds(3600), after.AddSeconds(3600));
         }
 
         [Fact]
-        public async Task RefreshAsync_SendsRefreshTokenGrantForm()
+        public async Task RefreshAsync_LegacyApi_SendsRefreshTokenGrantForm_WithComponentDefaultClientId()
         {
             var handler = new RecordingHandler(TokenOk(NewAccess, NewRefresh));
             var refresher = MakeRefresher(handler);
@@ -64,7 +70,39 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Equal($"{AsBaseUrl}/oauth/token", handler.LastRequestUri);
             Assert.Contains("grant_type=refresh_token", handler.LastBody);
             Assert.Contains("refresh_token=old-refresh", handler.LastBody);
+            // No family context on the legacy two-string API ⇒ the component default (04 §3.7).
             Assert.Contains($"client_id={GodotDeviceAuthFlow.DefaultClientId}", handler.LastBody);
+        }
+
+        /// <summary>
+        /// 04 §3.2 (G-SEC-1 plant-3 discriminator): a family-aware request's STORED <c>clientId</c> reaches
+        /// the wire verbatim — the adapter must never substitute the component default.
+        /// </summary>
+        [Fact]
+        public async Task RefreshAsync_FamilyAware_PresentsTheStoredClientId()
+        {
+            var handler = new RecordingHandler(TokenOk(NewAccess, NewRefresh));
+            var refresher = MakeRefresher(handler);
+
+            await refresher.RefreshAsync(
+                new TokenRefreshRequest("old-refresh", serverTarget: null, clientId: "stored-custom-id"));
+
+            Assert.Contains("client_id=stored-custom-id", handler.LastBody);
+            Assert.DoesNotContain(GodotDeviceAuthFlow.DefaultClientId, handler.LastBody);
+        }
+
+        /// <summary>04 §3.3 / P0-3 (G-SEC-1 plant-3 discriminator): no <c>scope</c>, no <c>resource</c> — ever.</summary>
+        [Fact]
+        public async Task RefreshAsync_OmitsScopeAndResourceEntirely()
+        {
+            var handler = new RecordingHandler(TokenOk(NewAccess, NewRefresh));
+            var refresher = MakeRefresher(handler);
+
+            await refresher.RefreshAsync(
+                new TokenRefreshRequest("old-refresh", serverTarget: null, clientId: "stored-custom-id"));
+
+            Assert.DoesNotContain("scope=", handler.LastBody);
+            Assert.DoesNotContain("resource=", handler.LastBody);
         }
 
         [Fact]
@@ -80,10 +118,14 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         }
 
         [Fact]
-        public async Task RefreshAsync_NullServerTarget_UsesDefaultBase()
+        public async Task RefreshAsync_NullServerTarget_UsesTheLiveDefaultBase()
         {
             var handler = new RecordingHandler(TokenOk(NewAccess, NewRefresh));
-            var refresher = MakeRefresher(handler, defaultBase: () => "https://local-as.example");
+            // Read LIVE per call (a .env cloud-URL override applies without a rebuild): flip the value
+            // between construction and the call to prove the resolution is not captured at construction.
+            var liveBase = "https://constructed.example";
+            var refresher = MakeRefresher(handler, defaultBase: () => liveBase);
+            liveBase = "https://local-as.example";
 
             await refresher.RefreshAsync("old-refresh", serverTarget: null);
 
@@ -91,7 +133,7 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         }
 
         [Fact]
-        public async Task RefreshAsync_ErrorBody_FailsClosedWithReason()
+        public async Task RefreshAsync_ErrorBody_FailsClosed_ClassifiedInvalidGrant()
         {
             var handler = new RecordingHandler(() => JsonResponse(HttpStatusCode.BadRequest,
                 "{ \"error\": \"invalid_grant\", \"error_description\": \"refresh token expired\" }"));
@@ -101,11 +143,12 @@ namespace com.IvanMurzak.Godot.MCP.Tests
 
             Assert.False(result.Succeeded);
             Assert.Null(result.AccessToken);
-            Assert.Equal("invalid_grant", result.FailureReason);
+            Assert.Contains("invalid_grant", result.FailureReason);
+            Assert.Equal(TokenRefreshFailureKind.InvalidGrant, result.FailureKind);
         }
 
         [Fact]
-        public async Task RefreshAsync_HttpFault_FailsClosed()
+        public async Task RefreshAsync_HttpFault_FailsClosed_AsTransient()
         {
             var handler = new RecordingHandler(() => throw new HttpRequestException("connection refused"));
             var refresher = MakeRefresher(handler);
@@ -114,18 +157,28 @@ namespace com.IvanMurzak.Godot.MCP.Tests
 
             Assert.False(result.Succeeded);
             Assert.Null(result.AccessToken);
+            Assert.Equal(TokenRefreshFailureKind.Transient, result.FailureKind);
         }
 
         [Fact]
-        public async Task RefreshAsync_Cancellation_Propagates()
+        public async Task RefreshAsync_PreCanceledToken_Propagates()
         {
-            var handler = new RecordingHandler(() => throw new OperationCanceledException());
+            var handler = new RecordingHandler(TokenOk(NewAccess, NewRefresh));
             var refresher = MakeRefresher(handler);
 
-            // A pre-canceled token makes HttpClient throw TaskCanceledException (a subclass); assert ANY
-            // OperationCanceledException so cancellation propagates rather than collapsing into a Failure.
             await Assert.ThrowsAnyAsync<OperationCanceledException>(
                 () => refresher.RefreshAsync("some-refresh", serverTarget: null, new CancellationToken(canceled: true)));
+        }
+
+        [Fact]
+        public async Task RefreshAsync_EmptyRefreshToken_FailsWithoutNetworkIo()
+        {
+            var handler = new RecordingHandler(() => throw new InvalidOperationException("unexpected network call"));
+            var refresher = MakeRefresher(handler);
+
+            var result = await refresher.RefreshAsync("", serverTarget: null);
+
+            Assert.False(result.Succeeded);
         }
 
         // --- helpers ---

--- a/addons/godot_mcp/Editor/Connection/GodotAccountAuth.cs
+++ b/addons/godot_mcp/Editor/Connection/GodotAccountAuth.cs
@@ -9,6 +9,7 @@
 */
 #nullable enable
 using System;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin;
@@ -17,116 +18,369 @@ using Microsoft.Extensions.Logging;
 
 namespace com.IvanMurzak.Godot.MCP.Connection
 {
+    /// <summary>How a <see cref="GodotAccountAuth.SignInAsync"/> attempt ended (non-secret).</summary>
+    public enum GodotAccountSignInStatus
+    {
+        /// <summary>Agent + plugin families committed to the machine store — fully signed in (F1 happy path).</summary>
+        SignedIn,
+
+        /// <summary>
+        /// The agent family was committed but the plugin family was not (failed/busy token exchange or a
+        /// busy/unreadable second lock hold) — the 03 F1 failure path. The machine holds a valid agent
+        /// credential; a retry of Authorize completes the derivation.
+        /// </summary>
+        PartiallyAuthorized,
+
+        /// <summary>The device flow ended without authorization (denied / expired / cancelled / failed). Nothing was written.</summary>
+        NotAuthorized,
+
+        /// <summary>The machine credential lock was busy before anything was written — retry.</summary>
+        Busy,
+
+        /// <summary>
+        /// The store belongs to a different account (F7/D6 subject guard) — nothing was written; an
+        /// account-switch confirmation flow is required before replacing it.
+        /// </summary>
+        SubjectConflict,
+
+        /// <summary>Any other terminal failure (e.g. a machine-wide sign-out raced the commit). Nothing usable was written.</summary>
+        Failed,
+    }
+
+    /// <summary>The outcome of a sign-in attempt. Carries NO token material.</summary>
+    public sealed class GodotAccountSignInResult
+    {
+        internal GodotAccountSignInResult(GodotAccountSignInStatus status, string? detail)
+        {
+            Status = status;
+            Detail = detail;
+        }
+
+        /// <summary>How the attempt ended.</summary>
+        public GodotAccountSignInStatus Status { get; }
+
+        /// <summary>Human-facing detail (busy path, exchange failure reason, …). Never token material.</summary>
+        public string? Detail { get; }
+
+        /// <summary>True when the machine is fully signed in (agent + plugin families committed).</summary>
+        public bool Succeeded => Status == GodotAccountSignInStatus.SignedIn;
+    }
+
+    /// <summary>Outcome of the O8/F11.2 legacy <c>user://</c> cloudToken migration (non-secret).</summary>
+    public enum GodotLegacyTokenMigrationResult
+    {
+        /// <summary>The legacy sink holds no cloudToken — nothing to migrate.</summary>
+        NoSinkToken,
+
+        /// <summary>The sink credential was written into the machine store (as a legacy family) under the lock.</summary>
+        Migrated,
+
+        /// <summary>The machine store already holds credential material — the store wins; sink untouched.</summary>
+        SkippedStoreHasCredential,
+
+        /// <summary>The store exists but cannot be read (04 §1) — never overwritten; migration skipped.</summary>
+        SkippedStoreUnreadable,
+
+        /// <summary>The machine credential lock was busy — migration retries on a later boot (idempotent).</summary>
+        Busy,
+    }
+
     /// <summary>
-    /// The Godot addon's ai-game.dev account-credential coordinator (mcp-authorize design 06, D12 — the
-    /// zero-button rule). It owns the shared machine credential store (<c>~/.ai-game-dev/credentials.json</c>)
-    /// through McpPlugin 7.0's <see cref="PluginCredentialProvider"/> and the Godot
-    /// <see cref="GodotTokenRefresher"/>, wiring the two device-flow endpoints (sign-in + refresh) into a
-    /// single seam the connection consumes.
-    ///
-    /// <para>Three behaviours:</para>
+    /// The Godot addon's ai-game.dev account-credential coordinator (unified-machine-auth design, task f1 —
+    /// the Godot adoption of the shared b3 credential stack). It owns the shared machine credential store
+    /// (<c>~/.ai-game-dev/credentials.json</c>) through McpPlugin 8.1's <see cref="PluginCredentialProvider"/>
+    /// + the cross-process <see cref="MachineCredentialLock"/>, and exposes the four account operations the
+    /// editor consumes:
     /// <list type="bullet">
-    ///   <item><b>Boot auto-adopt:</b> the machine store is read at construction. If a valid (or refreshable)
-    ///   credential is present the plugin is signed in with <b>zero UI interaction</b> — the connection
-    ///   presents its JWT and pairs on boot (the store is populated once per machine by a <c>godot-cli
-    ///   login</c>, an enrollment, or another engine).</item>
-    ///   <item><b>Sign-in (persist):</b> <see cref="SignInAsync"/> runs the device flow and persists the
-    ///   resulting credential into the machine store. (The in-editor "Sign in" button is wired to this by the
-    ///   ConnectionPanel UI flip in the follow-up PR; PR 2 delivers + unit-tests the capability.)</item>
-    ///   <item><b>Refresh:</b> <see cref="AccessTokenProvider"/> refreshes the token proactively before
-    ///   <c>exp</c> on every (re)connect; <see cref="RefreshAsync"/> refreshes reactively when the connection's
-    ///   3-strike authorization-rejected signal fires.</item>
+    ///   <item><b>Boot auto-adopt (zero-button rule):</b> the machine store is read at construction; a valid
+    ///   (or refreshable) credential signs the plugin in with zero UI interaction.</item>
+    ///   <item><b>Sign-in (F1):</b> <see cref="SignInAsync"/> runs the RFC 8628 device flow (scope
+    ///   <c>mcp:agent</c>), then the shared TWO-LOCK-HOLD commit
+    ///   (<see cref="MachineCredentialLoginCommit.CommitAsync"/>): agent family under the first hold, RFC 8693
+    ///   token exchange between the holds, plugin family + v1 mirror under the second. Credential writes go
+    ///   ONLY through the guarded helper — never through bare <see cref="PluginCredentialProvider.Adopt"/>
+    ///   (staged remediation G-SEC-2).</item>
+    ///   <item><b>Refresh:</b> proactive (before <c>exp</c>) and reactive (3-strike authorization-rejected)
+    ///   via the shared <see cref="HttpTokenRefresher"/> (through the <see cref="GodotTokenRefresher"/>
+    ///   adapter): stored <c>clientId</c>, no <c>scope</c>/<c>resource</c>, under the machine lock (04 §3).</item>
+    ///   <item><b>Sign-out (F6):</b> <see cref="SignOutMachineWideAsync"/> — best-effort RFC 7009 revocation
+    ///   of every stored family, then the lock-protocol store delete, machine-wide.</item>
     /// </list>
     ///
     /// <para>
-    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) so the whole store/adopt/refresh lifecycle is
-    /// unit-testable with a temp-directory <see cref="MachineCredentialStore"/> + a fake
-    /// <see cref="System.Net.Http.HttpMessageHandler"/>. Never logs token material.
+    /// It also owns the O8/F11.2 legacy migration (<see cref="TryMigrateLegacyCloudToken"/>): a
+    /// <c>user://godot-mcp-config.json</c> cloudToken found on start is copied into the machine store (under
+    /// the lock) when — and only when — the store holds no credential. The sink itself is NOT deleted here
+    /// (delete-source semantics are the f4 follow-up, one release later); the connection keeps its
+    /// read-fallback to the sink for the same window.
+    /// </para>
+    ///
+    /// <para>
+    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) so the whole store/adopt/refresh/commit
+    /// lifecycle is unit-testable with a temp-directory <see cref="MachineCredentialStore"/> + a fake
+    /// <see cref="HttpMessageHandler"/>. Never logs token material.
     /// </para>
     /// </summary>
     public sealed class GodotAccountAuth : IDisposable
     {
         readonly MachineCredentialStore _store;
-        readonly PluginCredentialProvider _provider;
+        readonly MachineCredentialLock _lock;
+        readonly Func<string> _asBaseUrlProvider;
+        readonly HttpClient? _httpClient;
+        readonly ILogger? _logger;
+        readonly Func<DateTimeOffset>? _clock;
         readonly string _clientId;
+
+        // The provider is REBUILT (auto-adopting from the store) after every guarded store mutation —
+        // login commit, machine-wide sign-out, legacy migration — because the guarded helpers write the
+        // store directly and the provider's in-memory credential would otherwise go stale. Swapped
+        // atomically; readers go through Provider below.
+        PluginCredentialProvider _provider;
 
         /// <summary>
         /// Construct the coordinator. <paramref name="asBaseUrlProvider"/> supplies the authorization-server
-        /// base URL for refreshes (read live so a <c>.env</c> cloud-URL override applies). The remaining
-        /// arguments are injectable seams for tests: a temp-directory <paramref name="store"/>, a fake-handler
-        /// <paramref name="service"/>, a deterministic <paramref name="clock"/>. Constructing this READS the
-        /// machine store (the auto-adopt), so a pre-existing credential leaves the coordinator
-        /// <see cref="IsSignedIn"/> immediately.
+        /// base URL (read live so a <c>.env</c> cloud-URL override applies) used for refreshes of
+        /// target-less credentials, token exchange, and revocation. The remaining arguments are injectable
+        /// seams for tests: a temp-directory <paramref name="store"/>, a fake-handler
+        /// <paramref name="httpClient"/>, a deterministic <paramref name="clock"/>, a test
+        /// <paramref name="credentialLock"/>. Constructing this READS the machine store (the auto-adopt), so
+        /// a pre-existing credential leaves the coordinator <see cref="IsSignedIn"/> immediately.
         /// </summary>
         public GodotAccountAuth(
             Func<string> asBaseUrlProvider,
             MachineCredentialStore? store = null,
-            GodotDeviceAuthService? service = null,
+            HttpClient? httpClient = null,
             ILogger? logger = null,
             string? clientId = null,
-            Func<DateTimeOffset>? clock = null)
+            Func<DateTimeOffset>? clock = null,
+            MachineCredentialLock? credentialLock = null)
         {
-            if (asBaseUrlProvider == null)
-                throw new ArgumentNullException(nameof(asBaseUrlProvider));
-
+            _asBaseUrlProvider = asBaseUrlProvider ?? throw new ArgumentNullException(nameof(asBaseUrlProvider));
             _store = store ?? new MachineCredentialStore();
+            _lock = credentialLock ?? new MachineCredentialLock(_store.BaseDirectory);
+            _httpClient = httpClient;
+            _logger = logger;
+            _clock = clock;
             _clientId = string.IsNullOrEmpty(clientId) ? GodotDeviceAuthFlow.DefaultClientId : clientId!;
-            var refresher = new GodotTokenRefresher(
-                service ?? new GodotDeviceAuthService(), asBaseUrlProvider, _clientId, clock);
 
             // Auto-adopt: PluginCredentialProvider reads the store at construction. No UI, no device flow.
-            _provider = new PluginCredentialProvider(_store, refresher, logger);
+            _provider = BuildProvider();
         }
 
+        PluginCredentialProvider BuildProvider()
+            => new PluginCredentialProvider(
+                _store,
+                refresher: new GodotTokenRefresher(_asBaseUrlProvider, _clientId, _httpClient),
+                logger: _logger,
+                clock: _clock,
+                credentialLock: _lock); // 04 §2: refresh writes run under the machine-wide lock
+
+        PluginCredentialProvider Provider => Volatile.Read(ref _provider);
+
         /// <summary>True when a usable machine-store credential is present (the zero-button signed-in state).</summary>
-        public bool IsSignedIn => _provider.IsSignedIn;
+        public bool IsSignedIn => Provider.IsSignedIn;
 
         /// <summary>The account id (<c>sub</c>) the current credential resolves to, if known (diagnostic only).</summary>
-        public string? Subject => _provider.Subject;
+        public string? Subject => Provider.Subject;
 
         /// <summary>
         /// The <c>Func&lt;Task&lt;string?&gt;&gt;</c> to compose into the connection's credential provider. It
         /// returns the current (proactively-refreshed) access token, or null when signed out — so a signed-out
-        /// machine transparently falls back to the connection's existing token resolution.
+        /// machine transparently falls back to the connection's existing token resolution. Late-bound to the
+        /// CURRENT provider so a post-commit/migration rebuild is picked up by an already-captured delegate.
         /// </summary>
-        public Func<Task<string?>> AccessTokenProvider => _provider.AsAccessTokenProvider();
+        public Func<Task<string?>> AccessTokenProvider => () => Provider.GetAccessTokenAsync(CancellationToken.None);
 
         /// <summary>
         /// Refresh the access token now (driven by the connection's 3-strike authorization-rejected signal).
-        /// Returns true when a fresh token was persisted; false when refresh failed or is impossible (in which
-        /// case the provider has surfaced sign-in-required and the caller must NOT loop).
+        /// Returns true when a fresh token was persisted (or adopted from a peer's rotation); false when
+        /// refresh failed or is impossible (in which case the provider has surfaced sign-in-required and the
+        /// caller must NOT loop).
         /// </summary>
         public Task<bool> RefreshAsync(CancellationToken cancellationToken = default)
-            => _provider.RefreshAsync(cancellationToken);
+            => Provider.RefreshAsync(cancellationToken);
 
         /// <summary>
-        /// Run the device flow against <paramref name="asBaseUrl"/> via <paramref name="flow"/> and, on
-        /// success, persist the resulting credential into the machine store (D12). The caller owns the flow so
-        /// it can subscribe to <see cref="GodotDeviceAuthFlow.OnStateChanged"/> for the browser-open. Returns
-        /// true when a credential was adopted (signed in), false on any non-Authorized terminal state.
+        /// Run the F1 sign-in end-to-end: the RFC 8628 device flow against <paramref name="asBaseUrl"/> via
+        /// <paramref name="flow"/> (scope <c>mcp:agent</c> — the flow's default), then the shared two-lock-hold
+        /// commit + RFC 8693 derivation (<see cref="MachineCredentialLoginCommit.CommitAsync"/>). The caller
+        /// owns the flow so it can subscribe to <see cref="GodotDeviceAuthFlow.OnStateChanged"/> for the
+        /// browser-open. On <see cref="GodotAccountSignInStatus.SignedIn"/> every AI-Game-Dev tool on the
+        /// machine is signed in (F1.5).
+        /// <para>
+        /// The device-grant token response carries no <c>sub</c> (only the exchange response does — O5), so
+        /// the commit's first-hold subject guard runs in its no-sub form (F7.3: proceed); the exchange
+        /// response's subject is backfilled into the store by the commit helper.
+        /// </para>
         /// </summary>
-        public async Task<bool> SignInAsync(GodotDeviceAuthFlow flow, string asBaseUrl)
+        public async Task<GodotAccountSignInResult> SignInAsync(
+            GodotDeviceAuthFlow flow, string asBaseUrl, CancellationToken cancellationToken = default)
         {
             if (flow == null)
                 throw new ArgumentNullException(nameof(flow));
+            if (string.IsNullOrEmpty(asBaseUrl))
+                throw new ArgumentException("The authorization-server base URL is required.", nameof(asBaseUrl));
 
             var result = await flow.AuthorizeAsync(asBaseUrl).ConfigureAwait(false);
             if (result == null)
-                return false;
+                return new GodotAccountSignInResult(GodotAccountSignInStatus.NotAuthorized, flow.ErrorMessage);
 
-            _provider.Adopt(new MachineCredentials
+            var agentFamily = new MachineCredentialFamily
             {
                 AccessToken = result.AccessToken,
                 RefreshToken = result.RefreshToken,
                 ExpiresAt = result.ExpiresAt,
-                ServerTarget = asBaseUrl,
-            });
-            return true;
+                // D8: written from the value actually presented, never inferred — the flow presents
+                // GodotDeviceAuthFlow.DefaultClientId on the RFC 8628 wire (its own hardcoded id), so
+                // that is what the agent family is stamped with, regardless of any injected _clientId.
+                ClientId = GodotDeviceAuthFlow.DefaultClientId,
+                Scope = result.Scope ?? GodotDeviceAuthFlow.AgentScope,
+            };
+
+            var commit = await MachineCredentialLoginCommit.CommitAsync(
+                _store,
+                _lock,
+                agentFamily,
+                serverTarget: asBaseUrl,
+                subject: null, // device-grant response carries no sub (O5 covers exchange/enroll only)
+                exchangeClient: new TokenExchangeClient(asBaseUrl, _clientId, _httpClient),
+                confirmedReplaceOfSubject: null,
+                revocationClient: new TokenRevocationClient(asBaseUrl, _httpClient),
+                logger: _logger,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            // The guarded helper wrote the store directly — rebuild the provider so its in-memory state
+            // (IsSignedIn / AccessTokenProvider) reflects what was actually committed.
+            ReloadFromStore();
+
+            return commit.Status switch
+            {
+                LoginCommitStatus.FullyCommitted =>
+                    new GodotAccountSignInResult(GodotAccountSignInStatus.SignedIn, null),
+                LoginCommitStatus.AgentOnly or LoginCommitStatus.PluginCommitBusy or LoginCommitStatus.StoreUnreadable =>
+                    new GodotAccountSignInResult(GodotAccountSignInStatus.PartiallyAuthorized, commit.Detail),
+                LoginCommitStatus.Busy =>
+                    new GodotAccountSignInResult(GodotAccountSignInStatus.Busy, commit.Detail),
+                LoginCommitStatus.SubjectMismatch or LoginCommitStatus.GuardPremiseChanged =>
+                    new GodotAccountSignInResult(GodotAccountSignInStatus.SubjectConflict, commit.Detail),
+                _ =>
+                    new GodotAccountSignInResult(GodotAccountSignInStatus.Failed, commit.Detail),
+            };
         }
 
-        /// <summary>Sign out: delete the stored credential and reset to signed-out.</summary>
-        public void SignOut() => _provider.SignOut();
+        /// <summary>
+        /// Machine-wide sign-out (F6): best-effort RFC 7009 revocation of EVERY stored family (each with its
+        /// stored <c>clientId</c>; the component default for a legacy family), then the 04 §2 lock-protocol
+        /// store delete. All other components on the machine observe the store gone and sign out (F6.3);
+        /// offline revocation failures never block the local delete (F6.4). The caller shows the
+        /// "signs out all tools on this machine" confirmation BEFORE calling this (F6.1).
+        /// </summary>
+        public async Task<MachineSignOutResult> SignOutMachineWideAsync(CancellationToken cancellationToken = default)
+        {
+            var result = await MachineWideSignOut.SignOutAsync(
+                _store,
+                _lock,
+                new TokenRevocationClient(_asBaseUrlProvider(), _httpClient),
+                _clientId,
+                _logger,
+                cancellationToken).ConfigureAwait(false);
 
-        public void Dispose() => _provider.Dispose();
+            ReloadFromStore();
+            return result;
+        }
+
+        /// <summary>
+        /// O8 / F11.2 legacy migration (migrate-on-touch): copy a pre-existing
+        /// <c>user://godot-mcp-config.json</c> <paramref name="legacyCloudToken"/> into the machine store —
+        /// UNDER the machine lock — when the store holds no credential. The v1-shaped document written here
+        /// is normalized by the store's write contract into a v2 <c>families.legacy</c> entry (+ the v1
+        /// compat mirror), i.e. exactly the F11.1 legacy-adoption shape. Rules:
+        /// <list type="bullet">
+        ///   <item>An existing store credential ALWAYS wins — the sink is never allowed to overwrite it.</item>
+        ///   <item>An unreadable store is never overwritten (04 §1) — migration is skipped.</item>
+        ///   <item>A busy lock skips this attempt; the migration is idempotent and re-runs next boot.</item>
+        ///   <item>The sink file is NOT modified — read-fallback + delete-source are the f4 follow-up.</item>
+        ///   <item><paramref name="legacyCloudToken"/> is SECRET MATERIAL: it is never logged and never
+        ///   surfaced in the returned result.</item>
+        /// </list>
+        /// </summary>
+        public GodotLegacyTokenMigrationResult TryMigrateLegacyCloudToken(string? legacyCloudToken, string? serverTarget)
+        {
+            if (string.IsNullOrEmpty(legacyCloudToken))
+                return GodotLegacyTokenMigrationResult.NoSinkToken;
+
+            // Cheap lock-free pre-check (F3.1): only an empty store is a migration candidate.
+            var preRead = _store.TryRead();
+            if (preRead.Status == MachineCredentialStoreStatus.Unreadable)
+                return GodotLegacyTokenMigrationResult.SkippedStoreUnreadable;
+            if (HasCredentialMaterial(preRead))
+                return GodotLegacyTokenMigrationResult.SkippedStoreHasCredential;
+
+            var hold = _lock.TryAcquire();
+            if (hold == null)
+                return GodotLegacyTokenMigrationResult.Busy;
+
+            using (hold)
+            {
+                // Re-read under the hold (double-checked): a peer login may have won the race.
+                var read = _store.TryRead();
+                if (read.Status == MachineCredentialStoreStatus.Unreadable)
+                    return GodotLegacyTokenMigrationResult.SkippedStoreUnreadable;
+                if (HasCredentialMaterial(read))
+                    return GodotLegacyTokenMigrationResult.SkippedStoreHasCredential;
+
+                if (!hold.IsStillOwned())
+                    return GodotLegacyTokenMigrationResult.Busy;
+
+                // v1-shaped document → the store's write contract normalizes it to a v2 families.legacy
+                // entry + version stamp + compat mirror (the same path F11.1 legacy adoption uses).
+                _store.Write(new MachineCredentials
+                {
+                    AccessToken = legacyCloudToken,
+                    ServerTarget = serverTarget,
+                });
+            }
+
+            ReloadFromStore();
+            _logger?.LogInformation("Migrated the legacy Godot user:// cloud credential into the machine store (O8/F11.2)."); // never token material
+            return GodotLegacyTokenMigrationResult.Migrated;
+        }
+
+        /// <summary>True when the read store document carries ANY token material (any family or the v1 top level).</summary>
+        static bool HasCredentialMaterial(MachineCredentialReadResult read)
+        {
+            if (read.Status != MachineCredentialStoreStatus.Ok || read.Credentials == null)
+                return false;
+
+            var credentials = read.Credentials;
+            return !string.IsNullOrEmpty(credentials.AccessToken)
+                || !string.IsNullOrEmpty(credentials.RefreshToken)
+                || FamilyHasMaterial(credentials.Families?.Agent)
+                || FamilyHasMaterial(credentials.Families?.Plugin)
+                || FamilyHasMaterial(credentials.Families?.Legacy);
+        }
+
+        static bool FamilyHasMaterial(MachineCredentialFamily? family)
+            => family != null && (!string.IsNullOrEmpty(family.AccessToken) || !string.IsNullOrEmpty(family.RefreshToken));
+
+        /// <summary>
+        /// Sign out THIS provider only: delete the stored credential via the lock-protocol delete path and
+        /// reset to signed-out. No server-side revocation — the machine-wide F6 path is
+        /// <see cref="SignOutMachineWideAsync"/>.
+        /// </summary>
+        public void SignOut() => Provider.SignOut();
+
+        /// <summary>
+        /// Swap in a freshly-built provider so the in-memory state re-adopts whatever the machine store now
+        /// holds (called after every guarded store mutation). The store read is cheap and lock-free (F3.1).
+        /// </summary>
+        void ReloadFromStore()
+        {
+            var fresh = BuildProvider();
+            var old = Interlocked.Exchange(ref _provider, fresh);
+            old.Dispose();
+        }
+
+        public void Dispose() => Provider.Dispose();
     }
 }

--- a/addons/godot_mcp/Editor/Connection/GodotAccountAuth.cs
+++ b/addons/godot_mcp/Editor/Connection/GodotAccountAuth.cs
@@ -123,19 +123,33 @@ namespace com.IvanMurzak.Godot.MCP.Connection
     /// </summary>
     public sealed class GodotAccountAuth : IDisposable
     {
+        /// <summary>
+        /// Backoff before the ONE bounded second-phase retry (03 F1 failure path: "P retries with
+        /// backoff") — applied before an exchange retry (<c>AgentOnly</c>) and before a
+        /// plugin-family commit retry (<c>PluginCommitBusy</c>/<c>StoreUnreadable</c>).
+        /// </summary>
+        public static readonly TimeSpan SecondPhaseRetryBackoff = TimeSpan.FromMilliseconds(750);
+
         readonly MachineCredentialStore _store;
         readonly MachineCredentialLock _lock;
         readonly Func<string> _asBaseUrlProvider;
         readonly HttpClient? _httpClient;
         readonly ILogger? _logger;
         readonly Func<DateTimeOffset>? _clock;
+        readonly Func<TimeSpan, CancellationToken, Task> _delay;
         readonly string _clientId;
 
         // The provider is REBUILT (auto-adopting from the store) after every guarded store mutation —
         // login commit, machine-wide sign-out, legacy migration — because the guarded helpers write the
         // store directly and the provider's in-memory credential would otherwise go stale. Swapped
-        // atomically; readers go through Provider below.
+        // atomically; readers go through Provider below. Retired providers are parked (not disposed)
+        // until this coordinator is disposed: a token resolution captured just before a swap may still
+        // be executing, and disposing under it would surface a transient ObjectDisposedException into
+        // the connection's credential resolution (review A2). Swaps are rare (sign-in / sign-out /
+        // migration), so the parked list stays tiny.
         PluginCredentialProvider _provider;
+        readonly object _retiredGate = new object();
+        readonly System.Collections.Generic.List<PluginCredentialProvider> _retiredProviders = new();
 
         /// <summary>
         /// Construct the coordinator. <paramref name="asBaseUrlProvider"/> supplies the authorization-server
@@ -153,7 +167,8 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             ILogger? logger = null,
             string? clientId = null,
             Func<DateTimeOffset>? clock = null,
-            MachineCredentialLock? credentialLock = null)
+            MachineCredentialLock? credentialLock = null,
+            Func<TimeSpan, CancellationToken, Task>? delay = null)
         {
             _asBaseUrlProvider = asBaseUrlProvider ?? throw new ArgumentNullException(nameof(asBaseUrlProvider));
             _store = store ?? new MachineCredentialStore();
@@ -161,6 +176,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             _httpClient = httpClient;
             _logger = logger;
             _clock = clock;
+            _delay = delay ?? Task.Delay;
             _clientId = string.IsNullOrEmpty(clientId) ? GodotDeviceAuthFlow.DefaultClientId : clientId!;
 
             // Auto-adopt: PluginCredentialProvider reads the store at construction. No UI, no device flow.
@@ -237,17 +253,30 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 Scope = result.Scope ?? GodotDeviceAuthFlow.AgentScope,
             };
 
+            var exchangeClient = new TokenExchangeClient(asBaseUrl, _clientId, _httpClient);
+            var revocationClient = new TokenRevocationClient(asBaseUrl, _httpClient);
+
             var commit = await MachineCredentialLoginCommit.CommitAsync(
                 _store,
                 _lock,
                 agentFamily,
                 serverTarget: asBaseUrl,
                 subject: null, // device-grant response carries no sub (O5 covers exchange/enroll only)
-                exchangeClient: new TokenExchangeClient(asBaseUrl, _clientId, _httpClient),
+                exchangeClient: exchangeClient,
                 confirmedReplaceOfSubject: null,
-                revocationClient: new TokenRevocationClient(asBaseUrl, _httpClient),
+                revocationClient: revocationClient,
                 logger: _logger,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            // Second-phase completion (03 F1 failure path / review B1): a failed exchange gets ONE
+            // bounded retry with backoff (the agent family is committed — no device flow needed), a
+            // retryable second-hold outcome gets ONE bounded CommitPluginFamilyAsync retry with the
+            // CARRIED mint (never a re-exchange), and a mint this coordinator is about to abandon is
+            // best-effort revoked (b3 twin rule 4's premise: retryable outcomes skip revocation only
+            // because the caller retries the same mint — once we stop retrying, we revoke).
+            commit = await CompleteSecondPhaseAsync(
+                commit, result.AccessToken, asBaseUrl, exchangeClient, revocationClient, cancellationToken)
+                .ConfigureAwait(false);
 
             // The guarded helper wrote the store directly — rebuild the provider so its in-memory state
             // (IsSignedIn / AccessTokenProvider) reflects what was actually committed.
@@ -266,6 +295,131 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 _ =>
                     new GodotAccountSignInResult(GodotAccountSignInStatus.Failed, commit.Detail),
             };
+        }
+
+        /// <summary>True for the second-hold outcomes the commit helper designed to be retried with the SAME mint.</summary>
+        static bool IsRetryableSecondPhase(LoginCommitStatus status)
+            => status == LoginCommitStatus.PluginCommitBusy || status == LoginCommitStatus.StoreUnreadable;
+
+        /// <summary>
+        /// The bounded second-phase completion behind <see cref="SignInAsync"/> (03 F1 failure path,
+        /// review B1). Exactly one backoff'd retry per stage, never a second device flow:
+        /// <list type="number">
+        ///   <item><b><see cref="LoginCommitStatus.AgentOnly"/>:</b> the agent family is committed, so
+        ///   retry the RFC 8693 exchange once (backoff first) and, if it succeeds, commit the plugin
+        ///   family via <see cref="MachineCredentialLoginCommit.CommitPluginFamilyAsync"/>.</item>
+        ///   <item><b><see cref="LoginCommitStatus.PluginCommitBusy"/> /
+        ///   <see cref="LoginCommitStatus.StoreUnreadable"/>:</b> retry the plugin-family commit once
+        ///   with the CARRIED <see cref="LoginCommitResult.ExchangeResult"/> — the helper returns it
+        ///   precisely so the caller retries without re-exchanging.</item>
+        ///   <item><b>Still retryable after the retry:</b> this coordinator stops retrying (the user's
+        ///   next action is a fresh device flow), so the mint is best-effort revoked before being
+        ///   discarded — otherwise it would stay live server-side for up to 30 d, invisible to every
+        ///   component (twin rule 4's exact scenario). Terminal hold-2 aborts
+        ///   (<c>SubjectMismatch</c>/<c>StoreSignedOut</c>) are already revoked inside the helper.</item>
+        /// </list>
+        /// The expected subject for a retried commit is the mint's own <c>sub</c> (O5) — the plugin
+        /// family derives from the agent token, so a store that now belongs to a DIFFERENT known
+        /// account voids the premise (F7) and the helper aborts + revokes internally.
+        /// </summary>
+        async Task<LoginCommitResult> CompleteSecondPhaseAsync(
+            LoginCommitResult commit,
+            string agentAccessToken,
+            string asBaseUrl,
+            ITokenExchangeClient exchangeClient,
+            ITokenRevocationClient revocationClient,
+            CancellationToken cancellationToken)
+        {
+            // Stage 1 — AgentOnly: one exchange retry with backoff (03 F1: "P retries with backoff").
+            if (commit.Status == LoginCommitStatus.AgentOnly)
+            {
+                await _delay(SecondPhaseRetryBackoff, cancellationToken).ConfigureAwait(false);
+
+                TokenExchangeResult retryExchange;
+                try
+                {
+                    retryExchange = await exchangeClient
+                        .ExchangeAsync(agentAccessToken, asBaseUrl, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogWarning("Token-exchange retry threw: {message}", ex.Message); // never token material
+                    return commit; // still AgentOnly — the committed agent family stands (F1 failure path)
+                }
+
+                if (retryExchange == null || !retryExchange.Succeeded || string.IsNullOrEmpty(retryExchange.AccessToken))
+                    return commit; // still AgentOnly
+
+                commit = await MachineCredentialLoginCommit.CommitPluginFamilyAsync(
+                    _store, _lock, retryExchange, _clientId,
+                    expectedSubject: retryExchange.Subject,
+                    serverTarget: asBaseUrl,
+                    revocationClient: revocationClient,
+                    logger: _logger,
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+                // Fall through — this commit may itself be retryable, and gets the stage-2 retry below.
+            }
+
+            // Stage 2 — a retryable second-hold outcome with a carried mint: one in-place retry.
+            if (IsRetryableSecondPhase(commit.Status)
+                && commit.ExchangeResult is { Succeeded: true } mint
+                && !string.IsNullOrEmpty(mint.AccessToken))
+            {
+                await _delay(SecondPhaseRetryBackoff, cancellationToken).ConfigureAwait(false);
+
+                commit = await MachineCredentialLoginCommit.CommitPluginFamilyAsync(
+                    _store, _lock, mint, _clientId,
+                    expectedSubject: mint.Subject,
+                    serverTarget: asBaseUrl,
+                    revocationClient: revocationClient,
+                    logger: _logger,
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                // Stage 3 — still not committed: the mint is being abandoned; revoke it (twin rule 4).
+                if (IsRetryableSecondPhase(commit.Status) && commit.ExchangeResult is { } abandoned)
+                    await RevokeAbandonedMintAsync(revocationClient, abandoned, asBaseUrl, cancellationToken).ConfigureAwait(false);
+            }
+
+            return commit;
+        }
+
+        /// <summary>
+        /// Best-effort RFC 7009 revocation of a minted-but-never-committed plugin family this
+        /// coordinator stops retrying (refresh token preferred — revoking it kills the family;
+        /// mirror of the helper's own orphan revocation). Single attempt; failures only logged —
+        /// the family also dies naturally at its own expiry.
+        /// </summary>
+        async Task RevokeAbandonedMintAsync(
+            ITokenRevocationClient revocationClient,
+            TokenExchangeResult mint,
+            string? serverTarget,
+            CancellationToken cancellationToken)
+        {
+            var token = !string.IsNullOrEmpty(mint.RefreshToken) ? mint.RefreshToken : mint.AccessToken;
+            if (string.IsNullOrEmpty(token))
+                return;
+
+            try
+            {
+                var acknowledged = await revocationClient
+                    .RevokeAsync(token!, _clientId, serverTarget, cancellationToken)
+                    .ConfigureAwait(false);
+                if (!acknowledged)
+                    _logger?.LogWarning("Best-effort revocation of the abandoned plugin mint was not acknowledged; it expires naturally.");
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning("Best-effort revocation of the abandoned plugin mint threw: {message}", ex.Message); // never token material
+            }
         }
 
         /// <summary>
@@ -373,14 +527,30 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// <summary>
         /// Swap in a freshly-built provider so the in-memory state re-adopts whatever the machine store now
         /// holds (called after every guarded store mutation). The store read is cheap and lock-free (F3.1).
+        /// The retired provider is PARKED, not disposed (review A2): a token resolution captured just before
+        /// the swap may still be executing, and disposing under it would throw a transient
+        /// <see cref="ObjectDisposedException"/> into the connection's credential resolution. All parked
+        /// providers are disposed with this coordinator.
         /// </summary>
         void ReloadFromStore()
         {
             var fresh = BuildProvider();
             var old = Interlocked.Exchange(ref _provider, fresh);
-            old.Dispose();
+            lock (_retiredGate)
+                _retiredProviders.Add(old);
         }
 
-        public void Dispose() => Provider.Dispose();
+        public void Dispose()
+        {
+            Provider.Dispose();
+            lock (_retiredGate)
+            {
+                foreach (var retired in _retiredProviders)
+                {
+                    try { retired.Dispose(); } catch { /* teardown must never throw */ }
+                }
+                _retiredProviders.Clear();
+            }
+        }
     }
 }

--- a/addons/godot_mcp/Editor/Connection/GodotCloudAccountController.cs
+++ b/addons/godot_mcp/Editor/Connection/GodotCloudAccountController.cs
@@ -1,0 +1,63 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// The pure-managed orchestration behind the dock's Cloud "Authorize" button (unified-machine-auth
+    /// task f1). The <c>#if TOOLS</c> <c>ConnectionPanel</c> is a thin adapter over this: it builds the
+    /// flow (browser-open, status UI) and calls <see cref="SignInAsync"/> for EVERYTHING that persists.
+    ///
+    /// <para>
+    /// <b>The load-bearing invariant (O8, pinned by test):</b> a successful authorize persists the
+    /// credential ONLY into the machine store (via <see cref="GodotAccountAuth.SignInAsync"/>'s guarded
+    /// two-lock-hold commit). <paramref name="config"/> — the layer serialized to the legacy
+    /// <c>user://godot-mcp-config.json</c> sink — is deliberately taken as a parameter and deliberately
+    /// NOT written: <c>config.CloudToken</c> was exactly where the pre-f1 Authorize wrote the token in
+    /// plaintext, and this seam existing is what lets a unit test assert that the sink gains no new
+    /// cloudToken on the authorize path (G-SEC-1 plant 1). Do not "tidy" the parameter away — removing
+    /// it removes the pin.
+    /// </para>
+    ///
+    /// <para>Pure-managed (no Godot native types, no <c>#if TOOLS</c>); never logs or returns token
+    /// material.</para>
+    /// </summary>
+    public static class GodotCloudAccountController
+    {
+        /// <summary>
+        /// Run the F1 sign-in via <paramref name="account"/> against <paramref name="asBaseUrl"/>.
+        /// <paramref name="config"/> is the persisted-config layer the LEGACY flow used to write the token
+        /// into — it is intentionally left untouched (see the class docs). Returns the non-secret outcome
+        /// for the caller's UI to render.
+        /// </summary>
+        public static async Task<GodotAccountSignInResult> SignInAsync(
+            GodotAccountAuth account,
+            GodotDeviceAuthFlow flow,
+            string asBaseUrl,
+            GodotMcpConfig config,
+            CancellationToken cancellationToken = default)
+        {
+            if (account == null) throw new ArgumentNullException(nameof(account));
+            if (flow == null) throw new ArgumentNullException(nameof(flow));
+            if (config == null) throw new ArgumentNullException(nameof(config));
+
+            var outcome = await account.SignInAsync(flow, asBaseUrl, cancellationToken).ConfigureAwait(false);
+
+            // O8: the machine store is the ONLY credential sink on this path. config.CloudToken (the
+            // user:// plaintext sink) gains no new value — read-fallback of a PRE-EXISTING value stays,
+            // its write-path removal is the f4 follow-up.
+            return outcome;
+        }
+    }
+}

--- a/addons/godot_mcp/Editor/Connection/GodotDeviceAuthFlow.cs
+++ b/addons/godot_mcp/Editor/Connection/GodotDeviceAuthFlow.cs
@@ -68,7 +68,16 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// </summary>
         public const string DefaultClientId = "godot-mcp-plugin";
 
-        /// <summary>The scope the plugin requests — selects the ES256 hub JWT (<c>aud=urn:agd:hub</c>) + refresh token.</summary>
+        /// <summary>
+        /// The scope this flow requests on the device-authorization request (unified-machine-auth 03 F1.2):
+        /// the AGENT scope — full account access, prominently disclosed on the D11 verification page. The
+        /// agent tokens are committed to the machine store's agent family and then DERIVED down to the
+        /// <see cref="PluginScope"/> plugin family via RFC 8693 token exchange (03 F1.4), so one in-editor
+        /// Authorize signs in every AI-Game-Dev tool on the machine.
+        /// </summary>
+        public const string AgentScope = "mcp:agent";
+
+        /// <summary>The plugin (tools-only) scope — the ES256 hub JWT (<c>aud=urn:agd:hub</c>) the derived plugin family carries.</summary>
         public const string PluginScope = "mcp:plugin";
 
         /// <summary>Minimum poll interval (seconds) the server's <c>interval</c> is clamped up to — the device-flow floor.</summary>
@@ -147,7 +156,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                 SetState(GodotDeviceAuthFlowState.Initiating);
 
                 var authResponse = await _service
-                    .RequestDeviceAuthorizationAsync(asBaseUrl, DefaultClientId, PluginScope, ct)
+                    .RequestDeviceAuthorizationAsync(asBaseUrl, DefaultClientId, AgentScope, ct)
                     .ConfigureAwait(false);
 
                 UserCode = authResponse.UserCode;
@@ -176,7 +185,8 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                             ? new DateTimeOffset(_utcNow(), TimeSpan.Zero).AddSeconds(tokenResponse.ExpiresIn)
                             : (DateTimeOffset?)null;
                         SetState(GodotDeviceAuthFlowState.Authorized);
-                        return new GodotDeviceAuthResult(tokenResponse.AccessToken!, tokenResponse.RefreshToken, expiresAt);
+                        return new GodotDeviceAuthResult(
+                            tokenResponse.AccessToken!, tokenResponse.RefreshToken, expiresAt, tokenResponse.Scope);
                     }
 
                     switch (tokenResponse.Error)

--- a/addons/godot_mcp/Editor/Connection/GodotDeviceAuthResult.cs
+++ b/addons/godot_mcp/Editor/Connection/GodotDeviceAuthResult.cs
@@ -31,11 +31,19 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// <summary>Absolute expiry of <see cref="AccessToken"/> (from the token response's <c>expires_in</c>), or null when unknown.</summary>
         public DateTimeOffset? ExpiresAt { get; }
 
-        public GodotDeviceAuthResult(string accessToken, string? refreshToken, DateTimeOffset? expiresAt)
+        /// <summary>
+        /// The scope the token response echoed (e.g. <c>mcp:agent</c> for the unified-machine-auth F1 login),
+        /// or null when the server omitted it. NOT a secret. Stamped onto the committed credential family so
+        /// the machine store records what the grant actually carries (design 04 §1).
+        /// </summary>
+        public string? Scope { get; }
+
+        public GodotDeviceAuthResult(string accessToken, string? refreshToken, DateTimeOffset? expiresAt, string? scope = null)
         {
             AccessToken = accessToken;
             RefreshToken = refreshToken;
             ExpiresAt = expiresAt;
+            Scope = scope;
         }
     }
 }

--- a/addons/godot_mcp/Editor/Connection/GodotDeviceAuthService.cs
+++ b/addons/godot_mcp/Editor/Connection/GodotDeviceAuthService.cs
@@ -30,15 +30,20 @@ namespace com.IvanMurzak.Godot.MCP.Connection
     /// The AS surface (verified against <c>cloud/AI-Game-Dev-Server</c> <c>routers/oauth.py</c>):
     /// <list type="bullet">
     ///   <item><c>POST /oauth/device_authorization</c> — <c>application/x-www-form-urlencoded</c>
-    ///   <c>client_id</c> (REQUIRED) + <c>scope</c> (<c>mcp:plugin</c>) → the standard device-authorization
-    ///   document.</item>
+    ///   <c>client_id</c> (REQUIRED) + <c>scope</c> (<c>mcp:agent</c>, unified-machine-auth 03 F1.2) → the
+    ///   standard device-authorization document.</item>
     ///   <item><c>POST /oauth/token</c> — the device-code URN grant (<c>grant_type</c> + <c>device_code</c> +
-    ///   <c>client_id</c>) polled until authorized, and the <c>refresh_token</c> grant. <c>scope=mcp:plugin</c>
-    ///   yields the ES256 hub JWT (<c>aud=urn:agd:hub</c>) + a rotating refresh token.</item>
+    ///   <c>client_id</c>) polled until authorized. <c>scope=mcp:agent</c> yields the agent tokens the F1
+    ///   login commits + derives via <see cref="com.IvanMurzak.McpPlugin.MachineCredentialLoginCommit"/>.</item>
     /// </list>
-    /// The SAME <c>client_id</c> MUST be presented to the device-authorization request, the device-code token
-    /// exchange, AND every subsequent refresh — the AS binds the grant to it and rejects a mismatch with
-    /// <c>invalid_grant</c> (<c>oauth_token_service.grant_device_code</c> / <c>grant_refresh_token</c>).
+    /// The SAME <c>client_id</c> MUST be presented to the device-authorization request and the device-code
+    /// token exchange — the AS binds the grant to it and rejects a mismatch with <c>invalid_grant</c>
+    /// (<c>oauth_token_service.grant_device_code</c>). Refresh is NOT this type's job anymore: the
+    /// <c>refresh_token</c> grant goes through the ONE shared
+    /// <see cref="com.IvanMurzak.McpPlugin.HttpTokenRefresher"/> (via <see cref="GodotTokenRefresher"/>),
+    /// which presents the family's STORED <c>clientId</c> and omits <c>scope</c>/<c>resource</c> entirely
+    /// (design 04 §3 — the local refresh path was removed in the f1 adoption so exactly one refresh wire
+    /// shape exists).
     /// </para>
     ///
     /// <para>
@@ -51,9 +56,6 @@ namespace com.IvanMurzak.Godot.MCP.Connection
     {
         /// <summary>The RFC 8628 device-code grant type presented at <c>/oauth/token</c>.</summary>
         public const string DeviceCodeGrantType = "urn:ietf:params:oauth:grant-type:device_code";
-
-        /// <summary>The refresh-token grant type presented at <c>/oauth/token</c>.</summary>
-        public const string RefreshTokenGrantType = "refresh_token";
 
         static readonly HttpClient SharedHttpClient = new();
 
@@ -113,25 +115,6 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             {
                 ["grant_type"] = DeviceCodeGrantType,
                 ["device_code"] = deviceCode,
-                ["client_id"] = clientId,
-            });
-            return await PostTokenAsync(asBaseUrl, content, ct).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// POST <c>&lt;asBaseUrl&gt;/oauth/token</c> with the <c>refresh_token</c> grant to mint a fresh
-        /// access token (and possibly a rotated refresh token). Does NOT throw on a non-2xx status — a
-        /// rejected/expired refresh token surfaces as a structured RFC 6749 §5.2 error body the caller reads
-        /// via <see cref="DeviceTokenResponse.Error"/>. The <paramref name="clientId"/> MUST equal the one the
-        /// refresh token was issued under (the AS rejects a mismatch with <c>invalid_grant</c>).
-        /// </summary>
-        public async Task<DeviceTokenResponse> RefreshTokenAsync(
-            string asBaseUrl, string refreshToken, string clientId, CancellationToken ct = default)
-        {
-            using var content = FormContent(new Dictionary<string, string>
-            {
-                ["grant_type"] = RefreshTokenGrantType,
-                ["refresh_token"] = refreshToken,
                 ["client_id"] = clientId,
             });
             return await PostTokenAsync(asBaseUrl, content, ct).ConfigureAwait(false);

--- a/addons/godot_mcp/Editor/Connection/GodotTokenRefresher.cs
+++ b/addons/godot_mcp/Editor/Connection/GodotTokenRefresher.cs
@@ -9,6 +9,7 @@
 */
 #nullable enable
 using System;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin;
@@ -16,92 +17,88 @@ using com.IvanMurzak.McpPlugin;
 namespace com.IvanMurzak.Godot.MCP.Connection
 {
     /// <summary>
-    /// Godot's implementation of McpPlugin 7.0's <see cref="ITokenRefresher"/> seam (mcp-authorize design 03
-    /// Flow B / 06): the ONE piece of the connection layer that talks to the ai-game.dev authorization server
-    /// over HTTP to exchange a refresh token for a fresh access token (<c>grant_type=refresh_token</c> at
-    /// <c>/oauth/token</c>). <see cref="PluginCredentialProvider"/> owns the machine-store credential and
-    /// invokes this both proactively (before <c>exp</c>) and reactively (on the connection's 3-strike
-    /// <c>_authorizationRejected</c> signal).
+    /// THIN ADAPTER over McpPlugin 8.1's shared <see cref="HttpTokenRefresher"/> (unified-machine-auth
+    /// 04 §3, task f1 — the engine-adoption cascade of b3). The former local refresh implementation
+    /// (its own <c>/oauth/token</c> form via <see cref="GodotDeviceAuthService"/>) is DELETED so exactly
+    /// one refresh wire shape exists per language; the shared refresher enforces the 04 §3 rules this
+    /// addon inherits by delegation:
+    /// <list type="bullet">
+    ///   <item><b>Stored <c>clientId</c> (04 §3.2):</b> a family's stored id is presented verbatim; the
+    ///   component default (<see cref="GodotDeviceAuthFlow.DefaultClientId"/>) is presented ONLY for a
+    ///   legacy family of unknown id (04 §3.7).</item>
+    ///   <item><b>No <c>scope</c>, no <c>resource</c> (04 §3.3 / P0-3):</b> the wire request omits both
+    ///   entirely — the server falls back to the stored grant.</item>
+    ///   <item>Rate discipline (one attempt per family per skew window), the 15 s contract HTTP timeout,
+    ///   and the <c>invalid_grant</c>-vs-transient failure split (04 §3.5/§3.6).</item>
+    /// </list>
     ///
     /// <para>
-    /// Pure-managed (no Godot native types, no <c>#if TOOLS</c>) so it is unit-testable with a fake
-    /// <see cref="System.Net.Http.HttpMessageHandler"/>. It <b>fails closed</b> — any error (a rejected token,
-    /// an HTTP/JSON fault) returns <see cref="TokenRefreshResult.Failure"/>, never a partial or fabricated
-    /// token — and never logs token material (a surfaced <see cref="Exception.Message"/> is HTTP/JSON only).
+    /// The one Godot-local behavior this adapter ADDS is the live default-AS-base seam: a stored
+    /// credential without a <c>serverTarget</c> refreshes against <paramref name="defaultAsBaseUrl"/>
+    /// READ LIVE per call (so a <c>.env</c>/env cloud-URL override applies without a rebuild — the
+    /// documented behavior of the pre-f1 refresher), where the shared refresher's own default is
+    /// captured once at construction. Trailing-<c>/mcp</c> stripping and target normalization stay with
+    /// the shared implementation. Pure-managed (no Godot native types, no <c>#if TOOLS</c>) and
+    /// unit-testable with a fake <see cref="HttpMessageHandler"/>; fails closed and never logs token
+    /// material (both inherited from the shared refresher).
     /// </para>
     /// </summary>
     public sealed class GodotTokenRefresher : ITokenRefresher
     {
-        readonly GodotDeviceAuthService _service;
+        readonly HttpTokenRefresher _inner;
         readonly Func<string> _defaultAsBaseUrl;
-        readonly string _clientId;
-        readonly Func<DateTimeOffset> _clock;
 
         /// <summary>
-        /// Construct a refresher. <paramref name="defaultAsBaseUrl"/> supplies the AS base URL when the stored
-        /// credential carries no <c>serverTarget</c> (read live so a <c>.env</c> cloud-URL override applies).
-        /// <paramref name="clientId"/> defaults to <see cref="GodotDeviceAuthFlow.DefaultClientId"/> — it MUST
-        /// match the id the refresh token was issued under. <paramref name="clock"/> is injectable for
-        /// deterministic expiry tests.
+        /// Construct the adapter. <paramref name="defaultAsBaseUrl"/> supplies the AS base URL when the
+        /// stored credential carries no <c>serverTarget</c> (read live so a <c>.env</c> cloud-URL override
+        /// applies). <paramref name="clientId"/> is this component's OWN id, presented only for legacy
+        /// families of unknown id (04 §3.7) — it defaults to
+        /// <see cref="GodotDeviceAuthFlow.DefaultClientId"/> and never overrides a family's stored id.
+        /// <paramref name="httpClient"/> is injectable for tests (fake handler); the shared refresher's
+        /// process-shared client is used when null.
         /// </summary>
         public GodotTokenRefresher(
-            GodotDeviceAuthService service,
             Func<string> defaultAsBaseUrl,
             string? clientId = null,
-            Func<DateTimeOffset>? clock = null)
+            HttpClient? httpClient = null)
         {
-            _service = service ?? throw new ArgumentNullException(nameof(service));
             _defaultAsBaseUrl = defaultAsBaseUrl ?? throw new ArgumentNullException(nameof(defaultAsBaseUrl));
-            _clientId = string.IsNullOrEmpty(clientId) ? GodotDeviceAuthFlow.DefaultClientId : clientId!;
-            _clock = clock ?? (() => DateTimeOffset.UtcNow);
-        }
-
-        public async Task<TokenRefreshResult> RefreshAsync(string refreshToken, string? serverTarget, CancellationToken cancellationToken = default)
-        {
-            try
-            {
-                var asBase = ResolveAsBaseUrl(serverTarget);
-                var response = await _service
-                    .RefreshTokenAsync(asBase, refreshToken, _clientId, cancellationToken)
-                    .ConfigureAwait(false);
-
-                if (!string.IsNullOrEmpty(response.AccessToken))
-                {
-                    var expiresAt = response.ExpiresIn > 0
-                        ? _clock().AddSeconds(response.ExpiresIn)
-                        : (DateTimeOffset?)null;
-                    // A null/empty RefreshToken tells the caller the AS did not rotate it (keep the old one).
-                    return TokenRefreshResult.Success(response.AccessToken!, response.RefreshToken, expiresAt);
-                }
-
-                return TokenRefreshResult.Failure(response.Error ?? "refresh failed");
-            }
-            catch (OperationCanceledException)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                // ex.Message is an HTTP/JSON transport fault, never token material — safe to surface as the
-                // (non-secret) failure reason the provider logs.
-                return TokenRefreshResult.Failure(ex.Message);
-            }
+            // The inner default target is deliberately unused (empty): every request is resolved against
+            // the LIVE default below before delegation, so the shared refresher always receives an
+            // explicit ServerTarget.
+            _inner = new HttpTokenRefresher(
+                defaultServerTarget: string.Empty,
+                componentClientId: string.IsNullOrEmpty(clientId) ? GodotDeviceAuthFlow.DefaultClientId : clientId!,
+                httpClient: httpClient);
         }
 
         /// <summary>
-        /// Resolve the AS base URL for the refresh POST. A stored <c>serverTarget</c> wins (an enrolled
-        /// hosted-vs-local target); a trailing <c>/mcp</c> hub path is stripped so we never POST to
-        /// <c>/mcp/oauth/token</c>. An empty target falls back to the live default (the plugin's cloud base).
+        /// Legacy two-string API (no family context): delegates to the family-aware overload with a null
+        /// <c>clientId</c>, so the shared refresher presents the component default (04 §3.7) and — as
+        /// always — omits <c>scope</c>/<c>resource</c> from the wire request.
         /// </summary>
-        string ResolveAsBaseUrl(string? serverTarget)
+        public Task<TokenRefreshResult> RefreshAsync(string refreshToken, string? serverTarget, CancellationToken cancellationToken = default)
         {
-            if (string.IsNullOrEmpty(serverTarget))
-                return _defaultAsBaseUrl();
+            if (string.IsNullOrEmpty(refreshToken))
+                return Task.FromResult(TokenRefreshResult.Failure("no refresh token"));
+            return RefreshAsync(new TokenRefreshRequest(refreshToken, serverTarget, clientId: null), cancellationToken);
+        }
 
-            var trimmed = serverTarget!.TrimEnd('/');
-            if (trimmed.EndsWith("/mcp", StringComparison.OrdinalIgnoreCase))
-                trimmed = trimmed[..^"/mcp".Length];
-            return trimmed;
+        /// <summary>
+        /// The family-aware refresh: resolve a missing <see cref="TokenRefreshRequest.ServerTarget"/> from
+        /// the LIVE default AS base, then delegate to the shared <see cref="HttpTokenRefresher"/> with the
+        /// request's family context (stored <c>clientId</c>) intact.
+        /// </summary>
+        public Task<TokenRefreshResult> RefreshAsync(TokenRefreshRequest request, CancellationToken cancellationToken = default)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+
+            var resolved = string.IsNullOrEmpty(request.ServerTarget)
+                ? new TokenRefreshRequest(request.RefreshToken, _defaultAsBaseUrl(), request.ClientId)
+                : request;
+
+            return _inner.RefreshAsync(resolved, cancellationToken);
         }
     }
 }

--- a/addons/godot_mcp/Editor/UI/ConnectionPanel.cs
+++ b/addons/godot_mcp/Editor/UI/ConnectionPanel.cs
@@ -124,6 +124,10 @@ namespace com.IvanMurzak.Godot.MCP.UI
         Button _revokeButton = null!;
         Label _cloudAuthStatus = null!;
 
+        // F6 sign-out confirmation ("signs out all tools on this machine") shown before the machine-wide
+        // sign-out revokes every stored credential family and deletes the shared machine store.
+        ConfirmationDialog _signOutConfirm = null!;
+
         // "Advanced: use access token" opt-in for the Cloud path (default OFF → the raw masked token field is
         // hidden; the sign-in chip conveys the account state instead).
         bool _useCloudAccessToken;
@@ -580,6 +584,19 @@ namespace com.IvanMurzak.Godot.MCP.UI
                                 // open a large gap between the token row and the timeline in Cloud mode.
             };
             _cloudAuthRow.AddChild(_cloudAuthStatus);
+
+            // F6.1: the machine-wide sign-out confirmation. Sign-out is no longer a local token wipe — it
+            // revokes + deletes the SHARED machine credential store, signing out every AI-Game-Dev tool on
+            // this machine, so it always confirms first. Object+method Callable (no delegate += into the
+            // ManagedCallable hot-reload registry) — same discipline as the buttons above.
+            _signOutConfirm = new ConfirmationDialog
+            {
+                Name = "SignOutConfirmDialog",
+                Title = "Sign out",
+                DialogText = ConnectionPanelView.SignOutConfirmText,
+            };
+            _signOutConfirm.Connect(AcceptDialog.SignalName.Confirmed, new Callable(this, MethodName.OnSignOutConfirmed));
+            AddChild(_signOutConfirm);
         }
 
         /// <summary>
@@ -699,7 +716,10 @@ namespace com.IvanMurzak.Godot.MCP.UI
         void ApplyAlertVisibility(ConnectionStatus status)
         {
             var isCloud = _connection.Config.ActiveMode == GodotMcpConnectionMode.Cloud;
-            var hasCloudToken = !string.IsNullOrEmpty(_connection.Config.CloudToken);
+            // Signed in via the machine store (F1) OR the legacy sink (O8 read-fallback) — a
+            // machine-store sign-in must not render the "Authorization Required" alert (task f1).
+            var hasCloudToken = ConnectionPanelView.IsCloudSignedIn(
+                _connection.Account.IsSignedIn, _connection.Config.CloudToken);
 
             _authRequiredAlert.Visible = ConnectionPanelView.ShowAuthorizationRequired(isCloud, hasCloudToken);
             _connectionRequiredAlert.Visible = ConnectionPanelView.ShowConnectionRequired(isCloud, hasCloudToken, status);
@@ -1020,18 +1040,20 @@ namespace com.IvanMurzak.Godot.MCP.UI
         }
 
         /// <summary>
-        /// Render the Cloud-mode auth controls from the persisted <see cref="GodotMcpConfig.CloudToken"/>:
-        /// the masked field carries the stored token (or shows the placeholder via empty text), and the
-        /// Revoke button is visible only when a token is stored. Called on Cloud-mode entry and after every
-        /// token change. The token is never shown in clear text or logged.
+        /// Render the Cloud-mode auth controls from the account sign-in state (unified-machine-auth f1):
+        /// signed in when the MACHINE STORE holds a usable credential (the F1 golden path) or — for the O8
+        /// read-fallback window — when the legacy persisted <see cref="GodotMcpConfig.CloudToken"/> still
+        /// carries one. The masked Advanced field shows only the LEGACY sink token (the machine-store
+        /// credential is never surfaced), and the Sign out button is visible whenever signed in. Called on
+        /// Cloud-mode entry and after every credential change. No token is ever shown in clear text or logged.
         /// </summary>
         void ApplyCloudAuthState()
         {
             var token = _connection.Config.CloudToken;
-            var hasToken = !string.IsNullOrEmpty(token);
+            var hasToken = ConnectionPanelView.IsCloudSignedIn(_connection.Account.IsSignedIn, token);
 
             // Sign-in / account-state chip (the default-path replacement for the raw token field): signed-in when a
-            // cloud credential is stored (from the device flow / machine store), signed-out otherwise.
+            // cloud credential is stored (machine store first, legacy sink fallback), signed-out otherwise.
             _cloudSignInStatus.Text = ConnectionPanelView.CloudSignInStatusLabel(hasToken);
             _cloudSignInStatus.AddThemeColorOverride("font_color", DockStyle.Rgb(ConnectionPanelView.CloudSignInStatusColor(hasToken)));
 
@@ -1042,12 +1064,13 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _cloudConnectionUrl.Text = urlText;
             _cloudConnectionUrl.Visible = !string.IsNullOrEmpty(urlText);
 
-            // Advanced (masked) token field — carries the stored token, shown only under the "Advanced: use access
-            // token" opt-in. Empty text → the masked LineEdit shows its PlaceholderText ("Token — press Authorize").
-            _cloudTokenField.Text = hasToken ? token! : string.Empty;
+            // Advanced (masked) token field — carries ONLY the legacy sink token (the machine-store
+            // credential is never surfaced here), shown only under the "Advanced: use access token" opt-in.
+            // Empty text → the masked LineEdit shows its PlaceholderText ("Token — press Authorize").
+            _cloudTokenField.Text = token ?? string.Empty;
             _cloudTokenLine.Visible = ConnectionPanelView.ShowCloudTokenField(_useCloudAccessToken);
 
-            // "Sign out" (Revoke) only when a credential is stored.
+            // "Sign out" only when signed in (machine store or legacy fallback).
             _revokeButton.Visible = hasToken;
         }
 
@@ -1090,29 +1113,57 @@ namespace com.IvanMurzak.Godot.MCP.UI
             flow.OnStateChanged += _authFlowStateChangedHandler;
 
             // Fire-and-forget; the state-change handler drives the status/button/browser UI, and the awaited
-            // result persists the token (the token NEVER lives on the flow instance — it only flows out as
-            // StartAsync's return value, so config writes stay on the main thread via the dispatcher).
+            // outcome drives the post-sign-in UI + reconnect. The credential itself never reaches this panel:
+            // the F1 flow persists it into the MACHINE STORE via the guarded two-lock-hold commit
+            // (GodotCloudAccountController → GodotAccountAuth.SignInAsync), and — unified-machine-auth O8 —
+            // Config.CloudToken (the plaintext user:// sink) is no longer written on authorize.
             _ = RunAuthFlowAsync(flow);
         }
 
         async Task RunAuthFlowAsync(GodotDeviceAuthFlow flow)
         {
-            var token = await flow.StartAsync(_connection.CloudBaseUrl, "Godot Editor");
-            if (string.IsNullOrEmpty(token))
-                return; // Non-Authorized terminal state: nothing to persist (UI already reflects it).
+            var outcome = await GodotCloudAccountController.SignInAsync(
+                _connection.Account, flow, _connection.CloudBaseUrl, _connection.Config);
 
-            // Persist + reconnect on the editor main thread (the awaited continuation may run off-thread).
+            // Render + reconnect on the editor main thread (the awaited continuation may run off-thread).
             if (MainThreadDispatcher.Instance != null && !MainThreadDispatcher.IsMainThread)
-                MainThreadDispatcher.Enqueue(() => PersistAuthorizedToken(flow, token!));
+                MainThreadDispatcher.Enqueue(() => ApplySignInOutcome(flow, outcome));
             else
-                PersistAuthorizedToken(flow, token!);
+                ApplySignInOutcome(flow, outcome);
+        }
+
+        /// <summary>
+        /// Apply a finished F1 sign-in attempt to the UI, and — when the machine is now signed in —
+        /// reconnect so the connection presents the machine-store JWT. MUST run on the editor main thread.
+        /// Ignores a stale flow (a newer Authorize click replaced <see cref="_deviceAuthFlow"/>). No token
+        /// material flows through here — <see cref="GodotAccountSignInResult"/> is non-secret by contract.
+        /// </summary>
+        void ApplySignInOutcome(GodotDeviceAuthFlow flow, GodotAccountSignInResult outcome)
+        {
+            if (!ReferenceEquals(_deviceAuthFlow, flow))
+                return;
+
+            var message = ConnectionPanelView.SignInOutcomeMessage(outcome);
+            if (!string.IsNullOrEmpty(message))
+                SetCloudAuthStatusText(message);
+
+            ApplyCloudAuthState();
+            ApplyAlertVisibility(_connection.ConnectionStatus);
+
+            // Reconnect so the fresh machine-store bearer is used — only meaningful when the live mode is
+            // Cloud and the sign-in actually yielded a usable credential.
+            if (outcome.Succeeded && _connection.Config.ActiveMode == GodotMcpConnectionMode.Cloud)
+                _connection.Reconnect();
+
+            ConfigChanged?.Invoke(); // account state changed → agent section re-checks config
         }
 
         /// <summary>
         /// Apply one device-auth flow state transition to the UI (status line, button label, browser-open).
         /// MUST run on the editor main thread. Ignores events from a stale flow (a newer Authorize click
-        /// replaced <see cref="_deviceAuthFlow"/>). Token persistence happens in
-        /// <see cref="PersistAuthorizedToken"/> off the awaited result, not here.
+        /// replaced <see cref="_deviceAuthFlow"/>). Credential persistence happens in the machine-store
+        /// commit inside <see cref="RunAuthFlowAsync"/> (via <see cref="GodotCloudAccountController"/>),
+        /// not here.
         /// </summary>
         void OnAuthFlowStateChanged(GodotDeviceAuthFlow flow, GodotDeviceAuthFlowState state)
         {
@@ -1130,23 +1181,13 @@ namespace com.IvanMurzak.Godot.MCP.UI
         }
 
         /// <summary>
-        /// Persist the cloud token produced by an Authorized flow, refresh the masked field, and reconnect.
-        /// MUST run on the editor main thread. Ignores a stale flow. The token is written straight to config
-        /// and never logged.
-        /// </summary>
-        void PersistAuthorizedToken(GodotDeviceAuthFlow flow, string token)
-        {
-            if (!ReferenceEquals(_deviceAuthFlow, flow))
-                return;
-
-            ApplyAuthorizedToken(token);
-        }
-
-        /// <summary>
-        /// Persist a freshly-obtained Cloud token, refresh the masked field + alerts, and reconnect so the new
-        /// bearer is used (Cloud mode only). Shared by the real device-auth flow
-        /// (<see cref="PersistAuthorizedToken"/>) and the DEV-ONLY <see cref="DevSimulateCloudAuthorized"/> so
-        /// both drive the identical persist → reconnect path. MUST run on the editor main thread.
+        /// DEV-ONLY (reached exclusively from <see cref="DevSimulateCloudAuthorized"/>): persist a token into
+        /// the LEGACY <see cref="GodotMcpConfig.CloudToken"/> sink, refresh the masked field + alerts, and
+        /// reconnect. The REAL authorize path no longer writes this sink (unified-machine-auth O8 — it
+        /// commits to the machine store via <see cref="GodotCloudAccountController"/>); this seam survives
+        /// one release so the dev-control bridge can exercise the O8 read-fallback + migrate-on-touch
+        /// states without a live OAuth round-trip, and is removed with the rest of the sink write path in
+        /// the f4 follow-up. MUST run on the editor main thread. Never logs the token.
         /// </summary>
         void ApplyAuthorizedToken(string token)
         {
@@ -1163,28 +1204,66 @@ namespace com.IvanMurzak.Godot.MCP.UI
         }
 
         /// <summary>
-        /// DEV-ONLY: simulate a successful Cloud device-authorization by persisting <paramref name="token"/>
-        /// through the EXACT same path the real flow uses (<see cref="ApplyAuthorizedToken"/>) — set + save the
-        /// token, refresh the masked field / Revoke button / alerts, and Reconnect(). Lets the dev-control
-        /// bridge exercise the "authorized → persist → reconnect" path (and the stale-rejection guard) without a
-        /// live browser OAuth round-trip. No-op behavior is identical to the real flow; never logs the token.
+        /// DEV-ONLY: simulate a LEGACY-sink Cloud authorization by persisting <paramref name="token"/> into
+        /// <see cref="GodotMcpConfig.CloudToken"/> (<see cref="ApplyAuthorizedToken"/>) — set + save the
+        /// token, refresh the masked field / Sign out button / alerts, and Reconnect(). NOTE (task f1): the
+        /// REAL authorize path no longer writes this sink — it commits to the machine store — so this hook
+        /// now specifically seeds the O8 read-fallback state (and still exercises persist → reconnect + the
+        /// stale-rejection guard) without a live browser OAuth round-trip. Never logs the token; the seam is
+        /// removed with the sink write path in f4.
         /// </summary>
         public void DevSimulateCloudAuthorized(string token) => ApplyAuthorizedToken(token);
 
         /// <summary>
-        /// Revoke the stored cloud token: clear it, persist, revert the UI to the Authorize state, and (if
-        /// the live mode is Cloud) disconnect so the now-unauthenticated session does not linger.
+        /// "Sign out" pressed: show the F6.1 confirmation ("signs out all tools on this machine") — the
+        /// actual machine-wide sign-out runs in <see cref="OnSignOutConfirmed"/> only after the user
+        /// confirms. Cancelling changes nothing.
         /// </summary>
-        public void OnRevokeButtonPressed()
-        {
-            _connection.Config.CloudToken = null;
-            _connection.Save();
-            SetCloudAuthStatusText("Token revoked.");
-            ApplyCloudAuthState();
-            ApplyAlertVisibility(_connection.ConnectionStatus);
+        public void OnRevokeButtonPressed() => _signOutConfirm.PopupCentered();
 
-            if (_connection.Config.ActiveMode == GodotMcpConnectionMode.Cloud)
-                _connection.Disconnect();
+        /// <summary>
+        /// The confirmed F6 machine-wide sign-out: best-effort RFC 7009 revocation of every stored family +
+        /// the lock-protocol machine-store delete (<see cref="GodotAccountAuth.SignOutMachineWideAsync"/>),
+        /// then — locally — drop the LEGACY <see cref="GodotMcpConfig.CloudToken"/> sink value too (the
+        /// Godot analog of the App dropping its keychain entry, F6.2; without this the O8 migrate-on-touch
+        /// would resurrect the credential from the sink on the next boot). Fire-and-forget async; the UI is
+        /// updated on the editor main thread when the sign-out settles.
+        /// </summary>
+        public void OnSignOutConfirmed() => _ = RunSignOutAsync();
+
+        async Task RunSignOutAsync()
+        {
+            var result = await _connection.Account.SignOutMachineWideAsync();
+
+            void Render()
+            {
+                if (result.StoreDeleted)
+                {
+                    // Local F6.2 cleanup: the legacy sink must not survive a machine-wide sign-out.
+                    _connection.Config.CloudToken = null;
+                    _connection.Save();
+                    SetCloudAuthStatusText(ConnectionPanelView.SignedOutStatusText);
+                }
+                else
+                {
+                    // Busy lock: the store was NOT deleted (F6 — never unlink outside the lock protocol);
+                    // keep the signed-in rendering honest and ask the user to retry.
+                    SetCloudAuthStatusText(ConnectionPanelView.SignOutBusyStatusText);
+                }
+
+                ApplyCloudAuthState();
+                ApplyAlertVisibility(_connection.ConnectionStatus);
+
+                if (result.StoreDeleted && _connection.Config.ActiveMode == GodotMcpConnectionMode.Cloud)
+                    _connection.Disconnect();
+
+                ConfigChanged?.Invoke(); // account state changed → agent section re-checks config
+            }
+
+            if (MainThreadDispatcher.Instance != null && !MainThreadDispatcher.IsMainThread)
+                MainThreadDispatcher.Enqueue(Render);
+            else
+                Render();
         }
 
         /// <summary>
@@ -1197,6 +1276,14 @@ namespace com.IvanMurzak.Godot.MCP.UI
         {
             // Only relevant to Cloud mode — a Custom-mode rejection is the Custom token's concern.
             if (_connection.Config.ActiveMode != GodotMcpConnectionMode.Cloud)
+                return;
+
+            // Machine-store account signed in: recovery belongs to the connection's reactive refresh
+            // (GodotMcpConnection.TryAccountRefreshAndReconnect — design 08 A1, expiry self-heals). Don't
+            // wipe the legacy sink or flip the UI to "press Authorize" for a rejection the refresh is about
+            // to heal; if the refresh fails terminally the provider surfaces sign-in-required and the next
+            // re-render shows signed-out.
+            if (_connection.Account.IsSignedIn)
                 return;
 
             _connection.Config.CloudToken = null;

--- a/addons/godot_mcp/Editor/UI/ConnectionPanelView.cs
+++ b/addons/godot_mcp/Editor/UI/ConnectionPanelView.cs
@@ -213,7 +213,9 @@ namespace com.IvanMurzak.Godot.MCP.UI
         public static string SignInOutcomeMessage(GodotAccountSignInResult outcome) => outcome.Status switch
         {
             GodotAccountSignInStatus.SignedIn => "Signed in — all AI-Game-Dev tools on this machine are authorized.",
-            GodotAccountSignInStatus.PartiallyAuthorized => "Partially authorized — press Authorize again to finish.",
+            // The retry already ran (GodotAccountAuth's bounded second phase) and any abandoned mint was
+            // revoked — a fresh Authorize re-runs the whole flow, so say "retry", never promise "finish".
+            GodotAccountSignInStatus.PartiallyAuthorized => "Partially authorized — sign-in didn't complete; press Authorize to retry.",
             GodotAccountSignInStatus.NotAuthorized => string.Empty, // the device-flow state line already rendered the terminal state
             GodotAccountSignInStatus.Busy => "Another tool holds the credential lock — try again.",
             GodotAccountSignInStatus.SubjectConflict => "This machine is signed in as a different account — sign out first.",

--- a/addons/godot_mcp/Editor/UI/ConnectionPanelView.cs
+++ b/addons/godot_mcp/Editor/UI/ConnectionPanelView.cs
@@ -180,6 +180,46 @@ namespace com.IvanMurzak.Godot.MCP.UI
         public static (float R, float G, float B) CloudSignInStatusColor(bool signedIn) =>
             signedIn ? ColorConnected : ColorDisconnected;
 
+        /// <summary>
+        /// The ONE cloud signed-in predicate the panel renders from (unified-machine-auth task f1): signed in
+        /// when the MACHINE STORE holds a usable account credential (<paramref name="accountSignedIn"/> — the
+        /// F1 golden path), OR when the legacy <c>user://</c> config still carries a
+        /// <paramref name="legacyCloudToken"/> (the O8 read-fallback window, one release). Pure-managed →
+        /// unit-tested; the panel must never re-derive this from <c>Config.CloudToken</c> alone, or a
+        /// machine-store sign-in would render as signed-out.
+        /// </summary>
+        public static bool IsCloudSignedIn(bool accountSignedIn, string? legacyCloudToken) =>
+            accountSignedIn || !string.IsNullOrEmpty(legacyCloudToken);
+
+        /// <summary>
+        /// The F6 sign-out confirmation copy ("signs out all tools on this machine" — design 03 F6.1). Shown
+        /// BEFORE the machine-wide sign-out revokes every stored credential family and deletes the shared
+        /// machine store.
+        /// </summary>
+        public const string SignOutConfirmText =
+            "Sign out of ai-game.dev on this machine?\nThis signs out ALL AI-Game-Dev tools on this machine (Unity, Godot, Unreal, CLI, desktop app).";
+
+        /// <summary>Cloud-auth status line after a completed machine-wide sign-out.</summary>
+        public const string SignedOutStatusText = "Signed out on this machine.";
+
+        /// <summary>Cloud-auth status line when the sign-out could not delete the store (credential lock busy).</summary>
+        public const string SignOutBusyStatusText = "Sign-out is busy (another tool holds the credential lock) — try again.";
+
+        /// <summary>
+        /// The Cloud-auth status line for a finished sign-in attempt (the machine-store F1 commit outcome —
+        /// distinct from <see cref="CloudAuthStatusMessage"/>, which renders the DEVICE-FLOW states). Never
+        /// carries token material; <see cref="GodotAccountSignInResult.Detail"/> is non-secret by contract.
+        /// </summary>
+        public static string SignInOutcomeMessage(GodotAccountSignInResult outcome) => outcome.Status switch
+        {
+            GodotAccountSignInStatus.SignedIn => "Signed in — all AI-Game-Dev tools on this machine are authorized.",
+            GodotAccountSignInStatus.PartiallyAuthorized => "Partially authorized — press Authorize again to finish.",
+            GodotAccountSignInStatus.NotAuthorized => string.Empty, // the device-flow state line already rendered the terminal state
+            GodotAccountSignInStatus.Busy => "Another tool holds the credential lock — try again.",
+            GodotAccountSignInStatus.SubjectConflict => "This machine is signed in as a different account — sign out first.",
+            _ => string.IsNullOrEmpty(outcome.Detail) ? "Sign-in failed — try again." : $"Sign-in failed: {outcome.Detail}",
+        };
+
         /// <summary>The "Advanced: use access token" opt-in label — reveals the legacy masked token field on the Cloud path.</summary>
         public const string AdvancedUseAccessTokenLabel = "Advanced: use access token";
 

--- a/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
+++ b/addons/godot_mcp/Runtime/Connection/GodotMcpConnection.cs
@@ -216,6 +216,18 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// </summary>
         int _accountRefreshInFlight;
 
+        /// <summary>
+        /// The <c>cloudToken</c> value the persisted <c>user://godot-mcp-config.json</c> SINK FILE itself
+        /// held at load time (unified-machine-auth O8/F11.2) — captured in <see cref="ApplyPersistedConfig"/>
+        /// BEFORE the <c>.env</c>/process-env layers can shadow <see cref="GodotMcpConfig.CloudToken"/>, so
+        /// the legacy migration acts on exactly what the sink persisted. Null when the sink holds none.
+        /// SECRET MATERIAL: never logged, never surfaced.
+        /// </summary>
+        string? _persistedSinkCloudToken;
+
+        /// <summary>One-shot guard so the O8 legacy migration runs at most once per editor session (0 = not yet, 1 = attempted).</summary>
+        int _legacyMigrationAttempted;
+
         /// <summary>The active config (resolved Host/Token/mode are read live off this).</summary>
         public GodotMcpConfig Config => _config;
 
@@ -340,6 +352,14 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             // built-in defaults (the first-load "Cloud token empty / Authorize prompted / wrong agent restored"
             // bug); this lazy call covers a Start() reached without that pre-step. A no-op once already resolved.
             ResolveConfig();
+
+            // O8 / F11.2 legacy migration (migrate-on-touch), once per session, OFF the main thread: a
+            // pre-existing user:// cloudToken is copied into the machine store (under the machine lock)
+            // when the store holds no credential. Fire-and-forget is safe here: until the migration lands,
+            // the credential-provider fallback below presents the IDENTICAL sink token, so the bearer on
+            // the wire is the same either way — the migration only moves where it is durably stored. The
+            // lock acquire can block up to its 75 s budget, which must never stall the editor boot.
+            MaybeMigrateLegacyCloudToken();
 
             // Compose the machine-store account credential into the connection's bearer resolution (D12 — the
             // zero-button rule). In Cloud mode, when the machine store holds a credential, present its
@@ -616,6 +636,39 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// and we do NOT reconnect — that stops a reject→refresh→reject loop; recovery is then an explicit
         /// re-sign-in.
         /// </summary>
+        /// <summary>
+        /// Kick off the O8/F11.2 legacy-sink migration on a background task, at most once per editor
+        /// session. Delegates the whole decision (empty-store check, lock, unreadable-store refusal) to
+        /// <see cref="GodotAccountAuth.TryMigrateLegacyCloudToken"/>; only the outcome KIND is logged —
+        /// never the token.
+        /// </summary>
+        void MaybeMigrateLegacyCloudToken()
+        {
+            if (string.IsNullOrEmpty(_persistedSinkCloudToken))
+                return;
+            if (Interlocked.CompareExchange(ref _legacyMigrationAttempted, 1, 0) != 0)
+                return;
+
+            var sinkToken = _persistedSinkCloudToken;
+            var serverTarget = GodotMcpConfig.ResolveCloudBaseUrl();
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    var outcome = _account.TryMigrateLegacyCloudToken(sinkToken, serverTarget);
+                    if (outcome == GodotLegacyTokenMigrationResult.Migrated)
+                        GodotMcpLog.Info("[Godot-MCP] migrated the legacy user:// cloud credential into the machine store (O8).");
+                    else if (outcome != GodotLegacyTokenMigrationResult.NoSinkToken)
+                        LogTrace($"[Godot-MCP] legacy cloud-credential migration skipped: {outcome}.");
+                }
+                catch (Exception ex)
+                {
+                    // ex.Message comes from IO/lock plumbing, never from token material.
+                    GodotMcpLog.Warning($"[Godot-MCP] legacy cloud-credential migration failed: {ex.Message}");
+                }
+            });
+        }
+
         void TryAccountRefreshAndReconnect()
         {
             if (!_account.IsSignedIn || _config.ActiveMode != GodotMcpConnectionMode.Cloud)
@@ -1381,6 +1434,11 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             var persisted = GodotMcpConfigStore.Load(path);
             if (persisted == null)
                 return;
+
+            // O8/F11.2: remember the cloudToken value the user:// SINK FILE itself holds — before the
+            // .env layer (which may also write _config.CloudToken) and the live env override shadow it.
+            // The legacy migration must act on exactly what the sink persisted, nothing else.
+            _persistedSinkCloudToken = persisted.CloudToken;
 
             GodotMcpConfigStore.ApplyPersisted(_config, persisted);
             GodotMcpLog.Info($"[Godot-MCP] loaded persisted config ({path}).");


### PR DESCRIPTION
unified-machine-auth **f1-godot-plugin-ui-rewire** — the Godot editor adopts the shared b3 credential stack (McpPlugin 8.1.0): the Authorize button stops writing `Config.CloudToken` to the plaintext `user://godot-mcp-config.json` sink and runs the F1 flow through `GodotAccountAuth` + the machine store; the legacy sink gains read-fallback + migrate-on-touch (O8/F11.2).

## What changed

- **F1 login (03 F1, 04 §4)** — `GodotDeviceAuthFlow` requests **`scope=mcp:agent`** (`client_id=godot-mcp-plugin`); `GodotAccountAuth.SignInAsync` commits via the shared **two-lock-hold** helper `MachineCredentialLoginCommit.CommitAsync` (agent family under hold 1 → RFC 8693 exchange between holds → plugin family + v1 mirror under hold 2). **No credential write goes through bare `PluginCredentialProvider.Adopt()`** (G-SEC-2) — guarded helpers only, and the provider is passed the machine lock (`credentialLock:` ctor param). The device-grant response carries no `sub` (O5 covers exchange/enroll), so the commit runs the no-sub F7 form and the exchange's `sub` is backfilled by the helper.
- **`GodotTokenRefresher` → thin adapter over the shared `HttpTokenRefresher`** (`ITokenRefresher` family-aware overload): stored `clientId` presented verbatim, component default only for legacy families (04 §3.7), **no `scope`/`resource` on the wire** (04 §3.3/P0-3), rate discipline + 15 s contract timeout + `invalid_grant` classification inherited. The adapter's one local behavior is the LIVE default-AS-base seam for target-less credentials. **The local refresh wire path (`GodotDeviceAuthService.RefreshTokenAsync`, `:131-136`) is deleted** so exactly one refresh wire shape exists.
- **`ConnectionPanel` rewire** — `RunAuthFlowAsync` routes through the new pure-managed `GodotCloudAccountController` (the single persistence seam; the panel never touches `CloudToken` on authorize; old `PersistAuthorizedToken` deleted). Signed-in rendering + alert visibility use `ConnectionPanelView.IsCloudSignedIn(machineStore || legacySink)`. Reactive auth-rejected recovery defers to the connection's account refresh (08 A1) when the machine store is signed in.
- **F6 sign-out** — "Sign out" now shows a `ConfirmationDialog` ("signs out ALL AI-Game-Dev tools on this machine", F6.1), then `MachineWideSignOut.SignOutAsync` (best-effort RFC 7009 revoke of every family with its stored `clientId`, lock-protocol store delete), then clears the legacy sink locally (so O8 migrate-on-touch cannot resurrect the credential). A busy lock reports honestly and deletes nothing.
- **O8 / F11.2 migration** — on start (background, once per session) a `cloudToken` held by the persisted sink FILE (captured before the `.env` layer can shadow it) is copied into the machine store **under the lock**, only when the store holds no credential: store-wins, unreadable-store-never-overwritten (04 §1), busy-lock retries next boot, v1-shaped write normalized to `families.legacy` + mirror by the store's write contract. **The sink is NOT deleted and the read-fallback stays — write-path removal is f4, one release later.**

## Mandated plants (G-SEC-1) — each RED-verified, then reverted

| # | Plant (temporary mutation) | RED evidence (full suite, 1284 tests*) |
|---|---|---|
| 1 | Re-enable the sink write on authorize (`config.CloudToken = …` in `GodotCloudAccountController.SignInAsync`) | **2 failed / 1275 passed**: `GodotCloudAccountControllerTests.SignIn_Success_WritesTheMachineStore_AndNeverTheCloudTokenSink`, `SignIn_Success_LeavesAPreExistingLegacySinkTokenUntouched` |
| 2 | Migration skips the store write (`_store.Write(...)` commented out, everything else intact — "succeeds" without persisting) | **1 failed / 1276 passed**: `GodotAccountAuthTests.Migrate_SeededSink_EmptyStore_WritesLegacyFamilyUnderLock_AndSignsIn` |
| 3a | Adapter drops the family context (`clientId: null` always → component default presented) | **2 failed / 1275 passed**: `GodotAccountAuthTests.Refresh_PresentsTheFamilysStoredClientId_NeverTheComponentDefault`, `GodotTokenRefresherTests.RefreshAsync_FamilyAware_PresentsTheStoredClientId` |
| 3b | Re-added LOCAL refresh wire path sending `scope=mcp:plugin` (the pre-b3 defect class) | **9 failed / 1268 passed**, incl. the targets `Refresh_OmitsScopeAndResourceEntirely` (both levels) + `Refresh_LegacyFamily_PresentsTheComponentDefault_AndStillOmitsScope`; the 5 collateral failures (fail-closed mapping, `/mcp` strip, expiry mapping) are the shared-contract divergence a local wire path re-introduces — the reason it was deleted |

\* plants 1/3a/3b ran before the 7 new ConnectionPanelView tests landed (1277-test baseline); plant totals reflect their run's baseline. Positive halves: plant 1's test pins a POSITIVE artifact (the machine store actually holding the committed families) in the same test, so the no-write assert cannot pass vacuously; plant 2's test asserts the store CONTENT (legacy family + mirror + sign-in), not an absence.

Suite after all reverts: **1284/1284 green** (`dotnet test Godot-MCP.Tests`, net8.0), build 0 warnings. `git grep PLANT` → no markers remain.

## O8 residual-reader record (negative findings carry invisible scope)

Grep scope: `git grep -n "CloudToken"` over all tracked `*.cs`/`*.ts` in this repo (excluding `Tests/`), plus `git grep "godot-mcp-config"` over `*.ts`, at this branch's HEAD. Readers of the `user://` `cloudToken` that remain:

1. **The sanctioned read-fallback** — `GodotMcpConnection.Start()` credential-provider composite → `_config.Token` → `ResolveCloudToken()` (the spec's `GodotMcpConnection.cs:350-359` path; line numbers shifted by this diff). The Custom-mode `oauth` auth option (`GodotMcpConfig.cs:390`) reaches the same value through the same composite fallback.
2. **UI display state** — `ConnectionPanel.ApplyCloudAuthState` (masked Advanced field) + `ApplyAlertVisibility`/`IsCloudSignedIn` (the legacy half of the signed-in predicate). Display only.
3. **`AgentConfiguratorSettingsFactory` → `ResolveSettingsToken(credentialMode, config.Token)`** — the "Advanced: use access token" escape-hatch configurator write reads `config.Token` (in Cloud mode = env token or the legacy sink). A machine-store-only sign-in currently yields NO token for that escape hatch. Residual reader beyond the connection fallback — flagged for f4 (either thread the machine-store token in, or accept URL-only for OAuth-incapable agents).
4. **`GodotMcpDock.cs:595` dev-control state dump** — reads the masked `CloudTokenField` LineEdit (dev bridge only).
5. **The Godot CLI does NOT read this sink** — its `readCloudToken` reads the CLI's own `<project>/.godot-mcp/credentials.json` (a different D7 sink with its own W2 disposition); `cli/src/utils/config.ts:6` mentions the filename in a comment only.

Remaining writers (all deliberate, all f4-flagged): `ApplyAuthorizedToken` (reached ONLY from the dev-bridge `DevSimulateCloudAuthorized`, now documented as the legacy-sink seeding hook), the F6 clear (`null`), the legacy-path auth-rejected clear (`null`, guarded off when the account is signed in), `GodotMcpEnvFile.Apply` (the `.env` layer writes the in-memory field — pre-existing; note a later user-triggered `Save()` could serialize an env-file token into the sink), and the load path (`ApplyPersisted`).

## Testbed smoke (honest scope)

Worktree-provisioned testbed (junction → this branch's addon; testbed csproj pin locally bumped 7.5.2→8.1.0 for the smoke — **the infra testbed's lockstep pin bump is pending upstream**, see report), `Godot_v4.5.1_mono_win64_console`, headless:

- **Editor boot**: `--import` + `dotnet build` (0 warnings) + `--editor --quit` in Custom mode → `[Godot-MCP] plugin loaded`, `resolved 'McpPlugin' -> …\com.ivanmurzak.mcpplugin\8.1.0\…`, clean unload, exit 0. No `FileNotFoundException`.
- **O8 skip path, live**: seeded the test project's real `user://godot-mcp-config.json` with a fake `cloudToken`, booted at Trace → `[Godot-MCP] legacy cloud-credential migration skipped: SkippedStoreHasCredential.`; the real `~/.ai-game-dev/credentials.json` was byte-identical before/after (sha256 match) and the sink was not deleted. Seed reverted from backup.
- **NOT smoke-verified interactively**: the full "Authorize in the editor yields v2 machine store" DoD requires a browser + account approval (RFC 8628) — not executable unattended. The commit sequence is proven by the unit suite against a scripted fake AS (device flow + exchange + store assertions). The MIGRATE (empty-store) half of O8 could not be run against this machine's real store (it is populated — correctly triggering the skip path); it is proven at unit level (+ plant 2 RED). Custom mode was used deliberately so the owner's real cloud credential was never presented or refreshed.

Design refs: `.taskflow/2026-08-14-unified-machine-auth/` 03 (F1/F6/F11), 04 (§1–§5), 06 (W2, O8 row); MCP-Plugin-dotnet #207 (b3 cascade note).

---
This report/PR is **not proof of completion** — every DoD item is verified by the orchestrator against the repository, CI, and the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
