### PR TITLE
feat(editor): sign-in-required panel + D4 assisted ladder against pinned McpPlugin 8.1.0 (taskflow e2)

### DIFF
--- a/Godot-MCP.Tests/ConnectionPanelViewTests.cs
+++ b/Godot-MCP.Tests/ConnectionPanelViewTests.cs
@@ -359,6 +359,65 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Contains("exchange refused", ConnectionPanelView.SignInOutcomeMessage(Make(GodotAccountSignInStatus.Failed, "exchange refused")));
         }
 
+        // --- Authorization-rejected presentation (oauth-client-error-hygiene e2 — the silent-red fix) ---
+
+        /// <summary>
+        /// THE e2 pin: signed-in + auth-rejected must RENDER the sign-in-required state. Before e2 the
+        /// panel handler early-returned for signed-in users (`if (_connection.Account.IsSignedIn) return;`),
+        /// so a dead machine-store credential showed NOTHING — the silent-red bug found in review (same as
+        /// Unity's). Restoring that early return (deciding <see cref="ConnectionPanelView.AuthRejectedPresentation.None"/>
+        /// for the signed-in case) reddens this test.
+        /// </summary>
+        [Fact]
+        public void AuthorizationRejected_CloudSignedIn_RendersSignInRequired()
+        {
+            Assert.Equal(
+                ConnectionPanelView.AuthRejectedPresentation.SignInRequired,
+                ConnectionPanelView.AuthorizationRejectedPresentation(isCloudMode: true, accountSignedIn: true));
+        }
+
+        /// <summary>Positive control on the same axis: the signed-out (legacy-sink) rejection keeps its
+        /// pre-e2 clear-and-prompt behavior — the fix must not have collapsed the two cases.</summary>
+        [Fact]
+        public void AuthorizationRejected_CloudSignedOut_ClearsLegacyTokenAndPrompts()
+        {
+            Assert.Equal(
+                ConnectionPanelView.AuthRejectedPresentation.ClearLegacyTokenAndPrompt,
+                ConnectionPanelView.AuthorizationRejectedPresentation(isCloudMode: true, accountSignedIn: false));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void AuthorizationRejected_CustomMode_RendersNothing(bool accountSignedIn)
+        {
+            // A Custom-mode rejection is the Custom token's concern — never the cloud auth row's.
+            Assert.Equal(
+                ConnectionPanelView.AuthRejectedPresentation.None,
+                ConnectionPanelView.AuthorizationRejectedPresentation(isCloudMode: false, accountSignedIn));
+        }
+
+        [Fact]
+        public void SignInRequiredStatus_IsRecognizedExactly_SoOnlyItIsCleared()
+        {
+            // The panel clears a now-disproved "sign in required" line (hub Connected / SignedIn edge)
+            // ONLY when the status line is exactly that text — unrelated messages must survive.
+            Assert.True(ConnectionPanelView.IsSignInRequiredStatus(ConnectionPanelView.SignInRequiredStatusText));
+            Assert.False(ConnectionPanelView.IsSignInRequiredStatus(ConnectionPanelView.AuthorizationRejectedPromptText));
+            Assert.False(ConnectionPanelView.IsSignInRequiredStatus(ConnectionPanelView.SignedOutStatusText));
+            Assert.False(ConnectionPanelView.IsSignInRequiredStatus(string.Empty));
+            Assert.False(ConnectionPanelView.IsSignInRequiredStatus(null));
+        }
+
+        [Fact]
+        public void SignInRequiredStatusText_TellsTheUserWhatToDo()
+        {
+            // The generic D4 line (the pinned McpPlugin 8.1.0 has no per-verdict reason — r4 adds
+            // reason-class rendering): it must name the state AND the action.
+            Assert.Contains("Sign in required", ConnectionPanelView.SignInRequiredStatusText);
+            Assert.Contains("Authorize", ConnectionPanelView.SignInRequiredStatusText);
+        }
+
         [Fact]
         public void CustomHost_PersistsAndReloads()
         {

--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -147,6 +147,13 @@
     <!-- unified-machine-auth f1: the pure orchestration behind the dock's Authorize button — the seam
          whose no-new-cloudToken invariant (O8) is pinned by GodotCloudAccountControllerTests. -->
     <Compile Include="..\addons\godot_mcp\Editor\Connection\GodotCloudAccountController.cs" Link="Source\GodotCloudAccountController.cs" />
+    <!-- oauth-client-error-hygiene e2: the D4 assisted-sign-in ladder — pure-managed (no Godot native
+         types, no #if TOOLS): the once-per-editor-session auto-open gate + carousel guard behind the
+         panel's sign-in-required verdict handling, with an injectable session store (process env vars by
+         default — they survive the collectible-ALC hot-reload). The browser-open + flow start wiring lives
+         in ConnectionPanel.cs (#if TOOLS, headless-smoke-verified); the gate/guard/dispatch decisions are
+         unit-tested here (GodotAssistedSignInTests). -->
+    <Compile Include="..\addons\godot_mcp\Editor\Connection\GodotAssistedSignIn.cs" Link="Source\GodotAssistedSignIn.cs" />
     <!-- Editor-runtime NuGet-dependency resolver. Pure-BCL (System.Runtime.Loader), no #if TOOLS,
          no Godot native types — so it is unit-testable in this plain-xUnit host. -->
     <Compile Include="..\addons\godot_mcp\Runtime\Connection\GodotMcpAssemblyResolver.cs" Link="Source\GodotMcpAssemblyResolver.cs" />

--- a/Godot-MCP.Tests/GodotAccountAuthTests.cs
+++ b/Godot-MCP.Tests/GodotAccountAuthTests.cs
@@ -17,6 +17,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using com.IvanMurzak.Godot.MCP.Connection;
+using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.McpPlugin.AgentConfig;
 using Xunit;
 
@@ -331,6 +332,113 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             var refreshed = await account.RefreshAsync();
 
             Assert.False(refreshed);
+        }
+
+        // --- Provider-state forwarding (oauth-client-error-hygiene e2): the panel's stable
+        // SignInRequired / AuthStateChanged / AuthState seam over the swapped-out provider ---
+
+        /// <summary>
+        /// A terminal <c>invalid_grant</c> refresh rejection surfaces through the coordinator's STABLE
+        /// events — the provider's own <c>OnSignInRequired</c>/<c>State</c> (02 §C3: the panel must not
+        /// rely solely on the connection's authorization-rejected signal) forwarded by
+        /// <see cref="GodotAccountAuth"/>.
+        /// </summary>
+        [Fact]
+        public async Task RefreshAsync_InvalidGrant_FiresSignInRequired_AndAuthStateReadsSignInRequired()
+        {
+            using var tmp = new TempDir();
+            WritePluginFamily(tmp, accessToken: "acc-old", refreshToken: "ref-old",
+                expiresAt: AlreadyExpired, clientId: ComponentClientId);
+
+            var server = new FakeAuthServer
+            {
+                Refresh = () => JsonResponse(HttpStatusCode.BadRequest, "{ \"error\": \"invalid_grant\" }"),
+            };
+            using var account = MakeAccount(tmp, server);
+            Assert.Equal(AuthState.SignedIn, account.AuthState);
+
+            var signInRequiredCount = 0;
+            var states = new List<AuthState>();
+            account.SignInRequired += () => Interlocked.Increment(ref signInRequiredCount);
+            account.AuthStateChanged += state => { lock (states) states.Add(state); };
+
+            var refreshed = await account.RefreshAsync();
+
+            Assert.False(refreshed);
+            Assert.Equal(1, signInRequiredCount);
+            Assert.Equal(AuthState.SignInRequired, account.AuthState);
+            lock (states)
+                Assert.Contains(AuthState.SignInRequired, states);
+        }
+
+        /// <summary>
+        /// Same-fixture negative control: a SUCCESSFUL refresh fires no sign-in-required — the forwarder
+        /// must not be an always-firing wrapper (and the state stays SignedIn).
+        /// </summary>
+        [Fact]
+        public async Task RefreshAsync_Success_DoesNotFireSignInRequired()
+        {
+            using var tmp = new TempDir();
+            WritePluginFamily(tmp, accessToken: "acc-old", refreshToken: "ref-old",
+                expiresAt: AlreadyExpired, clientId: ComponentClientId);
+
+            var server = new FakeAuthServer { Refresh = Ok(TokenJson("acc-new", "ref-new", 3600)) };
+            using var account = MakeAccount(tmp, server);
+
+            var signInRequiredCount = 0;
+            account.SignInRequired += () => Interlocked.Increment(ref signInRequiredCount);
+
+            var refreshed = await account.RefreshAsync();
+
+            Assert.True(refreshed);
+            Assert.Equal(0, signInRequiredCount);
+            Assert.Equal(AuthState.SignedIn, account.AuthState);
+        }
+
+        /// <summary>
+        /// THE load-bearing re-hook: the coordinator REBUILDS its provider after every guarded store
+        /// mutation (sign-in commit, sign-out, migration), so a subscription left on the old provider goes
+        /// silently dead. A panel subscription taken BEFORE a full F1 sign-in must still receive the
+        /// SignedIn edge from the swap and a later terminal verdict from the FRESH provider. Removing the
+        /// <c>HookProviderEvents</c> call from <c>ReloadFromStore</c> reddens this test.
+        /// </summary>
+        [Fact]
+        public async Task ProviderSwap_OnSignIn_KeepsForwardingStateAndSignInRequired()
+        {
+            using var tmp = new TempDir();
+            var server = new FakeAuthServer
+            {
+                DeviceAuthorize = Ok(DeviceAuthorizeJson("USER-1", "dev-1")),
+                DeviceToken = Ok(TokenJson("acc-agent", "ref-agent", 3600, scope: "mcp:agent")),
+                Exchange = Ok(ExchangeJson("acc-plugin", "ref-plugin", 3600, scope: "mcp:plugin", sub: "usr_1")),
+            };
+            using var account = MakeAccount(tmp, server);
+
+            var signInRequiredCount = 0;
+            var states = new List<AuthState>();
+            account.SignInRequired += () => Interlocked.Increment(ref signInRequiredCount);
+            account.AuthStateChanged += state => { lock (states) states.Add(state); };
+
+            // The F1 sign-in commits the store and SWAPS the provider (ReloadFromStore).
+            var outcome = await account.SignInAsync(MakeFlow(server), AsBaseUrl);
+            Assert.True(outcome.Succeeded);
+
+            // The swap forwarded the SignedIn edge (de-duplicated: exactly one, not one per re-subscribe)
+            // and no spurious sign-in-required fired during a successful sign-in.
+            lock (states)
+                Assert.Equal(new[] { AuthState.SignedIn }, states);
+            Assert.Equal(0, signInRequiredCount);
+
+            // A later terminal verdict must reach the SAME long-lived subscription through the FRESH
+            // provider — this is what dies silently without the ReloadFromStore re-hook.
+            server.Refresh = () => JsonResponse(HttpStatusCode.BadRequest, "{ \"error\": \"invalid_grant\" }");
+            var refreshed = await account.RefreshAsync();
+
+            Assert.False(refreshed);
+            Assert.Equal(1, signInRequiredCount);
+            Assert.Equal(AuthState.SignInRequired, account.AuthState);
+            lock (states)
+                Assert.Equal(new[] { AuthState.SignedIn, AuthState.SignInRequired }, states);
         }
 
         // --- Sign-out ---

--- a/Godot-MCP.Tests/GodotAssistedSignInTests.cs
+++ b/Godot-MCP.Tests/GodotAssistedSignInTests.cs
@@ -1,0 +1,166 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using com.IvanMurzak.Godot.MCP.Connection;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the D4 assisted-sign-in ladder (<see cref="GodotAssistedSignIn"/> — oauth-client-error-hygiene
+    /// e2, 02 §C5): the auto-open on the FIRST sign-in-required verdict of an editor session, the carousel
+    /// guard (a recurring verdict never re-opens unattended), the manual Authorize entry that is NEVER
+    /// gated, and the session store surviving the collectible-ALC hot-reload (a fresh instance over the
+    /// same session state stays claimed) while a fresh editor session re-arms. The flow start is the
+    /// injected <c>startAuthorize</c> seam — the browser-open itself (<c>OS.ShellOpen</c> on
+    /// WaitingForUser) lives in the <c>#if TOOLS</c> panel and is a Suite-3 smoke concern.
+    /// </summary>
+    public class GodotAssistedSignInTests
+    {
+        /// <summary>An in-memory session store + counting flow seam — one simulated editor session.</summary>
+        sealed class Session
+        {
+            public readonly Dictionary<string, string> Store = new();
+            public int FlowStarts;
+
+            public GodotAssistedSignIn NewLadder() => new(
+                startAuthorize: () => FlowStarts++,
+                getSessionValue: key => Store.TryGetValue(key, out var value) ? value : null,
+                setSessionValue: (key, value) => Store[key] = value);
+        }
+
+        [Fact]
+        public void FirstVerdict_ClaimsTheGate_AndStartsTheAuthorizeFlow()
+        {
+            var session = new Session();
+            var ladder = session.NewLadder();
+            Assert.True(ladder.AutoOpenAvailable);
+
+            var opened = ladder.OnSignInRequiredVerdict();
+
+            Assert.True(opened);
+            Assert.Equal(1, session.FlowStarts);
+            Assert.False(ladder.AutoOpenAvailable);
+            Assert.Equal(GodotAssistedSignIn.AutoOpenClaimedValue,
+                session.Store[GodotAssistedSignIn.AutoOpenClaimedSessionKey]);
+        }
+
+        /// <summary>
+        /// The carousel-guard fixture (task e2 DoD): the SECOND verdict of the session — a freshly-
+        /// authorized family dying again, or the device code expiring unattended — starts nothing, and the
+        /// user's manual Authorize still starts the flow (the same-fixture positive control: the spent gate
+        /// gates only the AUTO entry, never the flow itself).
+        /// </summary>
+        [Fact]
+        public void SecondVerdict_InSession_DoesNotReOpen_AndManualAuthorizeStillWorks()
+        {
+            var session = new Session();
+            var ladder = session.NewLadder();
+
+            Assert.True(ladder.OnSignInRequiredVerdict());
+            Assert.Equal(1, session.FlowStarts);
+
+            // The recurrence: no second unattended open.
+            Assert.False(ladder.OnSignInRequiredVerdict());
+            Assert.Equal(1, session.FlowStarts);
+
+            // Same-fixture positive control: manual Authorize still starts the flow.
+            ladder.OnManualAuthorize();
+            Assert.Equal(2, session.FlowStarts);
+        }
+
+        /// <summary>
+        /// The once-gate must survive the addon's collectible-ALC hot-reload ("Build Project"
+        /// re-instantiates every [Tool] script, so the panel — and this ladder — are rebuilt): a FRESH
+        /// ladder over the SAME session store stays claimed. Manual authorize keeps working there too.
+        /// </summary>
+        [Fact]
+        public void HotReload_FreshLadderOverTheSameSession_StaysClaimed()
+        {
+            var session = new Session();
+            Assert.True(session.NewLadder().OnSignInRequiredVerdict());
+            Assert.Equal(1, session.FlowStarts);
+
+            var reloaded = session.NewLadder(); // the post-reload instance, same process state
+            Assert.False(reloaded.AutoOpenAvailable);
+            Assert.False(reloaded.OnSignInRequiredVerdict());
+            Assert.Equal(1, session.FlowStarts);
+
+            reloaded.OnManualAuthorize();
+            Assert.Equal(2, session.FlowStarts);
+        }
+
+        /// <summary>A fresh editor session (empty session store) re-arms the auto-open (deliberate — D4
+        /// wants the user involved until authorization succeeds).</summary>
+        [Fact]
+        public void FreshEditorSession_ReArmsTheAutoOpen()
+        {
+            var first = new Session();
+            Assert.True(first.NewLadder().OnSignInRequiredVerdict());
+
+            var second = new Session(); // a new editor process: nothing carried over
+            Assert.True(second.NewLadder().OnSignInRequiredVerdict());
+            Assert.Equal(1, second.FlowStarts);
+        }
+
+        /// <summary>
+        /// The manual entry never spends the AUTO budget: a user-initiated Authorize before any verdict
+        /// leaves the session's one unattended auto-open available for a later verdict.
+        /// </summary>
+        [Fact]
+        public void ManualAuthorize_DoesNotClaimTheAutoOpenGate()
+        {
+            var session = new Session();
+            var ladder = session.NewLadder();
+
+            ladder.OnManualAuthorize();
+            Assert.Equal(1, session.FlowStarts);
+            Assert.True(ladder.AutoOpenAvailable);
+
+            Assert.True(ladder.OnSignInRequiredVerdict());
+            Assert.Equal(2, session.FlowStarts);
+        }
+
+        /// <summary>
+        /// The DEFAULT session store is the process environment (the seam that makes the gate survive the
+        /// collectible-ALC hot-reload and die with the editor process): claiming through one
+        /// default-constructed ladder is visible to another. Cleans the process env var up in all paths —
+        /// no other test touches this key.
+        /// </summary>
+        [Fact]
+        public void DefaultSessionStore_IsTheProcessEnvironment()
+        {
+            Environment.SetEnvironmentVariable(GodotAssistedSignIn.AutoOpenClaimedSessionKey, null);
+            try
+            {
+                var starts = 0;
+                var ladder = new GodotAssistedSignIn(() => starts++);
+                Assert.True(ladder.AutoOpenAvailable);
+
+                Assert.True(ladder.OnSignInRequiredVerdict());
+                Assert.Equal(1, starts);
+                Assert.Equal(GodotAssistedSignIn.AutoOpenClaimedValue,
+                    Environment.GetEnvironmentVariable(GodotAssistedSignIn.AutoOpenClaimedSessionKey));
+
+                // A second default-seam ladder (the hot-reloaded panel) sees the claim.
+                var reloaded = new GodotAssistedSignIn(() => starts++);
+                Assert.False(reloaded.AutoOpenAvailable);
+                Assert.False(reloaded.OnSignInRequiredVerdict());
+                Assert.Equal(1, starts);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(GodotAssistedSignIn.AutoOpenClaimedSessionKey, null);
+            }
+        }
+    }
+}

--- a/addons/godot_mcp/Editor/Connection/GodotAccountAuth.cs
+++ b/addons/godot_mcp/Editor/Connection/GodotAccountAuth.cs
@@ -15,6 +15,7 @@ using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.McpPlugin.AgentConfig;
 using Microsoft.Extensions.Logging;
+using R3;
 
 namespace com.IvanMurzak.Godot.MCP.Connection
 {
@@ -151,6 +152,15 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         readonly object _retiredGate = new object();
         readonly System.Collections.Generic.List<PluginCredentialProvider> _retiredProviders = new();
 
+        // The forwarding subscription onto the CURRENT provider's R3 surfaces (State +
+        // OnSignInRequired), rebuilt on every provider swap so the stable events below keep firing
+        // across ReloadFromStore. _lastForwardedAuthState de-dups the replay a fresh
+        // ReadOnlyReactiveProperty subscription emits (the current value fires immediately on
+        // subscribe), so AuthStateChanged stays edge-like across swaps. Guarded by _eventGate.
+        readonly object _eventGate = new object();
+        IDisposable? _providerEventsSubscription;
+        AuthState? _lastForwardedAuthState;
+
         /// <summary>
         /// Construct the coordinator. <paramref name="asBaseUrlProvider"/> supplies the authorization-server
         /// base URL (read live so a <c>.env</c> cloud-URL override applies) used for refreshes of
@@ -181,6 +191,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
             // Auto-adopt: PluginCredentialProvider reads the store at construction. No UI, no device flow.
             _provider = BuildProvider();
+            HookProviderEvents(_provider);
         }
 
         PluginCredentialProvider BuildProvider()
@@ -198,6 +209,60 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
         /// <summary>The account id (<c>sub</c>) the current credential resolves to, if known (diagnostic only).</summary>
         public string? Subject => Provider.Subject;
+
+        /// <summary>
+        /// The CURRENT provider's credential state (oauth-client-error-hygiene e2, 02 §C3: engine UIs read
+        /// the provider's own <c>State</c>, not just the connection's rejection signal). Stable across the
+        /// internal provider swaps.
+        /// </summary>
+        public AuthState AuthState => Provider.State.CurrentValue;
+
+        /// <summary>
+        /// Raised when the CURRENT provider surfaces a terminal sign-in-required verdict (its
+        /// <c>OnSignInRequired</c> — e.g. an <c>invalid_grant</c> refresh rejection). Survives the internal
+        /// provider swaps (<see cref="ReloadFromStore"/> re-hooks the fresh provider). May fire on ANY
+        /// thread — UI subscribers must marshal to the editor main thread themselves. Never carries token
+        /// material.
+        /// </summary>
+        public event Action? SignInRequired;
+
+        /// <summary>
+        /// Raised when the credential state changes (SignedOut / SignedIn / SignInRequired), de-duplicated
+        /// across the internal provider swaps (a swap re-subscribes and would otherwise replay the current
+        /// value). May fire on ANY thread — UI subscribers must marshal themselves.
+        /// </summary>
+        public event Action<AuthState>? AuthStateChanged;
+
+        /// <summary>
+        /// (Re)hook the stable <see cref="SignInRequired"/> / <see cref="AuthStateChanged"/> events onto
+        /// <paramref name="provider"/>'s R3 surfaces, replacing the previous provider's subscription. Called
+        /// at construction and after every swap (<see cref="ReloadFromStore"/>) — without the re-hook, the
+        /// panel's subscriptions would silently go dead on the first sign-in/sign-out/migration. The State
+        /// replay a fresh subscription emits is de-duplicated against the last forwarded value so
+        /// <see cref="AuthStateChanged"/> stays edge-like.
+        /// </summary>
+        void HookProviderEvents(PluginCredentialProvider provider)
+        {
+            var signInRequired = provider.OnSignInRequired.Subscribe(_ => SignInRequired?.Invoke());
+            var stateChanged = provider.State.Subscribe(state =>
+            {
+                lock (_eventGate)
+                {
+                    if (_lastForwardedAuthState == state)
+                        return;
+                    _lastForwardedAuthState = state;
+                }
+                AuthStateChanged?.Invoke(state);
+            });
+
+            IDisposable? previous;
+            lock (_eventGate)
+            {
+                previous = _providerEventsSubscription;
+                _providerEventsSubscription = Disposable.Combine(signInRequired, stateChanged);
+            }
+            previous?.Dispose();
+        }
 
         /// <summary>
         /// The <c>Func&lt;Task&lt;string?&gt;&gt;</c> to compose into the connection's credential provider. It
@@ -538,10 +603,22 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             var old = Interlocked.Exchange(ref _provider, fresh);
             lock (_retiredGate)
                 _retiredProviders.Add(old);
+
+            // Re-hook the stable events onto the fresh provider (the old provider keeps its R3 surfaces,
+            // but it no longer sees refreshes — a subscription left on it would go silently dead).
+            HookProviderEvents(fresh);
         }
 
         public void Dispose()
         {
+            IDisposable? events;
+            lock (_eventGate)
+            {
+                events = _providerEventsSubscription;
+                _providerEventsSubscription = null;
+            }
+            events?.Dispose();
+
             Provider.Dispose();
             lock (_retiredGate)
             {

--- a/addons/godot_mcp/Editor/Connection/GodotAssistedSignIn.cs
+++ b/addons/godot_mcp/Editor/Connection/GodotAssistedSignIn.cs
@@ -1,0 +1,105 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// The D4 assisted-sign-in ladder for the Godot dock (oauth-client-error-hygiene e2, 02 §C5): when the
+    /// credential provider surfaces a terminal sign-in-required verdict, the panel — besides rendering the
+    /// status — auto-starts the device-authorization flow ONCE per editor session, which opens the default
+    /// browser at the verification URL and polls until the user approves. Both entries funnel into the SAME
+    /// <c>startAuthorize</c> seam the panel wires to its Authorize-button flow:
+    /// <list type="bullet">
+    ///   <item><see cref="OnSignInRequiredVerdict"/> — the automatic entry. Gated: the FIRST verdict of the
+    ///   editor session starts the flow; every recurrence (the carousel guard — a freshly-authorized family
+    ///   dying again, or the device code expiring unattended) renders status only, never a second unattended
+    ///   browser-open. The pinned McpPlugin 8.1.0 exposes no <c>SignInRequiredReason</c>, so the guard keys
+    ///   on verdict RECURRENCE, not reason class.</item>
+    ///   <item><see cref="OnManualAuthorize"/> — the user's own Authorize click. NEVER gated: manual
+    ///   re-auth must keep working after the auto-open budget is spent.</item>
+    /// </list>
+    ///
+    /// <para>
+    /// <b>Session persistence:</b> the once-per-editor-session gate defaults to a PROCESS environment
+    /// variable (<see cref="AutoOpenClaimedSessionKey"/>). Process env is process state, not assembly
+    /// state — it survives the addon's collectible-ALC hot-reload (a "Build Project" re-instantiates every
+    /// [Tool] script and would reset a static field) and dies with the editor process, so a fresh editor
+    /// session re-arms the auto-open (deliberate — D4 wants the user involved until authorization
+    /// succeeds). The Godot analog of Unity's <c>SessionState</c> once-gate (02 §C4).
+    /// </para>
+    ///
+    /// <para>Pure-managed (no Godot native types, no <c>#if TOOLS</c>): the session store is an injectable
+    /// seam, so the once-gate + carousel guard are unit-tested in the plain-xUnit host. The browser-open
+    /// itself stays inside the panel's flow wiring (<c>OS.ShellOpen</c> on WaitingForUser).</para>
+    /// </summary>
+    public sealed class GodotAssistedSignIn
+    {
+        /// <summary>
+        /// The session-store key claimed by the first auto-open of the editor session. A process
+        /// environment variable by default (see the class docs for why: it must survive the collectible-ALC
+        /// hot-reload and die with the editor process).
+        /// </summary>
+        public const string AutoOpenClaimedSessionKey = "GODOT_MCP_ASSISTED_SIGNIN_AUTO_OPENED";
+
+        /// <summary>The value stored under <see cref="AutoOpenClaimedSessionKey"/> once claimed.</summary>
+        public const string AutoOpenClaimedValue = "1";
+
+        readonly Action _startAuthorize;
+        readonly Func<string, string?> _getSessionValue;
+        readonly Action<string, string> _setSessionValue;
+
+        /// <summary>
+        /// Construct the ladder. <paramref name="startAuthorize"/> is the ONE flow entry both the automatic
+        /// verdict path and the manual Authorize path invoke (the panel wires it to its device-auth flow
+        /// start, which opens the browser + polls). <paramref name="getSessionValue"/> /
+        /// <paramref name="setSessionValue"/> are the session-store seam — process environment variables by
+        /// default, injectable (a dictionary) for deterministic tests.
+        /// </summary>
+        public GodotAssistedSignIn(
+            Action startAuthorize,
+            Func<string, string?>? getSessionValue = null,
+            Action<string, string>? setSessionValue = null)
+        {
+            _startAuthorize = startAuthorize ?? throw new ArgumentNullException(nameof(startAuthorize));
+            _getSessionValue = getSessionValue ?? Environment.GetEnvironmentVariable;
+            _setSessionValue = setSessionValue ?? Environment.SetEnvironmentVariable;
+        }
+
+        /// <summary>
+        /// True while the auto-open budget for this editor session is unspent (no verdict has claimed it yet).
+        /// </summary>
+        public bool AutoOpenAvailable => _getSessionValue(AutoOpenClaimedSessionKey) != AutoOpenClaimedValue;
+
+        /// <summary>
+        /// The automatic entry — a terminal sign-in-required verdict from the credential provider. The
+        /// first verdict of the editor session claims the once-gate and starts the authorize flow (returns
+        /// <c>true</c>); every later verdict — the carousel guard — starts nothing and returns <c>false</c>
+        /// (the caller renders the persistent status; the user's manual Authorize keeps working via
+        /// <see cref="OnManualAuthorize"/>).
+        /// </summary>
+        public bool OnSignInRequiredVerdict()
+        {
+            if (!AutoOpenAvailable)
+                return false;
+
+            _setSessionValue(AutoOpenClaimedSessionKey, AutoOpenClaimedValue);
+            _startAuthorize();
+            return true;
+        }
+
+        /// <summary>
+        /// The manual entry — the user pressed Authorize. Always starts the flow, regardless of the
+        /// auto-open gate (spending the automatic budget must never lock the user out of re-auth).
+        /// </summary>
+        public void OnManualAuthorize() => _startAuthorize();
+    }
+}

--- a/addons/godot_mcp/Editor/UI/ConnectionPanel.cs
+++ b/addons/godot_mcp/Editor/UI/ConnectionPanel.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using com.IvanMurzak.Godot.MCP.Connection;
 using com.IvanMurzak.Godot.MCP.MainThreadDispatch;
 using Godot;
+using AuthState = com.IvanMurzak.McpPlugin.AuthState;
 using McpClientData = com.IvanMurzak.McpPlugin.Common.Model.McpClientData;
 using McpServerConsts = com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
 
@@ -135,6 +136,13 @@ namespace com.IvanMurzak.Godot.MCP.UI
         // The in-flight device-auth flow (null when none has run). Recreated per Authorize click.
         GodotDeviceAuthFlow? _deviceAuthFlow;
 
+        // The D4 assisted-sign-in ladder (oauth-client-error-hygiene e2, 02 §C5): both the automatic
+        // sign-in-required verdict and the manual Authorize click funnel into StartAuthorizeFlow through
+        // it. The auto entry is once-per-editor-session + carousel-guarded (its default session store is a
+        // process env var, so the gate survives the collectible-ALC hot-reload); the manual entry is never
+        // gated. = null! for the Godot-required parameterless ctor (see _connection above).
+        readonly GodotAssistedSignIn _assistedSignIn = null!;
+
         // The handler subscribed to _deviceAuthFlow.OnStateChanged, stored in a field (not an inline lambda)
         // so it can be deterministically removed before the flow is replaced or the panel is freed. An inline
         // `+= state => ...` was a genuine per-Authorize-click leak: every click built a NEW flow whose
@@ -219,6 +227,8 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 GD.PushWarning,
                 GD.PushError);
 
+            _assistedSignIn = new GodotAssistedSignIn(StartAuthorizeFlow);
+
             Name = "ConnectionPanel";
             BuildUi();
 
@@ -248,6 +258,16 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _connection.AuthorizationRejected -= OnAuthorizationRejected;
             _connection.AuthorizationRejected += OnAuthorizationRejected;
 
+            // The account provider's OWN credential state (oauth-client-error-hygiene e2, 02 §C3): the
+            // panel no longer relies solely on the connection's authorization-rejected signal (whose
+            // semantics stay "try to recover") — a terminal sign-in-required verdict and the SignedIn
+            // recovery edge both reach the panel from here. These fire on arbitrary threads; the handlers
+            // marshal onto the editor main thread themselves.
+            _connection.Account.SignInRequired -= OnAccountSignInRequired;
+            _connection.Account.SignInRequired += OnAccountSignInRequired;
+            _connection.Account.AuthStateChanged -= OnAccountAuthStateChanged;
+            _connection.Account.AuthStateChanged += OnAccountAuthStateChanged;
+
             // Same remove-then-add discipline for the local-server manager's status stream (#42/#56): the
             // manager outlives the panel's tree membership, so a status reached while the panel was detached
             // (e.g. the ~5s startup verification completing during a dock reparent) is pulled in by the
@@ -270,6 +290,13 @@ namespace com.IvanMurzak.Godot.MCP.UI
             ApplyServerStatus(_serverManager.Status);
             ApplyModeVisibility(_connection.Config.ActiveMode);
             RefreshAgents();
+
+            // Re-seed the sign-in-required state too: a terminal verdict that fired while the panel was
+            // detached (dock reparent) was missed by the event, so pull it from the provider's live State —
+            // the same #42 convergence discipline as the status re-seed above. Goes through the once-gated
+            // ladder, so a reparent never re-opens the browser once the session's auto-open is spent.
+            if (_connection.Account.AuthState == AuthState.SignInRequired)
+                ApplySignInRequired();
 
             // Belt-and-suspenders convergence: register a per-frame re-sync into the main-thread dispatcher's
             // tick hook. Every ResyncIntervalSeconds it re-reads the LIVE connection status off the connection
@@ -702,6 +729,12 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _renderedStatus = status;
             ApplyAlertVisibility(status);
 
+            // A live hub connection disproves "sign in required" (e.g. the reactive refresh healed the
+            // credential without a state edge) — clear that status line so it cannot linger stale. Only the
+            // sign-in-required text is cleared; unrelated status messages are left alone.
+            if (status == ConnectionStatus.Connected && ConnectionPanelView.IsSignInRequiredStatus(_cloudAuthStatus?.Text))
+                SetCloudAuthStatusText(string.Empty);
+
             // Trace the actual render so a Trace smoke run shows the terminal Connected reaching the label
             // (pairs with the connection's "status: X -> Y" push trace — see GodotMcpConnection.PublishStatus).
             _connection.LogStatusTrace($"[Godot-MCP] ApplyStatus rendered status: {status}");
@@ -1091,6 +1124,21 @@ namespace com.IvanMurzak.Godot.MCP.UI
                 return;
             }
 
