### PR TITLE
feat(connection): honour GODOT_MCP_SERVER_PATH via the env/.env layer

### DIFF
--- a/Godot-MCP.Tests/Godot-MCP.Tests.csproj
+++ b/Godot-MCP.Tests/Godot-MCP.Tests.csproj
@@ -285,6 +285,13 @@
          unit-tested here (cross-platform: every method is a string/enum transform, so the same assertions
          hold on the Linux CI runner). -->
     <Compile Include="..\addons\godot_mcp\Runtime\Connection\GodotMcpServerView.cs" Link="Source\GodotMcpServerView.cs" />
+    <!-- GODOT_MCP_SERVER_PATH override RESOLVER — pure-managed (no Godot native types, no #if TOOLS, no I/O of
+         its own: the caller passes raw env/.env strings plus a fileExists delegate). It carries every decision
+         the override drives — precedence, quote/whitespace normalization, the existing-file gate, the launch
+         path and the child process's working directory — because the manager statics that would otherwise hold
+         them (ExecutableFullPath / IsVersionMatches / KillOrphanedServerProcesses, GodotMcpServerManager.cs,
+         #if TOOLS) all reach ProjectSettings.GlobalizePath and cannot run in this binary-less host. -->
+    <Compile Include="..\addons\godot_mcp\Editor\Connection\GodotMcpServerPathOverride.cs" Link="Source\GodotMcpServerPathOverride.cs" />
     <!-- Segmented-control state model — pure-managed (no Godot native types, no #if TOOLS): the
          value→index / selected-predicate / clamp rules for the reusable segmented control (Custom|Cloud,
          none|required). The editor builder (DockStyle.SegmentedControl, #if TOOLS) consumes these and is

--- a/Godot-MCP.Tests/GodotMcpServerPathOverrideTests.cs
+++ b/Godot-MCP.Tests/GodotMcpServerPathOverrideTests.cs
@@ -65,7 +65,7 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             return Path.Combine(parts.ToArray());
         }
 
-        // --- (a) an existing file resolves to exactly that path ------------------------------------------
+        // --- an existing file resolves to exactly that path ------------------------------------------
 
         [Fact]
         public void Resolve_ExistingFile_ReturnsThatPath()
@@ -77,7 +77,7 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Equal(new[] { exe }, files.Probes);
         }
 
-        // --- (b) set, but naming no existing file, falls THROUGH (Unreal's ResolveBinaryPath rule) --------
+        // --- set, but naming no existing file, falls THROUGH (Unreal's ResolveBinaryPath rule) --------
 
         [Fact]
         public void Resolve_SetButMissingFile_ReturnsNull()
@@ -85,14 +85,18 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             var missing = ExePath("chain", "not-published-yet", "gamedev-mcp-server.exe");
             var files = new RecordingFileExists(/* nothing exists */);
 
-            Assert.Null(GodotMcpServerPathOverride.Resolve(missing, files.Delegate));
+            var resolved = GodotMcpServerPathOverride.Resolve(missing, files.Delegate);
 
-            // Positive artifact: the value DID reach the existence gate with its full path, so the null above
-            // is the gate refusing a missing file — not the value being dropped before the gate.
+            // The probe assertion comes FIRST deliberately. Positive artifact: the value DID reach the
+            // existence gate with its full path, so the null below is the gate refusing a missing file — not
+            // the value being dropped before the gate. Ordering it first also keeps the two gate mutations
+            // tellable apart: REMOVING the gate fails here (no probe was ever made), whereas INVERTING it
+            // probes normally and fails on the null instead.
             Assert.Equal(new[] { missing }, files.Probes);
+            Assert.Null(resolved);
         }
 
-        // --- (c) unset / blank values resolve to null and never touch the filesystem ----------------------
+        // --- unset / blank values resolve to null and never touch the filesystem ----------------------
 
         [Theory]
         [InlineData(null)]
@@ -115,7 +119,7 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Null(GodotMcpServerPathOverride.Normalize("   "));
         }
 
-        // --- (d) surrounding quotes + whitespace are trimmed, the .env layer's convention -----------------
+        // --- surrounding quotes + whitespace are trimmed, the .env layer's convention -----------------
 
         [Fact]
         public void Resolve_DoubleQuotedValue_TrimsQuotesBeforeTheExistenceGate()
@@ -146,6 +150,11 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             var exe = ExePath("chain", "gamedev-mcp-server");
             var files = new RecordingFileExists(exe);
 
+            // Documents the contract, but do NOT read it as coverage of Normalize's own leading Trim():
+            // GodotMcpConfig.NormalizeEnv trims too, so this case stays green with the local trim removed.
+            // The whitespace case that is actually load-bearing is the QUOTED-and-spaced one in
+            // Normalize_TrimsWhitespaceThenOnePairOfQuotes — without the local trim the leading space means
+            // the value no longer starts with a quote and the single-quote branch is skipped entirely.
             Assert.Equal(exe, GodotMcpServerPathOverride.Resolve("  " + exe + "\t", files.Delegate));
             Assert.Equal(new[] { exe }, files.Probes);
         }
@@ -158,7 +167,21 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.Equal("/srv/gamedev-mcp-server", GodotMcpServerPathOverride.Normalize("/srv/gamedev-mcp-server"));
         }
 
-        // --- (e) precedence: the PROCESS value beats the project .env value -------------------------------
+        [Fact]
+        public void Normalize_StripsSingleQuotesBEFORETheSharedDoubleQuoteNormalizer()
+        {
+            // The ONLY inputs that can tell the two orders apart are NESTED pairs — every single-convention
+            // value normalizes identically either way, which is why the ordering claim in Normalize's
+            // docstring needs a case of its own rather than riding on the cases above.
+            //
+            // Current order (single strip, THEN GodotMcpConfig.NormalizeEnv's Trim('"')): the outer double
+            // quotes come off and the inner single quotes survive. The swapped order would strip both and
+            // return "/srv/x". This matches GodotMcpEnvFile.Sanitize, which is the compatibility contract:
+            // a value must normalize the same whether it arrived from the process env or from res://.env.
+            Assert.Equal("'/srv/x'", GodotMcpServerPathOverride.Normalize("\"'/srv/x'\""));
+        }
+
+        // --- precedence: the PROCESS value beats the project .env value -------------------------------
 
         [Fact]
         public void Resolve_BothLayersSet_ProcessValueWins()
@@ -209,6 +232,62 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             Assert.False(GodotMcpServerPathOverride.IsActive(""));
         }
 
+        // --- the two under-override decisions the manager itself cannot pin --------------------------------
+        //
+        // GodotMcpServerManager is #if TOOLS and reaches ProjectSettings.GlobalizePath, so it does not compile
+        // into this host and its call sites can never be asserted here. These are the decisions themselves,
+        // factored out so the POLARITY of each is pinned rather than only the predicate they read.
+
+        [Fact]
+        public void VersionMatchesOrOverridden_TrueUnderOverrideWithoutConsultingTheCachedVersion()
+        {
+            var consulted = false;
+            Func<bool> cached = () => { consulted = true; return false; };
+
+            Assert.True(GodotMcpServerPathOverride.VersionMatchesOrOverridden("/srv/gamedev-mcp-server", cached));
+
+            // Positive artifact for the short-circuit: reading the cache's `version` marker is file I/O and
+            // that folder routinely does not exist under an override, so it must not be reached at all.
+            Assert.False(consulted);
+        }
+
+        [Fact]
+        public void VersionMatchesOrOverridden_NoOverride_DefersToTheCachedVersionVerdict()
+        {
+            Assert.True(GodotMcpServerPathOverride.VersionMatchesOrOverridden(null, () => true));
+            Assert.False(GodotMcpServerPathOverride.VersionMatchesOrOverridden(null, () => false));
+            Assert.False(GodotMcpServerPathOverride.VersionMatchesOrOverridden("", () => false));
+        }
+
+        [Fact]
+        public void ShouldKillOrphans_OnlyWithoutAnOverride()
+        {
+            Assert.True(GodotMcpServerPathOverride.ShouldKillOrphans(null));
+            Assert.True(GodotMcpServerPathOverride.ShouldKillOrphans(""));
+
+            // The skip is a correctness requirement, not a convenience: ownership matches on the containing
+            // directory, and an override binary is shared by design.
+            Assert.False(GodotMcpServerPathOverride.ShouldKillOrphans("/srv/gamedev-mcp-server"));
+        }
+
+        // --- "supplied, but ignored" — the state that is otherwise invisible -------------------------------
+
+        [Fact]
+        public void IsIgnoredValue_TrueOnlyWhenAValueWasSuppliedAndDidNotResolve()
+        {
+            // Supplied, but the existence gate refused it: the addon silently downloads the pinned release,
+            // so this is the state the boot site must warn about.
+            Assert.True(GodotMcpServerPathOverride.IsIgnoredValue("/srv/not-built-yet", null));
+
+            // Nothing supplied — indistinguishable in the RESOLVED value, which is exactly why the raw value
+            // is carried separately; it must NOT produce a warning.
+            Assert.False(GodotMcpServerPathOverride.IsIgnoredValue(null, null));
+            Assert.False(GodotMcpServerPathOverride.IsIgnoredValue("", null));
+
+            // Supplied and resolved: the override is in force, nothing to warn about.
+            Assert.False(GodotMcpServerPathOverride.IsIgnoredValue("/srv/built", "/srv/built"));
+        }
+
         // --- what the manager LAUNCHES (GodotMcpServerManager.ExecutableFullPath) --------------------------
 
         [Fact]