+            // The manual ladder entry — never gated: the user's own Authorize must keep working after the
+            // session's D4 auto-open budget is spent (the carousel guard applies to the AUTO entry only).
+            _assistedSignIn.OnManualAuthorize();
+        }
+
+        /// <summary>
+        /// Start a fresh device-authorization flow — the ONE flow entry both ladder paths invoke (the
+        /// manual Authorize click via <see cref="GodotAssistedSignIn.OnManualAuthorize"/>, and the D4
+        /// once-gated auto-open via <see cref="GodotAssistedSignIn.OnSignInRequiredVerdict"/>). The flow's
+        /// WaitingForUser transition opens the default browser at the verification URL
+        /// (<see cref="OnAuthFlowStateChanged"/>), and the run polls until approval / device-code expiry /
+        /// cancellation — never re-initiating unattended.
+        /// </summary>
+        void StartAuthorizeFlow()
+        {
             // Release the previous flow's state-change subscription before replacing it, so the old flow
             // instance + its closure are not leaked on every Authorize click (each click builds a new flow).
             if (_deviceAuthFlow != null && _authFlowStateChangedHandler != null)
@@ -1268,31 +1316,115 @@ namespace com.IvanMurzak.Godot.MCP.UI
 
         /// <summary>
         /// Handle a server-side authorization rejection (the connection's
-        /// <see cref="GodotMcpConnection.AuthorizationRejected"/> fired, already on the main thread): drop
-        /// the rejected cloud token, persist, revert the UI to Authorize, and warn the user WITHOUT logging
-        /// the token (it carries no payload through this event anyway).
+        /// <see cref="GodotMcpConnection.AuthorizationRejected"/> fired, already on the main thread). The
+        /// what-to-render decision is the pure-managed
+        /// <see cref="ConnectionPanelView.AuthorizationRejectedPresentation"/> (unit-tested — the e2
+        /// silent-red fix is pinned there):
+        /// <list type="bullet">
+        ///   <item><b>Signed in (machine store):</b> render the sign-in-required state. Recovery still
+        ///   belongs to the connection's reactive refresh (<c>TryAccountRefreshAndReconnect</c> — design
+        ///   08 A1; the rejection's semantics stay "try to recover"), and neither the machine store nor the
+        ///   legacy sink is wiped — but the user now SEES the state instead of the pre-e2 silent early
+        ///   return. A refresh that heals clears this status on the next Connected render; a terminal
+        ///   verdict escalates via the provider's <c>OnSignInRequired</c> (the D4 ladder).</item>
+        ///   <item><b>Signed out (legacy-sink token only):</b> drop the rejected cloud token, persist,
+        ///   revert the UI to Authorize, and warn WITHOUT logging the token (unchanged pre-e2 behavior).</item>
+        /// </list>
         /// </summary>
         void OnAuthorizationRejected()
         {
-            // Only relevant to Cloud mode — a Custom-mode rejection is the Custom token's concern.
+            var presentation = ConnectionPanelView.AuthorizationRejectedPresentation(
+                isCloudMode: _connection.Config.ActiveMode == GodotMcpConnectionMode.Cloud,
+                accountSignedIn: _connection.Account.IsSignedIn);
+
+            switch (presentation)
+            {
+                case ConnectionPanelView.AuthRejectedPresentation.SignInRequired:
+                    SetCloudAuthStatusText(ConnectionPanelView.SignInRequiredStatusText);
+                    ApplyCloudAuthState();
+                    ApplyAlertVisibility(_connection.ConnectionStatus);
+                    return;
+
+                case ConnectionPanelView.AuthRejectedPresentation.ClearLegacyTokenAndPrompt:
+                    _connection.Config.CloudToken = null;
+                    _connection.Save();
+                    SetCloudAuthStatusText(ConnectionPanelView.AuthorizationRejectedPromptText);
+                    ApplyCloudAuthState();
+                    ApplyAlertVisibility(_connection.ConnectionStatus);
+
+                    GodotMcpLog.Warning("[Godot-MCP] server rejected the authorization token; cleared — press Authorize.");
+                    return;
+
+                default:
+                    // None — a Custom-mode rejection is the Custom token's concern.
+                    return;
+            }
+        }
+
+        /// <summary>
+        /// The provider's terminal sign-in-required verdict (e.g. an <c>invalid_grant</c> refresh
+        /// rejection — <see cref="GodotAccountAuth.SignInRequired"/>, any thread): marshal onto the editor
+        /// main thread and render + run the D4 ladder.
+        /// </summary>
+        void OnAccountSignInRequired()
+        {
+            if (MainThreadDispatcher.Instance != null && !MainThreadDispatcher.IsMainThread)
+                MainThreadDispatcher.Enqueue(ApplySignInRequired);
+            else
+                ApplySignInRequired();
+        }
+
+        /// <summary>
+        /// Render the sign-in-required state and run the D4 assisted ladder: the FIRST verdict of the
+        /// editor session auto-starts the authorize flow (which opens the default browser at the
+        /// device-flow verification URL and polls until the user approves); every recurrence — the carousel
+        /// guard — renders the persistent status only, manual Authorize still working. MUST run on the
+        /// editor main thread. No-op outside Cloud mode (the account credential is not in play there, and
+        /// the cloud auth row is hidden).
+        /// </summary>
+        void ApplySignInRequired()
+        {
             if (_connection.Config.ActiveMode != GodotMcpConnectionMode.Cloud)
                 return;
 
-            // Machine-store account signed in: recovery belongs to the connection's reactive refresh
-            // (GodotMcpConnection.TryAccountRefreshAndReconnect — design 08 A1, expiry self-heals). Don't
-            // wipe the legacy sink or flip the UI to "press Authorize" for a rejection the refresh is about
-            // to heal; if the refresh fails terminally the provider surfaces sign-in-required and the next
-            // re-render shows signed-out.
-            if (_connection.Account.IsSignedIn)
-                return;
-
-            _connection.Config.CloudToken = null;
-            _connection.Save();
-            SetCloudAuthStatusText("Authorization rejected by server — press Authorize.");
+            SetCloudAuthStatusText(ConnectionPanelView.SignInRequiredStatusText);
             ApplyCloudAuthState();
             ApplyAlertVisibility(_connection.ConnectionStatus);
 
-            GodotMcpLog.Warning("[Godot-MCP] server rejected the authorization token; cleared — press Authorize.");
+            // D4 auto-open — never stomp a flow that is already running (a click mid-flow means Cancel;
+            // an unattended verdict must not). Skipping BEFORE the gate keeps the session's auto-open
+            // budget unspent for a verdict that arrives after the running flow settles.
+            if (_deviceAuthFlow != null && GodotDeviceAuthFlow.IsRunning(_deviceAuthFlow.State))
+                return;
+
+            _assistedSignIn.OnSignInRequiredVerdict();
+        }
+
+        /// <summary>
+        /// The provider's credential-state edge (<see cref="GodotAccountAuth.AuthStateChanged"/>, any
+        /// thread): marshal onto the editor main thread, clear a now-disproved sign-in-required status on
+        /// the SignedIn edge (the C3 resume — e.g. a peer surface re-authorized the machine), render the
+        /// sign-in-required status on the SignInRequired edge (belt-and-braces with
+        /// <see cref="OnAccountSignInRequired"/> — status only, the ladder rides the verdict event), and
+        /// re-render the account chip/alerts on every edge.
+        /// </summary>
+        void OnAccountAuthStateChanged(AuthState state)
+        {
+            void Render()
+            {
+                if (state == AuthState.SignedIn && ConnectionPanelView.IsSignInRequiredStatus(_cloudAuthStatus.Text))
+                    SetCloudAuthStatusText(string.Empty);
+                else if (state == AuthState.SignInRequired && _connection.Config.ActiveMode == GodotMcpConnectionMode.Cloud)
+                    SetCloudAuthStatusText(ConnectionPanelView.SignInRequiredStatusText);
+
+                ApplyCloudAuthState();
+                ApplyAlertVisibility(_connection.ConnectionStatus);
+            }
+
+            if (MainThreadDispatcher.Instance != null && !MainThreadDispatcher.IsMainThread)
+                MainThreadDispatcher.Enqueue(Render);
+            else
+                Render();
         }
 
         /// <summary>
@@ -1408,6 +1540,8 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _connection.AuthorizationRejected -= OnAuthorizationRejected;
             _serverManager.StatusChanged -= OnServerStatusChanged;
             _connection.AgentsUpdated -= OnAgentsUpdated;
+            _connection.Account.SignInRequired -= OnAccountSignInRequired;
+            _connection.Account.AuthStateChanged -= OnAccountAuthStateChanged;
 
             // Unregister the periodic re-sync so the dispatcher no longer ticks into a freed panel.
             _resyncRegistration?.Dispose();

--- a/addons/godot_mcp/Editor/UI/ConnectionPanelView.cs
+++ b/addons/godot_mcp/Editor/UI/ConnectionPanelView.cs
@@ -222,6 +222,69 @@ namespace com.IvanMurzak.Godot.MCP.UI
             _ => string.IsNullOrEmpty(outcome.Detail) ? "Sign-in failed — try again." : $"Sign-in failed: {outcome.Detail}",
         };
 
+        // --- Authorization-rejected / sign-in-required presentation (oauth-client-error-hygiene e2). ---
+
+        /// <summary>
+        /// What the panel's authorization-rejected handler renders. Pure decision (unit-tested) so the
+        /// <c>#if TOOLS</c> panel handler is a thin switch — and so the e2 silent-red fix (signed-in +
+        /// auth-rejected must RENDER, never early-return to silence) is pinned by a plain-xUnit test.
+        /// </summary>
+        public enum AuthRejectedPresentation
+        {
+            /// <summary>Not a Cloud-credential concern (Custom mode) — render nothing.</summary>
+            None,
+
+            /// <summary>
+            /// Signed in via the machine store: render the sign-in-required state. The store/sink are NOT
+            /// wiped (recovery belongs to the connection's reactive refresh; the store is never written on
+            /// a rejection) — but the user must SEE the state instead of a silent red (the e2 fix).
+            /// </summary>
+            SignInRequired,
+
+            /// <summary>
+            /// Signed out of the machine store (legacy-sink token only): drop the rejected legacy token,
+            /// persist, and prompt for a fresh Authorize (the pre-e2 behavior, unchanged).
+            /// </summary>
+            ClearLegacyTokenAndPrompt,
+        }
+
+        /// <summary>
+        /// Decide the authorization-rejected presentation. The signed-in case MUST NOT be silent: before e2
+        /// the panel early-returned for signed-in users, so a dead machine-store credential showed nothing
+        /// (the silent-red bug found in review — same as Unity's). Signed-in + rejected now renders
+        /// <see cref="AuthRejectedPresentation.SignInRequired"/>.
+        /// </summary>
+        public static AuthRejectedPresentation AuthorizationRejectedPresentation(bool isCloudMode, bool accountSignedIn)
+        {
+            if (!isCloudMode)
+                return AuthRejectedPresentation.None;
+
+            return accountSignedIn
+                ? AuthRejectedPresentation.SignInRequired
+                : AuthRejectedPresentation.ClearLegacyTokenAndPrompt;
+        }
+
+        /// <summary>
+        /// The generic sign-in-required status line (D4). Rendered for every terminal credential verdict —
+        /// the pinned McpPlugin 8.1.0 surfaces no per-verdict reason.
+        /// </summary>
+        // r4: when the McpPlugin pin bump brings SignInRequiredReason, render reason-class-specific status
+        // here (e.g. a "server configuration error" line for invalid_target) instead of this generic text.
+        public const string SignInRequiredStatusText =
+            "Sign in required — your session expired. Press Authorize.";
+
+        /// <summary>The status line for a legacy-sink token the server rejected (signed-out path).</summary>
+        public const string AuthorizationRejectedPromptText =
+            "Authorization rejected by server — press Authorize.";
+
+        /// <summary>
+        /// True when <paramref name="statusText"/> is the sign-in-required line — used by the panel to clear
+        /// a now-disproved "sign in required" (the hub reconnected, or the account state reached SignedIn)
+        /// without clobbering an unrelated status message.
+        /// </summary>
+        public static bool IsSignInRequiredStatus(string? statusText) =>
+            statusText == SignInRequiredStatusText;
+
         /// <summary>The "Advanced: use access token" opt-in label — reveals the legacy masked token field on the Cloud path.</summary>
         public const string AdvancedUseAccessTokenLabel = "Advanced: use access token";
 