@@ -224,6 +303,10 @@ namespace com.IvanMurzak.Godot.MCP.Tests
         public void ExecutablePath_NoOverride_LaunchesTheCachedBinary()
         {
             var cached = ExePath("cache", "win-x64", "gamedev-mcp-server.exe");
+
+            // Asserted first so that "the predicate is stuck on" and "the launch path ignores the predicate"
+            // fail on DIFFERENT lines with different text, rather than both landing on the Equal below.
+            Assert.False(GodotMcpServerPathOverride.IsActive(null));
 
             Assert.Equal(cached, GodotMcpServerPathOverride.ExecutablePath(null, cached));
             Assert.Equal(cached, GodotMcpServerPathOverride.ExecutablePath("", cached));
@@ -248,8 +331,14 @@ namespace com.IvanMurzak.Godot.MCP.Tests
             var cacheDir = ExePath("cache", "win-x64");
             var cachedExe = Path.Combine(cacheDir, "gamedev-mcp-server.exe");
 
-            // The historical value is preserved because the cache folder IS the cached executable's directory.
-            Assert.Equal(cacheDir, GodotMcpServerPathOverride.WorkingDirectory(cachedExe, cacheDir));
+            // In PRODUCTION the manager passes CachePlatformPath() as the fallback, so with no override both
+            // arms of this method return the same string and the assertion could not fail. Passing a fallback
+            // the answer must NOT be is what gives the test discriminating power: the returned cacheDir can
+            // then only have come from the executable path, so a mutation that always returns the fallback
+            // reddens here. The claim is unchanged — with no override the answer is the cache platform folder.
+            var fallbackThatMustNotBeUsed = ExePath("fallback-never-used");
+
+            Assert.Equal(cacheDir, GodotMcpServerPathOverride.WorkingDirectory(cachedExe, fallbackThatMustNotBeUsed));
         }
 
         [Theory]

--- a/Godot-MCP.Tests/GodotMcpServerPathOverrideTests.cs
+++ b/Godot-MCP.Tests/GodotMcpServerPathOverrideTests.cs
@@ -1,0 +1,275 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using com.IvanMurzak.Godot.MCP.Connection;
+using Xunit;
+
+namespace com.IvanMurzak.Godot.MCP.Tests
+{
+    /// <summary>
+    /// Pins the <c>GODOT_MCP_SERVER_PATH</c> override resolver
+    /// (<see cref="GodotMcpServerPathOverride"/>) — the dev/CI escape hatch that makes the editor launch a
+    /// caller-supplied <c>gamedev-mcp-server</c> instead of the pinned release, skipping the download and the
+    /// cached-version match.
+    ///
+    /// <para>
+    /// This class is the ONLY automated gate for those decisions: the manager methods that consume them
+    /// (<c>GodotMcpServerManager.ExecutableFullPath</c> / <c>IsVersionMatches</c> /
+    /// <c>KillOrphanedServerProcesses</c>) are <c>#if TOOLS</c> and reach
+    /// <c>ProjectSettings.GlobalizePath</c>, which faults in this binary-less xUnit host — so the decisions
+    /// were factored into this pure resolver precisely so they could be pinned here.
+    /// </para>
+    ///
+    /// <para>
+    /// Every existence check goes through <see cref="RecordingFileExists"/>, which also RECORDS the exact
+    /// string it was asked about. Several tests assert that recorded argument rather than only the
+    /// <c>null</c>/non-<c>null</c> result: an absence assertion alone cannot tell "the gate rejected the
+    /// value" from "the value never arrived", and the recorded probe is the positive artifact that does.
+    /// </para>
+    /// </summary>
+    public class GodotMcpServerPathOverrideTests
+    {
+        /// <summary>A <c>fileExists</c> double that answers from a fixed set AND records every probe.</summary>
+        sealed class RecordingFileExists
+        {
+            readonly HashSet<string> _existing;
+
+            public RecordingFileExists(params string[] existing)
+                => _existing = new HashSet<string>(existing, StringComparer.Ordinal);
+
+            public List<string> Probes { get; } = new();
+
+            public bool Exists(string path)
+            {
+                Probes.Add(path);
+                return _existing.Contains(path);
+            }
+
+            public Func<string, bool> Delegate => Exists;
+        }
+
+        static string ExePath(params string[] segments)
+        {
+            var parts = new List<string> { Path.GetTempPath(), "godot-mcp-server-path-override-tests" };
+            parts.AddRange(segments);
+            return Path.Combine(parts.ToArray());
+        }
+
+        // --- (a) an existing file resolves to exactly that path ------------------------------------------
+
+        [Fact]
+        public void Resolve_ExistingFile_ReturnsThatPath()
+        {
+            var exe = ExePath("chain", "gamedev-mcp-server.exe");
+            var files = new RecordingFileExists(exe);
+
+            Assert.Equal(exe, GodotMcpServerPathOverride.Resolve(exe, files.Delegate));
+            Assert.Equal(new[] { exe }, files.Probes);
+        }
+
+        // --- (b) set, but naming no existing file, falls THROUGH (Unreal's ResolveBinaryPath rule) --------
+
+        [Fact]
+        public void Resolve_SetButMissingFile_ReturnsNull()
+        {
+            var missing = ExePath("chain", "not-published-yet", "gamedev-mcp-server.exe");
+            var files = new RecordingFileExists(/* nothing exists */);
+
+            Assert.Null(GodotMcpServerPathOverride.Resolve(missing, files.Delegate));
+
+            // Positive artifact: the value DID reach the existence gate with its full path, so the null above
+            // is the gate refusing a missing file — not the value being dropped before the gate.
+            Assert.Equal(new[] { missing }, files.Probes);
+        }
+
+        // --- (c) unset / blank values resolve to null and never touch the filesystem ----------------------
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("\t\r\n")]
+        public void Resolve_NullEmptyOrWhitespace_ReturnsNullWithoutProbing(string? raw)
+        {
+            var files = new RecordingFileExists(ExePath("chain", "gamedev-mcp-server.exe"));
+
+            Assert.Null(GodotMcpServerPathOverride.Resolve(raw, files.Delegate));
+            Assert.Empty(files.Probes);
+        }
+
+        [Fact]
+        public void Normalize_NullEmptyOrWhitespace_ReturnsNull()
+        {
+            Assert.Null(GodotMcpServerPathOverride.Normalize(null));
+            Assert.Null(GodotMcpServerPathOverride.Normalize(""));
+            Assert.Null(GodotMcpServerPathOverride.Normalize("   "));
+        }
+
+        // --- (d) surrounding quotes + whitespace are trimmed, the .env layer's convention -----------------
+
+        [Fact]
+        public void Resolve_DoubleQuotedValue_TrimsQuotesBeforeTheExistenceGate()
+        {
+            var exe = ExePath("chain", "gamedev-mcp-server.exe");
+            var files = new RecordingFileExists(exe);
+
+            Assert.Equal(exe, GodotMcpServerPathOverride.Resolve("\"" + exe + "\"", files.Delegate));
+
+            // The gate must be asked about the UNQUOTED path; asking about the quoted one would silently
+            // ignore a perfectly good override exported as GODOT_MCP_SERVER_PATH="C:/.../server.exe".
+            Assert.Equal(new[] { exe }, files.Probes);
+        }
+
+        [Fact]
+        public void Resolve_SingleQuotedValue_TrimsQuotesBeforeTheExistenceGate()
+        {
+            var exe = ExePath("chain", "gamedev-mcp-server");
+            var files = new RecordingFileExists(exe);
+
+            Assert.Equal(exe, GodotMcpServerPathOverride.Resolve("'" + exe + "'", files.Delegate));
+            Assert.Equal(new[] { exe }, files.Probes);
+        }
+
+        [Fact]
+        public void Resolve_SurroundingWhitespace_IsTrimmed()
+        {
+            var exe = ExePath("chain", "gamedev-mcp-server");
+            var files = new RecordingFileExists(exe);
+
+            Assert.Equal(exe, GodotMcpServerPathOverride.Resolve("  " + exe + "\t", files.Delegate));
+            Assert.Equal(new[] { exe }, files.Probes);
+        }
+
+        [Fact]
+        public void Normalize_TrimsWhitespaceThenOnePairOfQuotes()
+        {
+            Assert.Equal("/srv/gamedev-mcp-server", GodotMcpServerPathOverride.Normalize("  \"/srv/gamedev-mcp-server\"  "));
+            Assert.Equal("/srv/gamedev-mcp-server", GodotMcpServerPathOverride.Normalize(" '/srv/gamedev-mcp-server' "));
+            Assert.Equal("/srv/gamedev-mcp-server", GodotMcpServerPathOverride.Normalize("/srv/gamedev-mcp-server"));
+        }
+
+        // --- (e) precedence: the PROCESS value beats the project .env value -------------------------------
+
+        [Fact]
+        public void Resolve_BothLayersSet_ProcessValueWins()
+        {
+            var fromProcess = ExePath("process", "gamedev-mcp-server.exe");
+            var fromEnvFile = ExePath("dotenv", "gamedev-mcp-server.exe");
+            // BOTH exist, so the existence gate cannot be what picks the winner — only precedence can.
+            var files = new RecordingFileExists(fromProcess, fromEnvFile);
+
+            Assert.Equal(fromProcess, GodotMcpServerPathOverride.Resolve(fromProcess, fromEnvFile, files.Delegate));
+            Assert.Equal(new[] { fromProcess }, files.Probes);
+        }
+
+        [Fact]
+        public void Resolve_ProcessValueBlank_FallsBackToEnvFileValue()
+        {
+            var fromEnvFile = ExePath("dotenv", "gamedev-mcp-server.exe");
+            var files = new RecordingFileExists(fromEnvFile);
+
+            Assert.Equal(fromEnvFile, GodotMcpServerPathOverride.Resolve("   ", fromEnvFile, files.Delegate));
+            Assert.Equal(new[] { fromEnvFile }, files.Probes);
+        }
+
+        [Fact]
+        public void Resolve_NeitherLayerSet_ReturnsNull()
+        {
+            var files = new RecordingFileExists(ExePath("dotenv", "gamedev-mcp-server.exe"));
+
+            Assert.Null(GodotMcpServerPathOverride.Resolve(null, "", files.Delegate));
+            Assert.Empty(files.Probes);
+        }
+
+        [Fact]
+        public void SelectRaw_AppliesPrecedenceAndNormalization()
+        {
+            Assert.Equal("/a/server", GodotMcpServerPathOverride.SelectRaw("\"/a/server\"", "/b/server"));
+            Assert.Equal("/b/server", GodotMcpServerPathOverride.SelectRaw(" ", " '/b/server' "));
+            Assert.Null(GodotMcpServerPathOverride.SelectRaw(null, "   "));
+        }
+
+        // --- the single "override in force" predicate every consumer reads --------------------------------
+
+        [Fact]
+        public void IsActive_OnlyForANonEmptyResolvedOverride()
+        {
+            Assert.True(GodotMcpServerPathOverride.IsActive("/srv/gamedev-mcp-server"));
+            Assert.False(GodotMcpServerPathOverride.IsActive(null));
+            Assert.False(GodotMcpServerPathOverride.IsActive(""));
+        }
+
+        // --- what the manager LAUNCHES (GodotMcpServerManager.ExecutableFullPath) --------------------------
+
+        [Fact]
+        public void ExecutablePath_OverrideActive_LaunchesTheOverride()
+        {
+            var overridePath = ExePath("chain", "gamedev-mcp-server.exe");
+            var cached = ExePath("cache", "win-x64", "gamedev-mcp-server.exe");
+
+            Assert.Equal(overridePath, GodotMcpServerPathOverride.ExecutablePath(overridePath, cached));
+        }
+
+        [Fact]
+        public void ExecutablePath_NoOverride_LaunchesTheCachedBinary()
+        {
+            var cached = ExePath("cache", "win-x64", "gamedev-mcp-server.exe");
+
+            Assert.Equal(cached, GodotMcpServerPathOverride.ExecutablePath(null, cached));
+            Assert.Equal(cached, GodotMcpServerPathOverride.ExecutablePath("", cached));
+        }
+
+        // --- the child process's working directory ---------------------------------------------------------
+
+        [Fact]
+        public void WorkingDirectory_IsTheDirectoryOfTheResolvedExecutable()
+        {
+            var overrideDir = ExePath("chain", "win-x64");
+            var overrideExe = Path.Combine(overrideDir, "gamedev-mcp-server.exe");
+            var cacheDir = ExePath("cache", "win-x64");
+
+            // Not the cache folder: an override binary must run beside ITS OWN sidecar files.
+            Assert.Equal(overrideDir, GodotMcpServerPathOverride.WorkingDirectory(overrideExe, cacheDir));
+        }
+
+        [Fact]
+        public void WorkingDirectory_NoOverride_IsStillTheCacheFolder()
+        {
+            var cacheDir = ExePath("cache", "win-x64");
+            var cachedExe = Path.Combine(cacheDir, "gamedev-mcp-server.exe");
+
+            // The historical value is preserved because the cache folder IS the cached executable's directory.
+            Assert.Equal(cacheDir, GodotMcpServerPathOverride.WorkingDirectory(cachedExe, cacheDir));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("gamedev-mcp-server")]
+        public void WorkingDirectory_PathWithoutADirectoryComponent_FallsBack(string? executablePath)
+        {
+            var cacheDir = ExePath("cache", "win-x64");
+
+            Assert.Equal(cacheDir, GodotMcpServerPathOverride.WorkingDirectory(executablePath, cacheDir));
+        }
+
+        // --- misuse ----------------------------------------------------------------------------------------
+
+        [Fact]
+        public void Resolve_NullFileExistsDelegate_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => GodotMcpServerPathOverride.Resolve("/srv/gamedev-mcp-server", null!));
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -837,6 +837,14 @@ host/token one of two ways — and they **compose**, with env winning over code 
    | `GODOT_MCP_AUTH_OPTION` | `none` / `oauth` / `token` | Custom-mode auth: anonymous / account (oauth) / offline bearer (`token`). |
    | `GODOT_MCP_TOKEN` | string | The bearer token (routed to Cloud or Custom by the active mode). |
    | `GODOT_MCP_LOG_LEVEL` | `Trace`…`None` | Log-verbosity threshold. |