### PR DESCRIPTION
Taskflow `2026-08-24-oauth-client-error-hygiene`, task `e2-godot-panel-ladder-against-810` (supersedes e1, whose guard fired: the McpPlugin pin is owned by upstream release pipelines and no published package carries a1-a3 — this lands compiled against the pinned **8.1.0**).

## What

**The silent-red fix.** `ConnectionPanel.OnAuthorizationRejected` early-returned for signed-in users (`if (_connection.Account.IsSignedIn) return;`), so a dead machine-store credential rendered NOTHING — the same bug review found in Unity. Signed-in + auth-rejected now renders the sign-in-required state through the existing `SetCloudAuthStatusText` / `ApplyCloudAuthState` / `ApplyAlertVisibility` surfaces. Recovery semantics are unchanged: the rejection still drives `TryAccountRefreshAndReconnect` ("try to recover"), neither the machine store nor the legacy sink is wiped on the signed-in path, and a heal clears the status on the next Connected render. The signed-out (legacy-sink) path keeps its pre-e2 clear-token-and-prompt behavior.

**Provider-state seam (02 §C3).** The panel no longer relies solely on `_authorizationRejected`: `GodotAccountAuth` now forwards the 8.1.0 provider's own `State` / `OnSignInRequired` (`PluginCredentialProvider.cs:119/:122`) as stable `AuthState` / `AuthStateChanged` / `SignInRequired` members, **re-hooked across every internal provider swap** (`ReloadFromStore` rebuilds the provider after each guarded store mutation — without the re-hook, a panel subscription goes silently dead on the first sign-in/sign-out/migration). Verified empirically against the real 8.1.0 package: an `invalid_grant` refresh rejection fires `OnSignInRequired` and transitions `State` to `SignInRequired`.