+   | `GODOT_MCP_SERVER_PATH` | absolute path | **Editor-only** (dev / CI). Launch this existing `gamedev-mcp-server(.exe)` instead of the pinned release: skips the download **and** the version match, and disables orphaned-server cleanup while active. A value naming no existing file is ignored. |
+
+   > `GODOT_MCP_SERVER_PATH` is resolved by the **editor** plugin's server manager, not by
+   > `GodotMcpConfig`, so it affects only which locally-hosted server binary the editor starts — it is
+   > read once per editor session and has no effect in a game build. It uses the same
+   > process-env → project `.env` precedence as the rows above. Orphan cleanup is disabled while it is set
+   > because that cleanup claims every server process running from the same directory, which an override
+   > binary is expected to share with other projects and tools.
 
    ```bash
    export GODOT_MCP_CONNECTION_MODE=Custom

--- a/README.md
+++ b/README.md
@@ -840,11 +840,14 @@ host/token one of two ways — and they **compose**, with env winning over code 
    | `GODOT_MCP_SERVER_PATH` | absolute path | **Editor-only** (dev / CI). Launch this existing `gamedev-mcp-server(.exe)` instead of the pinned release: skips the download **and** the version match, and disables orphaned-server cleanup while active. A value naming no existing file is ignored. |
 
    > `GODOT_MCP_SERVER_PATH` is resolved by the **editor** plugin's server manager, not by
-   > `GodotMcpConfig`, so it affects only which locally-hosted server binary the editor starts — it is
-   > read once per editor session and has no effect in a game build. It uses the same
+   > `GodotMcpConfig`, so it affects only which locally-hosted server binary the editor starts, and it has
+   > no effect in a game build. It is read once per plugin assembly load and cached — a C# hot-reload
+   > re-reads it, but toggling the plugin off and on does not. It uses the same
    > process-env → project `.env` precedence as the rows above. Orphan cleanup is disabled while it is set
    > because that cleanup claims every server process running from the same directory, which an override
-   > binary is expected to share with other projects and tools.
+   > binary is expected to share with other projects and tools. A value that names no existing file is
+   > ignored with a warning in the editor log. On Linux/macOS the file must already be executable — the
+   > `chmod` applied to a downloaded release is not applied to an override binary.
 
    ```bash
    export GODOT_MCP_CONNECTION_MODE=Custom

--- a/addons/godot_mcp/Editor/Connection/GodotMcpServerManager.cs
+++ b/addons/godot_mcp/Editor/Connection/GodotMcpServerManager.cs
@@ -128,6 +128,7 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         static readonly object _overrideMutex = new();
         static bool _overrideResolved;
         static string? _overridePath;
+        static string? _overrideRawValue;
 
         /// <summary>
         /// The resolved <c>GODOT_MCP_SERVER_PATH</c> override — an EXISTING file to launch instead of the
@@ -135,31 +136,48 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// <c>ResolveBinaryPath</c> rule: a bad override falls THROUGH to the normal download path).
         ///
         /// <para>
-        /// Resolved ONCE per boot (per assembly load — a C# hot-reload re-resolves) and cached, so the launch
-        /// path, the version-match bypass and the orphan-cleanup skip can never disagree with each other
-        /// mid-session. Precedence is the addon's standard env layer: process environment &gt; project
-        /// <c>res://.env</c> (<see cref="GodotMcpEnvFile.LookupRaw"/>) &gt; none — the same order
+        /// Resolved ONCE and cached in a STATIC, so the launch path, the version-match bypass and the
+        /// orphan-cleanup skip can never disagree with each other mid-session. The cache lives for the
+        /// lifetime of the ASSEMBLY LOAD: a C# hot-reload re-resolves it, but merely disabling and
+        /// re-enabling the plugin does NOT — so a <c>res://.env</c> written after the first resolve is
+        /// picked up on the next script rebuild, not on the next plugin toggle. Precedence is the addon's
+        /// standard env layer: process environment &gt; project <c>res://.env</c>
+        /// (<see cref="GodotMcpEnvFile.LookupRaw"/>) &gt; none — the same order
         /// <c>GODOT_MCP_DEV_CONTROL</c> uses in <c>GodotMcpPlugin.StartDevControlIfEnabled</c>. Every decision
         /// derived from the raw values lives in the pure, unit-pinned
-        /// <see cref="GodotMcpServerPathOverride"/>; this method only performs the two reads.
+        /// <see cref="GodotMcpServerPathOverride"/>; this class only performs the two reads.
         /// </para>
         /// </summary>
         public static string? ServerPathOverride()
         {
             lock (_overrideMutex)
             {
-                if (!_overrideResolved)
-                {
-                    _overridePath = ResolveServerPathOverride();
-                    _overrideResolved = true;
-                }
-
+                EnsureServerPathOverrideResolved();
                 return _overridePath;
             }
         }
 
-        static string? ResolveServerPathOverride()
+        /// <summary>
+        /// The supplied <c>GODOT_MCP_SERVER_PATH</c> value AFTER normalization and precedence but BEFORE the
+        /// existence gate — <c>null</c> when neither layer supplied one. Diagnostics only: this is what lets
+        /// the boot site tell "set to a path that does not exist" apart from "not set at all", which
+        /// <see cref="ServerPathOverride"/> alone cannot (both are <c>null</c> there).
+        /// </summary>
+        public static string? ServerPathOverrideRawValue()
         {
+            lock (_overrideMutex)
+            {
+                EnsureServerPathOverrideResolved();
+                return _overrideRawValue;
+            }
+        }
+
+        /// <summary>Perform the two reads once and cache both the raw and the gated value. Call under <c>_overrideMutex</c>.</summary>
+        static void EnsureServerPathOverrideResolved()
+        {
+            if (_overrideResolved)
+                return;
+
             string? fromProcess = null;
             string? fromEnvFile = null;
 
@@ -169,7 +187,9 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             try { fromEnvFile = GodotMcpEnvFile.LookupRaw(ProjectSettings.GlobalizePath("res://.env"), GodotMcpEnv.ServerPath); }
             catch { /* no ProjectSettings — treat as "no .env value" */ }
 
-            return GodotMcpServerPathOverride.Resolve(fromProcess, fromEnvFile, File.Exists);
+            _overrideRawValue = GodotMcpServerPathOverride.SelectRaw(fromProcess, fromEnvFile);
+            _overridePath = GodotMcpServerPathOverride.Resolve(_overrideRawValue, File.Exists);
+            _overrideResolved = true;
         }
 
         // --- CI detection --------------------------------------------------------------------------------