**D4 assisted flow, best-effort parity (02 §C5).** New pure-managed `GodotAssistedSignIn` ladder: the FIRST sign-in-required verdict of an editor session auto-starts the existing `GodotDeviceAuthFlow` authorize path — which opens the default browser (`OS.ShellOpen`) at the device-flow verification URL and polls until approval, bounded by the device-code expiry, never re-initiating unattended. Every recurrence (the carousel guard — keyed on **verdict recurrence**, since 8.1.0 has no `SignInRequiredReason`) renders the persistent status only; the manual Authorize button is never gated. The once-per-editor-session gate is stored in a **process environment variable** so it survives the addon's collectible-ALC hot-reload (a static would reset on every "Build Project") and dies with the editor process — the Godot analog of Unity's `SessionState` once-gate. A running flow is never stomped by a verdict (a click mid-flow means Cancel; an unattended verdict must not). A `// r4:` marker in `ConnectionPanelView` holds the slot where reason-class rendering (e.g. server-configuration-error for `invalid_target`) lands with r4's pin bump.

## Deferred to r4

- The a2-memo / a3-loop interplay evidence — "dead-family verdict ⇒ `TryAccountRefreshAndReconnect` is memo-blocked, the loop settles" — is **impossible against 8.1.0 by construction** (the memo and coordinator stop/resume land in the McpPlugin build r4 bumps to). r4 owns the pin bump and that verification.
- Reason-class status rendering (`SignInRequiredReason` does not exist in 8.1.0); the generic "Sign in required — your session expired. Press Authorize." renders for all terminal verdicts until then.