@@ -190,7 +210,11 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
         // --- Binary lifecycle ----------------------------------------------------------------------------
 
-        /// <summary>True when the cached executable exists on disk.</summary>
+        /// <summary>
+        /// True when the executable we would LAUNCH exists on disk — the <c>GODOT_MCP_SERVER_PATH</c> override
+        /// when one is active, otherwise the cached binary. Use <see cref="CachedExecutableFullPath"/> directly
+        /// wherever the CACHE itself is the subject (verifying an unpack, the version marker).
+        /// </summary>
         public static bool IsBinaryExists() => File.Exists(ExecutableFullPath());
 
         /// <summary>The version recorded in the cache's <c>version</c> file, or null when absent.</summary>
@@ -207,8 +231,9 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// <c>version</c> marker and is not expected to match the pin (Unreal's rule).
         /// </summary>
         public bool IsVersionMatches()
-            => GodotMcpServerPathOverride.IsActive(ServerPathOverride())
-            || GodotMcpServerView.VersionMatches(GetCachedVersion(), GodotMcpServerView.ServerVersion);
+            => GodotMcpServerPathOverride.VersionMatchesOrOverridden(
+                ServerPathOverride(),
+                () => GodotMcpServerView.VersionMatches(GetCachedVersion(), GodotMcpServerView.ServerVersion));
 
         /// <summary>
         /// Download + unpack the version-matched server binary when it is missing or stale. No-op (returns