## DoD evidence

- **No pin/version bumps anywhere in the diff** — both csproj pins untouched (the only csproj change is a `<Compile>` entry in the tests project for the new source file).
- Suite: `dotnet build Godot-MCP.sln` 0 warnings / 0 errors; `dotnet test` **1304/1304 green** against pinned 8.1.0 (15 new tests).
- Plants (each applied, run, reverted; attribution from the per-plant run):
  - **A — restore the early-return** (signed-in ⇒ `None`): `AuthorizationRejected_CloudSignedIn_RendersSignInRequired` RED, the 3 same-axis controls (signed-out, Custom×2) stay green.
  - **B — remove the once-gate claim** (every verdict opens): 4 RED incl. the carousel fixture `SecondVerdict_InSession_DoesNotReOpen_AndManualAuthorizeStillWorks`.
  - **C — remove the auto-open invocation** (the cannot-fail mirror): 6/6 ladder tests RED.
  - **D — remove the `ReloadFromStore` re-hook**: exactly `ProviderSwap_OnSignIn_KeepsForwardingStateAndSignInRequired` RED, 24 others green.
- Carousel fixture carries the same-fixture positive control (manual Authorize still starts the flow after the auto budget is spent), per the no-vacuous-negative rule.

## Not verified here

- The live `#if TOOLS` Control wiring (browser actually opening, status label pixels) is the repo's Suite-3 headless-smoke territory (operator/reviewer check, not a CI gate) — the presentation decisions, ladder, and provider forwarding are all pure-managed and CI-tested per the repo's established split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVipj7Xi4HouAmmdCYSdmz