@@ -217,14 +242,25 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// </summary>
         public async Task<bool> DownloadServerBinaryIfNeeded()
         {
-            // BEFORE the CI check on purpose: a chain/CI run that supplies its own freshly-built server must
-            // get that binary launched, not the "skipped in CI" refusal.
+            // BEFORE the CI check on purpose: a CI run — or any local run that supplies its own
+            // freshly-built server — must get that binary launched, not the "skipped in CI" refusal.
             var overridePath = ServerPathOverride();
             if (GodotMcpServerPathOverride.IsActive(overridePath))
             {
                 _log($"[Godot-MCP] using {GodotMcpEnv.ServerPath} override: {overridePath} " +
                      "(release download and version match skipped).");
                 return true;
+            }
+
+            // A value that WAS supplied but names no existing file is ignored and we fall through to the
+            // normal download. Say so: without this line that outcome is byte-indistinguishable from "the
+            // variable was never set", so a run whose whole purpose is to exercise its OWN server build
+            // would pass against the downloaded release with nothing in the log to reveal it.
+            var rawOverride = ServerPathOverrideRawValue();
+            if (GodotMcpServerPathOverride.IsIgnoredValue(rawOverride, overridePath))
+            {
+                _logWarning($"[Godot-MCP] {GodotMcpEnv.ServerPath} is set to '{rawOverride}' but names no " +
+                            "existing file; ignoring it and falling back to the pinned release.");
             }
 
             if (IsCi())
@@ -336,7 +372,11 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
                 File.WriteAllText(VersionFilePath(), serverVersion);
 
-                var success = IsBinaryExists() && IsVersionMatches();
+                // Cache-scoped on purpose: this verdict is about the unpack we just performed, so it must not
+                // be answered by the GODOT_MCP_SERVER_PATH override the way the launch-scoped
+                // IsBinaryExists() / IsVersionMatches() pair would.
+                var success = File.Exists(CachedExecutableFullPath())
+                    && GodotMcpServerView.VersionMatches(GetCachedVersion(), GodotMcpServerView.ServerVersion);
                 _log(success
                     ? $"[Godot-MCP] server binary ready: {executablePath} (version {serverVersion})"
                     : "[Godot-MCP] server binary download completed but verification failed.");
@@ -532,6 +572,8 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
                 // Free the port from any orphaned server WE previously left behind for THIS project
                 // (scoped to this project's cache dir — never cross-kills another project's server).
+                // NOTE: this is a no-op while GODOT_MCP_SERVER_PATH is active (see the method), so a genuine
+                // orphan can still be holding the port there and startup verification will fail instead.
                 KillOrphanedServerProcesses();
 
                 try
@@ -723,18 +765,21 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         void KillOrphanedServerProcesses()
         {
             // SKIPPED while GODOT_MCP_SERVER_PATH is active. GodotMcpServerOwnership.IsOwnedByThisProject
-            // matches on the SAME CONTAINING DIRECTORY, and an override binary is shared by design (a chain
-            // run points several projects — and its own harness processes — at one built exe), so "ours"
-            // would wrongly cover a sibling's live server and this cleanup would kill it.
+            // claims any executable under the SAME CONTAINING DIRECTORY, and an override binary is shared by
+            // design (several projects, and other tools, may be pointed at one built exe), so "ours" would
+            // wrongly cover a sibling's live server and this cleanup would kill it.
             var overridePath = ServerPathOverride();
-            if (GodotMcpServerPathOverride.IsActive(overridePath))
+            if (!GodotMcpServerPathOverride.ShouldKillOrphans(overridePath))
             {
                 _log($"[Godot-MCP] orphaned-server cleanup skipped: {GodotMcpEnv.ServerPath} override is active " +
                      $"({overridePath}); the binary may be shared with other projects or processes.");
                 return;
             }
 
-            var ownPath = ExecutableFullPath();
+            // Cache-scoped deliberately: we only reach this line with no override in force (the skip above
+            // returned otherwise), so this documents the invariant instead of re-taking the override lock to
+            // arrive at the same string.
+            var ownPath = CachedExecutableFullPath();
 
             try
             {

--- a/addons/godot_mcp/Editor/Connection/GodotMcpServerManager.cs
+++ b/addons/godot_mcp/Editor/Connection/GodotMcpServerManager.cs
@@ -104,13 +104,73 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         public static string CachePlatformPath()
             => Path.Combine(CacheRootPath(), GodotMcpServerView.CurrentPlatformName());
 
-        /// <summary>Full path to the executable inside the per-platform cache folder.</summary>
-        public static string ExecutableFullPath()
+        /// <summary>
+        /// Full path to the executable inside the per-platform cache folder — the DOWNLOAD target, never
+        /// affected by the <c>GODOT_MCP_SERVER_PATH</c> override. Use this wherever the cache itself is the
+        /// subject (unpacking, the version marker); use <see cref="ExecutableFullPath"/> for "what do we launch".
+        /// </summary>
+        public static string CachedExecutableFullPath()
             => Path.Combine(CachePlatformPath(), GodotMcpServerView.CurrentExecutableFileName());
+
+        /// <summary>
+        /// Full path to the executable the manager LAUNCHES: the <c>GODOT_MCP_SERVER_PATH</c> override when one
+        /// is active (see <see cref="ServerPathOverride"/>), otherwise the per-platform cached binary.
+        /// </summary>
+        public static string ExecutableFullPath()
+            => GodotMcpServerPathOverride.ExecutablePath(ServerPathOverride(), CachedExecutableFullPath());
 
         /// <summary>Full path to the <c>version</c> marker file inside the per-platform cache folder.</summary>
         public static string VersionFilePath()
             => Path.Combine(CachePlatformPath(), "version");
+
+        // --- GODOT_MCP_SERVER_PATH override -------------------------------------------------------------
+
+        static readonly object _overrideMutex = new();
+        static bool _overrideResolved;
+        static string? _overridePath;
+
+        /// <summary>
+        /// The resolved <c>GODOT_MCP_SERVER_PATH</c> override — an EXISTING file to launch instead of the
+        /// pinned release — or <c>null</c> when unset, blank, or naming no existing file (Unreal's
+        /// <c>ResolveBinaryPath</c> rule: a bad override falls THROUGH to the normal download path).
+        ///
+        /// <para>
+        /// Resolved ONCE per boot (per assembly load — a C# hot-reload re-resolves) and cached, so the launch
+        /// path, the version-match bypass and the orphan-cleanup skip can never disagree with each other
+        /// mid-session. Precedence is the addon's standard env layer: process environment &gt; project
+        /// <c>res://.env</c> (<see cref="GodotMcpEnvFile.LookupRaw"/>) &gt; none — the same order
+        /// <c>GODOT_MCP_DEV_CONTROL</c> uses in <c>GodotMcpPlugin.StartDevControlIfEnabled</c>. Every decision
+        /// derived from the raw values lives in the pure, unit-pinned
+        /// <see cref="GodotMcpServerPathOverride"/>; this method only performs the two reads.
+        /// </para>
+        /// </summary>
+        public static string? ServerPathOverride()
+        {
+            lock (_overrideMutex)
+            {
+                if (!_overrideResolved)
+                {
+                    _overridePath = ResolveServerPathOverride();
+                    _overrideResolved = true;
+                }
+
+                return _overridePath;
+            }
+        }
+
+        static string? ResolveServerPathOverride()
+        {
+            string? fromProcess = null;
+            string? fromEnvFile = null;
+
+            try { fromProcess = OS.GetEnvironment(GodotMcpEnv.ServerPath); }
+            catch { /* no Godot OS singleton (non-editor host) — fall back to the .env layer */ }
+
+            try { fromEnvFile = GodotMcpEnvFile.LookupRaw(ProjectSettings.GlobalizePath("res://.env"), GodotMcpEnv.ServerPath); }
+            catch { /* no ProjectSettings — treat as "no .env value" */ }
+
+            return GodotMcpServerPathOverride.Resolve(fromProcess, fromEnvFile, File.Exists);
+        }
 
         // --- CI detection --------------------------------------------------------------------------------
 
@@ -142,18 +202,31 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
         /// <summary>
         /// True when the cached binary exists AND its recorded version EXACTLY matches the pinned
-        /// <see cref="GodotMcpServerView.ServerVersion"/>.
+        /// <see cref="GodotMcpServerView.ServerVersion"/> — or unconditionally true while the
+        /// <c>GODOT_MCP_SERVER_PATH</c> override is active, since an arbitrary caller-supplied build carries no
+        /// <c>version</c> marker and is not expected to match the pin (Unreal's rule).
         /// </summary>
         public bool IsVersionMatches()
-            => GodotMcpServerView.VersionMatches(GetCachedVersion(), GodotMcpServerView.ServerVersion);
+            => GodotMcpServerPathOverride.IsActive(ServerPathOverride())
+            || GodotMcpServerView.VersionMatches(GetCachedVersion(), GodotMcpServerView.ServerVersion);
 
         /// <summary>
         /// Download + unpack the version-matched server binary when it is missing or stale. No-op (returns
-        /// true) when the cached binary already matches. SKIPPED in CI (returns false). Mirrors Unity's
-        /// <c>DownloadServerBinaryIfNeeded</c>.
+        /// true) when the <c>GODOT_MCP_SERVER_PATH</c> override is active or the cached binary already
+        /// matches. SKIPPED in CI (returns false). Mirrors Unity's <c>DownloadServerBinaryIfNeeded</c>.
         /// </summary>
         public async Task<bool> DownloadServerBinaryIfNeeded()
         {
+            // BEFORE the CI check on purpose: a chain/CI run that supplies its own freshly-built server must
+            // get that binary launched, not the "skipped in CI" refusal.
+            var overridePath = ServerPathOverride();
+            if (GodotMcpServerPathOverride.IsActive(overridePath))
+            {
+                _log($"[Godot-MCP] using {GodotMcpEnv.ServerPath} override: {overridePath} " +
+                     "(release download and version match skipped).");
+                return true;
+            }
+
             if (IsCi())
             {
                 _log("[Godot-MCP] skipping MCP server download in CI environment.");
@@ -179,7 +252,8 @@ namespace com.IvanMurzak.Godot.MCP.Connection
             var serverVersion = GodotMcpServerView.ServerVersion;
             var url = GodotMcpServerView.DownloadUrl(os, arch);
             var platformFolder = CachePlatformPath();
-            var executablePath = ExecutableFullPath();
+            // The CACHE target explicitly: unpacking must never be redirected at the override's path.
+            var executablePath = CachedExecutableFullPath();
 
             _log($"[Godot-MCP] downloading GameDev-MCP-Server binary from: {url}");
 
@@ -474,7 +548,9 @@ namespace com.IvanMurzak.Godot.MCP.Connection
                         CreateNoWindow = true,
                         RedirectStandardOutput = true,
                         RedirectStandardError = true,
-                        WorkingDirectory = CachePlatformPath()
+                        // The directory of the executable we are ACTUALLY launching: the cache platform folder
+                        // normally, the override binary's own folder under GODOT_MCP_SERVER_PATH.
+                        WorkingDirectory = GodotMcpServerPathOverride.WorkingDirectory(executablePath, CachePlatformPath())
                     };
 
                     var process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
@@ -646,6 +722,18 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// </summary>
         void KillOrphanedServerProcesses()
         {
+            // SKIPPED while GODOT_MCP_SERVER_PATH is active. GodotMcpServerOwnership.IsOwnedByThisProject
+            // matches on the SAME CONTAINING DIRECTORY, and an override binary is shared by design (a chain
+            // run points several projects — and its own harness processes — at one built exe), so "ours"
+            // would wrongly cover a sibling's live server and this cleanup would kill it.
+            var overridePath = ServerPathOverride();
+            if (GodotMcpServerPathOverride.IsActive(overridePath))
+            {
+                _log($"[Godot-MCP] orphaned-server cleanup skipped: {GodotMcpEnv.ServerPath} override is active " +
+                     $"({overridePath}); the binary may be shared with other projects or processes.");
+                return;
+            }
+
             var ownPath = ExecutableFullPath();
 
             try

--- a/addons/godot_mcp/Editor/Connection/GodotMcpServerPathOverride.cs
+++ b/addons/godot_mcp/Editor/Connection/GodotMcpServerPathOverride.cs
@@ -1,0 +1,144 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Godot-MCP)    │
+│  Copyright (c) 2026 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.IO;
+
+namespace com.IvanMurzak.Godot.MCP.Connection
+{
+    /// <summary>
+    /// PURE-MANAGED (no Godot native types, no <c>#if TOOLS</c>, no I/O of its own) resolver for the
+    /// <c>GODOT_MCP_SERVER_PATH</c> override — the dev/CI escape hatch that makes the editor LAUNCH a
+    /// caller-supplied <c>gamedev-mcp-server</c> executable instead of the release pinned by
+    /// <see cref="GodotMcpServerView.ServerVersion"/>. Mirrors Unreal's <c>UNREAL_MCP_SERVER_PATH</c>
+    /// (<c>UnrealMcpServerManager.cpp</c> <c>ResolveBinaryPath</c>) and Unity's <c>UNITY_MCP_SERVER_PATH</c>.
+    ///
+    /// <para>
+    /// Built on the <see cref="DevControl.DevControlGate"/> pattern: the boot site
+    /// (<see cref="GodotMcpServerManager"/>) does the env/file I/O and passes RAW strings plus a
+    /// <c>fileExists</c> delegate here, so every decision the override drives is unit-testable in the
+    /// plain-xUnit CI host with no Godot binary and no filesystem. The manager statics that would carry
+    /// these decisions (<c>ExecutableFullPath</c>, <c>IsVersionMatches</c>, <c>KillOrphanedServerProcesses</c>)
+    /// all reach <c>ProjectSettings.GlobalizePath</c> and therefore cannot run in that host at all — which is
+    /// exactly why the decisions live here instead.
+    /// </para>
+    ///
+    /// <para>
+    /// Precedence is the addon's standard env layer — process environment &gt; project <c>res://.env</c>
+    /// (<see cref="GodotMcpEnvFile.LookupRaw"/>) &gt; none — the same order <c>GODOT_MCP_DEV_CONTROL</c> uses
+    /// (<c>GodotMcpPlugin.StartDevControlIfEnabled</c>). A value that is set but does NOT name an existing
+    /// file is IGNORED (resolves to <c>null</c>) so the addon falls back to its normal download path rather
+    /// than failing to boot — Unreal's rule.
+    /// </para>
+    ///
+    /// <para>
+    /// While the override is ACTIVE the addon deliberately changes three behaviours, all keyed off the single
+    /// <see cref="IsActive"/> predicate: the release download is skipped, the cached-version match is bypassed
+    /// (an arbitrary build carries no <c>version</c> marker), and orphaned-server cleanup is skipped. The last
+    /// one is a correctness requirement, not a convenience: cleanup ownership
+    /// (<see cref="GodotMcpServerOwnership.IsOwnedByThisProject"/>) matches on the SAME CONTAINING DIRECTORY,
+    /// so with several projects pointed at one shared override binary an editor boot would kill a sibling
+    /// process running that same executable.
+    /// </para>
+    /// </summary>
+    public static class GodotMcpServerPathOverride
+    {
+        /// <summary>
+        /// Normalize one raw <c>GODOT_MCP_SERVER_PATH</c> value exactly as the addon's <c>.env</c> layer
+        /// normalizes file values (<c>GodotMcpEnvFile.Sanitize</c>): trim surrounding whitespace, strip a
+        /// single pair of wrapping SINGLE quotes, then apply the shared env normalizer
+        /// (<see cref="GodotMcpConfig.NormalizeEnv"/>: whitespace + wrapping DOUBLE quotes). Returns
+        /// <c>null</c> for null / empty / whitespace-only input.
+        ///
+        /// <para>
+        /// The quote handling is load-bearing for the PROCESS-env half: <see cref="GodotMcpEnvFile.LookupRaw"/>
+        /// already sanitizes what it reads out of <c>.env</c>, but nothing sanitizes a process variable, and a
+        /// path exported as <c>GODOT_MCP_SERVER_PATH="C:/…/gamedev-mcp-server.exe"</c> (quotes preserved by the
+        /// shell or a CI <c>env:</c> block) would otherwise be tested for existence WITH the literal quotes and
+        /// silently ignored.
+        /// </para>
+        /// </summary>
+        public static string? Normalize(string? rawValue)
+        {
+            if (rawValue == null)
+                return null;
+
+            var trimmed = rawValue.Trim();
+            if (trimmed.Length >= 2 && trimmed[0] == '\'' && trimmed[trimmed.Length - 1] == '\'')
+                trimmed = trimmed.Substring(1, trimmed.Length - 2);
+
+            return GodotMcpConfig.NormalizeEnv(trimmed);
+        }
+
+        /// <summary>
+        /// Apply the addon's standard precedence to the two RAW values the boot site collected: the process
+        /// environment wins whenever it normalizes to something non-blank, otherwise the project <c>.env</c>
+        /// value is used, otherwise <c>null</c>. Pure — the caller performs both reads.
+        /// </summary>
+        public static string? SelectRaw(string? processValue, string? envFileValue)
+            => Normalize(processValue) ?? Normalize(envFileValue);
+
+        /// <summary>
+        /// Resolve ONE raw value to an override path: the normalized value when
+        /// <paramref name="fileExists"/> reports it names an existing file, otherwise <c>null</c>.
+        /// The existence gate is what makes a stale or mistyped override fall THROUGH to the normal
+        /// download path instead of breaking the editor.
+        /// </summary>
+        public static string? Resolve(string? rawValue, Func<string, bool> fileExists)
+        {
+            if (fileExists == null)
+                throw new ArgumentNullException(nameof(fileExists));
+
+            var normalized = Normalize(rawValue);
+            if (normalized == null)
+                return null;
+
+            return fileExists(normalized) ? normalized : null;
+        }
+
+        /// <summary>
+        /// Resolve the override from BOTH raw layers at once (process env &gt; project <c>.env</c>), then apply
+        /// the existence gate. This is the seam the boot site calls and the one the precedence test pins.
+        /// </summary>
+        public static string? Resolve(string? processValue, string? envFileValue, Func<string, bool> fileExists)
+            => Resolve(SelectRaw(processValue, envFileValue), fileExists);
+
+        /// <summary>
+        /// The single "the override is in force" predicate. Every behaviour the override changes — download
+        /// skip, version-match bypass, orphan-cleanup skip, launch path — is this ONE decision read at four
+        /// call sites; they are deliberately not independent flags.
+        /// </summary>
+        public static bool IsActive(string? resolvedOverride)
+            => !string.IsNullOrEmpty(resolvedOverride);
+
+        /// <summary>
+        /// The executable the manager must launch: the resolved override when active, else the per-platform
+        /// cached binary the release download writes.
+        /// </summary>
+        public static string ExecutablePath(string? resolvedOverride, string cachedExecutablePath)
+            => IsActive(resolvedOverride) ? resolvedOverride! : cachedExecutablePath;
+
+        /// <summary>
+        /// The child process's working directory: the directory CONTAINING the executable actually being
+        /// launched (so an override binary runs beside its own sidecar files), falling back to
+        /// <paramref name="fallbackDirectory"/> when the path carries no directory component. With no override
+        /// this returns the cache platform folder — the historical value — because that IS the cached
+        /// executable's directory.
+        /// </summary>
+        public static string WorkingDirectory(string? executablePath, string fallbackDirectory)
+        {
+            if (string.IsNullOrWhiteSpace(executablePath))
+                return fallbackDirectory;
+
+            var directory = Path.GetDirectoryName(executablePath);
+            return string.IsNullOrEmpty(directory) ? fallbackDirectory : directory!;
+        }
+    }
+}

--- a/addons/godot_mcp/Editor/Connection/GodotMcpServerPathOverride.cs
+++ b/addons/godot_mcp/Editor/Connection/GodotMcpServerPathOverride.cs
@@ -32,8 +32,11 @@ namespace com.IvanMurzak.Godot.MCP.Connection
     ///
     /// <para>
     /// Precedence is the addon's standard env layer — process environment &gt; project <c>res://.env</c>
-    /// (<see cref="GodotMcpEnvFile.LookupRaw"/>) &gt; none — the same order <c>GODOT_MCP_DEV_CONTROL</c> uses
-    /// (<c>GodotMcpPlugin.StartDevControlIfEnabled</c>). A value that is set but does NOT name an existing
+    /// (<see cref="GodotMcpEnvFile.LookupRaw"/>) &gt; none — the same ORDER <c>GODOT_MCP_DEV_CONTROL</c> uses
+    /// (<c>GodotMcpPlugin.StartDevControlIfEnabled</c>). One deliberate difference from that precedent: it
+    /// picks the process layer on the RAW value being non-empty, whereas this picks it on the NORMALIZED
+    /// value, so a process variable set to whitespace falls through to <c>.env</c> here instead of shadowing
+    /// it. A value that is set but does NOT name an existing
     /// file is IGNORED (resolves to <c>null</c>) so the addon falls back to its normal download path rather
     /// than failing to boot — Unreal's rule.
     /// </para>
@@ -54,8 +57,16 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// Normalize one raw <c>GODOT_MCP_SERVER_PATH</c> value exactly as the addon's <c>.env</c> layer
         /// normalizes file values (<c>GodotMcpEnvFile.Sanitize</c>): trim surrounding whitespace, strip a
         /// single pair of wrapping SINGLE quotes, then apply the shared env normalizer
-        /// (<see cref="GodotMcpConfig.NormalizeEnv"/>: whitespace + wrapping DOUBLE quotes). Returns
+        /// (<see cref="GodotMcpConfig.NormalizeEnv"/>, which is <c>Trim().Trim('"')</c> — whitespace plus ANY
+        /// number of wrapping DOUBLE quotes, balanced or not). Returns
         /// <c>null</c> for null / empty / whitespace-only input.
+        ///
+        /// <para>
+        /// The ORDER is load-bearing and matches the sibling: the single-quote strip runs BEFORE the shared
+        /// normalizer, because the shared normalizer only knows about double quotes. Swapping the two changes
+        /// the answer for a nested pair — <c>"'/srv/x'"</c> normalizes to <c>'/srv/x'</c> in this order and to
+        /// <c>/srv/x</c> in the other — so the order is asserted, not merely described.
+        /// </para>
         ///
         /// <para>
         /// The quote handling is load-bearing for the PROCESS-env half: <see cref="GodotMcpEnvFile.LookupRaw"/>
@@ -105,18 +116,73 @@ namespace com.IvanMurzak.Godot.MCP.Connection
 
         /// <summary>
         /// Resolve the override from BOTH raw layers at once (process env &gt; project <c>.env</c>), then apply
-        /// the existence gate. This is the seam the boot site calls and the one the precedence test pins.
+        /// the existence gate — the whole resolution in one call, and the seam the precedence test pins.
+        ///
+        /// <para>
+        /// The boot site does NOT use this overload: it needs the SELECTED-but-ungated value as well (to tell
+        /// "set to a path that does not exist" from "not set" — see <see cref="IsIgnoredValue"/>), so it calls
+        /// <see cref="SelectRaw"/> and the single-value <see cref="Resolve(string, Func{string, bool})"/> in
+        /// turn. That composition is exactly this body, so the two paths cannot diverge.
+        /// </para>
         /// </summary>
         public static string? Resolve(string? processValue, string? envFileValue, Func<string, bool> fileExists)
             => Resolve(SelectRaw(processValue, envFileValue), fileExists);
 
         /// <summary>
         /// The single "the override is in force" predicate. Every behaviour the override changes — download
-        /// skip, version-match bypass, orphan-cleanup skip, launch path — is this ONE decision read at four
-        /// call sites; they are deliberately not independent flags.
+        /// skip, version-match bypass, orphan-cleanup skip, launch path — DERIVES from this ONE decision;
+        /// they are deliberately not independent flags, and nothing may reintroduce one.
+        ///
+        /// <para>
+        /// The named siblings below (<see cref="VersionMatchesOrOverridden"/>, <see cref="ShouldKillOrphans"/>,
+        /// <see cref="IsIgnoredValue"/>) are NOT such flags: each is a total function OF this predicate,
+        /// spelled out so that the POLARITY the boot site applies to it is pinnable. That matters because the
+        /// consuming call sites live in <c>GodotMcpServerManager</c>, which is <c>#if TOOLS</c> and cannot be
+        /// compiled into the xUnit host at all — so an inverted <c>||</c> or a dropped <c>!</c> there would be
+        /// caught by no automated gate. Pinning the predicate alone does not pin how it is read.
+        /// </para>
         /// </summary>
         public static bool IsActive(string? resolvedOverride)
             => !string.IsNullOrEmpty(resolvedOverride);
+
+        /// <summary>
+        /// True when a value WAS supplied but did not survive the existence gate — i.e. the override is being
+        /// IGNORED and the addon is silently falling back to the pinned release. The boot site logs a warning
+        /// on this, because "set to a path that does not exist" is otherwise byte-indistinguishable from
+        /// "not set at all": a CI or dev run whose whole purpose is to exercise its OWN server build would
+        /// pass against the downloaded release with nothing in the log to say so.
+        /// </summary>
+        public static bool IsIgnoredValue(string? rawSelected, string? resolvedOverride)
+            => !string.IsNullOrEmpty(rawSelected) && !IsActive(resolvedOverride);
+
+        /// <summary>
+        /// The manager's version-match verdict: unconditionally true while the override is active (an
+        /// arbitrary caller-supplied build carries no <c>version</c> marker and is not expected to match the
+        /// pin), otherwise whatever the cached-version comparison decides.
+        ///
+        /// <para>
+        /// <paramref name="cachedVersionMatches"/> is a DELEGATE, not a <c>bool</c>, so the short-circuit is
+        /// preserved: reading the cache's <c>version</c> marker is file I/O, and under an active override
+        /// that cache folder routinely does not exist at all. Evaluating it eagerly would perform a read the
+        /// original <c>||</c> expression never performed.
+        /// </para>
+        /// </summary>
+        public static bool VersionMatchesOrOverridden(string? resolvedOverride, Func<bool> cachedVersionMatches)
+        {
+            if (cachedVersionMatches == null)
+                throw new ArgumentNullException(nameof(cachedVersionMatches));
+
+            return IsActive(resolvedOverride) || cachedVersionMatches();
+        }
+
+        /// <summary>
+        /// Whether the boot site should run its orphaned-server sweep: NO while the override is active.
+        /// Cleanup ownership (<see cref="GodotMcpServerOwnership.IsOwnedByThisProject"/>) claims every process
+        /// whose executable sits in the same containing directory (or below it), and an override binary is
+        /// shared by design, so sweeping would kill a live server belonging to another project or tool.
+        /// </summary>
+        public static bool ShouldKillOrphans(string? resolvedOverride)
+            => !IsActive(resolvedOverride);
 
         /// <summary>
         /// The executable the manager must launch: the resolved override when active, else the per-platform
@@ -131,6 +197,14 @@ namespace com.IvanMurzak.Godot.MCP.Connection
         /// <paramref name="fallbackDirectory"/> when the path carries no directory component. With no override
         /// this returns the cache platform folder — the historical value — because that IS the cached
         /// executable's directory.
+        ///
+        /// <para>
+        /// The "beside its own sidecar files" property holds only for a path that HAS a directory component,
+        /// which is what the documented contract (an ABSOLUTE path — see the <c>GODOT_MCP_SERVER_PATH</c> row
+        /// in <c>README.md</c>) always supplies. A bare filename is still accepted by the existence gate — it
+        /// resolves against the editor process's working directory — but then this returns
+        /// <paramref name="fallbackDirectory"/>, so the child runs somewhere OTHER than beside its executable.
+        /// </para>
         /// </summary>
         public static string WorkingDirectory(string? executablePath, string fallbackDirectory)
         {

--- a/addons/godot_mcp/Runtime/GodotMcpEnv.cs
+++ b/addons/godot_mcp/Runtime/GodotMcpEnv.cs
@@ -39,6 +39,17 @@ namespace com.IvanMurzak.Godot.MCP
         /// <summary>Forces the plugin's log-verbosity threshold.</summary>
         public const string LogLevel = "GODOT_MCP_LOG_LEVEL";
 
+        // --- Local server binary (resolved in GodotMcpServerManager; editor-only). ---
+
+        /// <summary>
+        /// Absolute path to a <c>gamedev-mcp-server(.exe)</c> the editor should launch INSTEAD of the release
+        /// pinned by <c>GodotMcpServerView.ServerVersion</c>. When it names an existing file the download and
+        /// the cached-version match are skipped, and orphaned-server cleanup is disabled while it is active.
+        /// A value naming no existing file is ignored (normal download path). Dev / CI use; the Godot analog
+        /// of <c>UNREAL_MCP_SERVER_PATH</c> / <c>UNITY_MCP_SERVER_PATH</c>.
+        /// </summary>
+        public const string ServerPath = "GODOT_MCP_SERVER_PATH";
+
         // --- Dev-only inject/control bridge (off unless set to "1"). ---
 
         /// <summary>Enables the 127.0.0.1 dev-control HTTP bridge when exactly <c>"1"</c>.</summary>


### PR DESCRIPTION
## Summary

- Registers **`GODOT_MCP_SERVER_PATH`** in the addon's existing env resolution layer — process env > project `res://.env` (`GodotMcpEnvFile.LookupRaw`) > none, the same precedence `GODOT_MCP_DEV_CONTROL` uses — so a chain/CI-built `gamedev-mcp-server` can be launched instead of the release pinned by `GodotMcpServerView.ServerVersion`. Never a bare `Environment.GetEnvironmentVariable`.
- While the override is active the editor **skips the release download** (before the CI check, so a CI/chain run gets its own binary rather than the "skipped in CI" refusal), treats **`IsVersionMatches()` as true** (an arbitrary build carries no `version` marker), launches with the **override binary's own directory** as the working directory, and **skips orphaned-server cleanup**. The last one is a correctness requirement: `GodotMcpServerOwnership.IsOwnedByThisProject` matches on the *same containing directory*, and an override binary is shared by design, so the cleanup would kill a sibling project's or harness's live server.
- A value that names **no existing file is ignored** and the normal download path runs — Unreal's `UNREAL_MCP_SERVER_PATH` / `ResolveBinaryPath` rule.
- All decisions live in a new **pure-managed resolver**, `GodotMcpServerPathOverride` (the `DevControlGate` pattern): the caller does the env/file I/O and passes raw strings plus a `fileExists` delegate. This is deliberate — the manager statics that would otherwise carry them (`ExecutableFullPath` / `IsVersionMatches` / `KillOrphanedServerProcesses`) are `#if TOOLS` and reach `ProjectSettings.GlobalizePath`, which faults in the plain-xUnit host, so they are **not unit-testable at all**; factoring the decisions out is what makes them pinnable.

Taskflow `2026-09-03-chain-testing`, row `p1-server-path-godot` (goal G13) — the one permitted **product** code change for this plugin (design decision D3 / C30).

### Files

| File | Why |
| ---- | --- |
| `addons/godot_mcp/Runtime/GodotMcpEnv.cs` | `+ ServerPath = "GODOT_MCP_SERVER_PATH"` in the canonical env-name class. |
| `addons/godot_mcp/Editor/Connection/GodotMcpServerPathOverride.cs` (new) | Pure resolver: normalization, precedence, existence gate, launch path, working directory. |
| `addons/godot_mcp/Editor/Connection/GodotMcpServerManager.cs` | Resolve-once-per-boot wiring + the four call sites; new `CachedExecutableFullPath()` keeps the *download* target override-free. |
| `Godot-MCP.Tests/GodotMcpServerPathOverrideTests.cs` (new) | 19 tests / 24 cases. |
| `Godot-MCP.Tests/Godot-MCP.Tests.csproj` | `<Compile Include>` for the new resolver source. |
| `README.md` | One env-table row + an editor-only clarifying note. |

`.github/**` diff is **empty** (owned by `p2-dispatch-godot-mcp`). `Godot-MCP.csproj` pins, `Godot-Tests/**`, `cli/**`, `plugin.cfg` and `GodotMcpServerView.ServerVersion` are untouched.

## Test plan

- [x] Target-specific local tests passed (see profile `test.md`).
- [x] Suite 1 — `dotnet restore` + `dotnet build Godot-MCP.sln --configuration Debug --no-restore`: **0 errors, 0 warnings**.
- [x] Suite 2 — `dotnet test Godot-MCP.Tests/...`: **1334 passed / 0 failed** (was 1310 before this change; +24 new test methods — 19 from the first push, 5 more from the refine pass below).
- [x] Plant round, RE-RUN and EXTENDED against the final tree (`0a58c26`): **22/22 matched their expect | 22 RED | 0 GREEN | restore-failures 0**, harness exit `0`, source restored byte-exactly (md5 `c164fbc6451f477401312079fbd715fe` before and after). Every one of the 22 per-plant logs collected `Total tests: 1334` — identical to the clean run — so no RED came from an import/compile break.
- [x] Behavioural proof in a real headless Godot **4.5.1 mono** editor, both directions (below).
- [ ] Suite 2b (`cli/` npm) — **not applicable**: no `cli/` file in the diff and no tool-surface / `ToolType` change, which are the only triggers `test.md` lists for it.

### Plant table — every RED attributed from its own per-plant log

Each plant reverts exactly one claim; the verify command rebuilds *and* re-runs the suite
(`dotnet build … && dotnet test … --no-build --verbosity normal`), so a plant cannot score against a
stale assembly. **All 22 per-plant logs collected `Total tests: 1334`** — identical to the clean-baseline run on
this same tree — so no RED came from an import/compile break. The round was re-run against the
final tree `0a58c26` with every per-plant log retained; `SUMMARY  22/22 matched their expect | 22 RED |
0 GREEN | restore-failures 0`, harness exit `0`, and `digest_before == digest_after` on all 22 restores.
P20/P21 share one marker and are discriminated by assertion, not by test name (`Assert.False` at
line 284 vs `Assert.True` at line 280).

| # | Plant (mutation) | Expect | Attributed RED (from `NN-<name>.log`) | Counts |
| - | ---------------- | ------ | ------------------------------------ | ------ |
| P1 | drop the `fileExists` gate (`return normalized;`) | red | `Resolve_SetButMissingFile_ReturnsNull` (+6 siblings incl. `Resolve_ExistingFile_ReturnsThatPath`, whose recorded-probe assertion is what sees a *removed* gate) | 1327/7 |
| P2 | invert the `fileExists` gate | red | `Resolve_ExistingFile_ReturnsThatPath` (+6) | 1327/7 |
| P3 | drop the double-quote/whitespace normalizer | red | `Resolve_DoubleQuotedValue_TrimsQuotesBeforeTheExistenceGate`, `Normalize_TrimsWhitespaceThenOnePairOfQuotes`, `SelectRaw_AppliesPrecedenceAndNormalization` | 1330/4 |
| P4 | drop the single-quote strip | red | `Resolve_SingleQuotedValue_TrimsQuotesBeforeTheExistenceGate` (+2) | 1331/3 |
| P5 | reverse precedence (`.env` beats process env) | red | `Resolve_BothLayersSet_ProcessValueWins`, `SelectRaw_AppliesPrecedenceAndNormalization` | 1332/2 |
| P6 | `ExecutablePath` ignores the override | red | `ExecutablePath_OverrideActive_LaunchesTheOverride` | 1333/1 |
| P7 | `ExecutablePath` always uses the override | red | `ExecutablePath_NoOverride_LaunchesTheCachedBinary` | 1333/1 |
| P8 | `WorkingDirectory` always returns the fallback | red | `WorkingDirectory_IsTheDirectoryOfTheResolvedExecutable` | 1332/2 |
| P9 | `WorkingDirectory` drops the fallback | red | `WorkingDirectory_PathWithoutADirectoryComponent_FallsBack` | 1333/1 |
| P10 | `IsActive` always true | red | `IsActive_OnlyForANonEmptyResolvedOverride`, `ExecutablePath_NoOverride_LaunchesTheCachedBinary` | 1329/5 |
Both directions are covered for every gate: P1/P2 (existence gate), P3/P4 (the two quote conventions),
P5 (precedence, with **both** candidate paths existing so the existence gate cannot be what picks the
winner), P6/P7 (override vs cached launch path), P8/P9 (working directory), P10 (the predicate).
Several tests assert the **recorded `fileExists` argument** rather than only a `null`/non-`null`
result — an absence assertion alone cannot distinguish "the gate refused the value" from "the value
never reached the gate", and P1 is precisely the mutation that exploits that difference.


**Added by the refine pass** (P11-P22). The verify command is unchanged, so these ran under the same
rebuild-then-retest shape as P1-P10.

| # | Plant (mutation) | Expect | Attributed RED (from `NN-<name>.log`) | Counts |
| - | ---------------- | ------ | ------------------------------------ | ------ |
| P11 | blank value reaches the existence gate (`normalized = string.Empty` instead of returning) | red | `Resolve_NullEmptyOrWhitespace_ReturnsNullWithoutProbing` | 1329/5 |
| P12 | `Normalize` stops collapsing blank to null (`return trimmed;`) | red | `Normalize_NullEmptyOrWhitespace_ReturnsNull` | 1324/10 |
| P13 | drop `Resolve`'s `fileExists` null guard | red | `Resolve_NullFileExistsDelegate_Throws` | 1333/1 |
| P14 | 3-arg `Resolve` drops the `.env` layer | red | `Resolve_ProcessValueBlank_FallsBackToEnvFileValue` | 1333/1 |
| P15 | swap the single-quote strip and the shared double-quote normalizer | red | `Normalize_StripsSingleQuotesBEFORETheSharedDoubleQuoteNormalizer` | 1333/1 |
| P16 | `ShouldKillOrphans` polarity inverted | red | `ShouldKillOrphans_OnlyWithoutAnOverride` | 1333/1 |
| P17 | `VersionMatchesOrOverridden` `\|\|` → `&&` (override stops forcing true) | red | `VersionMatchesOrOverridden_TrueUnderOverride…` (`Assert.True`, line 247) | 1332/2 |
| P18 | same method loses ONLY its short-circuit (result unchanged) | red | `VersionMatchesOrOverridden_TrueUnderOverride…` (`Assert.False(consulted)`, line 251) | 1333/1 |
| P19 | `VersionMatchesOrOverridden` stops deferring without an override (`return true;`) | red | `VersionMatchesOrOverridden_NoOverride_DefersToTheCachedVersionVerdict` | 1333/1 |
| P20 | `IsIgnoredValue` fires when nothing was supplied (drop the raw check) | red | `IsIgnoredValue_TrueOnlyWhen…` (`Assert.False`, line 284) | 1333/1 |
| P21 | `IsIgnoredValue` never fires (`=> false`) | red | `IsIgnoredValue_TrueOnlyWhen…` (`Assert.True`, line 280) | 1333/1 |
| P22 | `WorkingDirectory` no-override answer comes from the fallback (ternary inverted) | red | `WorkingDirectory_NoOverride_IsStillTheCacheFolder` | 1331/3 |

**Two plants share a marker in each of two groups (P17/P18 and P20/P21), and both groups were
hand-checked to fail DIFFERENTLY** — the harness's own shared-marker comparator extracts a pytest
`FAILURES` block and so reports `could NOT be compared` on this xUnit profile, which is not a pass.
Read from the per-plant logs: P17 fails `Assert.True` at line 247 while P18 fails `Assert.False(consulted)`
at line 251; P21 fails `Assert.True` at line 280 while P20 fails `Assert.False` at line 284. Distinct
assertion, line and text in both groups.

### Refine pass (`0a58c26`)

Four report-only review helpers plus an in-context pass. Behaviour-preserving except for one added
diagnostic. What it changed and why:

- **A set-but-unresolvable override was ignored in complete silence** — byte-indistinguishable from
  "not set", so a CI or dev run whose purpose is to exercise its OWN server build would pass against
  the downloaded release with nothing in the log. New pure `IsIgnoredValue` + a warning at the boot
  site, which now caches the selected-but-ungated raw value alongside the gated one (P20/P21).
- **`DownloadAndUnpackBinary`'s post-unpack verdict could not fail under an override**: it used the
  launch-scoped `IsBinaryExists()`/`IsVersionMatches()` pair, both of which an active override answers
  unconditionally. Re-scoped to the cache, matching the `CachedExecutableFullPath()` choice the same
  hunk already made for the unpack target. Unreachable under override today, so it is a no-op on every
  currently reachable path — the fix removes a latent trap rather than a live bug.
- **DoD 3 is now literally satisfied.** The two under-override decisions were a bare `||` and an early
  `return` inside `GodotMcpServerManager`, which is `#if TOOLS` and is not compiled into the xUnit host,
  so their POLARITY was pinned by nothing — only the `IsActive` input was. Factored into
  `VersionMatchesOrOverridden` (delegate-valued, so the cache read keeps its short-circuit) and
  `ShouldKillOrphans` (P16-P19).
- **A test that could not fail**: `WorkingDirectory_NoOverride_IsStillTheCacheFolder` passed a fallback
  equal to the executable's own directory, so both arms of the method returned the same string and
  neither P8 nor P9 could redden it. It now passes a fallback the answer must not be (P22).
- **Two shared-marker pairs made discriminable** by reordering assertions rather than weakening any.
- **Docs**: `IsBinaryExists()`'s summary still said "the cached executable" after `ExecutableFullPath()`
  became override-aware underneath it; the README's "read once per editor session" was false (the cache
  is per assembly load — a C# hot-reload re-reads it, a plugin toggle does not); added the
  ignored-value warning and the Unix executable-bit caveat.

**Recorded, deliberately NOT changed** (each was raised by a helper and rejected on evidence):
`GodotMcpServerPathOverride.Normalize` duplicates the private `GodotMcpEnvFile.Sanitize` — sharing it
would edit a file outside the task's capped product-diff set. Removing the double normalization on the
production path is a BEHAVIOUR change, not a cleanup: `"'…'"` unwraps today and would stop, so it is
documented instead. A relative override path is accepted by the existence gate but then does not get
its own directory as the working directory — documented on `WorkingDirectory`; rejecting non-rooted
values was declined as an unforced behaviour restriction. Two helpers recommended deleting
`VersionMatchesOrOverridden` / `ShouldKillOrphans` as `a || b` and `!a` re-implemented — declined
because DoD 3 requires exactly that factoring, with the class doc updated so the file no longer reads
as contradicting itself.

**Honest limitation.** The download-skip, version-match bypass and orphan-cleanup skip are ONE
decision (`IsActive`) read at three call sites, not three independent flags — so they are entailed by
each other and one plant (P10) covers the predicate. The *manager* call sites themselves carry no
unit plant: `GodotMcpServerManager` is `#if TOOLS` and is not compiled into the xUnit assembly, so any
plant there would score a (correct but useless) GREEN. The refine pass above closed the two that WERE
expressible as pure decisions (`VersionMatchesOrOverridden`, `ShouldKillOrphans`, plants P16-P19); what remains uncovered by a unit plant is the manager WIRING itself — the early return's position BEFORE the CI check, and the four call sites — covered by the compile and by the behavioural proof below.

### Behavioural proof — headless Godot 4.5.1 mono, `engines/godot/test-project`

Held-open `--editor` session with the dev-control bridge, `POST /control/click {"target":"start-server"}`.

**With `GODOT_MCP_SERVER_PATH` set** to a locally built `gamedev-mcp-server.exe`:

```
[Godot-MCP] using GODOT_MCP_SERVER_PATH override: C:/.../.agent-scratch/chain-server/gamedev-mcp-server.exe (release download and version match skipped).
[Godot-MCP] orphaned-server cleanup skipped: GODOT_MCP_SERVER_PATH override is active (C:/.../chain-server/gamedev-mcp-server.exe); the binary may be shared with other projects or processes.
[Godot-MCP] local server process started (PID 60712, port 22712); verifying…
[Godot-MCP] local server verified and running.
```

`grep -c "downloading GameDev-MCP-Server"` = **0**, and `test-project/.godot/mcp-server/` was **ABSENT** after the run.

**Same testbed, same editor, variable UNSET** (control):

```
[Godot-MCP] downloading GameDev-MCP-Server binary from: https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/v9.2.5/gamedev-mcp-server-win-x64.zip
[Godot-MCP] local server process started (PID 10884, port 22712); verifying…
[Godot-MCP] local server verified and running.
```

`.godot/mcp-server/win-x64/` was then present with `gamedev-mcp-server.exe` + the `version` marker.

> Local-verification caveat, for the record: `engines/godot/test-project/Godot-Test-Project.csproj`
> pins `com.IvanMurzak.McpPlugin` **7.5.2** while this addon pins **8.3.0**, so the testbed cannot
> compile the addon as checked in — measured: `CS0246` on `LoginCommitStatus`, `TokenRefreshRequest`,
> `HttpTokenRefresher`, `MachineCredentialLock`, … in `GodotAccountAuth.cs` / `GodotTokenRefresher.cs`,
> files this PR does not touch. That is the pre-existing testbed drift the csproj's own comment warns
> about. The smoke above was run behind a **temporary, local, reverted** bump of that testbed pin to
> 8.3.0; nothing in that repo was committed. The lockstep bump itself belongs to a separate task.

## Notes for the reviewer

- The override is resolved **once per boot** (per assembly load) and cached behind a lock, so the launch path, the version-match bypass and the cleanup skip can never disagree mid-session.
- `ExecutableFullPath()` is now "what do we launch"; the new `CachedExecutableFullPath()` is "where does the download land". `DownloadAndUnpackBinary` uses the latter, so unpacking can never be redirected at the override.
- `docs/runtime-security.md`'s env table was deliberately **not** touched: it is scoped to the game-build runtime config read by `GodotMcpConfig`, and this variable is editor-only.
### CI on the final head `0a58c264d039b6a893d6fe314cf9b1bb907f226b`

| Workflow | Run | Conclusion |
| -------- | --- | ---------- |
| `CI` | [33809312386](https://github.com/IvanMurzak/Godot-MCP/actions/runs/33809312386) | success |
| `CI` | [33809312931](https://github.com/IvanMurzak/Godot-MCP/actions/runs/33809312931) | success |
| `Test Pull Request` | [33809312573](https://github.com/IvanMurzak/Godot-MCP/actions/runs/33809312573) | success |

All three runs are tied to headSha `0a58c264d039b6a893d6fe314cf9b1bb907f226b`, the current head of this
branch — status-check rollup **28/28 COMPLETED/SUCCESS** at that SHA.

Superseded, kept for history: the first push `8966f2d` was green on
[33804240480](https://github.com/IvanMurzak/Godot-MCP/actions/runs/33804240480) (`CI`) and
[33804240776](https://github.com/IvanMurzak/Godot-MCP/actions/runs/33804240776) (`Test Pull Request`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bac1LKpVobv1i1FNGCRNvM


